### PR TITLE
docs: update README and plan to remove P2SH template references

### DIFF
--- a/.claude/plans/20260210-advanced-script-templates.md
+++ b/.claude/plans/20260210-advanced-script-templates.md
@@ -2,7 +2,9 @@
 
 ## Context
 
-Issue #22, sub-task of HLR #8. Adds template constructors for P2PK, P2SH, and bare multisig (P2MS) script types. Currently only `p2pkh_lock`, `p2pkh_unlock`, and `op_return` exist.
+Issue #22, sub-task of HLR #8. Adds template constructors for P2PK and bare multisig (P2MS) script types. Currently only `p2pkh_lock`, `p2pkh_unlock`, and `op_return` exist.
+
+> **Note:** P2SH constructors (`p2sh_lock`, `p2sh_unlock`) were originally implemented in this task but later removed per #52 (Protocol Philosophy). P2SH is not valid on BSV. Detection (`p2sh?`, `script_hash`) is retained for parsing historical outputs.
 
 The "custom locking scripts" acceptance criterion is already met by the Builder API (#23).
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ puts tx.to_hex
 - **Cryptographic Primitives** — ECDSA signing with RFC 6979 deterministic nonces, Schnorr signatures, ECIES encryption/decryption, Bitcoin Signed Messages. All built on Ruby's stdlib OpenSSL.
 - **Key Management** — BIP-32 HD key derivation, BIP-39 mnemonic generation (12/24-word phrases), WIF import/export, Base58Check encoding/decoding.
 - **Script Layer** — Complete opcode set, script parsing and serialisation, type detection and predicates (`p2pkh?`, `p2pk?`, `p2sh?`, `multisig?`, `op_return?`), data extraction (pubkey hashes, script hashes, addresses), and a fluent builder API.
-- **Script Templates** — Ready-made locking and unlocking script generators for P2PKH, P2PK, P2SH, P2MS (multisig), and OP_RETURN.
+- **Script Templates** — Ready-made locking and unlocking script generators for P2PKH, P2PK, P2MS (multisig), and OP_RETURN.
 - **Transaction Construction** — Input/output building, BIP-143 sighash computation (all SIGHASH types with FORKID), P2PKH signing, fee estimation.
 - **SPV Structures** — Merkle path construction and verification, BEEF (Background Evaluation Extended Format) serialisation and deserialisation.
 - **Network Integration** — ARC broadcaster for transaction submission, WhatsOnChain chain provider for UTXO queries and fee rates.


### PR DESCRIPTION
## Summary

- Remove P2SH from script templates list in README (detection still listed)
- Annotate advanced script templates plan with note about P2SH removal per #52

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)