### PR TITLE
feat(transaction): implement Benford's law change distribution

### DIFF
--- a/lib/bsv/transaction/transaction.rb
+++ b/lib/bsv/transaction/transaction.rb
@@ -600,15 +600,35 @@ module BSV
       # Accepts a {FeeModel} instance, a numeric fee in satoshis, or nil
       # (defaults to {FeeModels::SatoshisPerKilobyte} at 50 sat/kB).
       #
-      # After computing the fee, distributes remaining satoshis equally
-      # across outputs marked as change. If insufficient change, removes
-      # all change outputs (excess goes to miners).
+      # After computing the fee, distributes remaining satoshis across outputs
+      # marked as change. The distribution strategy is controlled by the
+      # +change_distribution:+ keyword argument:
+      #
+      # - +:equal+ (default) — divides change equally across all change outputs,
+      #   matching TS SDK default behaviour.
+      # - +:random+ — Benford-inspired distribution that biases amounts towards
+      #   the lower end of the available range, improving privacy by producing
+      #   varied change amounts.
+      #
+      # If insufficient change remains, all change outputs are removed.
+      #
+      # An optional +rng:+ keyword argument may be supplied to inject a seeded
+      # {Random} instance for deterministic testing. Defaults to
+      # {Random}.
       #
       # @param model_or_fee [FeeModel, Integer, nil] fee model, fixed fee, or nil for default
+      # @param change_distribution [Symbol] +:equal+ or +:random+ (default: +:equal+)
+      # @param rng [Random, nil] injectable RNG for deterministic testing; defaults to +Random+
       # @return [self] for chaining
-      def fee(model_or_fee = nil)
+      # @raise [ArgumentError] if +change_distribution+ is not +:random+ or +:equal+
+      def fee(model_or_fee = nil, change_distribution: :equal, rng: nil)
+        unless %i[random equal].include?(change_distribution)
+          raise ArgumentError, "invalid change_distribution #{change_distribution.inspect}; expected :random or :equal"
+        end
+
+        rng ||= Random
         fee_sats = compute_fee_sats(model_or_fee)
-        distribute_change(fee_sats)
+        distribute_change(fee_sats, change_distribution, rng)
         self
       end
 
@@ -709,7 +729,7 @@ module BSV
         end
       end
 
-      def distribute_change(fee_sats)
+      def distribute_change(fee_sats, change_distribution, rng)
         change_outputs = @outputs.select(&:change)
         return if change_outputs.empty?
 
@@ -719,13 +739,83 @@ module BSV
 
         if available <= change_outputs.length
           @outputs.reject!(&:change)
-        else
-          per_output = available / change_outputs.length
-          remainder = available % change_outputs.length
-          change_outputs.each_with_index do |output, i|
-            output.satoshis = per_output + (i < remainder ? 1 : 0)
-          end
+          return
         end
+
+        if change_distribution == :random
+          distribute_random_change(available, change_outputs, rng)
+        else
+          distribute_equal_change(available, change_outputs)
+        end
+      end
+
+      def distribute_equal_change(available, change_outputs)
+        per_output = available / change_outputs.length
+        remainder = available % change_outputs.length
+        change_outputs.each_with_index do |output, i|
+          output.satoshis = per_output + (i < remainder ? 1 : 0)
+        end
+      end
+
+      # Distribute change using a Benford-inspired algorithm that biases amounts
+      # towards the lower end of the available range.
+      #
+      # Algorithm:
+      # 1. Reserve 1 satoshi per change output as a minimum guarantee.
+      # 2. For each output except the last, take a Benford-scaled portion of the
+      #    remaining pool and add it to that output's base amount.
+      # 3. The last change output receives only its 1 sat base.
+      # 4. Any remainder (from floor rounding) is assigned to the last transaction
+      #    output, matching TS SDK behaviour.
+      #
+      # @param available [Integer] total satoshis to distribute
+      # @param change_outputs [Array<TransactionOutput>] outputs flagged as change
+      # @param rng [Random] RNG instance (injectable for testing)
+      # @return [void]
+      def distribute_random_change(available, change_outputs, rng)
+        n = change_outputs.length
+
+        # Initialise each output with a 1-sat base and reserve that pool
+        amounts = Array.new(n, 1)
+        pool = available - n
+        distributed = n
+
+        # Allocate Benford-scaled portions to all outputs except the last
+        (n - 1).times do |i|
+          portion = benford_number(0, pool, rng)
+          amounts[i] += portion
+          distributed += portion
+          pool -= portion
+        end
+
+        # Assign computed amounts to change outputs
+        change_outputs.each_with_index do |output, i|
+          output.satoshis = amounts[i]
+        end
+
+        # Assign any remainder (floor-rounding loss) to the last transaction output
+        remainder = available - distributed
+        return unless remainder.positive?
+
+        last_output = @outputs.last
+        last_output.satoshis = (last_output.satoshis || 0) + remainder
+      end
+
+      # Generate a Benford-inspired integer in the range [min, max).
+      #
+      # Picks a random digit d in 1..9 and uses log10(1 + 1/d) as a scaling
+      # factor on the range. This biases the result towards the lower end of
+      # the range, matching the Benford distribution of leading digits.
+      #
+      # Since log10(10) = 1, the TS SDK's division by log10(10) is omitted.
+      #
+      # @param min [Integer] lower bound (inclusive)
+      # @param max [Integer] upper bound (exclusive)
+      # @param rng [Random] RNG instance
+      # @return [Integer] Benford-distributed integer
+      def benford_number(min, max, rng)
+        d = rng.rand(1..9)
+        (min + ((max - min) * Math.log10(1 + (1.0 / d)))).floor
       end
     end
   end

--- a/spec/bsv/transaction/benford_distribution_spec.rb
+++ b/spec/bsv/transaction/benford_distribution_spec.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+# Statistical validation of the Benford-inspired change distribution.
+#
+# These specs verify the statistical properties of the `benford_number` helper
+# and `distribute_random_change` method. They use large sample sizes to avoid
+# flakiness and test against known mathematical expectations.
+#
+# ## How `benford_number` works
+#
+# `benford_number(min, max, rng)` picks digit d uniformly from 1..9 and
+# returns:
+#
+#   floor(min + (max - min) * log10(1 + 1/d))
+#
+# This produces exactly 9 possible output values, one per digit. Because
+# log10(1 + 1/d) is a decreasing function of d, smaller d values produce
+# larger outputs — but d itself is chosen uniformly, so the 9 outputs each
+# occur with probability ~1/9.
+#
+# The "Benford" property is in the *scaling*: the sizes of the 9 outputs are
+# proportional to Benford's probability formula, not that the output leading
+# digits follow Benford's distribution.
+#
+# ## What these tests validate
+#
+# 1. Chi-squared uniformity test on d selection (9 output values, each ~1/9).
+# 2. Bias towards lower values: the majority of outputs fall below the range
+#    midpoint, because smaller d → larger output, but the d=1 output (the
+#    largest) still sits well below (max - min).
+# 3. `distribute_random_change` sum invariant over 1000 samples.
+# 4. All change outputs receive >= 1 satoshi over 1000 samples.
+# 5. Variance is non-zero across repeated distributions.
+
+# Chi-squared critical value for df=8 at p=0.01 significance level.
+# We use df=8 because there are 9 output values (9 - 1 = 8 degrees of freedom).
+BENFORD_CHI_SQUARED_CRITICAL_P01 = 20.09
+
+RSpec.describe 'Benford change distribution — statistical validation' do # rubocop:disable RSpec/DescribeClass
+  # Expose the private helper via a thin wrapper so we can test it directly.
+  let(:tx_class) { BSV::Transaction::Transaction }
+
+  def benford_number(min, max, rng)
+    priv_tx = tx_class.allocate
+    priv_tx.send(:benford_number, min, max, rng)
+  end
+
+  # Compute a chi-squared statistic.
+  #
+  # @param observed [Array<Integer>] observed counts per bucket
+  # @param expected_counts [Array<Float>] expected counts per bucket
+  # @return [Float]
+  def chi_squared(observed, expected_counts)
+    observed.zip(expected_counts).sum do |obs, exp|
+      ((obs - exp)**2) / exp
+    end
+  end
+
+  describe 'benford_number output distribution' do
+    let(:sample_size) { 18_000 } # divisible by 9 for clean expected counts
+    let(:range_min)   { 0 }
+    let(:range_max)   { 1_000_000 }
+
+    # Compute the 9 distinct output values this function can produce.
+    let(:possible_outputs) do
+      (1..9).map do |d|
+        (range_min + ((range_max - range_min) * Math.log10(1 + (1.0 / d)))).floor
+      end
+    end
+
+    it 'produces exactly the 9 expected distinct values' do
+      rng = Random.new(42)
+      actual_values = Array.new(sample_size) { benford_number(range_min, range_max, rng) }
+      unique_values = actual_values.uniq.sort
+      expect(unique_values).to eq(possible_outputs.uniq.sort)
+    end
+
+    it 'selects d uniformly — each of the 9 outputs appears ~1/9 of the time (chi-squared p > 0.01)' do
+      # Since d is chosen uniformly from 1..9, each output value should occur
+      # with frequency 1/9. A chi-squared test against equal expected counts
+      # verifies this.
+      expected_count = sample_size / 9.0
+
+      [42, 137, 999, 271_828, 314_159].each do |seed|
+        rng = Random.new(seed)
+        counts = Hash.new(0)
+        sample_size.times { counts[benford_number(range_min, range_max, rng)] += 1 }
+
+        observed = possible_outputs.map { |v| counts[v] }
+        expected = Array.new(9, expected_count)
+
+        chi2 = chi_squared(observed, expected)
+        expect(chi2).to be < BENFORD_CHI_SQUARED_CRITICAL_P01,
+                        "Chi-squared #{chi2.round(2)} >= #{BENFORD_CHI_SQUARED_CRITICAL_P01} " \
+                        "for seed #{seed} (digit d is not uniformly distributed)"
+      end
+    end
+
+    it 'biases towards lower end of range — majority of outputs below midpoint' do
+      # Each output value is below the midpoint because log10(1 + 1/d) < 0.5 for all d in 1..9:
+      #   max scaling factor (d=1): log10(2) ≈ 0.301 < 0.5
+      # Therefore ALL outputs of benford_number(0, max) are below max/2.
+      rng = Random.new(42)
+      midpoint = (range_max - range_min) / 2
+      values = Array.new(10_000) { benford_number(range_min, range_max, rng) }
+      below_mid = values.count { |v| v < midpoint }
+
+      # Every possible output is below midpoint (log10(2) ≈ 0.301), so 100% expected.
+      expect(below_mid).to eq(10_000),
+                           "Expected all values below midpoint #{midpoint}; " \
+                           "got #{10_000 - below_mid} above"
+    end
+
+    it 'returns values within [min, max) for multiple seeds' do
+      [1, 7, 42, 100, 999].each do |seed|
+        rng = Random.new(seed)
+        1_000.times do
+          n = benford_number(range_min, range_max, rng)
+          expect(n).to be >= range_min
+          expect(n).to be < range_max
+        end
+      end
+    end
+
+    it 'smaller d values produce larger outputs (Benford scaling)' do
+      # The 9 outputs should be strictly decreasing as d increases 1..9,
+      # because log10(1 + 1/d) is strictly decreasing.
+      expect(possible_outputs).to eq(possible_outputs.sort.reverse)
+    end
+  end
+
+  describe 'distribute_random_change integration' do
+    let(:priv) { BSV::Primitives::PrivateKey.generate }
+    let(:lock_script) { BSV::Script::Script.p2pkh_lock(priv.public_key.hash160) }
+
+    def build_tx(input_sats:, output_sats:, change_count:)
+      tx = tx_class.new
+      input = BSV::Transaction::TransactionInput.new(
+        prev_tx_id: BSV::Primitives::Digest.sha256d('test'),
+        prev_tx_out_index: 0
+      )
+      input.source_satoshis = input_sats
+      input.source_locking_script = lock_script
+      input.unlocking_script_template = BSV::Transaction::P2PKH.new(priv)
+      tx.add_input(input)
+
+      tx.add_output(BSV::Transaction::TransactionOutput.new(
+                      satoshis: output_sats,
+                      locking_script: lock_script
+                    ))
+
+      change_count.times do
+        tx.add_output(BSV::Transaction::TransactionOutput.new(
+                        satoshis: 0,
+                        locking_script: lock_script,
+                        change: true
+                      ))
+      end
+
+      tx
+    end
+
+    it 'sum of all outputs equals total inputs minus fee across 1000 samples' do
+      input_sats   = 100_000
+      output_sats  = 10_000
+      fee_sats     = 1_000
+      change_count = 3
+      expected_total = input_sats - fee_sats
+
+      1_000.times do |i|
+        rng = Random.new(i)
+        tx = build_tx(input_sats: input_sats, output_sats: output_sats, change_count: change_count)
+        tx.fee(fee_sats, change_distribution: :random, rng: rng)
+        total = tx.outputs.sum(&:satoshis)
+        expect(total).to eq(expected_total), "Seed #{i}: expected #{expected_total}, got #{total}"
+      end
+    end
+
+    it 'all change outputs receive >= 1 satoshi across 1000 samples' do
+      input_sats   = 100_000
+      output_sats  = 10_000
+      fee_sats     = 1_000
+      change_count = 4
+
+      1_000.times do |i|
+        rng = Random.new(i)
+        tx = build_tx(input_sats: input_sats, output_sats: output_sats, change_count: change_count)
+        tx.fee(fee_sats, change_distribution: :random, rng: rng)
+
+        tx.outputs.select(&:change).each_with_index do |output, j|
+          expect(output.satoshis).to be >= 1,
+                                     "Seed #{i}, change output #{j}: got #{output.satoshis} sats"
+        end
+      end
+    end
+
+    it 'produces meaningfully varied change amounts (non-zero variance)' do
+      # Run 1000 distributions and collect the first change output's amount.
+      # If the distribution were always equal, every sample would be the same.
+      first_change_amounts = Array.new(1_000) do |i|
+        rng = Random.new(i)
+        tx = build_tx(input_sats: 100_000, output_sats: 10_000, change_count: 3)
+        tx.fee(1_000, change_distribution: :random, rng: rng)
+        tx.outputs.select(&:change).first.satoshis
+      end
+
+      unique_values = first_change_amounts.uniq
+      expect(unique_values.length).to be > 1,
+                                      'Expected varied change amounts but all samples were identical'
+
+      mean = first_change_amounts.sum.to_f / first_change_amounts.length
+      variance = first_change_amounts.sum { |v| (v - mean)**2 } / first_change_amounts.length
+      expect(variance).to be > 0, 'Variance of change amounts should be > 0'
+    end
+  end
+end

--- a/spec/bsv/transaction/transaction_fee_spec.rb
+++ b/spec/bsv/transaction/transaction_fee_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe BSV::Transaction::Transaction do
     describe 'change distribution' do
       it 'distributes change across multiple change outputs equally' do
         tx = build_tx(input_sats: 100_000, output_sats: 50_000, change_count: 2)
-        tx.fee(1000)
+        tx.fee(1000, change_distribution: :equal)
 
         change_outputs = tx.outputs.select(&:change)
         expect(change_outputs.length).to eq(2)
@@ -84,7 +84,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
       it 'distributes remainder to first outputs' do
         tx = build_tx(input_sats: 100_000, output_sats: 50_000, change_count: 3)
-        tx.fee(1000)
+        tx.fee(1000, change_distribution: :equal)
 
         change_outputs = tx.outputs.select(&:change)
         expect(change_outputs.length).to eq(3)
@@ -152,6 +152,122 @@ RSpec.describe BSV::Transaction::Transaction do
       it 'raises ArgumentError for unexpected types' do
         tx = build_tx(input_sats: 100_000, output_sats: 50_000)
         expect { tx.fee('invalid') }.to raise_error(ArgumentError, /expected FeeModel/)
+      end
+
+      it 'raises ArgumentError for invalid change_distribution' do
+        tx = build_tx(input_sats: 100_000, output_sats: 50_000)
+        expect { tx.fee(1000, change_distribution: :banana) }
+          .to raise_error(ArgumentError, /invalid change_distribution/)
+      end
+    end
+
+    it 'defaults to :equal distribution' do
+      # No change_distribution: argument — should behave identically to :equal
+      tx = build_tx(input_sats: 100_000, output_sats: 50_000, change_count: 2)
+      tx.fee(1000)
+
+      change_outputs = tx.outputs.select(&:change)
+      expect(change_outputs.length).to eq(2)
+      expect(change_outputs[0].satoshis).to eq(24_500)
+      expect(change_outputs[1].satoshis).to eq(24_500)
+    end
+
+    describe 'random change distribution' do
+      it 'single change output receives the full available amount' do
+        tx = build_tx(input_sats: 100_000, output_sats: 50_000)
+        tx.fee(1000, change_distribution: :random)
+
+        change_outputs = tx.outputs.select(&:change)
+        expect(change_outputs.length).to eq(1)
+        expect(change_outputs[0].satoshis).to eq(49_000)
+      end
+
+      it 'preserves total satoshis exactly — no satoshis lost or created' do
+        rng = Random.new(42)
+        tx = build_tx(input_sats: 100_000, output_sats: 50_000, change_count: 3)
+        tx.fee(1000, change_distribution: :random, rng: rng)
+
+        # Total of all outputs (including non-change) must equal inputs minus fee
+        total = tx.outputs.sum(&:satoshis)
+        expect(total).to eq(99_000) # 100_000 - 1_000
+      end
+
+      it 'allocates at least 1 satoshi to each change output' do
+        rng = Random.new(42)
+        tx = build_tx(input_sats: 100_000, output_sats: 50_000, change_count: 4)
+        tx.fee(1000, change_distribution: :random, rng: rng)
+
+        change_outputs = tx.outputs.select(&:change)
+        change_outputs.each do |output|
+          expect(output.satoshis).to be >= 1
+        end
+      end
+
+      it 'produces varied amounts with multiple change outputs (injected RNG)' do
+        rng = Random.new(12_345)
+        tx = build_tx(input_sats: 1_000_000, output_sats: 100_000, change_count: 3)
+        tx.fee(1000, change_distribution: :random, rng: rng)
+
+        change_outputs = tx.outputs.select(&:change)
+        amounts = change_outputs.map(&:satoshis)
+        # With a seeded RNG and multiple outputs, amounts should not all be equal
+        expect(amounts.uniq.length).to be > 1
+      end
+
+      it 'assigns any floor-rounding remainder to the last transaction output' do
+        # Use a tiny pool where rounding will definitely produce a remainder.
+        # For d in 1..9, benford_number(0, 2) = floor(2 * log10(1 + 1/d))
+        # d=1: floor(2 * log10(2)) = floor(0.602) = 0; remainder sent to last tx output.
+        # We verify the sum invariant: all sats accounted for.
+        rng = Random.new(99)
+        tx = build_tx(input_sats: 60_000, output_sats: 50_000, change_count: 3)
+        tx.fee(1000, change_distribution: :random, rng: rng)
+
+        total = tx.outputs.sum(&:satoshis)
+        expect(total).to eq(59_000) # 60_000 - 1_000
+      end
+
+      it 'is deterministic with the same seeded RNG' do
+        tx1 = build_tx(input_sats: 500_000, output_sats: 100_000, change_count: 3)
+        tx1.fee(1000, change_distribution: :random, rng: Random.new(7))
+
+        tx2 = build_tx(input_sats: 500_000, output_sats: 100_000, change_count: 3)
+        tx2.fee(1000, change_distribution: :random, rng: Random.new(7))
+
+        amounts1 = tx1.outputs.select(&:change).map(&:satoshis)
+        amounts2 = tx2.outputs.select(&:change).map(&:satoshis)
+        expect(amounts1).to eq(amounts2)
+      end
+
+      it 'removes change outputs when available equals number of change outputs' do
+        # available = 51002 - 50000 - 1000 = 2, change_count = 2
+        # 2 <= 2 → remove change outputs
+        tx = build_tx(input_sats: 51_002, output_sats: 50_000, change_count: 2)
+        tx.fee(1000, change_distribution: :random)
+        expect(tx.outputs.select(&:change)).to be_empty
+      end
+
+      it 'handles two change outputs (single iteration plus remainder)' do
+        rng = Random.new(1)
+        tx = build_tx(input_sats: 100_000, output_sats: 50_000, change_count: 2)
+        tx.fee(1000, change_distribution: :random, rng: rng)
+
+        change_outputs = tx.outputs.select(&:change)
+        expect(change_outputs.length).to eq(2)
+        # Sum of all outputs must equal inputs minus fee
+        expect(tx.outputs.sum(&:satoshis)).to eq(99_000)
+      end
+
+      it 'handles very large change amounts without integer overflow' do
+        # 100 BTC = 10_000_000_000 sats — Ruby handles big integers natively
+        rng = Random.new(3)
+        large_input = 10_000_000_000
+        fee_sats = 1000
+        tx = build_tx(input_sats: large_input, output_sats: 1_000_000, change_count: 3)
+        tx.fee(fee_sats, change_distribution: :random, rng: rng)
+
+        total = tx.outputs.sum(&:satoshis)
+        expect(total).to eq(large_input - fee_sats)
       end
     end
   end


### PR DESCRIPTION
## Summary

- Add Benford-inspired change distribution strategy (`change_distribution: :random`) to `Transaction#fee`, biasing change amounts towards the lower end of the available range for improved transaction privacy
- Default distribution remains `:equal`, preserving backwards compatibility with TS SDK behaviour
- Injectable `rng:` parameter enables deterministic testing; remainder from floor rounding assigned to last transaction output (matching TS SDK)
- Statistical validation specs: chi-squared uniformity test (df=8, p=0.01), bias verification, 1000-sample sum invariant, and minimum satoshi guarantees

## Test plan

- [x] All specs pass (1710 examples, 0 failures)
- [x] RuboCop clean (0 offences)
- [x] Chi-squared test confirms uniform digit selection across 5 seeds
- [x] Sum invariant holds across 1000 random samples (no satoshis lost)
- [x] All change outputs receive >= 1 satoshi across 1000 samples
- [x] Single change output trivial case works correctly
- [x] Default `:equal` distribution unchanged
- [x] Seeded RNG produces deterministic results

Closes #156
