### PR TITLE
fix!: replace broken linkage proof with Schnorr ZKP (BRC-69/72)

### DIFF
--- a/lib/bsv/wallet_interface/proto_wallet.rb
+++ b/lib/bsv/wallet_interface/proto_wallet.rb
@@ -212,6 +212,8 @@ module BSV
         counterparty = args[:counterparty]
         verifier = args[:verifier]
 
+        raise InvalidParameterError.new('counterparty', 'a specific public key hex, not "anyone"') if counterparty == 'anyone'
+
         Validators.validate_pub_key_hex!(verifier, 'verifier')
 
         linkage = @key_deriver.reveal_counterparty_secret(counterparty)
@@ -273,6 +275,8 @@ module BSV
         verifier = args[:verifier]
         protocol_id = args[:protocol_id]
         key_id = args[:key_id]
+
+        raise InvalidParameterError.new('counterparty', 'a specific public key hex, not "anyone"') if counterparty == 'anyone'
 
         Validators.validate_pub_key_hex!(verifier, 'verifier')
 

--- a/spec/bsv/wallet_interface/proto_wallet_spec.rb
+++ b/spec/bsv/wallet_interface/proto_wallet_spec.rb
@@ -239,6 +239,15 @@ RSpec.describe BSV::Wallet::ProtoWallet do
       end.to raise_error(BSV::Wallet::InvalidParameterError)
     end
 
+    it 'raises InvalidParameterError when counterparty is "anyone"' do
+      expect do
+        prover_wallet.reveal_counterparty_key_linkage({
+                                                        counterparty: 'anyone',
+                                                        verifier: verifier_key.public_key.to_hex
+                                                      })
+      end.to raise_error(BSV::Wallet::InvalidParameterError)
+    end
+
     it 'verifier can decrypt the linkage using the prover identity key as counterparty' do
       prover_identity_pub = prover_wallet.key_deriver.identity_key
 
@@ -338,6 +347,17 @@ RSpec.describe BSV::Wallet::ProtoWallet do
         prover_wallet.reveal_specific_key_linkage({
                                                     counterparty: counterparty_key.public_key.to_hex,
                                                     verifier: 'invalid',
+                                                    protocol_id: protocol_id,
+                                                    key_id: key_id
+                                                  })
+      end.to raise_error(BSV::Wallet::InvalidParameterError)
+    end
+
+    it 'raises InvalidParameterError when counterparty is "anyone"' do
+      expect do
+        prover_wallet.reveal_specific_key_linkage({
+                                                    counterparty: 'anyone',
+                                                    verifier: verifier_key.public_key.to_hex,
                                                     protocol_id: protocol_id,
                                                     key_id: key_id
                                                   })


### PR DESCRIPTION
## Summary

- Replaces broken HMAC proof in `reveal_counterparty_key_linkage` with a Schnorr zero-knowledge proof (`BSV::Primitives::Schnorr.generate_proof`), verifiable using only public keys
- Replaces broken HMAC proof in `reveal_specific_key_linkage` with encrypted `[0]` payload matching `proof_type: 0` semantics
- Replaces raw ECDH encryption in both methods with BRC-72 protocol-derived encryption via `self.encrypt`
- Adds `Validators.validate_pub_key_hex!` on the `verifier` parameter in both methods
- Full round-trip tests: prover reveals linkage, verifier decrypts and verifies Schnorr proof

## What was broken

Both methods computed `proof = HMAC(linkage, encrypted_linkage)` which was:
1. **Circular** — verifier needs the secret to verify the proof
2. **Forgeable** — counterparty knows the linkage and can forge proofs
3. **Wrong encryption** — raw ECDH instead of protocol-derived keys meant ts-sdk verifiers couldn't decrypt

## Test plan

- [x] 225 wallet_interface tests pass (0 failures)
- [x] 1944 total tests pass (0 failures)
- [x] Rubocop clean on changed files
- [x] Schnorr proof round-trip verified (generate → encrypt → decrypt → verify)
- [x] Verifier decryption round-trip verified (both methods)
- [x] Invalid verifier raises `InvalidParameterError`

Closes #198, closes #199, closes #200, closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)