### PR TITLE
feat(script): add crypto and signature verification opcodes

### DIFF
--- a/lib/bsv/primitives/digest.rb
+++ b/lib/bsv/primitives/digest.rb
@@ -7,6 +7,10 @@ module BSV
     module Digest
       module_function
 
+      def sha1(data)
+        OpenSSL::Digest::SHA1.digest(data)
+      end
+
       def sha256(data)
         OpenSSL::Digest::SHA256.digest(data)
       end

--- a/lib/bsv/script/interpreter/error.rb
+++ b/lib/bsv/script/interpreter/error.rb
@@ -31,6 +31,9 @@ module BSV
       INVALID_SIG_COUNT = :invalid_sig_count
       SIG_NULLFAIL = :sig_nullfail
       SIG_NULLDUMMY = :sig_nulldummy
+      SIG_DER = :sig_der
+      SIG_HIGH_S = :sig_high_s
+      PUBKEY_TYPE = :pubkey_type
       INVALID_SIGHASH_TYPE = :invalid_sighash_type
       EARLY_RETURN = :early_return
       IMPOSSIBLE_ENCODING = :impossible_encoding

--- a/lib/bsv/script/interpreter/interpreter.rb
+++ b/lib/bsv/script/interpreter/interpreter.rb
@@ -9,6 +9,7 @@ require_relative 'operations/flow_control'
 require_relative 'operations/bitwise'
 require_relative 'operations/arithmetic'
 require_relative 'operations/splice'
+require_relative 'operations/crypto'
 
 module BSV
   module Script
@@ -19,6 +20,7 @@ module BSV
       include Operations::Bitwise
       include Operations::Arithmetic
       include Operations::Splice
+      include Operations::Crypto
 
       attr_reader :dstack, :astack
 
@@ -53,9 +55,11 @@ module BSV
         scripts = [@unlock_script, @lock_script]
 
         scripts.each_with_index do |script, script_idx|
+          @current_script = script
           chunks = script.chunks
 
-          chunks.each do |chunk|
+          chunks.each_with_index do |chunk, chunk_idx|
+            @current_chunk_idx = chunk_idx
             execute_opcode(chunk)
             break if @early_return
           end
@@ -94,6 +98,8 @@ module BSV
         @else_stack = []
         @last_code_sep = 0
         @early_return = false
+        @current_script = nil
+        @current_chunk_idx = 0
       end
 
       def execute_opcode(chunk)
@@ -202,6 +208,18 @@ module BSV
         when Opcodes::OP_MIN then op_min
         when Opcodes::OP_MAX then op_max
         when Opcodes::OP_WITHIN then op_within
+
+        # --- Crypto ---
+        when Opcodes::OP_RIPEMD160 then op_ripemd160
+        when Opcodes::OP_SHA1 then op_sha1
+        when Opcodes::OP_SHA256 then op_sha256
+        when Opcodes::OP_HASH160 then op_hash160
+        when Opcodes::OP_HASH256 then op_hash256
+        when Opcodes::OP_CODESEPARATOR then op_codeseparator
+        when Opcodes::OP_CHECKSIG then op_checksig
+        when Opcodes::OP_CHECKSIGVERIFY then op_checksigverify
+        when Opcodes::OP_CHECKMULTISIG then op_checkmultisig
+        when Opcodes::OP_CHECKMULTISIGVERIFY then op_checkmultisigverify
 
         else
           raise ScriptError.new(

--- a/lib/bsv/script/interpreter/operations/crypto.rb
+++ b/lib/bsv/script/interpreter/operations/crypto.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+module BSV
+  module Script
+    class Interpreter
+      module Operations
+        module Crypto # rubocop:disable Metrics/ModuleLength
+          private
+
+          # --- Hash operations ---
+
+          def op_ripemd160
+            @dstack.push_bytes(BSV::Primitives::Digest.ripemd160(@dstack.pop_bytes))
+          end
+
+          def op_sha1
+            @dstack.push_bytes(BSV::Primitives::Digest.sha1(@dstack.pop_bytes))
+          end
+
+          def op_sha256
+            @dstack.push_bytes(BSV::Primitives::Digest.sha256(@dstack.pop_bytes))
+          end
+
+          def op_hash160
+            @dstack.push_bytes(BSV::Primitives::Digest.hash160(@dstack.pop_bytes))
+          end
+
+          def op_hash256
+            @dstack.push_bytes(BSV::Primitives::Digest.sha256d(@dstack.pop_bytes))
+          end
+
+          # --- Code separator ---
+
+          # OP_CODESEPARATOR: mark subscript boundary for sighash
+          def op_codeseparator
+            @last_code_sep = @current_chunk_idx + 1
+          end
+
+          # --- Signature verification ---
+
+          # OP_CHECKSIG: verify a single signature
+          def op_checksig
+            pubkey_bytes = @dstack.pop_bytes
+            full_sig = @dstack.pop_bytes
+
+            if full_sig.empty?
+              @dstack.push_bool(false)
+              return
+            end
+
+            result = verify_checksig(full_sig, pubkey_bytes)
+
+            # NULLFAIL: non-empty signature that failed verification
+            unless result
+              raise ScriptError.new(ScriptErrorCode::SIG_NULLFAIL, 'non-empty signature failed verification')
+            end
+
+            @dstack.push_bool(true)
+          end
+
+          # OP_CHECKSIGVERIFY: OP_CHECKSIG then OP_VERIFY
+          def op_checksigverify
+            op_checksig
+            return if @dstack.pop_bool
+
+            raise ScriptError.new(ScriptErrorCode::CHECKSIGVERIFY_FAILED, 'OP_CHECKSIGVERIFY failed')
+          end
+
+          # OP_CHECKMULTISIG: verify M-of-N signatures
+          def op_checkmultisig
+            num_pubkeys = @dstack.pop_int.to_i32
+            if num_pubkeys.negative? || num_pubkeys > 20
+              raise ScriptError.new(ScriptErrorCode::INVALID_PUBKEY_COUNT, "invalid pubkey count: #{num_pubkeys}")
+            end
+
+            pubkeys = Array.new(num_pubkeys) { @dstack.pop_bytes }
+
+            num_sigs = @dstack.pop_int.to_i32
+            if num_sigs.negative? || num_sigs > num_pubkeys
+              raise ScriptError.new(ScriptErrorCode::INVALID_SIG_COUNT, "invalid signature count: #{num_sigs}")
+            end
+
+            signatures = Array.new(num_sigs) { @dstack.pop_bytes }
+
+            # Dummy element (off-by-one bug compatibility)
+            dummy = @dstack.pop_bytes
+            unless dummy.empty?
+              raise ScriptError.new(ScriptErrorCode::SIG_NULLDUMMY, 'CHECKMULTISIG dummy element must be empty')
+            end
+
+            success = multisig_match?(signatures, pubkeys)
+
+            # NULLFAIL: if failed, all signatures must be empty
+            unless success
+              signatures.each do |sig|
+                unless sig.empty?
+                  raise ScriptError.new(ScriptErrorCode::SIG_NULLFAIL, 'non-empty signature failed verification')
+                end
+              end
+            end
+
+            @dstack.push_bool(success)
+          end
+
+          # OP_CHECKMULTISIGVERIFY: OP_CHECKMULTISIG then OP_VERIFY
+          def op_checkmultisigverify
+            op_checkmultisig
+            return if @dstack.pop_bool
+
+            raise ScriptError.new(ScriptErrorCode::CHECKMULTISIGVERIFY_FAILED, 'OP_CHECKMULTISIGVERIFY failed')
+          end
+
+          # --- Helpers ---
+
+          # Verify a single signature against a public key.
+          def verify_checksig(full_sig, pubkey_bytes)
+            sighash_type = full_sig.getbyte(full_sig.bytesize - 1)
+            sig_bytes = full_sig.byteslice(0, full_sig.bytesize - 1)
+
+            validate_sighash_type!(sighash_type)
+            sig = parse_der_signature!(sig_bytes)
+            validate_pubkey_encoding!(pubkey_bytes)
+
+            return false unless @tx
+
+            pubkey = BSV::Primitives::PublicKey.from_bytes(pubkey_bytes)
+            hash = @tx.sighash(@input_index, sighash_type, subscript: sub_script)
+            pubkey.verify(hash, sig)
+          rescue ArgumentError
+            false
+          end
+
+          # Match M signatures against N public keys (standard Bitcoin CHECKMULTISIG algorithm).
+          # Signatures must appear in the same order as their matching pubkeys.
+          def multisig_match?(signatures, pubkeys)
+            return true if signatures.empty?
+
+            num_sigs = signatures.length
+            num_keys = pubkeys.length + 1 # off-by-one compensation
+            pub_idx = -1
+            sig_idx = 0
+
+            while num_sigs.positive?
+              pub_idx += 1
+              num_keys -= 1
+
+              # More signatures remaining than available keys — impossible
+              return false if num_sigs > num_keys
+
+              full_sig = signatures[sig_idx]
+              pubkey_bytes = pubkeys[pub_idx]
+
+              # Empty signature — try next pubkey
+              next if full_sig.empty?
+
+              if verify_checksig(full_sig, pubkey_bytes)
+                sig_idx += 1
+                num_sigs -= 1
+              end
+            end
+
+            true
+          end
+
+          # Validate sighash type has FORKID set and valid base type.
+          def validate_sighash_type!(sighash_type)
+            unless sighash_type & BSV::Transaction::Sighash::FORK_ID != 0
+              raise ScriptError.new(ScriptErrorCode::INVALID_SIGHASH_TYPE, 'sighash type missing FORKID')
+            end
+
+            base = sighash_type & BSV::Transaction::Sighash::MASK
+            return if [BSV::Transaction::Sighash::ALL, BSV::Transaction::Sighash::NONE,
+                       BSV::Transaction::Sighash::SINGLE].include?(base)
+
+            raise ScriptError.new(
+              ScriptErrorCode::INVALID_SIGHASH_TYPE, "invalid sighash base type: 0x#{base.to_s(16)}"
+            )
+          end
+
+          # Parse DER-encoded signature bytes (without sighash byte).
+          # Raises ScriptError on invalid DER format.
+          def parse_der_signature!(sig_bytes)
+            sig = BSV::Primitives::Signature.from_der(sig_bytes)
+            raise ScriptError.new(ScriptErrorCode::SIG_HIGH_S, 'signature S value is too high') unless sig.low_s?
+
+            sig
+          rescue ArgumentError => e
+            raise ScriptError.new(ScriptErrorCode::SIG_DER, "invalid DER signature: #{e.message}")
+          end
+
+          # Validate public key encoding (compressed or uncompressed).
+          def validate_pubkey_encoding!(bytes)
+            return if bytes.bytesize == 33 && [0x02, 0x03].include?(bytes.getbyte(0))
+            return if bytes.bytesize == 65 && bytes.getbyte(0) == 0x04
+
+            raise ScriptError.new(ScriptErrorCode::PUBKEY_TYPE, 'invalid public key encoding')
+          end
+
+          # Build subscript from current script starting after last CODESEPARATOR.
+          def sub_script
+            chunks = @current_script.chunks[@last_code_sep..]
+            Script.from_chunks(chunks || [])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bsv/transaction/transaction.rb
+++ b/lib/bsv/transaction/transaction.rb
@@ -116,7 +116,7 @@ module BSV
 
       # --- Sighash (BIP-143 with FORKID) ---
 
-      def sighash_preimage(input_index, sighash_type = Sighash::ALL_FORK_ID)
+      def sighash_preimage(input_index, sighash_type = Sighash::ALL_FORK_ID, subscript: nil)
         raise ArgumentError, 'only SIGHASH_FORKID types are supported' unless sighash_type & Sighash::FORK_ID != 0
 
         input = @inputs[input_index]
@@ -136,7 +136,7 @@ module BSV
         buf << input.outpoint_binary
 
         # 5. scriptCode of this input (varint + script)
-        script_bytes = input.source_locking_script.to_binary
+        script_bytes = (subscript || input.source_locking_script).to_binary
         buf << VarInt.encode(script_bytes.bytesize)
         buf << script_bytes
 
@@ -158,8 +158,8 @@ module BSV
         buf
       end
 
-      def sighash(input_index, sighash_type = Sighash::ALL_FORK_ID)
-        BSV::Primitives::Digest.sha256d(sighash_preimage(input_index, sighash_type))
+      def sighash(input_index, sighash_type = Sighash::ALL_FORK_ID, subscript: nil)
+        BSV::Primitives::Digest.sha256d(sighash_preimage(input_index, sighash_type, subscript: subscript))
       end
 
       # --- Signing ---

--- a/spec/bsv/script/interpreter/interpreter_spec.rb
+++ b/spec/bsv/script/interpreter/interpreter_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe BSV::Script::Interpreter do # rubocop:disable RSpec/SpecFilePathF
 
     it 'raises INVALID_OPCODE for unhandled opcodes' do
       expect do
-        evaluate('', 'OP_1 OP_1 OP_CHECKSIG')
+        evaluate('', 'OP_1 OP_INVALIDOPCODE')
       end.to raise_error(BSV::Script::ScriptError) { |e|
         expect(e.code).to eq(:invalid_opcode)
       }

--- a/spec/bsv/script/interpreter/operations/crypto_spec.rb
+++ b/spec/bsv/script/interpreter/operations/crypto_spec.rb
@@ -1,0 +1,401 @@
+# frozen_string_literal: true
+
+RSpec.describe BSV::Script::Interpreter do # rubocop:disable RSpec/SpecFilePathFormat
+  def build_interpreter
+    empty = BSV::Script::Script.new
+    described_class.send(:new, unlock_script: empty, lock_script: empty)
+  end
+
+  def evaluate(unlock_asm, lock_asm)
+    unlock = unlock_asm.empty? ? BSV::Script::Script.new : BSV::Script::Script.from_asm(unlock_asm)
+    lock = lock_asm.empty? ? BSV::Script::Script.new : BSV::Script::Script.from_asm(lock_asm)
+    described_class.evaluate(unlock, lock)
+  end
+
+  # Build a signed P2PKH transaction for signature verification tests
+  def build_p2pkh_tx # rubocop:disable Metrics/MethodLength
+    priv = BSV::Primitives::PrivateKey.generate
+    pub = priv.public_key
+    lock_script = BSV::Script::Script.p2pkh_lock(pub.hash160)
+
+    tx = BSV::Transaction::Transaction.new
+    input = BSV::Transaction::TransactionInput.new(
+      prev_tx_id: "\x00" * 32,
+      prev_tx_out_index: 0
+    )
+    input.source_locking_script = lock_script
+    input.source_satoshis = 100_000
+    tx.add_input(input)
+    tx.add_output(BSV::Transaction::TransactionOutput.new(
+                    satoshis: 99_000,
+                    locking_script: lock_script
+                  ))
+    tx.sign(0, priv)
+
+    { tx: tx, lock_script: lock_script, private_key: priv, public_key: pub }
+  end
+
+  # Build a signed P2PK transaction
+  def build_p2pk_tx # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+    priv = BSV::Primitives::PrivateKey.generate
+    pub = priv.public_key
+    lock_script = BSV::Script::Script.p2pk_lock(pub.compressed)
+
+    tx = BSV::Transaction::Transaction.new
+    input = BSV::Transaction::TransactionInput.new(
+      prev_tx_id: "\x00" * 32,
+      prev_tx_out_index: 0
+    )
+    input.source_locking_script = lock_script
+    input.source_satoshis = 50_000
+    tx.add_input(input)
+    tx.add_output(BSV::Transaction::TransactionOutput.new(
+                    satoshis: 49_000,
+                    locking_script: lock_script
+                  ))
+
+    # Sign: push DER sig + hashtype
+    hash = tx.sighash(0)
+    sig = priv.sign(hash)
+    sig_bytes = sig.to_der + [BSV::Transaction::Sighash::ALL_FORK_ID].pack('C')
+    tx.inputs[0].unlocking_script = BSV::Script::Script.p2pk_unlock(sig_bytes)
+
+    { tx: tx, lock_script: lock_script }
+  end
+
+  describe 'OP_RIPEMD160' do
+    it 'hashes data with RIPEMD-160' do
+      interp = build_interpreter
+      interp.dstack.push_bytes('hello'.b)
+      interp.send(:op_ripemd160)
+      expect(interp.dstack.pop_bytes).to eq(BSV::Primitives::Digest.ripemd160('hello'))
+    end
+  end
+
+  describe 'OP_SHA1' do
+    it 'hashes data with SHA-1' do
+      interp = build_interpreter
+      interp.dstack.push_bytes('hello'.b)
+      interp.send(:op_sha1)
+      expect(interp.dstack.pop_bytes).to eq(BSV::Primitives::Digest.sha1('hello'))
+    end
+  end
+
+  describe 'OP_SHA256' do
+    it 'hashes data with SHA-256' do
+      interp = build_interpreter
+      interp.dstack.push_bytes('hello'.b)
+      interp.send(:op_sha256)
+      expect(interp.dstack.pop_bytes).to eq(BSV::Primitives::Digest.sha256('hello'))
+    end
+  end
+
+  describe 'OP_HASH160' do
+    it 'hashes data with SHA-256 then RIPEMD-160' do
+      interp = build_interpreter
+      interp.dstack.push_bytes('hello'.b)
+      interp.send(:op_hash160)
+      expect(interp.dstack.pop_bytes).to eq(BSV::Primitives::Digest.hash160('hello'))
+    end
+  end
+
+  describe 'OP_HASH256' do
+    it 'hashes data with double SHA-256' do
+      interp = build_interpreter
+      interp.dstack.push_bytes('hello'.b)
+      interp.send(:op_hash256)
+      expect(interp.dstack.pop_bytes).to eq(BSV::Primitives::Digest.sha256d('hello'))
+    end
+  end
+
+  describe 'hash operations via ASM' do
+    it 'HASH160 of OP_1 matches known preimage' do
+      # Push 1, hash it, then push the known hash and compare
+      data = "\x01".b
+      expected = BSV::Primitives::Digest.hash160(data)
+      hex = expected.unpack1('H*')
+      expect(evaluate('', "OP_1 OP_HASH160 #{hex} OP_EQUAL")).to be true
+    end
+  end
+
+  describe 'OP_CHECKSIG (P2PKH)' do
+    it 'verifies a valid P2PKH transaction' do
+      ctx = build_p2pkh_tx
+      result = described_class.verify(
+        tx: ctx[:tx],
+        input_index: 0,
+        unlock_script: ctx[:tx].inputs[0].unlocking_script,
+        lock_script: ctx[:lock_script],
+        satoshis: 100_000
+      )
+      expect(result).to be true
+    end
+
+    it 'fails with wrong public key' do
+      ctx = build_p2pkh_tx
+      # Replace lock script with a different key's hash
+      wrong_key = BSV::Primitives::PrivateKey.generate.public_key
+      wrong_lock = BSV::Script::Script.p2pkh_lock(wrong_key.hash160)
+
+      expect do
+        described_class.verify(
+          tx: ctx[:tx],
+          input_index: 0,
+          unlock_script: ctx[:tx].inputs[0].unlocking_script,
+          lock_script: wrong_lock,
+          satoshis: 100_000
+        )
+      end.to raise_error(BSV::Script::ScriptError) { |e|
+        expect(e.code).to eq(:equalverify_failed)
+      }
+    end
+  end
+
+  describe 'OP_CHECKSIG (P2PK)' do
+    it 'verifies a valid P2PK transaction' do
+      ctx = build_p2pk_tx
+      result = described_class.verify(
+        tx: ctx[:tx],
+        input_index: 0,
+        unlock_script: ctx[:tx].inputs[0].unlocking_script,
+        lock_script: ctx[:lock_script],
+        satoshis: 50_000
+      )
+      expect(result).to be true
+    end
+  end
+
+  describe 'OP_CHECKSIG without transaction context' do
+    it 'pushes false for empty signature' do
+      # Empty sig + any pubkey → false (but OP_NOT flips to true)
+      priv = BSV::Primitives::PrivateKey.generate
+      pub_hex = priv.public_key.to_hex
+      expect(evaluate('OP_0', "#{pub_hex} OP_CHECKSIG OP_NOT")).to be true
+    end
+  end
+
+  describe 'OP_CHECKSIGVERIFY' do
+    it 'succeeds for valid signature' do
+      priv = BSV::Primitives::PrivateKey.generate
+      pub = priv.public_key
+
+      # Lock: <pubkey> CHECKSIGVERIFY OP_1
+      lock_script = BSV::Script::Script.from_asm("#{pub.to_hex} OP_CHECKSIGVERIFY OP_1")
+
+      tx = BSV::Transaction::Transaction.new
+      input = BSV::Transaction::TransactionInput.new(prev_tx_id: "\x00" * 32, prev_tx_out_index: 0)
+      input.source_locking_script = lock_script
+      input.source_satoshis = 100_000
+      tx.add_input(input)
+      tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 99_000, locking_script: lock_script))
+
+      # Sign against this lock script
+      hash = tx.sighash(0)
+      sig = priv.sign(hash)
+      sig_bytes = sig.to_der + [BSV::Transaction::Sighash::ALL_FORK_ID].pack('C')
+      unlock_script = BSV::Script::Script.from_asm(sig_bytes.unpack1('H*'))
+      tx.inputs[0].unlocking_script = unlock_script
+
+      result = described_class.verify(
+        tx: tx,
+        input_index: 0,
+        unlock_script: unlock_script,
+        lock_script: lock_script,
+        satoshis: 100_000
+      )
+      expect(result).to be true
+    end
+  end
+
+  describe 'OP_CHECKMULTISIG' do
+    it 'verifies a valid 1-of-2 multisig' do
+      priv1 = BSV::Primitives::PrivateKey.generate
+      priv2 = BSV::Primitives::PrivateKey.generate
+      pub1 = priv1.public_key
+      pub2 = priv2.public_key
+
+      lock_script = BSV::Script::Script.p2ms_lock(1,
+                                                  [pub1.compressed, pub2.compressed])
+
+      tx = BSV::Transaction::Transaction.new
+      input = BSV::Transaction::TransactionInput.new(
+        prev_tx_id: "\x00" * 32, prev_tx_out_index: 0
+      )
+      input.source_locking_script = lock_script
+      input.source_satoshis = 100_000
+      tx.add_input(input)
+      tx.add_output(BSV::Transaction::TransactionOutput.new(
+                      satoshis: 99_000, locking_script: lock_script
+                    ))
+
+      # Sign with first key
+      hash = tx.sighash(0)
+      sig = priv1.sign(hash)
+      sig_bytes = sig.to_der + [BSV::Transaction::Sighash::ALL_FORK_ID].pack('C')
+      unlock_script = BSV::Script::Script.p2ms_unlock(sig_bytes)
+
+      tx.inputs[0].unlocking_script = unlock_script
+
+      result = described_class.verify(
+        tx: tx,
+        input_index: 0,
+        unlock_script: unlock_script,
+        lock_script: lock_script,
+        satoshis: 100_000
+      )
+      expect(result).to be true
+    end
+
+    it 'verifies a valid 2-of-2 multisig' do
+      priv1 = BSV::Primitives::PrivateKey.generate
+      priv2 = BSV::Primitives::PrivateKey.generate
+      pub1 = priv1.public_key
+      pub2 = priv2.public_key
+
+      lock_script = BSV::Script::Script.p2ms_lock(2,
+                                                  [pub1.compressed, pub2.compressed])
+
+      tx = BSV::Transaction::Transaction.new
+      input = BSV::Transaction::TransactionInput.new(
+        prev_tx_id: "\x00" * 32, prev_tx_out_index: 0
+      )
+      input.source_locking_script = lock_script
+      input.source_satoshis = 100_000
+      tx.add_input(input)
+      tx.add_output(BSV::Transaction::TransactionOutput.new(
+                      satoshis: 99_000, locking_script: lock_script
+                    ))
+
+      # Sign with both keys (order must match pubkey order)
+      hash = tx.sighash(0)
+      sig1 = priv1.sign(hash).to_der + [BSV::Transaction::Sighash::ALL_FORK_ID].pack('C')
+      sig2 = priv2.sign(hash).to_der + [BSV::Transaction::Sighash::ALL_FORK_ID].pack('C')
+      unlock_script = BSV::Script::Script.p2ms_unlock(sig1, sig2)
+
+      tx.inputs[0].unlocking_script = unlock_script
+
+      result = described_class.verify(
+        tx: tx,
+        input_index: 0,
+        unlock_script: unlock_script,
+        lock_script: lock_script,
+        satoshis: 100_000
+      )
+      expect(result).to be true
+    end
+
+    it 'fails when signatures are in wrong order' do
+      priv1 = BSV::Primitives::PrivateKey.generate
+      priv2 = BSV::Primitives::PrivateKey.generate
+      pub1 = priv1.public_key
+      pub2 = priv2.public_key
+
+      lock_script = BSV::Script::Script.p2ms_lock(2,
+                                                  [pub1.compressed, pub2.compressed])
+
+      tx = BSV::Transaction::Transaction.new
+      input = BSV::Transaction::TransactionInput.new(
+        prev_tx_id: "\x00" * 32, prev_tx_out_index: 0
+      )
+      input.source_locking_script = lock_script
+      input.source_satoshis = 100_000
+      tx.add_input(input)
+      tx.add_output(BSV::Transaction::TransactionOutput.new(
+                      satoshis: 99_000, locking_script: lock_script
+                    ))
+
+      # Sign in WRONG order (sig2 before sig1)
+      hash = tx.sighash(0)
+      sig1 = priv1.sign(hash).to_der + [BSV::Transaction::Sighash::ALL_FORK_ID].pack('C')
+      sig2 = priv2.sign(hash).to_der + [BSV::Transaction::Sighash::ALL_FORK_ID].pack('C')
+      unlock_script = BSV::Script::Script.p2ms_unlock(sig2, sig1)
+
+      tx.inputs[0].unlocking_script = unlock_script
+
+      # NULLFAIL triggers because non-empty sigs failed
+      expect do
+        described_class.verify(
+          tx: tx,
+          input_index: 0,
+          unlock_script: unlock_script,
+          lock_script: lock_script,
+          satoshis: 100_000
+        )
+      end.to raise_error(BSV::Script::ScriptError) { |e|
+        expect(e.code).to eq(:sig_nullfail)
+      }
+    end
+
+    it 'raises on non-empty dummy element' do
+      priv = BSV::Primitives::PrivateKey.generate
+      pub = priv.public_key
+      lock_script = BSV::Script::Script.p2ms_lock(1, [pub.compressed])
+
+      tx = BSV::Transaction::Transaction.new
+      input = BSV::Transaction::TransactionInput.new(prev_tx_id: "\x00" * 32, prev_tx_out_index: 0)
+      input.source_locking_script = lock_script
+      input.source_satoshis = 100_000
+      tx.add_input(input)
+      tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 99_000, locking_script: lock_script))
+
+      hash = tx.sighash(0)
+      sig = priv.sign(hash).to_der + [BSV::Transaction::Sighash::ALL_FORK_ID].pack('C')
+
+      # Build unlock with non-empty dummy (OP_1 instead of OP_0)
+      sig_hex = sig.unpack1('H*')
+      unlock_script = BSV::Script::Script.from_asm("OP_1 #{sig_hex}")
+      tx.inputs[0].unlocking_script = unlock_script
+
+      expect do
+        described_class.verify(
+          tx: tx,
+          input_index: 0,
+          unlock_script: unlock_script,
+          lock_script: lock_script,
+          satoshis: 100_000
+        )
+      end.to raise_error(BSV::Script::ScriptError) { |e|
+        expect(e.code).to eq(:sig_nulldummy)
+      }
+    end
+  end
+
+  describe 'signature encoding validation' do
+    it 'rejects signature missing FORKID' do
+      interp = build_interpreter
+      # Signature with sighash type 0x01 (ALL, no FORKID)
+      fake_sig = BSV::Primitives::Signature.new(1, 1).to_der + "\x01".b
+      pub = BSV::Primitives::PrivateKey.generate.public_key.compressed
+      interp.dstack.push_bytes(fake_sig)
+      interp.dstack.push_bytes(pub)
+      interp.instance_variable_set(:@current_script, BSV::Script::Script.new)
+
+      expect do
+        interp.send(:op_checksig)
+      end.to raise_error(BSV::Script::ScriptError) { |e|
+        expect(e.code).to eq(:invalid_sighash_type)
+      }
+    end
+
+    it 'rejects invalid pubkey encoding' do
+      interp = build_interpreter
+      # Valid-looking DER sig with FORKID
+      fake_sig = BSV::Primitives::Signature.new(1, 1).to_der + "\x41".b
+      interp.dstack.push_bytes(fake_sig)
+      interp.dstack.push_bytes("\x05#{"\x00" * 32}") # Invalid prefix
+      interp.instance_variable_set(:@current_script, BSV::Script::Script.new)
+
+      expect do
+        interp.send(:op_checksig)
+      end.to raise_error(BSV::Script::ScriptError) { |e|
+        expect(e.code).to eq(:pubkey_type)
+      }
+    end
+  end
+
+  describe 'OP_CODESEPARATOR' do
+    it 'does not affect non-signature operations' do
+      expect(evaluate('', 'OP_1 OP_CODESEPARATOR')).to be true
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Implement Phase 5 of the script interpreter (#61): crypto operations and signature verification
- Add hash opcodes: OP_RIPEMD160, OP_SHA1, OP_SHA256, OP_HASH160, OP_HASH256
- Add OP_CODESEPARATOR with subscript tracking for sighash computation
- Add OP_CHECKSIG / OP_CHECKSIGVERIFY with full BSV validation (FORKID, strict DER, low-S, NULLFAIL)
- Add OP_CHECKMULTISIG / OP_CHECKMULTISIGVERIFY with classic Bitcoin M-of-N algorithm, NULLDUMMY enforcement
- Add `Digest.sha1` to primitives
- Add `subscript:` parameter to `Transaction#sighash` for CODESEPARATOR support

## Test plan

- [x] Hash operation unit tests (direct and via ASM evaluation)
- [x] P2PKH end-to-end: build tx, sign, verify through interpreter
- [x] P2PK end-to-end verification
- [x] CHECKSIGVERIFY with custom lock script
- [x] 1-of-2 and 2-of-2 multisig verification
- [x] Wrong-order signatures trigger NULLFAIL
- [x] Non-empty dummy element triggers NULLDUMMY
- [x] Encoding validation: missing FORKID, invalid pubkey
- [x] CODESEPARATOR basic test
- [x] Full suite: 906 examples, 0 failures
- [x] RuboCop clean

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)