### PR TITLE
feat(script): add OP_CAT script template

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -201,6 +201,7 @@ RSpec/SpecFilePathFormat:
     - 'spec/bsv/script/interpreter/**/*'
     - 'spec/bsv/primitives/shamir/**/*'
     - 'spec/bsv/transaction/benford_number/**/*'
+    - 'spec/bsv/script/op_cat_spec.rb'
     - 'spec/conformance/**/*'
     - 'spec/bsv/wallet_interface/**/*'
 

--- a/lib/bsv/script/script.rb
+++ b/lib/bsv/script/script.rb
@@ -271,6 +271,36 @@ module BSV
         p2pkh_unlock(signature_der, pubkey_bytes)
       end
 
+      # Construct an OP_CAT locking script.
+      #
+      # The script concatenates two stack items and compares the result
+      # against the expected data. The spender must push two values whose
+      # concatenation equals +expected_data+.
+      #
+      # @param expected_data [String] binary string — the expected result of
+      #   concatenating the two unlocking values
+      # @return [Script]
+      def self.op_cat_lock(expected_data)
+        buf = [Opcodes::OP_CAT].pack('C')
+        buf << encode_push_data(expected_data.b)
+        buf << [Opcodes::OP_EQUAL].pack('C')
+        new(buf)
+      end
+
+      # Construct an OP_CAT unlocking script.
+      #
+      # Pushes two data items onto the stack. The locking script's OP_CAT
+      # will concatenate them and compare against the expected value.
+      #
+      # @param data1 [String] binary string — first item (pushed first, deeper on stack)
+      # @param data2 [String] binary string — second item (pushed second, top of stack)
+      # @return [Script]
+      def self.op_cat_unlock(data1, data2)
+        buf = encode_push_data(data1.b)
+        buf << encode_push_data(data2.b)
+        new(buf)
+      end
+
       # --- Serialisation ---
 
       # @return [String] a copy of the raw script bytes
@@ -420,6 +450,19 @@ module BSV
         end
       end
 
+      # Whether this is an OP_CAT puzzle script.
+      #
+      # Pattern: +OP_CAT <expected_data> OP_EQUAL+
+      #
+      # @return [Boolean]
+      def op_cat?
+        c = chunks
+        c.length == 3 &&
+          c[0].opcode == Opcodes::OP_CAT &&
+          c[1].data? &&
+          c[2].opcode == Opcodes::OP_EQUAL
+      end
+
       # Whether this is a bare multisig script.
       #
       # Pattern: +OP_M <pubkey1> ... <pubkeyN> OP_N OP_CHECKMULTISIG+
@@ -450,6 +493,7 @@ module BSV
         elsif multisig? then 'multisig'
         elsif pushdrop? then 'pushdrop'
         elsif rpuzzle? then 'rpuzzle'
+        elsif op_cat? then 'opcat'
         else 'nonstandard'
         end
       end

--- a/spec/bsv/script/op_cat_spec.rb
+++ b/spec/bsv/script/op_cat_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe BSV::Script::Script do
+  describe '.op_cat_lock' do
+    it 'creates a script with OP_CAT <data> OP_EQUAL' do
+      expected = 'hello world'
+      script = described_class.op_cat_lock(expected)
+      expect(script.op_cat?).to be true
+      expect(script.type).to eq('opcat')
+    end
+
+    it 'round-trips through hex serialisation' do
+      script = described_class.op_cat_lock('test data')
+      rebuilt = described_class.from_hex(script.to_hex)
+      expect(rebuilt.op_cat?).to be true
+    end
+
+    it 'round-trips through binary serialisation' do
+      script = described_class.op_cat_lock('binary data')
+      rebuilt = described_class.from_binary(script.to_binary)
+      expect(rebuilt.op_cat?).to be true
+    end
+  end
+
+  describe '.op_cat_unlock' do
+    it 'creates a script pushing two data items' do
+      script = described_class.op_cat_unlock('hello ', 'world')
+      chunks = script.chunks
+      expect(chunks.length).to eq(2)
+      expect(chunks[0].data).to eq('hello '.b)
+      expect(chunks[1].data).to eq('world'.b)
+    end
+  end
+
+  describe 'interpreter verification' do
+    it 'verifies when concatenation matches expected data' do
+      expected = 'hello world'
+      lock = described_class.op_cat_lock(expected)
+      unlock = described_class.op_cat_unlock('hello ', 'world')
+
+      result = BSV::Script::Interpreter.evaluate(unlock, lock)
+      expect(result).to be true
+    end
+
+    it 'fails when concatenation does not match' do
+      lock = described_class.op_cat_lock('hello world')
+      unlock = described_class.op_cat_unlock('wrong ', 'data')
+
+      expect { BSV::Script::Interpreter.evaluate(unlock, lock) }.to raise_error(BSV::Script::ScriptError)
+    end
+
+    it 'works with empty data items' do
+      lock = described_class.op_cat_lock('')
+      unlock = described_class.op_cat_unlock('', '')
+
+      result = BSV::Script::Interpreter.evaluate(unlock, lock)
+      expect(result).to be true
+    end
+
+    it 'works with binary data' do
+      binary_data = (0..255).to_a.pack('C*')
+      half = binary_data.bytesize / 2
+      lock = described_class.op_cat_lock(binary_data)
+      unlock = described_class.op_cat_unlock(binary_data[0, half], binary_data[half..])
+
+      result = BSV::Script::Interpreter.evaluate(unlock, lock)
+      expect(result).to be true
+    end
+  end
+
+  describe '#op_cat?' do
+    it 'returns true for an OP_CAT puzzle script' do
+      script = described_class.op_cat_lock('test')
+      expect(script.op_cat?).to be true
+    end
+
+    it 'returns false for a P2PKH script' do
+      hash160 = BSV::Primitives::Digest.hash160('test key')
+      script = described_class.p2pkh_lock(hash160)
+      expect(script.op_cat?).to be false
+    end
+
+    it 'returns false for an empty script' do
+      script = described_class.from_binary('')
+      expect(script.op_cat?).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Script.op_cat_lock(expected_data)` and `Script.op_cat_unlock(data1, data2)` constructors
- Adds `#op_cat?` type detection and `'opcat'` type classifier
- Interpreter-verified: matching, mismatching, empty, and binary data

## Test plan

- [x] 11 examples, 0 failures
- [x] Rubocop clean
- [x] Interpreter verifies lock/unlock round-trip

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)