### PR TITLE
feat(wallet): implement certificate issuance protocol

### DIFF
--- a/lib/bsv/wallet_interface/wallet_client.rb
+++ b/lib/bsv/wallet_interface/wallet_client.rb
@@ -2,6 +2,9 @@
 
 require 'securerandom'
 require 'base64'
+require 'net/http'
+require 'json'
+require 'uri'
 
 module BSV
   module Wallet
@@ -36,11 +39,13 @@ module BSV
       # @param storage [StorageAdapter] persistence adapter (default: MemoryStore)
       # @param network [String] 'mainnet' (default) or 'testnet'
       # @param chain_provider [ChainProvider] blockchain data provider (default: NullChainProvider)
-      def initialize(key, storage: MemoryStore.new, network: 'mainnet', chain_provider: NullChainProvider.new)
+      # @param http_client [#request, nil] injectable HTTP client for certificate issuance
+      def initialize(key, storage: MemoryStore.new, network: 'mainnet', chain_provider: NullChainProvider.new, http_client: nil)
         super(key)
         @storage = storage
         @network = network
         @chain_provider = chain_provider
+        @http_client = http_client
         @pending = {}
       end
 
@@ -254,18 +259,11 @@ module BSV
       def acquire_certificate(args, _originator: nil)
         validate_acquire_certificate!(args)
 
-        raise UnsupportedActionError, 'acquire_certificate with issuance protocol' if args[:acquisition_protocol] == 'issuance'
-
-        cert = {
-          type: args[:type],
-          subject: @key_deriver.identity_key,
-          serial_number: args[:serial_number],
-          certifier: args[:certifier],
-          revocation_outpoint: args[:revocation_outpoint],
-          signature: args[:signature],
-          fields: args[:fields],
-          keyring: args[:keyring_for_subject]
-        }
+        cert = if args[:acquisition_protocol] == 'issuance'
+                 acquire_via_issuance(args)
+               else
+                 acquire_via_direct(args)
+               end
 
         @storage.store_certificate(cert)
         cert_without_keyring(cert)
@@ -721,12 +719,69 @@ module BSV
         protocol = args[:acquisition_protocol]
         raise InvalidParameterError.new('acquisition_protocol', '"direct" or "issuance"') unless %w[direct issuance].include?(protocol)
 
-        return unless protocol == 'direct'
+        if protocol == 'direct'
+          raise InvalidParameterError.new('serial_number', 'present for direct acquisition') unless args[:serial_number]
+          raise InvalidParameterError.new('revocation_outpoint', 'present for direct acquisition') unless args[:revocation_outpoint]
+          raise InvalidParameterError.new('signature', 'present for direct acquisition') unless args[:signature]
+          raise InvalidParameterError.new('keyring_for_subject', 'a Hash for direct acquisition') unless args[:keyring_for_subject].is_a?(Hash)
+        elsif protocol == 'issuance'
+          raise InvalidParameterError.new('certifier_url', 'present for issuance acquisition') unless args[:certifier_url].is_a?(String)
+        end
+      end
 
-        raise InvalidParameterError.new('serial_number', 'present for direct acquisition') unless args[:serial_number]
-        raise InvalidParameterError.new('revocation_outpoint', 'present for direct acquisition') unless args[:revocation_outpoint]
-        raise InvalidParameterError.new('signature', 'present for direct acquisition') unless args[:signature]
-        raise InvalidParameterError.new('keyring_for_subject', 'a Hash for direct acquisition') unless args[:keyring_for_subject].is_a?(Hash)
+      def acquire_via_direct(args)
+        {
+          type: args[:type],
+          subject: @key_deriver.identity_key,
+          serial_number: args[:serial_number],
+          certifier: args[:certifier],
+          revocation_outpoint: args[:revocation_outpoint],
+          signature: args[:signature],
+          fields: args[:fields],
+          keyring: args[:keyring_for_subject]
+        }
+      end
+
+      def acquire_via_issuance(args)
+        uri = URI(args[:certifier_url])
+        request = Net::HTTP::Post.new(uri)
+        request['Content-Type'] = 'application/json'
+        request.body = JSON.generate({
+                                       type: args[:type],
+                                       subject: @key_deriver.identity_key,
+                                       certifier: args[:certifier],
+                                       fields: args[:fields]
+                                     })
+
+        response = execute_http(uri, request)
+        code = response.code.to_i
+
+        raise WalletError, "Certificate issuance failed: HTTP #{code}" unless (200..299).cover?(code)
+
+        body = JSON.parse(response.body)
+
+        {
+          type: body['type'] || args[:type],
+          subject: body['subject'] || @key_deriver.identity_key,
+          serial_number: body['serialNumber'],
+          certifier: body['certifier'] || args[:certifier],
+          revocation_outpoint: body['revocationOutpoint'],
+          signature: body['signature'],
+          fields: body['fields'] || args[:fields],
+          keyring: body['keyringForSubject']
+        }
+      rescue JSON::ParserError
+        raise WalletError, 'Certificate issuance failed: invalid JSON response'
+      end
+
+      def execute_http(uri, request)
+        if @http_client
+          @http_client.request(uri, request)
+        else
+          Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+            http.request(request)
+          end
+        end
       end
 
       def find_stored_certificate(cert_arg)

--- a/spec/bsv/wallet_interface/certificate_spec.rb
+++ b/spec/bsv/wallet_interface/certificate_spec.rb
@@ -51,9 +51,86 @@ RSpec.describe 'WalletClient certificate methods' do
       expect(result).not_to have_key(:keyring)
     end
 
-    it 'raises UnsupportedActionError for issuance protocol' do
+    it 'raises InvalidParameterError for issuance without certifier_url' do
       args = direct_args.merge(acquisition_protocol: 'issuance')
-      expect { wallet.acquire_certificate(args) }.to raise_error(BSV::Wallet::UnsupportedActionError)
+      args.delete(:serial_number)
+      args.delete(:revocation_outpoint)
+      args.delete(:signature)
+      args.delete(:keyring_for_subject)
+      expect { wallet.acquire_certificate(args) }.to raise_error(BSV::Wallet::InvalidParameterError)
+    end
+
+    context 'with issuance protocol' do
+      let(:issuance_response) do
+        {
+          'type' => cert_type,
+          'subject' => wallet.key_deriver.identity_key,
+          'serialNumber' => serial_number,
+          'certifier' => certifier_hex,
+          'revocationOutpoint' => revocation_outpoint,
+          'signature' => signature,
+          'fields' => fields,
+          'keyringForSubject' => keyring
+        }
+      end
+
+      let(:mock_http) do
+        resp = issuance_response
+        Class.new do
+          define_method(:request) do |_uri, _req|
+            Struct.new(:code, :body).new('200', JSON.generate(resp))
+          end
+        end.new
+      end
+
+      let(:issuance_wallet) do
+        BSV::Wallet::WalletClient.new(private_key, http_client: mock_http)
+      end
+
+      let(:issuance_args) do
+        {
+          type: cert_type,
+          certifier: certifier_hex,
+          acquisition_protocol: 'issuance',
+          fields: fields,
+          certifier_url: 'https://certifier.example.com/api/issue'
+        }
+      end
+
+      it 'acquires a certificate via issuance protocol' do
+        result = issuance_wallet.acquire_certificate(issuance_args)
+        expect(result[:type]).to eq(cert_type)
+        expect(result[:subject]).to eq(wallet.key_deriver.identity_key)
+        expect(result[:serial_number]).to eq(serial_number)
+        expect(result[:certifier]).to eq(certifier_hex)
+      end
+
+      it 'does not return the keyring in the result' do
+        result = issuance_wallet.acquire_certificate(issuance_args)
+        expect(result).not_to have_key(:keyring)
+      end
+
+      it 'stores the certificate in storage' do
+        issuance_wallet.acquire_certificate(issuance_args)
+        certs = issuance_wallet.list_certificates({ certifiers: [certifier_hex], types: [cert_type] })
+        expect(certs[:total_certificates]).to eq(1)
+      end
+
+      it 'raises WalletError on HTTP failure' do
+        failing_http = Class.new do
+          define_method(:request) { |_uri, _req| Struct.new(:code, :body).new('500', 'error') }
+        end.new
+        w = BSV::Wallet::WalletClient.new(private_key, http_client: failing_http)
+        expect { w.acquire_certificate(issuance_args) }.to raise_error(BSV::Wallet::WalletError, /HTTP 500/)
+      end
+
+      it 'raises WalletError on invalid JSON response' do
+        bad_http = Class.new do
+          define_method(:request) { |_uri, _req| Struct.new(:code, :body).new('200', 'not json') }
+        end.new
+        w = BSV::Wallet::WalletClient.new(private_key, http_client: bad_http)
+        expect { w.acquire_certificate(issuance_args) }.to raise_error(BSV::Wallet::WalletError, /invalid JSON/)
+      end
     end
 
     it 'raises InvalidParameterError for invalid protocol' do


### PR DESCRIPTION
## Summary

- `acquire_certificate` now supports `acquisition_protocol: 'issuance'` — POSTs to `certifier_url` and stores the signed certificate
- Injectable `http_client:` on WalletClient constructor for testability
- Error handling for HTTP failures and invalid JSON responses

## Test plan

- [x] 30 certificate examples pass (5 new for issuance)
- [x] Rubocop clean
- [x] Issuance round-trip: mock certifier → store → list

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)