### PR TITLE
feat(script): add data push and stack manipulation opcodes

### DIFF
--- a/lib/bsv/script/interpreter/interpreter.rb
+++ b/lib/bsv/script/interpreter/interpreter.rb
@@ -3,10 +3,15 @@
 require_relative 'error'
 require_relative 'script_number'
 require_relative 'stack'
+require_relative 'operations/data_push'
+require_relative 'operations/stack_ops'
 
 module BSV
   module Script
-    class Interpreter
+    class Interpreter # rubocop:disable Metrics/ClassLength
+      include Operations::DataPush
+      include Operations::StackOps
+
       attr_reader :dstack, :astack
 
       # Evaluate unlock + lock scripts without transaction context.
@@ -29,6 +34,36 @@ module BSV
         ).execute
       end
 
+      def execute # rubocop:disable Naming/PredicateMethod
+        scripts = [@unlock_script, @lock_script]
+
+        scripts.each_with_index do |script, script_idx|
+          chunks = script.chunks
+
+          chunks.each do |chunk|
+            execute_opcode(chunk)
+            break if @early_return
+          end
+
+          break if @early_return && script_idx == 1
+
+          # Between scripts: verify conditionals balanced
+          unless @cond_stack.empty?
+            raise ScriptError.new(ScriptErrorCode::UNBALANCED_CONDITIONAL, 'unbalanced conditional')
+          end
+
+          # Clear alt stack between scripts
+          @astack.clear
+
+          # Reset state for next script
+          @last_code_sep = 0
+          @early_return = false
+        end
+
+        check_final_stack
+        true
+      end
+
       private
 
       def initialize(unlock_script:, lock_script:, tx: nil, input_index: nil, satoshis: nil)
@@ -46,8 +81,83 @@ module BSV
         @early_return = false
       end
 
-      def execute
-        raise NotImplementedError, 'execution loop added in Phase 2'
+      def execute_opcode(chunk)
+        opcode = chunk.opcode
+
+        # Conditional execution check: if we're in a non-executing branch,
+        # only process conditional opcodes (IF/NOTIF/ELSE/ENDIF).
+        # This will be implemented in Phase 3 (flow control).
+        # For now, all opcodes execute unconditionally.
+        unless branch_executing?
+          return if conditional_opcode?(opcode)
+
+          return
+        end
+
+        dispatch_opcode(opcode, chunk)
+      end
+
+      def dispatch_opcode(opcode, chunk)
+        case opcode
+        # --- Data push ---
+        when Opcodes::OP_0
+          op_false
+        when Opcodes::OP_1NEGATE
+          op_1negate
+        when Opcodes::OP_1..Opcodes::OP_16
+          op_n(opcode)
+        when 0x01..0x4b, Opcodes::OP_PUSHDATA1, Opcodes::OP_PUSHDATA2, Opcodes::OP_PUSHDATA4
+          op_push_data(chunk)
+
+        # --- Stack manipulation ---
+        when Opcodes::OP_TOALTSTACK then op_toaltstack
+        when Opcodes::OP_FROMALTSTACK then op_fromaltstack
+        when Opcodes::OP_IFDUP then op_ifdup
+        when Opcodes::OP_DEPTH then op_depth
+        when Opcodes::OP_DROP then op_drop
+        when Opcodes::OP_2DROP then op_2drop
+        when Opcodes::OP_DUP then op_dup
+        when Opcodes::OP_2DUP then op_2dup
+        when Opcodes::OP_3DUP then op_3dup
+        when Opcodes::OP_NIP then op_nip
+        when Opcodes::OP_OVER then op_over
+        when Opcodes::OP_2OVER then op_2over
+        when Opcodes::OP_PICK then op_pick
+        when Opcodes::OP_ROLL then op_roll
+        when Opcodes::OP_ROT then op_rot
+        when Opcodes::OP_2ROT then op_2rot
+        when Opcodes::OP_SWAP then op_swap
+        when Opcodes::OP_2SWAP then op_2swap
+        when Opcodes::OP_TUCK then op_tuck
+
+        else
+          raise ScriptError.new(
+            ScriptErrorCode::INVALID_OPCODE,
+            "unhandled opcode: 0x#{opcode.to_s(16).rjust(2, '0')}"
+          )
+        end
+      end
+
+      # Is the current conditional branch executing?
+      # True when not inside any conditional, or inside a true branch.
+      # Uses symbol :true (not boolean) because Phase 3 adds :false and :skip states.
+      def branch_executing?
+        @cond_stack.empty? || @cond_stack.last == :true # rubocop:disable Lint/BooleanSymbol
+      end
+
+      # Is this a conditional opcode that must be processed even in non-executing branches?
+      def conditional_opcode?(_opcode)
+        # Implemented in Phase 3 (flow control): OP_IF, OP_NOTIF, OP_ELSE, OP_ENDIF
+        false
+      end
+
+      # Verify final stack state: must have at least one truthy element on top.
+      def check_final_stack
+        raise ScriptError.new(ScriptErrorCode::EMPTY_STACK, 'stack empty at end of script execution') if @dstack.empty?
+
+        return if @dstack.pop_bool
+
+        raise ScriptError.new(ScriptErrorCode::EVAL_FALSE, 'false stack entry at end of script execution')
       end
     end
   end

--- a/lib/bsv/script/interpreter/operations/data_push.rb
+++ b/lib/bsv/script/interpreter/operations/data_push.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module BSV
+  module Script
+    class Interpreter
+      module Operations
+        module DataPush
+          private
+
+          # OP_0 / OP_FALSE: push empty byte array
+          def op_false
+            @dstack.push_bytes(''.b)
+          end
+
+          # OP_1NEGATE: push -1
+          def op_1negate
+            @dstack.push_int(ScriptNumber.new(-1))
+          end
+
+          # OP_1..OP_16: push the corresponding integer value
+          def op_n(opcode)
+            @dstack.push_int(ScriptNumber.new(opcode - Opcodes::OP_1 + 1))
+          end
+
+          # Data push: chunk carries its own data
+          def op_push_data(chunk)
+            @dstack.push_bytes(chunk.data)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bsv/script/interpreter/operations/stack_ops.rb
+++ b/lib/bsv/script/interpreter/operations/stack_ops.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module BSV
+  module Script
+    class Interpreter
+      module Operations
+        module StackOps
+          private
+
+          # OP_TOALTSTACK: move top of data stack to alt stack
+          def op_toaltstack
+            @astack.push_bytes(@dstack.pop_bytes)
+          end
+
+          # OP_FROMALTSTACK: move top of alt stack to data stack
+          def op_fromaltstack
+            @dstack.push_bytes(@astack.pop_bytes)
+          end
+
+          # OP_IFDUP: duplicate top if truthy
+          def op_ifdup
+            val = @dstack.peek_bytes(0)
+            @dstack.push_bytes(val.dup) if Stack.cast_bool(val)
+          end
+
+          # OP_DEPTH: push stack depth as number
+          def op_depth
+            @dstack.push_int(ScriptNumber.new(@dstack.depth))
+          end
+
+          # OP_DROP
+          def op_drop
+            @dstack.drop_n(1)
+          end
+
+          # OP_2DROP
+          def op_2drop
+            @dstack.drop_n(2)
+          end
+
+          # OP_DUP
+          def op_dup
+            @dstack.dup_n(1)
+          end
+
+          # OP_2DUP
+          def op_2dup
+            @dstack.dup_n(2)
+          end
+
+          # OP_3DUP
+          def op_3dup
+            @dstack.dup_n(3)
+          end
+
+          # OP_NIP: remove second-to-top
+          def op_nip
+            @dstack.nip_n(1)
+          end
+
+          # OP_OVER
+          def op_over
+            @dstack.over_n(1)
+          end
+
+          # OP_2OVER
+          def op_2over
+            @dstack.over_n(2)
+          end
+
+          # OP_PICK: copy item at depth n to top
+          def op_pick
+            idx = @dstack.pop_int.to_i32
+            @dstack.pick_n(idx)
+          end
+
+          # OP_ROLL: move item at depth n to top
+          def op_roll
+            idx = @dstack.pop_int.to_i32
+            @dstack.roll_n(idx)
+          end
+
+          # OP_ROT
+          def op_rot
+            @dstack.rot_n(1)
+          end
+
+          # OP_2ROT
+          def op_2rot
+            @dstack.rot_n(2)
+          end
+
+          # OP_SWAP
+          def op_swap
+            @dstack.swap_n(1)
+          end
+
+          # OP_2SWAP
+          def op_2swap
+            @dstack.swap_n(2)
+          end
+
+          # OP_TUCK
+          def op_tuck
+            @dstack.tuck
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/bsv/script/interpreter/interpreter_spec.rb
+++ b/spec/bsv/script/interpreter/interpreter_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+RSpec.describe BSV::Script::Interpreter do # rubocop:disable RSpec/SpecFilePathFormat
+  def evaluate(unlock_asm, lock_asm)
+    unlock = unlock_asm.empty? ? BSV::Script::Script.new : BSV::Script::Script.from_asm(unlock_asm)
+    lock = lock_asm.empty? ? BSV::Script::Script.new : BSV::Script::Script.from_asm(lock_asm)
+    described_class.evaluate(unlock, lock)
+  end
+
+  describe '.evaluate' do
+    it 'returns true for simple truthy script' do
+      expect(evaluate('', 'OP_1')).to be true
+    end
+
+    it 'executes unlock then lock script sequentially' do
+      # Unlock pushes 1 and 2, lock drops 2, top is 1
+      expect(evaluate('OP_1 OP_2', 'OP_DROP')).to be true
+    end
+
+    it 'carries data stack from unlock to lock' do
+      # Unlock pushes data, lock duplicates and drops — proves data carried over
+      expect(evaluate('deadbeef', 'OP_DUP OP_DROP')).to be true
+    end
+
+    it 'raises EMPTY_STACK when both scripts are empty' do
+      expect do
+        evaluate('', '')
+      end.to raise_error(BSV::Script::ScriptError) { |e|
+        expect(e.code).to eq(:empty_stack)
+      }
+    end
+
+    it 'raises EVAL_FALSE when top of stack is falsy' do
+      expect do
+        evaluate('', 'OP_0')
+      end.to raise_error(BSV::Script::ScriptError) { |e|
+        expect(e.code).to eq(:eval_false)
+      }
+    end
+
+    it 'raises INVALID_OPCODE for unhandled opcodes' do
+      expect do
+        evaluate('', 'OP_1 OP_1 OP_EQUAL')
+      end.to raise_error(BSV::Script::ScriptError) { |e|
+        expect(e.code).to eq(:invalid_opcode)
+      }
+    end
+
+    it 'clears alt stack between scripts' do
+      # Unlock pushes 1 to alt stack, alt stack is cleared between scripts,
+      # lock tries to pop from empty alt stack
+      expect do
+        evaluate('OP_1 OP_TOALTSTACK', 'OP_FROMALTSTACK')
+      end.to raise_error(BSV::Script::ScriptError) { |e|
+        expect(e.code).to eq(:invalid_stack_operation)
+      }
+    end
+
+    it 'only checks top of final stack for truthiness' do
+      # Multiple items on stack — only top matters
+      expect(evaluate('OP_0 OP_0 OP_0', 'OP_1')).to be true
+    end
+  end
+end

--- a/spec/bsv/script/interpreter/operations/data_push_spec.rb
+++ b/spec/bsv/script/interpreter/operations/data_push_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+RSpec.describe BSV::Script::Interpreter do # rubocop:disable RSpec/SpecFilePathFormat
+  def build_interpreter
+    empty = BSV::Script::Script.new
+    described_class.send(:new, unlock_script: empty, lock_script: empty)
+  end
+
+  def evaluate(unlock_asm, lock_asm)
+    unlock = unlock_asm.empty? ? BSV::Script::Script.new : BSV::Script::Script.from_asm(unlock_asm)
+    lock = lock_asm.empty? ? BSV::Script::Script.new : BSV::Script::Script.from_asm(lock_asm)
+    described_class.evaluate(unlock, lock)
+  end
+
+  describe 'OP_0 / OP_FALSE' do
+    it 'pushes empty byte string' do
+      interp = build_interpreter
+      interp.send(:op_false)
+      expect(interp.dstack.pop_bytes).to eq(''.b)
+    end
+
+    it 'pushes a falsy value' do
+      expect do
+        evaluate('', 'OP_0')
+      end.to raise_error(BSV::Script::ScriptError) { |e|
+        expect(e.code).to eq(:eval_false)
+      }
+    end
+
+    it 'is consumable by OP_DROP' do
+      expect(evaluate('OP_1', 'OP_0 OP_DROP')).to be true
+    end
+  end
+
+  describe 'OP_1NEGATE' do
+    it 'pushes -1' do
+      interp = build_interpreter
+      interp.send(:op_1negate)
+      expect(interp.dstack.pop_int.value).to eq(-1)
+    end
+
+    it 'is truthy' do
+      expect(evaluate('', 'OP_1NEGATE')).to be true
+    end
+  end
+
+  describe 'OP_1 through OP_16' do
+    (1..16).each do |n|
+      it "OP_#{n} pushes #{n}" do
+        interp = build_interpreter
+        opcode = BSV::Script::Opcodes::OP_1 + n - 1
+        interp.send(:op_n, opcode)
+        expect(interp.dstack.pop_int.value).to eq(n)
+      end
+    end
+
+    it 'all push truthy values' do
+      (1..16).each do |n|
+        expect(evaluate('', "OP_#{n}")).to be true
+      end
+    end
+  end
+
+  describe 'data push (1-75 bytes)' do
+    it 'pushes 1-byte data' do
+      expect(evaluate('', 'ff')).to be true
+    end
+
+    it 'pushes multi-byte data' do
+      interp = build_interpreter
+      chunk = BSV::Script::Chunk.new(opcode: 0x04, data: "\xde\xad\xbe\xef".b)
+      interp.send(:op_push_data, chunk)
+      expect(interp.dstack.pop_bytes).to eq("\xde\xad\xbe\xef".b)
+    end
+
+    it 'pushes 75 bytes' do
+      hex = 'ab' * 75
+      expect(evaluate('', hex)).to be true
+    end
+  end
+
+  describe 'OP_PUSHDATA1' do
+    it 'pushes 76 bytes' do
+      hex = 'cd' * 76
+      expect(evaluate('', hex)).to be true
+    end
+
+    it 'pushes 255 bytes' do
+      hex = 'ef' * 255
+      expect(evaluate('', hex)).to be true
+    end
+  end
+
+  describe 'OP_PUSHDATA2' do
+    it 'pushes 256 bytes' do
+      hex = 'ab' * 256
+      expect(evaluate('', hex)).to be true
+    end
+  end
+end

--- a/spec/bsv/script/interpreter/operations/stack_ops_spec.rb
+++ b/spec/bsv/script/interpreter/operations/stack_ops_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+RSpec.describe BSV::Script::Interpreter do # rubocop:disable RSpec/SpecFilePathFormat
+  def build_interpreter
+    empty = BSV::Script::Script.new
+    described_class.send(:new, unlock_script: empty, lock_script: empty)
+  end
+
+  def evaluate(unlock_asm, lock_asm)
+    unlock = unlock_asm.empty? ? BSV::Script::Script.new : BSV::Script::Script.from_asm(unlock_asm)
+    lock = lock_asm.empty? ? BSV::Script::Script.new : BSV::Script::Script.from_asm(lock_asm)
+    described_class.evaluate(unlock, lock)
+  end
+
+  describe 'OP_TOALTSTACK / OP_FROMALTSTACK' do
+    it 'moves item to alt stack and back' do
+      interp = build_interpreter
+      interp.dstack.push_bytes('hello'.b)
+      interp.dstack.push_bytes('world'.b)
+
+      interp.send(:op_toaltstack)
+      expect(interp.dstack.depth).to eq(1)
+      expect(interp.astack.depth).to eq(1)
+
+      interp.send(:op_fromaltstack)
+      expect(interp.dstack.depth).to eq(2)
+      expect(interp.dstack.pop_bytes).to eq('world'.b)
+    end
+
+    it 'roundtrips through evaluate' do
+      # unlock: [1, 2]. lock: TOALT moves 2 to alt, DROP removes 1, FROMALT pushes 2 back
+      expect(evaluate('OP_1 OP_2', 'OP_TOALTSTACK OP_DROP OP_FROMALTSTACK')).to be true
+    end
+  end
+
+  describe 'OP_IFDUP' do
+    it 'duplicates truthy value' do
+      interp = build_interpreter
+      interp.dstack.push_bytes("\x01".b)
+      interp.send(:op_ifdup)
+      expect(interp.dstack.depth).to eq(2)
+    end
+
+    it 'does not duplicate falsy value' do
+      interp = build_interpreter
+      interp.dstack.push_bytes(''.b)
+      interp.send(:op_ifdup)
+      expect(interp.dstack.depth).to eq(1)
+    end
+  end
+
+  describe 'OP_DEPTH' do
+    it 'pushes current stack depth' do
+      interp = build_interpreter
+      interp.dstack.push_bytes('a'.b)
+      interp.dstack.push_bytes('b'.b)
+      interp.send(:op_depth)
+      expect(interp.dstack.pop_int.value).to eq(2)
+    end
+  end
+
+  describe 'OP_DROP' do
+    it 'removes top item' do
+      expect(evaluate('OP_1 OP_2', 'OP_DROP')).to be true
+    end
+  end
+
+  describe 'OP_2DROP' do
+    it 'removes top two items' do
+      expect(evaluate('OP_1 OP_2 OP_3', 'OP_2DROP')).to be true
+    end
+  end
+
+  describe 'OP_DUP' do
+    it 'duplicates top item' do
+      interp = build_interpreter
+      interp.dstack.push_bytes('a'.b)
+      interp.send(:op_dup)
+      expect(interp.dstack.depth).to eq(2)
+      expect(interp.dstack.pop_bytes).to eq('a'.b)
+      expect(interp.dstack.pop_bytes).to eq('a'.b)
+    end
+  end
+
+  describe 'OP_2DUP' do
+    it 'duplicates top two items' do
+      interp = build_interpreter
+      interp.dstack.push_bytes('a'.b)
+      interp.dstack.push_bytes('b'.b)
+      interp.send(:op_2dup)
+      expect(interp.dstack.depth).to eq(4)
+    end
+  end
+
+  describe 'OP_3DUP' do
+    it 'duplicates top three items' do
+      interp = build_interpreter
+      interp.dstack.push_bytes('a'.b)
+      interp.dstack.push_bytes('b'.b)
+      interp.dstack.push_bytes('c'.b)
+      interp.send(:op_3dup)
+      expect(interp.dstack.depth).to eq(6)
+    end
+  end
+
+  describe 'OP_NIP' do
+    it 'removes second-to-top item' do
+      interp = build_interpreter
+      interp.dstack.push_bytes('a'.b)
+      interp.dstack.push_bytes('b'.b)
+      interp.send(:op_nip)
+      expect(interp.dstack.depth).to eq(1)
+      expect(interp.dstack.pop_bytes).to eq('b'.b)
+    end
+  end
+
+  describe 'OP_OVER' do
+    it 'copies second item to top' do
+      interp = build_interpreter
+      interp.dstack.push_bytes('a'.b)
+      interp.dstack.push_bytes('b'.b)
+      interp.send(:op_over)
+      expect(interp.dstack.depth).to eq(3)
+      expect(interp.dstack.pop_bytes).to eq('a'.b)
+    end
+  end
+
+  describe 'OP_2OVER' do
+    it 'copies third and fourth items to top' do
+      interp = build_interpreter
+      %w[a b c d].each { |v| interp.dstack.push_bytes(v.b) }
+      interp.send(:op_2over)
+      expect(interp.dstack.depth).to eq(6)
+      expect(interp.dstack.pop_bytes).to eq('b'.b)
+      expect(interp.dstack.pop_bytes).to eq('a'.b)
+    end
+  end
+
+  describe 'OP_PICK' do
+    it 'copies nth item to top' do
+      interp = build_interpreter
+      interp.dstack.push_bytes('a'.b)
+      interp.dstack.push_bytes('b'.b)
+      interp.dstack.push_bytes('c'.b)
+      interp.dstack.push_int(BSV::Script::ScriptNumber.new(2))
+      interp.send(:op_pick)
+      expect(interp.dstack.pop_bytes).to eq('a'.b)
+    end
+  end
+
+  describe 'OP_ROLL' do
+    it 'moves nth item to top' do
+      interp = build_interpreter
+      interp.dstack.push_bytes('a'.b)
+      interp.dstack.push_bytes('b'.b)
+      interp.dstack.push_bytes('c'.b)
+      interp.dstack.push_int(BSV::Script::ScriptNumber.new(2))
+      interp.send(:op_roll)
+      expect(interp.dstack.depth).to eq(3)
+      expect(interp.dstack.pop_bytes).to eq('a'.b)
+    end
+  end
+
+  describe 'OP_ROT' do
+    it 'rotates top three items' do
+      interp = build_interpreter
+      interp.dstack.push_bytes('a'.b)
+      interp.dstack.push_bytes('b'.b)
+      interp.dstack.push_bytes('c'.b)
+      interp.send(:op_rot)
+      expect(interp.dstack.pop_bytes).to eq('a'.b)
+      expect(interp.dstack.pop_bytes).to eq('c'.b)
+      expect(interp.dstack.pop_bytes).to eq('b'.b)
+    end
+  end
+
+  describe 'OP_2ROT' do
+    it 'rotates top six items in pairs' do
+      interp = build_interpreter
+      %w[a b c d e f].each { |v| interp.dstack.push_bytes(v.b) }
+      interp.send(:op_2rot)
+      expect(interp.dstack.pop_bytes).to eq('b'.b)
+      expect(interp.dstack.pop_bytes).to eq('a'.b)
+    end
+  end
+
+  describe 'OP_SWAP' do
+    it 'swaps top two items' do
+      interp = build_interpreter
+      interp.dstack.push_bytes('a'.b)
+      interp.dstack.push_bytes('b'.b)
+      interp.send(:op_swap)
+      expect(interp.dstack.pop_bytes).to eq('a'.b)
+      expect(interp.dstack.pop_bytes).to eq('b'.b)
+    end
+  end
+
+  describe 'OP_2SWAP' do
+    it 'swaps top two pairs' do
+      interp = build_interpreter
+      %w[a b c d].each { |v| interp.dstack.push_bytes(v.b) }
+      interp.send(:op_2swap)
+      expect(interp.dstack.pop_bytes).to eq('b'.b)
+      expect(interp.dstack.pop_bytes).to eq('a'.b)
+      expect(interp.dstack.pop_bytes).to eq('d'.b)
+      expect(interp.dstack.pop_bytes).to eq('c'.b)
+    end
+  end
+
+  describe 'OP_TUCK' do
+    it 'copies top item before second' do
+      interp = build_interpreter
+      interp.dstack.push_bytes('a'.b)
+      interp.dstack.push_bytes('b'.b)
+      interp.send(:op_tuck)
+      expect(interp.dstack.depth).to eq(3)
+      expect(interp.dstack.pop_bytes).to eq('b'.b)
+      expect(interp.dstack.pop_bytes).to eq('a'.b)
+      expect(interp.dstack.pop_bytes).to eq('b'.b)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Implement interpreter execution loop with two-script sequential execution, alt stack clearing between scripts, and final stack truthiness check
- Add all data push operations: OP_0, OP_1..16, OP_1NEGATE, PUSHDATA1/2/4
- Add 19 stack manipulation opcodes: DUP, 2DUP, 3DUP, DROP, 2DROP, SWAP, 2SWAP, ROT, 2ROT, OVER, 2OVER, NIP, TUCK, PICK, ROLL, DEPTH, IFDUP, TOALTSTACK, FROMALTSTACK

Closes #58

## Test plan
- [x] 56 new examples across 3 spec files (data_push, stack_ops, interpreter execution loop)
- [x] RuboCop clean (0 offences across all 103 files)
- [x] Full suite passes (768 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)