### PR TITLE
fix(script): deterministic Opcodes NAME lookup

### DIFF
--- a/lib/bsv/script/opcodes.rb
+++ b/lib/bsv/script/opcodes.rb
@@ -137,9 +137,12 @@ module BSV
       OP_PUBKEY         = 0xfe
       OP_INVALIDOPCODE  = 0xff
 
-      # Reverse lookup: opcode byte → name string
+      # Reverse lookup: opcode byte → name string.
+      # Sorted so canonical names (OP_0, OP_1) win over aliases (OP_FALSE, OP_TRUE)
+      # regardless of Module#constants enumeration order.
       NAME = constants
              .select { |c| c.to_s.start_with?('OP_') }
+             .sort
              .each_with_object({}) { |c, h| h[const_get(c)] ||= c.to_s }
              .freeze
 


### PR DESCRIPTION
## Summary

Fixes #33.

- Sort `Module#constants` before building the `NAME` reverse-lookup hash so canonical names (`OP_0`, `OP_1`) always win over aliases (`OP_FALSE`, `OP_TRUE`)
- Digits sort before letters in ASCII, making the result deterministic regardless of Ruby version
- Fixes CI failures on Ruby 2.7 and 3.4

## Test plan

- [ ] `bundle exec rspec spec/bsv/script/opcodes_spec.rb` — `name_for` returns `OP_0` for `0x00`
- [ ] `bundle exec rake` — full suite green across all Ruby versions
- [ ] CI passes on 2.7, 3.0, 3.1, 3.2, 3.3, 3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)