### PR TITLE
feat(script): remove P2SH constructors, retain detection

### DIFF
--- a/lib/bsv/script/script.rb
+++ b/lib/bsv/script/script.rb
@@ -82,22 +82,6 @@ module BSV
         new(encode_push_data(signature_der))
       end
 
-      def self.p2sh_lock(script_hash)
-        raise ArgumentError, 'script_hash must be 20 bytes' unless script_hash.bytesize == 20
-
-        buf = [Opcodes::OP_HASH160].pack('C')
-        buf << encode_push_data(script_hash)
-        buf << [Opcodes::OP_EQUAL].pack('C')
-        new(buf)
-      end
-
-      def self.p2sh_unlock(redeem_script, *push_items)
-        buf = ''.b
-        push_items.each { |item| buf << encode_push_data(item.b) }
-        buf << encode_push_data(redeem_script.to_binary)
-        new(buf)
-      end
-
       def self.p2ms_lock(required, pubkeys)
         n = pubkeys.length
         raise ArgumentError, 'm must be between 1 and n' unless required.between?(1, n)
@@ -213,16 +197,10 @@ module BSV
         Script.new(@bytes.byteslice(start..)).chunks.select(&:data?).map(&:data)
       end
 
-      MAINNET_P2SH_PREFIX = "\x05".b.freeze
-      TESTNET_P2SH_PREFIX = "\xc4".b.freeze
-
       def addresses(network: :mainnet)
         if p2pkh?
           prefix = network == :testnet ? BSV::Primitives::PublicKey::TESTNET_PUBKEY_HASH : BSV::Primitives::PublicKey::MAINNET_PUBKEY_HASH
           [BSV::Primitives::Base58.check_encode(prefix + pubkey_hash)]
-        elsif p2sh?
-          prefix = network == :testnet ? TESTNET_P2SH_PREFIX : MAINNET_P2SH_PREFIX
-          [BSV::Primitives::Base58.check_encode(prefix + script_hash)]
         else
           []
         end

--- a/spec/bsv/script/script_spec.rb
+++ b/spec/bsv/script/script_spec.rb
@@ -161,50 +161,6 @@ RSpec.describe BSV::Script::Script do
     end
   end
 
-  describe '.p2sh_lock / .p2sh_unlock' do
-    let(:script_hash) { "\x9d\xe5\xae\xaf\xf9\xc4\x84\x31\xba\x4d\xd6\xe8\xaf\x73\xd5\x1f\x38\xe4\x51\xcb".b }
-
-    it 'creates a P2SH locking script' do
-      script = described_class.p2sh_lock(script_hash)
-
-      expect(script).to be_p2sh
-      expect(script.script_hash).to eq(script_hash)
-      chunks = script.chunks
-      expect(chunks.length).to eq(3)
-      expect(chunks[0].opcode).to eq(BSV::Script::Opcodes::OP_HASH160)
-      expect(chunks[1].data).to eq(script_hash)
-      expect(chunks[2].opcode).to eq(BSV::Script::Opcodes::OP_EQUAL)
-    end
-
-    it 'raises on invalid hash length' do
-      expect { described_class.p2sh_lock("\x00".b * 19) }
-        .to raise_error(ArgumentError, /20 bytes/)
-    end
-
-    it 'creates a P2SH unlocking script with push items and redeem script' do
-      sig1 = "\x30".b + ("\x01".b * 70)
-      sig2 = "\x30".b + ("\x02".b * 70)
-      redeem = described_class.p2pkh_lock("\x00".b * 20)
-
-      script = described_class.p2sh_unlock(redeem, sig1, sig2)
-      chunks = script.chunks
-
-      expect(chunks.length).to eq(3)
-      expect(chunks[0].data).to eq(sig1)
-      expect(chunks[1].data).to eq(sig2)
-      expect(chunks[2].data).to eq(redeem.to_binary)
-    end
-
-    it 'creates a P2SH unlocking script with no push items' do
-      redeem = described_class.p2pkh_lock("\x00".b * 20)
-      script = described_class.p2sh_unlock(redeem)
-
-      chunks = script.chunks
-      expect(chunks.length).to eq(1)
-      expect(chunks[0].data).to eq(redeem.to_binary)
-    end
-  end
-
   describe '.p2ms_lock / .p2ms_unlock' do
     let(:alice_key) { "\x02".b + ("\x11".b * 32) }
     let(:bob_key) { "\x03".b + ("\x22".b * 32) }
@@ -493,17 +449,14 @@ RSpec.describe BSV::Script::Script do
         expect(addresses[0]).to eq(key.public_key.address(network: :testnet))
       end
 
-      it 'extracts address from P2SH' do
+      it 'returns empty array for P2SH (no address encoding)' do
         hash = "\x00".b * 20
         script = described_class.builder
                                 .push_op(:OP_HASH160)
                                 .push_data(hash)
                                 .push_op(:OP_EQUAL)
                                 .build
-
-        addresses = script.addresses
-        expect(addresses.length).to eq(1)
-        expect(addresses[0]).to start_with('3')
+        expect(script.addresses).to eq([])
       end
 
       it 'returns empty array for unknown types' do


### PR DESCRIPTION
## Summary

- Remove `Script.p2sh_lock` and `Script.p2sh_unlock` constructors
- Remove P2SH address encoding branch from `#addresses`
- Remove `MAINNET_P2SH_PREFIX` / `TESTNET_P2SH_PREFIX` constants
- Retain all read-only P2SH capabilities: `p2sh?`, `script_hash`, `'scripthash'` type
- Implements "recognise everything, construct only what's valid" principle for P2SH

## Test plan

- [x] P2SH detection specs still pass (`p2sh?`, `script_hash`, `'scripthash'` type)
- [x] P2SH address encoding now returns empty array (spec updated)
- [x] Constructor specs removed (4 specs)
- [x] Full suite: 920 examples, 0 failures
- [x] RuboCop clean

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)