### PR TITLE
feat: implement SPV verification (Transaction#verify)

### DIFF
--- a/lib/bsv/transaction.rb
+++ b/lib/bsv/transaction.rb
@@ -15,6 +15,7 @@ module BSV
     autoload :MerklePath,        'bsv/transaction/merkle_path'
     autoload :FeeModel,                  'bsv/transaction/fee_model'
     autoload :FeeModels,                 'bsv/transaction/fee_models'
+    autoload :VerificationError, 'bsv/transaction/verification_error'
     autoload :ChainTracker,              'bsv/transaction/chain_tracker'
     autoload :ChainTrackers,             'bsv/transaction/chain_trackers'
     autoload :Beef,                      'bsv/transaction/beef'

--- a/lib/bsv/transaction/transaction.rb
+++ b/lib/bsv/transaction/transaction.rb
@@ -513,7 +513,7 @@ module BSV
       # @return [true] on successful verification
       # @raise [ArgumentError] if a source transaction or unlocking script is missing
       # @raise [BSV::Script::ScriptError] if script execution fails
-      # @raise [RuntimeError] for merkle path failures, fee validation, or output overflow
+      # @raise [VerificationError] for merkle path failures, fee validation, or output overflow
       def verify(chain_tracker:, fee_model: nil)
         verified = {}
         queue = [self]
@@ -525,7 +525,10 @@ module BSV
 
           # Merkle path short-circuit: proven transaction needs no input verification
           if tx.merkle_path
-            raise "invalid merkle proof for transaction #{tx_id}" unless tx.merkle_path.verify(tx_id, chain_tracker)
+            unless tx.merkle_path.verify(tx_id, chain_tracker)
+              raise VerificationError.new(:invalid_merkle_proof,
+                                          "invalid merkle proof for transaction #{tx_id}")
+            end
 
             verified[tx_id] = true
             next
@@ -649,17 +652,19 @@ module BSV
         actual_fee = total_input_satoshis - total_output_satoshis
         return if actual_fee >= required_fee
 
-        raise "insufficient fee: transaction pays #{actual_fee} sat " \
-              "but fee model requires #{required_fee} sat"
+        raise VerificationError.new(:insufficient_fee,
+                                    "insufficient fee: transaction pays #{actual_fee} sat " \
+                                    "but fee model requires #{required_fee} sat")
       end
 
       def verify_output_constraint(tx)
-        input_total = tx.inputs.sum { |i| i.source_satoshis || 0 }
+        input_total = tx.total_input_satoshis
         output_total = tx.total_output_satoshis
         return if output_total <= input_total
 
-        raise "outputs (#{output_total}) exceed inputs (#{input_total}) " \
-              "for transaction #{tx.txid_hex}"
+        raise VerificationError.new(:output_overflow,
+                                    "outputs (#{output_total}) exceed inputs (#{input_total}) " \
+                                    "for transaction #{tx.txid_hex}")
       end
 
       ZERO_HASH = "\x00".b * 32

--- a/lib/bsv/transaction/verification_error.rb
+++ b/lib/bsv/transaction/verification_error.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module BSV
+  module Transaction
+    # Error raised during SPV verification.
+    #
+    # Carries a machine-readable code alongside a human-readable message,
+    # matching the typed error pattern used by the Go SDK
+    # (ErrInvalidMerklePath, ErrFeeTooLow, ErrScriptVerificationFailed).
+    class VerificationError < StandardError
+      # @return [Symbol] the error code
+      attr_reader :code
+
+      INVALID_MERKLE_PROOF = :invalid_merkle_proof
+      INSUFFICIENT_FEE = :insufficient_fee
+      OUTPUT_OVERFLOW = :output_overflow
+
+      # @param code [Symbol] error code
+      # @param message [String] human-readable description
+      def initialize(code, message)
+        @code = code
+        super(message)
+      end
+    end
+  end
+end

--- a/spec/bsv/transaction/transaction_verify_spec.rb
+++ b/spec/bsv/transaction/transaction_verify_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe BSV::Transaction::Transaction do
         tx = build_spending_tx(source_tx)
 
         expect { tx.verify(chain_tracker: chain_tracker) }
-          .to raise_error(RuntimeError, /invalid merkle proof/)
+          .to raise_error(BSV::Transaction::VerificationError, /invalid merkle proof/)
       end
 
       it 'skips input verification for proven transactions' do
@@ -205,7 +205,7 @@ RSpec.describe BSV::Transaction::Transaction do
         allow(fee_model).to receive(:compute_fee).and_return(100)
 
         expect { tx.verify(chain_tracker: chain_tracker, fee_model: fee_model) }
-          .to raise_error(RuntimeError, /insufficient fee/)
+          .to raise_error(BSV::Transaction::VerificationError, /insufficient fee/)
       end
 
       it 'skips fee validation when fee_model is nil' do
@@ -233,7 +233,7 @@ RSpec.describe BSV::Transaction::Transaction do
         allow(fee_model).to receive(:compute_fee).and_return(50)
 
         expect { child.verify(chain_tracker: chain_tracker, fee_model: fee_model) }
-          .to raise_error(RuntimeError, /insufficient fee/)
+          .to raise_error(BSV::Transaction::VerificationError, /insufficient fee/)
       end
     end
 
@@ -259,7 +259,7 @@ RSpec.describe BSV::Transaction::Transaction do
                       ))
 
         expect { tx.verify(chain_tracker: chain_tracker) }
-          .to raise_error(RuntimeError, /outputs.*exceed inputs/)
+          .to raise_error(BSV::Transaction::VerificationError, /outputs.*exceed inputs/)
       end
     end
 

--- a/spec/conformance/spv_verify_spec.rb
+++ b/spec/conformance/spv_verify_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe BSV::Transaction::Transaction do # rubocop:disable RSpec/Multiple
       tx = build_spending_tx(source_tx)
 
       expect { tx.verify(chain_tracker: chain_tracker) }
-        .to raise_error(/invalid merkle proof/)
+        .to raise_error(BSV::Transaction::VerificationError, /invalid merkle proof/)
     end
 
     # TS/Go: fee validation only on root transaction, not ancestors
@@ -111,7 +111,7 @@ RSpec.describe BSV::Transaction::Transaction do # rubocop:disable RSpec/Multiple
 
       # Child's fee (1 sat) is below model requirement (50 sat)
       expect { child.verify(chain_tracker: chain_tracker, fee_model: fee_model) }
-        .to raise_error(/insufficient fee/)
+        .to raise_error(BSV::Transaction::VerificationError, /insufficient fee/)
     end
 
     # TS/Python: verify outputs ≤ inputs
@@ -137,7 +137,7 @@ RSpec.describe BSV::Transaction::Transaction do # rubocop:disable RSpec/Multiple
                     ))
 
       expect { tx.verify(chain_tracker: chain_tracker) }
-        .to raise_error(/outputs.*exceed inputs/)
+        .to raise_error(BSV::Transaction::VerificationError, /outputs.*exceed inputs/)
     end
 
     # All three SDKs: deduplication of verified transactions


### PR DESCRIPTION
## Summary

- Implements `Transaction#verify(chain_tracker:, fee_model: nil)` for full SPV verification matching all three reference SDKs (TS, Go, Python)
- Queue-based ancestry traversal with merkle path short-circuit, script execution, optional fee validation, output ≤ input constraint, and txid deduplication
- 25 new specs (17 unit + 8 conformance) validating all verification paths

## Changes

- `lib/bsv/transaction/transaction.rb` — Added `#verify` public method and private helpers (`verify_input_requirements`, `verify_fee`, `verify_output_constraint`)
- `spec/bsv/transaction/transaction_verify_spec.rb` — 17 unit/integration specs
- `spec/conformance/spv_verify_spec.rb` — 8 cross-SDK conformance specs

Closes #95, #132, #133, #134

## Test plan

- [x] All 1464 examples pass, 0 failures
- [x] RuboCop clean
- [x] Merkle path short-circuit verified (sabotaged inputs still pass)
- [x] Script execution failure correctly raises ScriptError
- [x] Fee validation only on root transaction
- [x] Output overflow detected
- [x] Deduplication confirmed via mock expectation

🤖 Generated with [Claude Code](https://claude.com/claude-code)