### PR TITLE
feat: add chain data provider and wallet

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,7 @@ Metrics/AbcSize:
     - 'lib/bsv/script/**/*'
     - 'lib/bsv/transaction/**/*'
     - 'lib/bsv/network/**/*'
+    - 'lib/bsv/wallet/**/*'
 
 Metrics/MethodLength:
   Exclude:
@@ -45,6 +46,7 @@ Metrics/MethodLength:
     - 'lib/bsv/script/**/*'
     - 'lib/bsv/transaction/**/*'
     - 'lib/bsv/network/**/*'
+    - 'lib/bsv/wallet/**/*'
 
 Metrics/CyclomaticComplexity:
   Exclude:
@@ -52,6 +54,7 @@ Metrics/CyclomaticComplexity:
     - 'lib/bsv/script/**/*'
     - 'lib/bsv/transaction/**/*'
     - 'lib/bsv/network/**/*'
+    - 'lib/bsv/wallet/**/*'
 
 Metrics/PerceivedComplexity:
   Exclude:
@@ -59,6 +62,7 @@ Metrics/PerceivedComplexity:
     - 'lib/bsv/script/**/*'
     - 'lib/bsv/transaction/**/*'
     - 'lib/bsv/network/**/*'
+    - 'lib/bsv/wallet/**/*'
 
 Metrics/ModuleLength:
   Exclude:
@@ -77,6 +81,8 @@ RSpec/MultipleExpectations:
     - 'spec/bsv/script/**/*'
     - 'spec/bsv/transaction/**/*'
     - 'spec/bsv/network/**/*'
+    - 'spec/bsv/wallet/**/*'
+    - 'spec/integration/**/*'
 
 RSpec/ExampleLength:
   Exclude:
@@ -84,3 +90,5 @@ RSpec/ExampleLength:
     - 'spec/bsv/script/**/*'
     - 'spec/bsv/transaction/**/*'
     - 'spec/bsv/network/**/*'
+    - 'spec/bsv/wallet/**/*'
+    - 'spec/integration/**/*'

--- a/lib/bsv-sdk.rb
+++ b/lib/bsv-sdk.rb
@@ -7,4 +7,5 @@ module BSV
   autoload :Script,      'bsv/script'
   autoload :Transaction, 'bsv/transaction'
   autoload :Network,     'bsv/network'
+  autoload :Wallet,      'bsv/wallet'
 end

--- a/lib/bsv/network.rb
+++ b/lib/bsv/network.rb
@@ -2,8 +2,11 @@
 
 module BSV
   module Network
-    autoload :BroadcastError,    'bsv/network/broadcast_error'
-    autoload :BroadcastResponse, 'bsv/network/broadcast_response'
-    autoload :ARC,               'bsv/network/arc'
+    autoload :BroadcastError,     'bsv/network/broadcast_error'
+    autoload :BroadcastResponse,  'bsv/network/broadcast_response'
+    autoload :ChainProviderError, 'bsv/network/chain_provider_error'
+    autoload :UTXO,               'bsv/network/utxo'
+    autoload :ARC,                'bsv/network/arc'
+    autoload :WhatsOnChain,       'bsv/network/whats_on_chain'
   end
 end

--- a/lib/bsv/network/chain_provider_error.rb
+++ b/lib/bsv/network/chain_provider_error.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module BSV
+  module Network
+    class ChainProviderError < StandardError
+      attr_reader :status_code
+
+      def initialize(message, status_code: nil)
+        @status_code = status_code
+        super(message)
+      end
+    end
+  end
+end

--- a/lib/bsv/network/utxo.rb
+++ b/lib/bsv/network/utxo.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module BSV
+  module Network
+    class UTXO
+      attr_reader :tx_hash, :tx_pos, :satoshis, :height
+
+      def initialize(tx_hash:, tx_pos:, satoshis:, height: nil)
+        @tx_hash = tx_hash
+        @tx_pos = tx_pos
+        @satoshis = satoshis
+        @height = height
+      end
+
+      def ==(other)
+        other.is_a?(self.class) &&
+          tx_hash == other.tx_hash &&
+          tx_pos == other.tx_pos
+      end
+
+      alias eql? ==
+
+      def hash
+        [tx_hash, tx_pos].hash
+      end
+    end
+  end
+end

--- a/lib/bsv/network/whats_on_chain.rb
+++ b/lib/bsv/network/whats_on_chain.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+require 'uri'
+
+module BSV
+  module Network
+    # WhatsOnChain chain data provider for reading transactions and UTXOs
+    # from the BSV network.
+    #
+    # Any object responding to #fetch_utxos(address) and
+    # #fetch_transaction(txid) can serve as a chain data provider;
+    # this class implements that contract using the WhatsOnChain API.
+    #
+    # The HTTP client is injectable for testability. It must respond to
+    # #request(uri, request) and return an object with #code and #body.
+    class WhatsOnChain
+      BASE_URL = 'https://api.whatsonchain.com'
+
+      def initialize(network: :mainnet, http_client: nil)
+        @network = network == :mainnet ? 'main' : 'test'
+        @http_client = http_client
+      end
+
+      # Fetch unspent transaction outputs for an address.
+      # @param address [String] BSV address
+      # @return [Array<UTXO>]
+      def fetch_utxos(address)
+        response = get("/v1/bsv/#{@network}/address/#{address}/unspent")
+        body = JSON.parse(response.body)
+
+        body.map do |entry|
+          UTXO.new(
+            tx_hash: entry['tx_hash'],
+            tx_pos: entry['tx_pos'],
+            satoshis: entry['value'],
+            height: entry['height']
+          )
+        end
+      end
+
+      # Fetch a raw transaction by its txid and parse it.
+      # @param txid [String] transaction ID (hex)
+      # @return [BSV::Transaction::Transaction]
+      def fetch_transaction(txid)
+        response = get("/v1/bsv/#{@network}/tx/#{txid}/hex")
+        BSV::Transaction::Transaction.from_hex(response.body)
+      end
+
+      private
+
+      def get(path)
+        uri = URI("#{BASE_URL}#{path}")
+        request = Net::HTTP::Get.new(uri)
+        response = execute(uri, request)
+        handle_response(response)
+        response
+      end
+
+      def execute(uri, request)
+        if @http_client
+          @http_client.request(uri, request)
+        else
+          Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+            http.request(request)
+          end
+        end
+      end
+
+      def handle_response(response)
+        code = response.code.to_i
+        return if (200..299).cover?(code)
+
+        raise ChainProviderError.new(
+          response.body || "HTTP #{code}",
+          status_code: code
+        )
+      end
+    end
+  end
+end

--- a/lib/bsv/wallet.rb
+++ b/lib/bsv/wallet.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module BSV
+  module Wallet
+    autoload :InsufficientFundsError, 'bsv/wallet/insufficient_funds_error'
+    autoload :Wallet,                 'bsv/wallet/wallet'
+  end
+end

--- a/lib/bsv/wallet/insufficient_funds_error.rb
+++ b/lib/bsv/wallet/insufficient_funds_error.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module BSV
+  module Wallet
+    class InsufficientFundsError < StandardError
+      attr_reader :required, :available
+
+      def initialize(message = nil, required: nil, available: nil)
+        @required = required
+        @available = available
+        super(message || "insufficient funds: need #{required}, have #{available}")
+      end
+    end
+  end
+end

--- a/lib/bsv/wallet/wallet.rb
+++ b/lib/bsv/wallet/wallet.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+module BSV
+  module Wallet
+    # Holds a private key, sources UTXOs via a chain data provider, and
+    # funds and signs P2PKH transactions.
+    #
+    # The provider is duck-typed — any object responding to
+    # #fetch_utxos(address) and #fetch_transaction(txid) qualifies.
+    class Wallet
+      DUST_THRESHOLD = 1
+
+      attr_reader :private_key, :provider
+
+      def initialize(private_key:, provider:)
+        @private_key = private_key
+        @provider = provider
+      end
+
+      def address(network: :mainnet)
+        @private_key.public_key.address(network: network)
+      end
+
+      def balance(network: :mainnet)
+        @provider.fetch_utxos(address(network: network)).sum(&:satoshis)
+      end
+
+      def fund(tx, network: :mainnet, satoshis_per_byte: 0.5)
+        utxos = @provider.fetch_utxos(address(network: network))
+        output_total = tx.total_output_satoshis
+
+        # Add a dummy change output so fee estimation accounts for its size
+        dummy_change = BSV::Transaction::TransactionOutput.new(
+          satoshis: 0, locking_script: locking_script
+        )
+        tx.add_output(dummy_change)
+
+        input_total = tx.total_input_satoshis
+        funded = false
+
+        utxos.each do |utxo|
+          tx.add_input(build_input(utxo))
+          input_total += utxo.satoshis
+
+          fee = tx.estimated_fee(satoshis_per_byte: satoshis_per_byte)
+          if input_total >= output_total + fee
+            funded = true
+            break
+          end
+        end
+
+        # Remove the dummy change output
+        tx.outputs.delete(dummy_change)
+
+        unless funded
+          fee = tx.estimated_fee(satoshis_per_byte: satoshis_per_byte)
+          raise InsufficientFundsError.new(required: output_total + fee, available: input_total)
+        end
+
+        add_change_if_needed(tx, input_total, output_total, satoshis_per_byte)
+
+        tx
+      end
+
+      def sign(tx)
+        tx.sign_all(@private_key)
+      end
+
+      def fund_and_sign(tx, network: :mainnet, satoshis_per_byte: 0.5)
+        fund(tx, network: network, satoshis_per_byte: satoshis_per_byte)
+        sign(tx)
+      end
+
+      private
+
+      def locking_script
+        @locking_script ||= BSV::Script::Script.p2pkh_lock(@private_key.public_key.hash160)
+      end
+
+      def build_input(utxo)
+        input = BSV::Transaction::TransactionInput.new(
+          prev_tx_id: BSV::Transaction::TransactionInput.txid_from_hex(utxo.tx_hash),
+          prev_tx_out_index: utxo.tx_pos
+        )
+        input.source_satoshis = utxo.satoshis
+        input.source_locking_script = locking_script
+        input
+      end
+
+      def add_change_if_needed(tx, input_total, output_total, satoshis_per_byte)
+        fee_without_change = tx.estimated_fee(satoshis_per_byte: satoshis_per_byte)
+        remainder = input_total - output_total - fee_without_change
+
+        return if remainder < DUST_THRESHOLD
+
+        change_output = BSV::Transaction::TransactionOutput.new(
+          satoshis: remainder, locking_script: locking_script
+        )
+        tx.add_output(change_output)
+
+        # Recalculate: adding the change output increases fee slightly
+        new_fee = tx.estimated_fee(satoshis_per_byte: satoshis_per_byte)
+        fee_increase = new_fee - fee_without_change
+        final_change = remainder - fee_increase
+
+        if final_change >= DUST_THRESHOLD
+          tx.outputs.delete(change_output)
+          tx.add_output(
+            BSV::Transaction::TransactionOutput.new(
+              satoshis: final_change, locking_script: locking_script
+            )
+          )
+        else
+          tx.outputs.delete(change_output) # change absorbed by fee
+        end
+      end
+    end
+  end
+end

--- a/spec/bsv/network/chain_provider_error_spec.rb
+++ b/spec/bsv/network/chain_provider_error_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe BSV::Network::ChainProviderError do
+  it 'is a StandardError subclass' do
+    expect(described_class).to be < StandardError
+  end
+
+  it 'stores the message' do
+    error = described_class.new('something went wrong')
+    expect(error.message).to eq('something went wrong')
+  end
+
+  it 'stores the status_code' do
+    error = described_class.new('not found', status_code: 404)
+    expect(error.status_code).to eq(404)
+  end
+
+  it 'defaults status_code to nil' do
+    error = described_class.new('oops')
+    expect(error.status_code).to be_nil
+  end
+end

--- a/spec/bsv/network/utxo_spec.rb
+++ b/spec/bsv/network/utxo_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe BSV::Network::UTXO do
+  subject(:utxo) do
+    described_class.new(tx_hash: 'abcd1234', tx_pos: 0, satoshis: 50_000, height: 800_000)
+  end
+
+  describe '#initialize' do
+    it 'stores all attributes' do
+      expect(utxo.tx_hash).to eq('abcd1234')
+      expect(utxo.tx_pos).to eq(0)
+      expect(utxo.satoshis).to eq(50_000)
+      expect(utxo.height).to eq(800_000)
+    end
+
+    it 'defaults height to nil' do
+      u = described_class.new(tx_hash: 'abcd1234', tx_pos: 0, satoshis: 1000)
+      expect(u.height).to be_nil
+    end
+  end
+
+  describe '#==' do
+    it 'considers UTXOs with the same outpoint equal' do
+      other = described_class.new(tx_hash: 'abcd1234', tx_pos: 0, satoshis: 99_999, height: 1)
+      expect(utxo).to eq(other)
+    end
+
+    it 'considers UTXOs with different tx_hash unequal' do
+      other = described_class.new(tx_hash: 'different', tx_pos: 0, satoshis: 50_000)
+      expect(utxo).not_to eq(other)
+    end
+
+    it 'considers UTXOs with different tx_pos unequal' do
+      other = described_class.new(tx_hash: 'abcd1234', tx_pos: 1, satoshis: 50_000)
+      expect(utxo).not_to eq(other)
+    end
+
+    it 'returns false for non-UTXO objects' do
+      expect(utxo).not_to eq('not a utxo')
+    end
+  end
+
+  describe '#hash' do
+    it 'is consistent with ==' do
+      other = described_class.new(tx_hash: 'abcd1234', tx_pos: 0, satoshis: 99_999)
+      expect(utxo.hash).to eq(other.hash)
+    end
+
+    it 'differs for different outpoints' do
+      other = described_class.new(tx_hash: 'abcd1234', tx_pos: 1, satoshis: 50_000)
+      expect(utxo.hash).not_to eq(other.hash)
+    end
+
+    it 'works correctly as a Hash key' do
+      other = described_class.new(tx_hash: 'abcd1234', tx_pos: 0, satoshis: 99_999)
+      h = { utxo => 'found' }
+      expect(h[other]).to eq('found')
+    end
+  end
+
+  describe 'read-only attributes' do
+    it 'does not allow setting attributes' do
+      expect(utxo).not_to respond_to(:tx_hash=)
+      expect(utxo).not_to respond_to(:tx_pos=)
+      expect(utxo).not_to respond_to(:satoshis=)
+      expect(utxo).not_to respond_to(:height=)
+    end
+  end
+end

--- a/spec/bsv/network/whats_on_chain_spec.rb
+++ b/spec/bsv/network/whats_on_chain_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+RSpec.describe BSV::Network::WhatsOnChain do
+  # Mock HTTP client that stores the last request and returns a configurable response
+  let(:mock_http) do
+    Class.new do
+      attr_reader :last_uri, :last_request
+
+      def initialize(code, body)
+        @code = code
+        @body = body
+      end
+
+      def request(uri, req)
+        @last_uri = uri
+        @last_request = req
+        Struct.new(:code, :body).new(@code.to_s, @body)
+      end
+    end
+  end
+
+  let(:utxo_response_body) do
+    [
+      { 'tx_hash' => 'aabb11', 'tx_pos' => 0, 'value' => 50_000, 'height' => 800_000 },
+      { 'tx_hash' => 'ccdd22', 'tx_pos' => 1, 'value' => 25_000, 'height' => 0 }
+    ].to_json
+  end
+
+  # Minimal valid coinbase transaction hex (1 input, 1 output)
+  let(:raw_tx_hex) do
+    '0100000001' \
+      '0000000000000000000000000000000000000000000000000000000000000000' \
+      'ffffffff' \
+      '04deadbeef' \
+      'ffffffff' \
+      '01' \
+      '0100000000000000' \
+      '00' \
+      '00000000'
+  end
+
+  describe '#fetch_utxos' do
+    it 'returns an array of UTXOs' do
+      http = mock_http.new(200, utxo_response_body)
+      provider = described_class.new(http_client: http)
+
+      utxos = provider.fetch_utxos('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa')
+
+      expect(utxos).to be_an(Array)
+      expect(utxos.length).to eq(2)
+      expect(utxos.first).to be_a(BSV::Network::UTXO)
+    end
+
+    it 'maps WoC fields correctly (value to satoshis)' do
+      http = mock_http.new(200, utxo_response_body)
+      provider = described_class.new(http_client: http)
+
+      utxos = provider.fetch_utxos('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa')
+
+      first = utxos.first
+      expect(first.tx_hash).to eq('aabb11')
+      expect(first.tx_pos).to eq(0)
+      expect(first.satoshis).to eq(50_000)
+      expect(first.height).to eq(800_000)
+    end
+
+    it 'sends GET to the correct mainnet URL' do
+      http = mock_http.new(200, '[]')
+      provider = described_class.new(http_client: http)
+
+      provider.fetch_utxos('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa')
+
+      expect(http.last_uri.to_s).to eq(
+        'https://api.whatsonchain.com/v1/bsv/main/address/1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa/unspent'
+      )
+      expect(http.last_request).to be_a(Net::HTTP::Get)
+    end
+
+    it 'uses testnet URL when network is :testnet' do
+      http = mock_http.new(200, '[]')
+      provider = described_class.new(network: :testnet, http_client: http)
+
+      provider.fetch_utxos('mfWxJ45yp2SFn7UciZyNpvDKrzbi36LaVX')
+
+      expect(http.last_uri.to_s).to include('/v1/bsv/test/')
+    end
+
+    it 'returns an empty array when there are no UTXOs' do
+      http = mock_http.new(200, '[]')
+      provider = described_class.new(http_client: http)
+
+      utxos = provider.fetch_utxos('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa')
+
+      expect(utxos).to eq([])
+    end
+
+    it 'raises ChainProviderError on HTTP error' do
+      http = mock_http.new(404, 'Address not found')
+      provider = described_class.new(http_client: http)
+
+      expect { provider.fetch_utxos('invalid') }.to raise_error(BSV::Network::ChainProviderError) do |error|
+        expect(error.message).to eq('Address not found')
+        expect(error.status_code).to eq(404)
+      end
+    end
+  end
+
+  describe '#fetch_transaction' do
+    it 'returns a parsed Transaction' do
+      http = mock_http.new(200, raw_tx_hex)
+      provider = described_class.new(http_client: http)
+
+      tx = provider.fetch_transaction('abc123')
+
+      expect(tx).to be_a(BSV::Transaction::Transaction)
+    end
+
+    it 'sends GET to the correct URL' do
+      http = mock_http.new(200, raw_tx_hex)
+      provider = described_class.new(http_client: http)
+
+      provider.fetch_transaction('abc123')
+
+      expect(http.last_uri.to_s).to eq(
+        'https://api.whatsonchain.com/v1/bsv/main/tx/abc123/hex'
+      )
+    end
+
+    it 'raises ChainProviderError on HTTP error' do
+      http = mock_http.new(404, 'Transaction not found')
+      provider = described_class.new(http_client: http)
+
+      expect { provider.fetch_transaction('unknown') }.to raise_error(BSV::Network::ChainProviderError) do |error|
+        expect(error.message).to eq('Transaction not found')
+        expect(error.status_code).to eq(404)
+      end
+    end
+  end
+end

--- a/spec/bsv/wallet/insufficient_funds_error_spec.rb
+++ b/spec/bsv/wallet/insufficient_funds_error_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe BSV::Wallet::InsufficientFundsError do
+  it 'is a StandardError subclass' do
+    expect(described_class).to be < StandardError
+  end
+
+  it 'stores required and available amounts' do
+    error = described_class.new(required: 10_000, available: 5_000)
+    expect(error.required).to eq(10_000)
+    expect(error.available).to eq(5_000)
+  end
+
+  it 'generates a default message from required and available' do
+    error = described_class.new(required: 10_000, available: 5_000)
+    expect(error.message).to eq('insufficient funds: need 10000, have 5000')
+  end
+
+  it 'accepts a custom message' do
+    error = described_class.new('custom message', required: 10_000, available: 5_000)
+    expect(error.message).to eq('custom message')
+  end
+
+  it 'defaults required and available to nil' do
+    error = described_class.new('oops')
+    expect(error.required).to be_nil
+    expect(error.available).to be_nil
+  end
+end

--- a/spec/bsv/wallet/wallet_spec.rb
+++ b/spec/bsv/wallet/wallet_spec.rb
@@ -1,0 +1,274 @@
+# frozen_string_literal: true
+
+RSpec.describe BSV::Wallet::Wallet do
+  let(:private_key) { BSV::Primitives::PrivateKey.generate }
+  let(:public_key) { private_key.public_key }
+  let(:address) { public_key.address(network: :mainnet) }
+  let(:locking_script) { BSV::Script::Script.p2pkh_lock(public_key.hash160) }
+
+  # A mock provider returning configurable UTXOs
+  let(:provider_class) do
+    Class.new do
+      attr_accessor :utxos
+
+      def initialize(utxos = [])
+        @utxos = utxos
+      end
+
+      def fetch_utxos(_address)
+        @utxos
+      end
+
+      def fetch_transaction(_txid)
+        nil
+      end
+    end
+  end
+
+  def make_utxo(satoshis, tx_hash: SecureRandom.hex(32), tx_pos: 0)
+    BSV::Network::UTXO.new(tx_hash: tx_hash, tx_pos: tx_pos, satoshis: satoshis)
+  end
+
+  def make_op_return_output(data = 'hello')
+    BSV::Transaction::TransactionOutput.new(
+      satoshis: 0,
+      locking_script: BSV::Script::Script.op_return(data)
+    )
+  end
+
+  def make_p2pkh_output(satoshis)
+    BSV::Transaction::TransactionOutput.new(
+      satoshis: satoshis,
+      locking_script: locking_script
+    )
+  end
+
+  describe '#address' do
+    it 'returns the address derived from the private key' do
+      provider = provider_class.new
+      wallet = described_class.new(private_key: private_key, provider: provider)
+
+      expect(wallet.address).to eq(address)
+    end
+
+    it 'supports testnet network' do
+      provider = provider_class.new
+      wallet = described_class.new(private_key: private_key, provider: provider)
+      testnet_address = public_key.address(network: :testnet)
+
+      expect(wallet.address(network: :testnet)).to eq(testnet_address)
+    end
+  end
+
+  describe '#balance' do
+    it 'returns the sum of UTXO satoshis' do
+      utxos = [make_utxo(50_000), make_utxo(30_000)]
+      provider = provider_class.new(utxos)
+      wallet = described_class.new(private_key: private_key, provider: provider)
+
+      expect(wallet.balance).to eq(80_000)
+    end
+
+    it 'returns 0 when there are no UTXOs' do
+      provider = provider_class.new([])
+      wallet = described_class.new(private_key: private_key, provider: provider)
+
+      expect(wallet.balance).to eq(0)
+    end
+  end
+
+  describe '#fund' do
+    it 'adds inputs from UTXOs to cover outputs plus fee' do
+      utxos = [make_utxo(100_000)]
+      provider = provider_class.new(utxos)
+      wallet = described_class.new(private_key: private_key, provider: provider)
+
+      tx = BSV::Transaction::Transaction.new
+      tx.add_output(make_p2pkh_output(10_000))
+
+      wallet.fund(tx)
+
+      expect(tx.inputs.length).to eq(1)
+      expect(tx.inputs.first.source_satoshis).to eq(100_000)
+    end
+
+    it 'sets source_locking_script on inputs' do
+      utxos = [make_utxo(100_000)]
+      provider = provider_class.new(utxos)
+      wallet = described_class.new(private_key: private_key, provider: provider)
+
+      tx = BSV::Transaction::Transaction.new
+      tx.add_output(make_p2pkh_output(10_000))
+
+      wallet.fund(tx)
+
+      expect(tx.inputs.first.source_locking_script).to eq(locking_script)
+    end
+
+    it 'adds a change output when remainder is above dust threshold' do
+      utxos = [make_utxo(100_000)]
+      provider = provider_class.new(utxos)
+      wallet = described_class.new(private_key: private_key, provider: provider)
+
+      tx = BSV::Transaction::Transaction.new
+      tx.add_output(make_p2pkh_output(10_000))
+
+      wallet.fund(tx)
+
+      # Should have original output + change output
+      expect(tx.outputs.length).to eq(2)
+      change = tx.outputs.last
+      expect(change.satoshis).to be > 0
+      expect(change.locking_script.to_hex).to eq(locking_script.to_hex)
+    end
+
+    it 'omits change output when remainder is below dust threshold' do
+      # Build a dummy tx with 1 input + 2 outputs (including dummy change)
+      # to estimate the fee the fund algorithm will see during UTXO selection.
+      dummy_tx = BSV::Transaction::Transaction.new
+      dummy_tx.add_output(make_p2pkh_output(10_000))
+      dummy_tx.add_output(make_p2pkh_output(0)) # dummy change
+      dummy_tx.add_input(
+        BSV::Transaction::TransactionInput.new(
+          prev_tx_id: "\x00" * 32,
+          prev_tx_out_index: 0
+        )
+      )
+      fee_with_change = dummy_tx.estimated_fee(satoshis_per_byte: 0.5)
+
+      # UTXO covers output + fee (with change) exactly — no room for actual change
+      utxos = [make_utxo(10_000 + fee_with_change)]
+      provider = provider_class.new(utxos)
+      wallet = described_class.new(private_key: private_key, provider: provider)
+
+      tx = BSV::Transaction::Transaction.new
+      tx.add_output(make_p2pkh_output(10_000))
+
+      wallet.fund(tx)
+
+      expect(tx.outputs.length).to eq(1) # no change output
+    end
+
+    it 'preserves existing outputs' do
+      utxos = [make_utxo(100_000)]
+      provider = provider_class.new(utxos)
+      wallet = described_class.new(private_key: private_key, provider: provider)
+
+      tx = BSV::Transaction::Transaction.new
+      tx.add_output(make_op_return_output)
+      tx.add_output(make_p2pkh_output(5_000))
+
+      wallet.fund(tx)
+
+      expect(tx.outputs[0].satoshis).to eq(0)
+      expect(tx.outputs[1].satoshis).to eq(5_000)
+    end
+
+    it 'raises InsufficientFundsError when UTXOs cannot cover outputs' do
+      utxos = [make_utxo(100)]
+      provider = provider_class.new(utxos)
+      wallet = described_class.new(private_key: private_key, provider: provider)
+
+      tx = BSV::Transaction::Transaction.new
+      tx.add_output(make_p2pkh_output(100_000))
+
+      expect { wallet.fund(tx) }.to raise_error(BSV::Wallet::InsufficientFundsError) do |error|
+        expect(error.available).to eq(100)
+        expect(error.required).to be > 100_000
+      end
+    end
+
+    it 'raises InsufficientFundsError when there are no UTXOs' do
+      provider = provider_class.new([])
+      wallet = described_class.new(private_key: private_key, provider: provider)
+
+      tx = BSV::Transaction::Transaction.new
+      tx.add_output(make_p2pkh_output(1_000))
+
+      expect { wallet.fund(tx) }.to raise_error(BSV::Wallet::InsufficientFundsError) do |error|
+        expect(error.available).to eq(0)
+      end
+    end
+
+    it 'uses multiple UTXOs when one is not enough' do
+      utxos = [make_utxo(3_000, tx_hash: 'aa' * 32), make_utxo(3_000, tx_hash: 'bb' * 32)]
+      provider = provider_class.new(utxos)
+      wallet = described_class.new(private_key: private_key, provider: provider)
+
+      tx = BSV::Transaction::Transaction.new
+      tx.add_output(make_p2pkh_output(5_000))
+
+      wallet.fund(tx)
+
+      expect(tx.inputs.length).to eq(2)
+    end
+
+    it 'returns the transaction for chaining' do
+      utxos = [make_utxo(100_000)]
+      provider = provider_class.new(utxos)
+      wallet = described_class.new(private_key: private_key, provider: provider)
+
+      tx = BSV::Transaction::Transaction.new
+      tx.add_output(make_p2pkh_output(10_000))
+
+      result = wallet.fund(tx)
+
+      expect(result).to be(tx)
+    end
+  end
+
+  describe '#sign' do
+    it 'delegates to tx.sign_all and adds unlocking scripts' do
+      utxos = [make_utxo(100_000)]
+      provider = provider_class.new(utxos)
+      wallet = described_class.new(private_key: private_key, provider: provider)
+
+      tx = BSV::Transaction::Transaction.new
+      tx.add_output(make_p2pkh_output(10_000))
+      wallet.fund(tx)
+
+      wallet.sign(tx)
+
+      tx.inputs.each do |input|
+        expect(input.unlocking_script).not_to be_nil
+      end
+    end
+  end
+
+  describe '#fund_and_sign' do
+    it 'produces a funded and signed transaction' do
+      utxos = [make_utxo(100_000)]
+      provider = provider_class.new(utxos)
+      wallet = described_class.new(private_key: private_key, provider: provider)
+
+      tx = BSV::Transaction::Transaction.new
+      tx.add_output(make_p2pkh_output(10_000))
+
+      wallet.fund_and_sign(tx)
+
+      expect(tx.inputs.length).to be >= 1
+      expect(tx.inputs.first.unlocking_script).not_to be_nil
+      expect(tx.total_input_satoshis).to be >= tx.total_output_satoshis
+    end
+
+    it 'produces a serialisable transaction' do
+      utxos = [make_utxo(100_000)]
+      provider = provider_class.new(utxos)
+      wallet = described_class.new(private_key: private_key, provider: provider)
+
+      tx = BSV::Transaction::Transaction.new
+      tx.add_output(make_p2pkh_output(10_000))
+
+      wallet.fund_and_sign(tx)
+
+      hex = tx.to_hex
+      expect(hex).to be_a(String)
+      expect(hex.length).to be > 0
+
+      # Round-trip: parse the serialised hex back
+      parsed = BSV::Transaction::Transaction.from_hex(hex)
+      expect(parsed.inputs.length).to eq(tx.inputs.length)
+      expect(parsed.outputs.length).to eq(tx.outputs.length)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,9 @@
 
 require 'bsv-sdk'
 
+# Load support files (test helpers, shared contexts, etc.)
+Dir[File.join(__dir__, 'support', '**', '*.rb')].sort.each { |f| require f }
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -13,6 +16,7 @@ RSpec.configure do |config|
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.disable_monkey_patching!
+  config.filter_run_excluding testnet: true
   config.order = :random
   Kernel.srand config.seed
 end


### PR DESCRIPTION
## Summary

- **Chain data provider** (`BSV::Network::WhatsOnChain`): reads UTXOs and raw transactions from the BSV network via the WhatsOnChain API, with injectable HTTP client for testability
- **Wallet** (`BSV::Wallet::Wallet`): holds a private key, sources UTXOs via a chain data provider, funds and signs P2PKH transactions with greedy UTXO selection and change output handling
- **Supporting types**: `UTXO` value object, `ChainProviderError` and `InsufficientFundsError` exceptions

## Test plan

- [x] 42 new specs across 5 spec files (21 network, 21 wallet)
- [x] Full suite green (240 examples, 0 failures)
- [x] RuboCop clean on all new/modified files
- [ ] Verify `WhatsOnChain#fetch_utxos` and `#fetch_transaction` against live API (testnet)
- [ ] Verify `Wallet#fund_and_sign` produces a broadcastable transaction (testnet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)