### PR TITLE
feat(transaction): add LivePolicy fee model from ARC endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -202,6 +202,7 @@ RSpec/SpecFilePathFormat:
     - 'spec/bsv/primitives/shamir/**/*'
     - 'spec/bsv/transaction/benford_number/**/*'
     - 'spec/bsv/script/op_cat_spec.rb'
+    - 'spec/bsv/transaction/live_policy_spec.rb'
     - 'spec/conformance/**/*'
     - 'spec/bsv/wallet_interface/**/*'
 

--- a/lib/bsv/transaction/fee_models.rb
+++ b/lib/bsv/transaction/fee_models.rb
@@ -5,6 +5,7 @@ module BSV
     # Namespace for fee model implementations.
     module FeeModels
       autoload :SatoshisPerKilobyte, 'bsv/transaction/fee_models/satoshis_per_kilobyte'
+      autoload :LivePolicy,          'bsv/transaction/fee_models/live_policy'
     end
   end
 end

--- a/lib/bsv/transaction/fee_models/live_policy.rb
+++ b/lib/bsv/transaction/fee_models/live_policy.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+require 'uri'
+
+module BSV
+  module Transaction
+    module FeeModels
+      # Dynamic fee model that fetches the live mining fee rate from an ARC
+      # policy endpoint.
+      #
+      # The fetched rate is cached for a configurable TTL (default 5 minutes)
+      # so repeated calls to {#compute_fee} do not repeatedly query the API.
+      # If a fetch fails, the model falls back to a configurable default rate.
+      #
+      # @example
+      #   model = BSV::Transaction::FeeModels::LivePolicy.new(
+      #     arc_url: 'https://arc.gorillapool.io',
+      #     fallback_rate: 50
+      #   )
+      #   fee = model.compute_fee(transaction)
+      class LivePolicy < FeeModel
+        DEFAULT_CACHE_TTL = 300 # 5 minutes in seconds
+
+        # @return [String] the ARC base URL
+        attr_reader :arc_url
+
+        # @return [Integer] fallback sat/kB when fetch fails
+        attr_reader :fallback_rate
+
+        # @return [Integer] cache TTL in seconds
+        attr_reader :cache_ttl
+
+        # @param arc_url [String] ARC base URL (e.g. 'https://arc.gorillapool.io')
+        # @param fallback_rate [Integer] sat/kB to use when fetch fails (default: 50)
+        # @param cache_ttl [Integer] seconds to cache a fetched rate (default: 300)
+        # @param api_key [String, nil] optional Bearer token for ARC authentication
+        # @param http_client [#request, nil] injectable HTTP client for testing
+        def initialize(arc_url:, fallback_rate: 50, cache_ttl: DEFAULT_CACHE_TTL, api_key: nil, http_client: nil)
+          super()
+          @arc_url = arc_url.chomp('/')
+          @fallback_rate = fallback_rate
+          @cache_ttl = cache_ttl
+          @api_key = api_key
+          @http_client = http_client
+          @cached_rate = nil
+          @cached_at = nil
+          @mutex = Mutex.new
+        end
+
+        # Compute the fee for a transaction using the latest ARC rate.
+        #
+        # @param transaction [Transaction] the transaction to compute the fee for
+        # @return [Integer] the fee in satoshis
+        def compute_fee(transaction)
+          rate = current_rate
+          size = transaction.estimated_size
+          (size / 1000.0 * rate).ceil
+        end
+
+        # Return the current sat/kB rate, fetching from ARC if the cache
+        # has expired.
+        #
+        # @return [Integer] satoshis per kilobyte
+        def current_rate
+          @mutex.synchronize do
+            return @cached_rate if cache_valid?
+
+            rate = fetch_rate
+            if rate
+              @cached_rate = rate
+              @cached_at = Time.now
+              rate
+            elsif @cached_rate
+              @cached_rate
+            else
+              @fallback_rate
+            end
+          end
+        end
+
+        private
+
+        def cache_valid?
+          @cached_rate && @cached_at && (Time.now - @cached_at) < @cache_ttl
+        end
+
+        def fetch_rate
+          uri = URI("#{@arc_url}/v1/policy")
+          request = Net::HTTP::Get.new(uri)
+          request['Accept'] = 'application/json'
+          request['Authorization'] = "Bearer #{@api_key}" if @api_key
+
+          response = execute(uri, request)
+          return unless (200..299).cover?(response.code.to_i)
+
+          payload = JSON.parse(response.body)
+          # Some endpoints wrap the policy in a 'data' key
+          payload = payload['data'] if payload.is_a?(Hash) && payload.key?('data') && payload['data'].is_a?(Hash)
+
+          extract_rate(payload)
+        rescue StandardError
+          nil
+        end
+
+        def extract_rate(payload)
+          policy = payload.is_a?(Hash) ? payload['policy'] : nil
+          return unless policy.is_a?(Hash)
+
+          # Primary: policy.fees.miningFee { satoshis: x, bytes: y }
+          fees = policy['fees']
+          mining_fee = fees.is_a?(Hash) ? fees['miningFee'] : nil
+          mining_fee ||= policy['miningFee']
+
+          if mining_fee.is_a?(Hash)
+            satoshis = mining_fee['satoshis']
+            bytes = mining_fee['bytes']
+            return [1, (satoshis.to_f / bytes * 1000).round].max if satoshis.is_a?(Numeric) && bytes.is_a?(Numeric) && bytes.positive?
+          end
+
+          # Fallback: direct sat/kB keys
+          %w[satPerKb sat_per_kb satoshisPerKb].each do |key|
+            value = policy[key]
+            return [1, value.round].max if value.is_a?(Numeric) && value.positive?
+          end
+
+          nil
+        end
+
+        def execute(uri, request)
+          if @http_client
+            @http_client.request(uri, request)
+          else
+            Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+              http.request(request)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/bsv/transaction/live_policy_spec.rb
+++ b/spec/bsv/transaction/live_policy_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe BSV::Transaction::FeeModels::LivePolicy do
+  let(:arc_url) { 'https://arc.example.com' }
+
+  # Mock HTTP client that returns a configurable response
+  let(:mock_client) do
+    Class.new do
+      attr_accessor :response_code, :response_body, :call_count
+
+      def initialize(code, body)
+        @response_code = code
+        @response_body = body
+        @call_count = 0
+      end
+
+      def request(_uri, _request)
+        @call_count += 1
+        response = Struct.new(:code, :body).new
+        response.code = @response_code.to_s
+        response.body = @response_body
+        response
+      end
+    end
+  end
+
+  let(:policy_response) do
+    {
+      'policy' => {
+        'fees' => {
+          'miningFee' => { 'satoshis' => 50, 'bytes' => 1000 }
+        }
+      }
+    }.to_json
+  end
+
+  let(:http) { mock_client.new(200, policy_response) }
+
+  let(:model) do
+    described_class.new(arc_url: arc_url, http_client: http, cache_ttl: 60)
+  end
+
+  describe '#current_rate' do
+    it 'fetches the rate from the ARC policy endpoint' do
+      expect(model.current_rate).to eq(50)
+      expect(http.call_count).to eq(1)
+    end
+
+    it 'parses policy.fees.miningFee with satoshis/bytes' do
+      body = { 'policy' => { 'fees' => { 'miningFee' => { 'satoshis' => 100, 'bytes' => 1000 } } } }.to_json
+      h = mock_client.new(200, body)
+      m = described_class.new(arc_url: arc_url, http_client: h)
+      expect(m.current_rate).to eq(100)
+    end
+
+    it 'parses policy.miningFee directly' do
+      body = { 'policy' => { 'miningFee' => { 'satoshis' => 25, 'bytes' => 1000 } } }.to_json
+      h = mock_client.new(200, body)
+      m = described_class.new(arc_url: arc_url, http_client: h)
+      expect(m.current_rate).to eq(25)
+    end
+
+    it 'parses policy.satPerKb fallback' do
+      body = { 'policy' => { 'satPerKb' => 75 } }.to_json
+      h = mock_client.new(200, body)
+      m = described_class.new(arc_url: arc_url, http_client: h)
+      expect(m.current_rate).to eq(75)
+    end
+
+    it 'unwraps a data envelope' do
+      body = { 'data' => { 'policy' => { 'satPerKb' => 42 } } }.to_json
+      h = mock_client.new(200, body)
+      m = described_class.new(arc_url: arc_url, http_client: h)
+      expect(m.current_rate).to eq(42)
+    end
+
+    it 'ensures minimum rate of 1 sat/kB' do
+      body = { 'policy' => { 'fees' => { 'miningFee' => { 'satoshis' => 1, 'bytes' => 100_000 } } } }.to_json
+      h = mock_client.new(200, body)
+      m = described_class.new(arc_url: arc_url, http_client: h)
+      expect(m.current_rate).to eq(1)
+    end
+  end
+
+  describe 'caching' do
+    it 'does not re-fetch while cache is valid' do
+      model.current_rate
+      model.current_rate
+      model.current_rate
+      expect(http.call_count).to eq(1)
+    end
+
+    it 're-fetches after cache expires' do
+      m = described_class.new(arc_url: arc_url, http_client: http, cache_ttl: 0)
+      m.current_rate
+      m.current_rate
+      expect(http.call_count).to eq(2)
+    end
+  end
+
+  describe 'fallback' do
+    it 'returns fallback rate on HTTP error' do
+      h = mock_client.new(500, 'Internal Server Error')
+      m = described_class.new(arc_url: arc_url, http_client: h, fallback_rate: 99)
+      expect(m.current_rate).to eq(99)
+    end
+
+    it 'returns fallback rate on invalid JSON' do
+      h = mock_client.new(200, 'not json')
+      m = described_class.new(arc_url: arc_url, http_client: h, fallback_rate: 77)
+      expect(m.current_rate).to eq(77)
+    end
+
+    it 'returns fallback rate on missing policy key' do
+      h = mock_client.new(200, { 'something' => 'else' }.to_json)
+      m = described_class.new(arc_url: arc_url, http_client: h, fallback_rate: 55)
+      expect(m.current_rate).to eq(55)
+    end
+
+    it 'returns stale cached rate over fallback when fetch fails' do
+      m = described_class.new(arc_url: arc_url, http_client: http, cache_ttl: 0, fallback_rate: 1)
+      expect(m.current_rate).to eq(50) # first fetch succeeds
+
+      # Now make the endpoint fail
+      http.response_code = 500
+      http.response_body = 'error'
+      expect(m.current_rate).to eq(50) # returns stale cached value
+    end
+  end
+
+  describe '#compute_fee' do
+    it 'computes fee using the live rate' do
+      tx = instance_double(BSV::Transaction::Transaction, estimated_size: 250)
+      fee = model.compute_fee(tx)
+      # 250 / 1000 * 50 = 12.5, ceil = 13
+      expect(fee).to eq(13)
+    end
+  end
+
+  describe 'api_key' do
+    it 'includes Authorization header when api_key is set' do
+      # Use a recording client to verify headers
+      recording_client = Class.new do
+        define_method(:initialize) { |reqs| @reqs = reqs }
+        define_method(:request) do |_uri, req|
+          @reqs << req
+          Struct.new(:code, :body).new('200', policy_response)
+        end
+      end
+
+      reqs = []
+      h = recording_client.new(reqs)
+      m = described_class.new(arc_url: arc_url, http_client: h, api_key: 'test-key')
+      m.current_rate
+
+      expect(reqs.first['Authorization']).to eq('Bearer test-key')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `BSV::Transaction::FeeModels::LivePolicy` — fetches live mining fee rate from ARC `/v1/policy`
- Thread-safe caching with configurable TTL (default 5 minutes)
- Graceful fallback: stale cache > configured default > never crashes
- Parses multiple ARC response formats (miningFee, satPerKb, data envelope)
- Injectable HTTP client for testing

## Test plan

- [x] 14 examples, 0 failures
- [x] Rubocop clean
- [x] Rate parsing, caching, fallback, API key header all tested

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)