### PR TITLE
feat(wallet): implement BRC-100 binary wire protocol (ABI)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ Style/Documentation:
 
 Metrics/BlockLength:
   Exclude:
+    - 'lib/bsv/wallet_interface/wire/**/*'
     - 'spec/**/*'
 
 Naming/FileName:
@@ -27,6 +28,7 @@ Naming/MethodParameterName:
     - b
     - r
     - s
+    - w
     - z
     - x
     - y
@@ -120,6 +122,7 @@ Metrics/ModuleLength:
     - 'lib/bsv/primitives/ecdsa.rb'
     - 'lib/bsv/script/opcodes.rb'
     - 'lib/bsv/script/interpreter/operations/**/*'
+    - 'lib/bsv/wallet_interface/wire/**/*'
     - 'spec/**/*'
 
 Metrics/ClassLength:
@@ -189,8 +192,10 @@ RSpec/ExampleLength:
     - 'spec/conformance/**/*'
 
 # Bitcoin opcodes use numbered names (OP_1, OP_2, etc.) — protocol constants.
+# Wire protocol helpers use base64_32 to denote 32-byte base64 values (protocol constraint).
 Naming/VariableNumber:
   Exclude:
+    - 'lib/bsv/wallet_interface/wire/**/*'
     - 'spec/**/*'
 
 # Interpreter sub-specs and conformance specs legitimately describe parent

--- a/lib/bsv/wallet_interface.rb
+++ b/lib/bsv/wallet_interface.rb
@@ -16,6 +16,7 @@ module BSV
     autoload :ChainProvider,     'bsv/wallet_interface/chain_provider'
     autoload :NullChainProvider, 'bsv/wallet_interface/null_chain_provider'
     autoload :WalletClient,      'bsv/wallet_interface/wallet_client'
+    autoload :Wire,              'bsv/wallet_interface/wire'
 
     # Error classes
     autoload :WalletError,            'bsv/wallet_interface/errors/wallet_error'

--- a/lib/bsv/wallet_interface/wire.rb
+++ b/lib/bsv/wallet_interface/wire.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module BSV
+  module Wallet
+    # BRC-100 binary wire protocol.
+    #
+    # Provides low-level serialisation primitives ({Writer}, {Reader}) and a
+    # higher-level {Serializer} that encodes/decodes all 28 BRC-100 method calls.
+    #
+    # Usage:
+    #   frame = BSV::Wallet::Wire::Serializer.serialize_request(:get_height, {})
+    #   method_name, args, originator = BSV::Wallet::Wire::Serializer.deserialize_request(frame)
+    module Wire
+      autoload :Writer,     'bsv/wallet_interface/wire/writer'
+      autoload :Reader,     'bsv/wallet_interface/wire/reader'
+      autoload :Serializer, 'bsv/wallet_interface/wire/serializer'
+    end
+  end
+end

--- a/lib/bsv/wallet_interface/wire/reader.rb
+++ b/lib/bsv/wallet_interface/wire/reader.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+module BSV
+  module Wallet
+    module Wire
+      # Consumes a binary byte string using BRC-100 wire protocol decoding conventions.
+      #
+      # All multi-byte integers use little-endian order unless stated otherwise.
+      # VarInts follow Bitcoin encoding; the 9-byte MaxUint64 sentinel decodes as -1.
+      class Reader
+        # The 64-bit sentinel value that encodes -1 in a signed VarInt.
+        MAX_UINT64 = 0xFFFF_FFFF_FFFF_FFFF
+
+        def initialize(data)
+          @data = data.b
+          @offset = 0
+        end
+
+        # Current read position (bytes consumed so far).
+        attr_reader :offset
+
+        # Reads a single unsigned byte (0–255).
+        #
+        # @return [Integer]
+        def read_byte
+          require_bytes(1)
+          byte = @data.getbyte(@offset)
+          @offset += 1
+          byte
+        end
+
+        # Reads a signed 8-bit integer (-128–127).
+        #
+        # @return [Integer]
+        def read_int8
+          require_bytes(1)
+          val = @data.byteslice(@offset, 1).unpack1('c')
+          @offset += 1
+          val
+        end
+
+        # Reads an unsigned Bitcoin VarInt.
+        #
+        # @return [Integer]
+        def read_varint
+          require_bytes(1)
+          first = @data.getbyte(@offset)
+
+          case first
+          when 0..0xFC
+            @offset += 1
+            first
+          when 0xFD
+            require_bytes(3)
+            val = @data.byteslice(@offset + 1, 2).unpack1('v')
+            @offset += 3
+            val
+          when 0xFE
+            require_bytes(5)
+            val = @data.byteslice(@offset + 1, 4).unpack1('V')
+            @offset += 5
+            val
+          else # 0xFF
+            require_bytes(9)
+            val = @data.byteslice(@offset + 1, 8).unpack1('Q<')
+            @offset += 9
+            val
+          end
+        end
+
+        # Reads a signed VarInt, returning -1 for the MaxUint64 sentinel.
+        #
+        # @return [Integer] non-negative value or -1
+        def read_signed_varint
+          val = read_varint
+          val == MAX_UINT64 ? -1 : val
+        end
+
+        # Reads exactly n raw bytes.
+        #
+        # @param n [Integer]
+        # @return [String] binary string
+        def read_bytes(n)
+          require_bytes(n)
+          slice = @data.byteslice(@offset, n)
+          @offset += n
+          slice
+        end
+
+        # Reads all remaining bytes from the current offset.
+        #
+        # @return [String] binary string
+        def read_remaining
+          slice = @data.byteslice(@offset, @data.bytesize - @offset) || ''.b
+          @offset = @data.bytesize
+          slice
+        end
+
+        # Reads a VarInt-prefixed byte array.
+        #
+        # @return [String] binary string
+        def read_byte_array
+          len = read_varint
+          read_bytes(len)
+        end
+
+        # Reads an optional VarInt-prefixed byte array; returns nil for the -1 sentinel.
+        #
+        # @return [String, nil]
+        def read_optional_byte_array
+          len = read_signed_varint
+          return nil if len == -1
+
+          read_bytes(len)
+        end
+
+        # Reads a VarInt-prefixed UTF-8 string.
+        #
+        # @return [String]
+        def read_utf8_string
+          len = read_varint
+          read_bytes(len).force_encoding('UTF-8')
+        end
+
+        # Reads an optional VarInt-prefixed UTF-8 string; returns nil for the -1 sentinel.
+        #
+        # @return [String, nil]
+        def read_optional_utf8_string
+          len = read_signed_varint
+          return nil if len == -1
+
+          read_bytes(len).force_encoding('UTF-8')
+        end
+
+        # Reads a signed Int8 optional boolean: 1=true, 0=false, -1=nil.
+        #
+        # @return [Boolean, nil]
+        def read_optional_bool
+          val = read_int8
+          return nil if val == -1
+
+          val == 1
+        end
+
+        # Reads an outpoint: 32 bytes (txid hex in display order) + VarInt index.
+        #
+        # @return [Array(String, Integer)] [txid_hex, index]
+        def read_outpoint
+          txid_bytes = read_bytes(32)
+          txid_hex = txid_bytes.unpack1('H*')
+          index = read_varint
+          [txid_hex, index]
+        end
+
+        # Reads a counterparty value using the first-byte dispatch scheme.
+        #
+        # @return [String, nil] 'self', 'anyone', nil, or 66-char hex pubkey
+        def read_counterparty
+          flag = read_byte
+          case flag
+          when 11
+            'self'
+          when 12
+            'anyone'
+          when 0
+            nil
+          else
+            # First byte is part of the 33-byte compressed pubkey; read 32 more
+            remaining = read_bytes(32)
+            ([flag].pack('C') + remaining).unpack1('H*')
+          end
+        end
+
+        # Reads a protocol ID: UInt8 security level + VarInt-prefixed UTF-8 name.
+        #
+        # @return [Array(Integer, String)] [level, name]
+        def read_protocol_id
+          level = read_byte
+          name = read_utf8_string
+          [level, name]
+        end
+
+        # Reads an optional string array: VarInt count + strings, or nil for the -1 sentinel.
+        #
+        # @return [Array<String>, nil]
+        def read_string_array
+          count = read_signed_varint
+          return nil if count == -1
+
+          count.times.map { read_utf8_string }
+        end
+
+        # Reads an optional string→string map: VarInt count + key/value pairs, or nil.
+        #
+        # @return [Hash, nil]
+        def read_map
+          count = read_signed_varint
+          return nil if count == -1
+
+          count.times.each_with_object({}) do |_, hash|
+            key = read_utf8_string
+            val = read_utf8_string
+            hash[key] = val
+          end
+        end
+
+        # Reads privileged parameters: optional bool + Int8-length reason string.
+        #
+        # @return [Array(Boolean|nil, String|nil)] [privileged, privileged_reason]
+        def read_privileged
+          privileged = read_optional_bool
+          reason_len = read_int8
+          privileged_reason = if reason_len == -1
+                                nil
+                              else
+                                read_bytes(reason_len).force_encoding('UTF-8')
+                              end
+          [privileged, privileged_reason]
+        end
+
+        private
+
+        def require_bytes(n)
+          remaining = @data.bytesize - @offset
+          return if remaining >= n
+
+          raise ArgumentError,
+                "truncated wire data: need #{n} bytes at offset #{@offset}, " \
+                "got #{remaining}"
+        end
+      end
+    end
+  end
+end

--- a/lib/bsv/wallet_interface/wire/serializer.rb
+++ b/lib/bsv/wallet_interface/wire/serializer.rb
@@ -1,0 +1,1993 @@
+# frozen_string_literal: true
+
+module BSV
+  module Wallet
+    module Wire
+      # Serialises and deserialises all 28 BRC-100 wire protocol method calls.
+      #
+      # Frame layout:
+      #   Request:  [UInt8 call_code] [UInt8 originator_length] [UTF-8 originator] [params…]
+      #   Response: [UInt8 error_code] [result…]
+      #   Error:    [UInt8 error_code ≠ 0] [VarInt msg_len] [UTF-8 message] [VarInt stack_len] [UTF-8 stack]
+      #
+      # For every method:
+      #   serialize_request(method_name, args, originator:)  → binary String
+      #   deserialize_request(data)                          → [method_name, args, originator]
+      #   serialize_response(method_name, result)            → binary String (error_code=0 prefix)
+      #   deserialize_response(method_name, data)            → result Hash  (raises on error_code≠0)
+      #   serialize_error(code, message, stack_trace:)       → binary String
+      module Serializer
+        # Maps method name symbols to their wire call codes (1-28).
+        CALL_CODES = {
+          create_action: 1,
+          sign_action: 2,
+          abort_action: 3,
+          list_actions: 4,
+          internalize_action: 5,
+          list_outputs: 6,
+          relinquish_output: 7,
+          get_public_key: 8,
+          reveal_counterparty_key_linkage: 9,
+          reveal_specific_key_linkage: 10,
+          encrypt: 11,
+          decrypt: 12,
+          create_hmac: 13,
+          verify_hmac: 14,
+          create_signature: 15,
+          verify_signature: 16,
+          acquire_certificate: 17,
+          list_certificates: 18,
+          prove_certificate: 19,
+          relinquish_certificate: 20,
+          discover_by_identity_key: 21,
+          discover_by_attributes: 22,
+          is_authenticated: 23,
+          wait_for_authentication: 24,
+          get_height: 25,
+          get_header_for_height: 26,
+          get_network: 27,
+          get_version: 28
+        }.freeze
+
+        # Inverse mapping: call code Integer → method name Symbol.
+        METHODS_BY_CODE = CALL_CODES.invert.freeze
+
+        module_function
+
+        # Serialises a method call request into a binary frame.
+        #
+        # @param method_name [Symbol]
+        # @param args [Hash]
+        # @param originator [String, nil] FQDN of the calling application
+        # @return [String] binary frame (ASCII-8BIT)
+        def serialize_request(method_name, args, originator: nil)
+          code = CALL_CODES.fetch(method_name) do
+            raise ArgumentError, "unknown method: #{method_name}"
+          end
+
+          w = Writer.new
+          w.write_byte(code)
+
+          orig = originator.to_s
+          orig_bytes = orig.encode('UTF-8').b
+          w.write_byte(orig_bytes.bytesize)
+          w.write_bytes(orig_bytes)
+
+          params_writer = Writer.new
+          send(:"write_#{method_name}_params", params_writer, args)
+          w.write_bytes(params_writer.to_binary)
+
+          w.to_binary
+        end
+
+        # Deserialises a binary request frame.
+        #
+        # @param data [String] binary frame
+        # @return [Array(Symbol, Hash, String)] [method_name, args, originator]
+        def deserialize_request(data)
+          r = Reader.new(data)
+          code = r.read_byte
+          method_name = METHODS_BY_CODE.fetch(code) do
+            raise ArgumentError, "unknown call code: #{code}"
+          end
+
+          orig_len = r.read_byte
+          originator = r.read_bytes(orig_len).force_encoding('UTF-8')
+
+          args = send(:"read_#{method_name}_params", r)
+          [method_name, args, originator]
+        end
+
+        # Serialises a successful response.
+        #
+        # @param method_name [Symbol]
+        # @param result [Hash]
+        # @return [String] binary frame
+        def serialize_response(method_name, result)
+          w = Writer.new
+          w.write_byte(0) # error_code = 0
+          result_writer = Writer.new
+          send(:"write_#{method_name}_result", result_writer, result)
+          w.write_bytes(result_writer.to_binary)
+          w.to_binary
+        end
+
+        # Serialises an error response.
+        #
+        # @param code [Integer] non-zero error code
+        # @param message [String]
+        # @param stack_trace [String, nil]
+        # @return [String] binary frame
+        def serialize_error(code, message, stack_trace: nil)
+          w = Writer.new
+          w.write_byte(code)
+          w.write_utf8_string(message.to_s)
+          w.write_utf8_string(stack_trace.to_s)
+          w.to_binary
+        end
+
+        # Deserialises a response frame, raising a WalletError on non-zero error code.
+        #
+        # @param method_name [Symbol]
+        # @param data [String] binary frame
+        # @return [Hash] result
+        def deserialize_response(method_name, data)
+          r = Reader.new(data)
+          error_code = r.read_byte
+
+          unless error_code.zero?
+            message = r.read_utf8_string
+            raise BSV::Wallet::WalletError.new(message, error_code)
+          end
+
+          send(:"read_#{method_name}_result", r)
+        end
+
+        # -----------------------------------------------------------------------
+        # Private helpers — all defined via module_function so they become
+        # private module-level methods callable from within the module.
+        # -----------------------------------------------------------------------
+
+        # --- write_outpoint / read_outpoint helpers ---
+
+        def write_outpoint_str(w, outpoint_str)
+          txid, index = outpoint_str.split('.')
+          w.write_outpoint(txid, index.to_i)
+        end
+
+        def read_outpoint_str(r)
+          txid, index = r.read_outpoint
+          "#{txid}.#{index}"
+        end
+
+        # --- key-related params (shared by encrypt/decrypt/hmac/signature/revealSpecific) ---
+
+        def write_key_related_params(w, args)
+          w.write_protocol_id(args[:protocol_id])
+          w.write_utf8_string(args[:key_id].to_s)
+          w.write_counterparty(args[:counterparty])
+          w.write_privileged(args[:privileged], args[:privileged_reason])
+        end
+
+        # Reads key-related params: protocolID, keyID, counterparty, privileged, privilegedReason.
+        def read_key_related_from_reader(r)
+          protocol_id = r.read_protocol_id
+          key_id = r.read_utf8_string
+          counterparty = r.read_counterparty
+          privileged, privileged_reason = r.read_privileged
+          {
+            protocol_id: protocol_id,
+            key_id: key_id,
+            counterparty: counterparty,
+            privileged: privileged,
+            privileged_reason: privileged_reason
+          }
+        end
+
+        # --- certificate binary encoding helpers ---
+
+        # Writes a certificate struct to the writer (without length prefix).
+        def write_certificate_fields(w, cert)
+          # type: 32 bytes (base64-decoded)
+          w.write_bytes(decode_base64_32(cert[:type]))
+          # subject: 33 bytes (hex-decoded compressed pubkey)
+          w.write_bytes([cert[:subject]].pack('H*'))
+          # serial_number: 32 bytes (base64-decoded)
+          w.write_bytes(decode_base64_32(cert[:serial_number]))
+          # certifier: 33 bytes
+          w.write_bytes([cert[:certifier]].pack('H*'))
+          # revocation_outpoint
+          write_outpoint_str(w, cert[:revocation_outpoint])
+          # signature: VarInt-prefixed hex
+          sig_bytes = [cert[:signature]].pack('H*')
+          w.write_varint(sig_bytes.bytesize)
+          w.write_bytes(sig_bytes)
+          # fields: map
+          fields = cert[:fields] || {}
+          w.write_varint(fields.length)
+          fields.each do |k, v|
+            w.write_utf8_string(k.to_s)
+            w.write_utf8_string(v.to_s)
+          end
+        end
+
+        # Reads a certificate struct from the reader (without length prefix).
+        def read_cert_from_reader(r)
+          require 'base64'
+          type = encode_base64(r.read_bytes(32))
+          subject = r.read_bytes(33).unpack1('H*')
+          serial_number = encode_base64(r.read_bytes(32))
+          certifier = r.read_bytes(33).unpack1('H*')
+          revocation_outpoint = read_outpoint_str(r)
+          sig_len = r.read_varint
+          signature = r.read_bytes(sig_len).unpack1('H*')
+          fields_count = r.read_varint
+          fields = {}
+          fields_count.times do
+            k = r.read_utf8_string
+            v = r.read_utf8_string
+            fields[k] = v
+          end
+          {
+            type: type,
+            subject: subject,
+            serial_number: serial_number,
+            certifier: certifier,
+            revocation_outpoint: revocation_outpoint,
+            signature: signature,
+            fields: fields
+          }
+        end
+
+        def decode_base64_32(b64_str)
+          require 'base64'
+          raw = Base64.strict_decode64(b64_str)
+          raise ArgumentError, "expected 32-byte base64 value, got #{raw.bytesize}" unless raw.bytesize == 32
+
+          raw
+        end
+
+        def encode_base64(raw_bytes)
+          require 'base64'
+          Base64.strict_encode64(raw_bytes)
+        end
+
+        # Serialises a discovery certificate result (shared by discoverByIdentityKey/Attributes).
+        def write_discovery_result(w, result)
+          certs = result[:certificates] || []
+          w.write_varint(result[:total_certificates] || certs.length)
+          certs.each do |cert|
+            # Write certificate binary (length-prefixed)
+            cert_w = Writer.new
+            write_certificate_fields(cert_w, cert)
+            cert_bin = cert_w.to_binary
+            w.write_varint(cert_bin.bytesize)
+            w.write_bytes(cert_bin)
+
+            # certifierInfo
+            info = cert[:certifier_info] || {}
+            w.write_utf8_string(info[:name].to_s)
+            w.write_utf8_string(info[:icon_url].to_s)
+            w.write_utf8_string(info[:description].to_s)
+            w.write_byte(info[:trust].to_i)
+
+            # publiclyRevealedKeyring: map of field→base64
+            keyring = cert[:publicly_revealed_keyring] || {}
+            w.write_varint(keyring.length)
+            keyring.each do |k, v|
+              w.write_utf8_string(k.to_s)
+              val_bytes = decode_base64_32_safe(v.to_s)
+              w.write_varint(val_bytes.bytesize)
+              w.write_bytes(val_bytes)
+            end
+
+            # decryptedFields: map of field→utf8
+            decrypted = cert[:decrypted_fields] || {}
+            w.write_varint(decrypted.length)
+            decrypted.each do |k, v|
+              w.write_utf8_string(k.to_s)
+              w.write_utf8_string(v.to_s)
+            end
+          end
+        end
+
+        def read_discovery_result(r)
+          total = r.read_varint
+          certs = total.times.map do
+            cert_len = r.read_varint
+            cert_r = Reader.new(r.read_bytes(cert_len))
+            cert = read_cert_from_reader(cert_r)
+
+            info_name = r.read_utf8_string
+            info_icon = r.read_utf8_string
+            info_desc = r.read_utf8_string
+            info_trust = r.read_byte
+
+            pub_count = r.read_varint
+            public_keyring = {}
+            pub_count.times do
+              k = r.read_utf8_string
+              v_len = r.read_varint
+              public_keyring[k] = encode_base64(r.read_bytes(v_len))
+            end
+
+            dec_count = r.read_varint
+            decrypted = {}
+            dec_count.times do
+              k = r.read_utf8_string
+              decrypted[k] = r.read_utf8_string
+            end
+
+            cert.merge(
+              certifier_info: {
+                name: info_name,
+                icon_url: info_icon,
+                description: info_desc,
+                trust: info_trust
+              },
+              publicly_revealed_keyring: public_keyring,
+              decrypted_fields: decrypted
+            )
+          end
+          { total_certificates: total, certificates: certs }
+        end
+
+        def decode_base64_32_safe(str)
+          require 'base64'
+          Base64.strict_decode64(str)
+        rescue StandardError
+          str.b
+        end
+
+        # -----------------------------------------------------------------------
+        # 1. createAction
+        # -----------------------------------------------------------------------
+
+        def write_create_action_params(w, args)
+          w.write_utf8_string(args[:description].to_s)
+          w.write_optional_byte_array(args[:input_beef]&.pack('C*'))
+
+          inputs = args[:inputs]
+          if inputs.nil?
+            w.write_signed_varint(-1)
+          else
+            w.write_varint(inputs.length)
+            inputs.each do |inp|
+              write_outpoint_str(w, inp[:outpoint])
+              if inp[:unlocking_script]
+                script_bytes = [inp[:unlocking_script]].pack('H*')
+                w.write_varint(script_bytes.bytesize)
+                w.write_bytes(script_bytes)
+              else
+                w.write_signed_varint(-1)
+                w.write_varint(inp[:unlocking_script_length] || 0)
+              end
+              w.write_utf8_string(inp[:input_description].to_s)
+              if inp[:sequence_number]
+                w.write_varint(inp[:sequence_number])
+              else
+                w.write_signed_varint(-1)
+              end
+            end
+          end
+
+          outputs = args[:outputs]
+          if outputs.nil?
+            w.write_signed_varint(-1)
+          else
+            w.write_varint(outputs.length)
+            outputs.each do |out|
+              script_bytes = [out[:locking_script].to_s].pack('H*')
+              w.write_varint(script_bytes.bytesize)
+              w.write_bytes(script_bytes)
+              w.write_varint(out[:satoshis].to_i)
+              w.write_utf8_string(out[:output_description].to_s)
+              w.write_optional_utf8_string(out[:basket])
+              w.write_optional_utf8_string(out[:custom_instructions])
+              w.write_string_array(out[:tags])
+            end
+          end
+
+          if args[:lock_time]
+            w.write_varint(args[:lock_time])
+          else
+            w.write_signed_varint(-1)
+          end
+
+          if args[:version]
+            w.write_varint(args[:version])
+          else
+            w.write_signed_varint(-1)
+          end
+
+          w.write_string_array(args[:labels])
+
+          opts = args[:options]
+          if opts.nil?
+            w.write_int8(0)
+          else
+            w.write_int8(1)
+            w.write_optional_bool(opts[:sign_and_process])
+            w.write_optional_bool(opts[:accept_delayed_broadcast])
+            if opts[:trust_self] == 'known'
+              w.write_int8(1)
+            elsif opts[:trust_self].nil?
+              w.write_int8(-1)
+            else
+              w.write_int8(0)
+            end
+            known_txids = opts[:known_txids]
+            if known_txids.nil?
+              w.write_signed_varint(-1)
+            else
+              w.write_varint(known_txids.length)
+              known_txids.each { |txid| w.write_bytes([txid].pack('H*')) }
+            end
+            w.write_optional_bool(opts[:return_txid_only])
+            w.write_optional_bool(opts[:no_send])
+            no_send_change = opts[:no_send_change]
+            if no_send_change.nil?
+              w.write_signed_varint(-1)
+            else
+              w.write_varint(no_send_change.length)
+              no_send_change.each { |op| write_outpoint_str(w, op) }
+            end
+            send_with = opts[:send_with]
+            if send_with.nil?
+              w.write_signed_varint(-1)
+            else
+              w.write_varint(send_with.length)
+              send_with.each { |txid| w.write_bytes([txid].pack('H*')) }
+            end
+            w.write_optional_bool(opts[:randomize_outputs])
+          end
+        end
+
+        def read_create_action_params(r)
+          args = {}
+          args[:description] = r.read_utf8_string
+
+          input_beef_raw = r.read_optional_byte_array
+          args[:input_beef] = input_beef_raw&.bytes
+
+          inputs_count = r.read_signed_varint
+          args[:inputs] = if inputs_count == -1
+                            nil
+                          else
+                            inputs_count.times.map do
+                              inp = {}
+                              inp[:outpoint] = read_outpoint_str(r)
+                              script_len = r.read_signed_varint
+                              if script_len >= 0
+                                inp[:unlocking_script] = r.read_bytes(script_len).unpack1('H*')
+                              else
+                                inp[:unlocking_script] = nil
+                                inp[:unlocking_script_length] = r.read_varint
+                              end
+                              inp[:input_description] = r.read_utf8_string
+                              seq = r.read_signed_varint
+                              inp[:sequence_number] = seq == -1 ? nil : seq
+                              inp
+                            end
+                          end
+
+          outputs_count = r.read_signed_varint
+          args[:outputs] = if outputs_count == -1
+                             nil
+                           else
+                             outputs_count.times.map do
+                               out = {}
+                               ls_len = r.read_varint
+                               out[:locking_script] = r.read_bytes(ls_len).unpack1('H*')
+                               out[:satoshis] = r.read_varint
+                               out[:output_description] = r.read_utf8_string
+                               out[:basket] = r.read_optional_utf8_string
+                               out[:custom_instructions] = r.read_optional_utf8_string
+                               out[:tags] = r.read_string_array
+                               out
+                             end
+                           end
+
+          lock_time = r.read_signed_varint
+          args[:lock_time] = lock_time == -1 ? nil : lock_time
+          version = r.read_signed_varint
+          args[:version] = version == -1 ? nil : version
+          args[:labels] = r.read_string_array
+
+          opts_flag = r.read_int8
+          if opts_flag == 1
+            opts = {}
+            opts[:sign_and_process] = r.read_optional_bool
+            opts[:accept_delayed_broadcast] = r.read_optional_bool
+            trust_self_flag = r.read_int8
+            opts[:trust_self] = if trust_self_flag == -1
+                                  nil
+                                elsif trust_self_flag == 1
+                                  'known'
+                                end
+            known_count = r.read_signed_varint
+            opts[:known_txids] = if known_count == -1
+                                   nil
+                                 else
+                                   known_count.times.map { r.read_bytes(32).unpack1('H*') }
+                                 end
+            opts[:return_txid_only] = r.read_optional_bool
+            opts[:no_send] = r.read_optional_bool
+            no_send_change_count = r.read_signed_varint
+            opts[:no_send_change] = if no_send_change_count == -1
+                                      nil
+                                    else
+                                      no_send_change_count.times.map { read_outpoint_str(r) }
+                                    end
+            send_with_count = r.read_signed_varint
+            opts[:send_with] = if send_with_count == -1
+                                 nil
+                               else
+                                 send_with_count.times.map { r.read_bytes(32).unpack1('H*') }
+                               end
+            opts[:randomize_outputs] = r.read_optional_bool
+            args[:options] = opts
+          else
+            args[:options] = nil
+          end
+
+          args
+        end
+
+        def write_create_action_result(w, result)
+          txid = result[:txid]
+          if txid && !txid.empty?
+            w.write_int8(1)
+            w.write_bytes([txid].pack('H*'))
+          else
+            w.write_int8(0)
+          end
+
+          tx = result[:tx]
+          if tx
+            w.write_int8(1)
+            tx_bytes = tx.is_a?(Array) ? tx.pack('C*') : tx
+            w.write_varint(tx_bytes.bytesize)
+            w.write_bytes(tx_bytes)
+          else
+            w.write_int8(0)
+          end
+
+          no_send_change = result[:no_send_change]
+          if no_send_change
+            w.write_varint(no_send_change.length)
+            no_send_change.each { |op| write_outpoint_str(w, op) }
+          else
+            w.write_signed_varint(-1)
+          end
+
+          send_with_results = result[:send_with_results]
+          if send_with_results
+            w.write_varint(send_with_results.length)
+            send_with_results.each do |swr|
+              w.write_bytes([swr[:txid]].pack('H*'))
+              status_code = { 'unproven' => 1, 'sending' => 2, 'failed' => 3 }[swr[:status]] || 1
+              w.write_int8(status_code)
+            end
+          else
+            w.write_signed_varint(-1)
+          end
+
+          signable = result[:signable_transaction]
+          if signable
+            w.write_int8(1)
+            tx_bytes = signable[:tx].is_a?(Array) ? signable[:tx].pack('C*') : signable[:tx]
+            w.write_varint(tx_bytes.bytesize)
+            w.write_bytes(tx_bytes)
+            require 'base64'
+            ref_bytes = Base64.strict_decode64(signable[:reference])
+            w.write_varint(ref_bytes.bytesize)
+            w.write_bytes(ref_bytes)
+          else
+            w.write_int8(0)
+          end
+        end
+
+        def read_create_action_result(r)
+          result = {}
+          txid_flag = r.read_int8
+          result[:txid] = txid_flag == 1 ? r.read_bytes(32).unpack1('H*') : nil
+
+          tx_flag = r.read_int8
+          if tx_flag == 1
+            tx_len = r.read_varint
+            result[:tx] = r.read_bytes(tx_len).bytes
+          else
+            result[:tx] = nil
+          end
+
+          no_send_change_count = r.read_signed_varint
+          result[:no_send_change] = if no_send_change_count == -1
+                                      nil
+                                    else
+                                      no_send_change_count.times.map { read_outpoint_str(r) }
+                                    end
+
+          swr_count = r.read_signed_varint
+          result[:send_with_results] = if swr_count == -1
+                                         nil
+                                       else
+                                         swr_count.times.map do
+                                           txid = r.read_bytes(32).unpack1('H*')
+                                           status = { 1 => 'unproven', 2 => 'sending', 3 => 'failed' }[r.read_int8] || 'failed'
+                                           { txid: txid, status: status }
+                                         end
+                                       end
+
+          signable_flag = r.read_int8
+          if signable_flag == 1
+            tx_len = r.read_varint
+            tx = r.read_bytes(tx_len).bytes
+            ref_len = r.read_varint
+            ref = encode_base64(r.read_bytes(ref_len))
+            result[:signable_transaction] = { tx: tx, reference: ref }
+          else
+            result[:signable_transaction] = nil
+          end
+
+          result
+        end
+
+        # -----------------------------------------------------------------------
+        # 2. signAction
+        # -----------------------------------------------------------------------
+
+        def write_sign_action_params(w, args)
+          spends = args[:spends] || {}
+          w.write_varint(spends.length)
+          spends.each do |idx, spend|
+            w.write_varint(idx.to_i)
+            script_bytes = [spend[:unlocking_script].to_s].pack('H*')
+            w.write_varint(script_bytes.bytesize)
+            w.write_bytes(script_bytes)
+            if spend[:sequence_number]
+              w.write_varint(spend[:sequence_number])
+            else
+              w.write_signed_varint(-1)
+            end
+          end
+
+          require 'base64'
+          ref_bytes = Base64.strict_decode64(args[:reference].to_s)
+          w.write_varint(ref_bytes.bytesize)
+          w.write_bytes(ref_bytes)
+
+          opts = args[:options]
+          if opts.nil?
+            w.write_int8(0)
+          else
+            w.write_int8(1)
+            w.write_optional_bool(opts[:accept_delayed_broadcast])
+            w.write_optional_bool(opts[:return_txid_only])
+            w.write_optional_bool(opts[:no_send])
+            send_with = opts[:send_with]
+            if send_with.nil?
+              w.write_signed_varint(-1)
+            else
+              w.write_varint(send_with.length)
+              send_with.each { |txid| w.write_bytes([txid].pack('H*')) }
+            end
+          end
+        end
+
+        def read_sign_action_params(r)
+          spends = {}
+          spend_count = r.read_varint
+          spend_count.times do
+            idx = r.read_varint
+            us_len = r.read_varint
+            us = r.read_bytes(us_len).unpack1('H*')
+            seq = r.read_signed_varint
+            spends[idx] = { unlocking_script: us, sequence_number: seq == -1 ? nil : seq }
+          end
+
+          ref_len = r.read_varint
+          reference = encode_base64(r.read_bytes(ref_len))
+
+          opts_flag = r.read_int8
+          options = if opts_flag == 1
+                      opts = {}
+                      opts[:accept_delayed_broadcast] = r.read_optional_bool
+                      opts[:return_txid_only] = r.read_optional_bool
+                      opts[:no_send] = r.read_optional_bool
+                      sw_count = r.read_signed_varint
+                      opts[:send_with] = if sw_count == -1
+                                           nil
+                                         else
+                                           sw_count.times.map { r.read_bytes(32).unpack1('H*') }
+                                         end
+                      opts
+                    end
+
+          { spends: spends, reference: reference, options: options }
+        end
+
+        def write_sign_action_result(w, result)
+          txid = result[:txid]
+          if txid && !txid.empty?
+            w.write_int8(1)
+            w.write_bytes([txid].pack('H*'))
+          else
+            w.write_int8(0)
+          end
+
+          tx = result[:tx]
+          if tx
+            w.write_int8(1)
+            tx_bytes = tx.is_a?(Array) ? tx.pack('C*') : tx
+            w.write_varint(tx_bytes.bytesize)
+            w.write_bytes(tx_bytes)
+          else
+            w.write_int8(0)
+          end
+
+          swr = result[:send_with_results]
+          if swr
+            w.write_varint(swr.length)
+            swr.each do |item|
+              w.write_bytes([item[:txid]].pack('H*'))
+              status_code = { 'unproven' => 1, 'sending' => 2, 'failed' => 3 }[item[:status]] || 1
+              w.write_int8(status_code)
+            end
+          else
+            w.write_signed_varint(-1)
+          end
+        end
+
+        def read_sign_action_result(r)
+          result = {}
+          txid_flag = r.read_int8
+          result[:txid] = txid_flag == 1 ? r.read_bytes(32).unpack1('H*') : nil
+
+          tx_flag = r.read_int8
+          if tx_flag == 1
+            tx_len = r.read_varint
+            result[:tx] = r.read_bytes(tx_len).bytes
+          else
+            result[:tx] = nil
+          end
+
+          swr_count = r.read_signed_varint
+          result[:send_with_results] = if swr_count == -1
+                                         nil
+                                       else
+                                         swr_count.times.map do
+                                           txid = r.read_bytes(32).unpack1('H*')
+                                           status = { 1 => 'unproven', 2 => 'sending', 3 => 'failed' }[r.read_int8] || 'failed'
+                                           { txid: txid, status: status }
+                                         end
+                                       end
+
+          result
+        end
+
+        # -----------------------------------------------------------------------
+        # 3. abortAction — reference is the entire params payload (no length prefix)
+        # -----------------------------------------------------------------------
+
+        def write_abort_action_params(w, args)
+          require 'base64'
+          ref_bytes = Base64.strict_decode64(args[:reference].to_s)
+          w.write_bytes(ref_bytes)
+        end
+
+        def read_abort_action_params(r)
+          ref_bytes = r.read_remaining
+          { reference: encode_base64(ref_bytes) }
+        end
+
+        def write_abort_action_result(w, _result)
+          # No payload — response is just the zero error byte written by serialize_response
+        end
+
+        def read_abort_action_result(_r)
+          { aborted: true }
+        end
+
+        # -----------------------------------------------------------------------
+        # 4. listActions
+        # -----------------------------------------------------------------------
+
+        LIST_ACTIONS_INCLUDE_FLAGS = %i[
+          include_labels include_inputs include_input_source_locking_scripts
+          include_input_unlocking_scripts include_outputs include_output_locking_scripts
+        ].freeze
+
+        def write_list_actions_params(w, args)
+          labels = args[:labels] || []
+          w.write_varint(labels.length)
+          labels.each { |l| w.write_utf8_string(l) }
+
+          lqm = args[:label_query_mode]
+          if lqm.nil?
+            w.write_int8(-1)
+          elsif lqm == 'any'
+            w.write_int8(1)
+          else
+            w.write_int8(2)
+          end
+
+          LIST_ACTIONS_INCLUDE_FLAGS.each do |flag|
+            w.write_optional_bool(args[flag])
+          end
+
+          w.write_signed_varint(args[:limit].nil? ? -1 : args[:limit])
+          w.write_signed_varint(args[:offset].nil? ? -1 : args[:offset])
+          w.write_optional_bool(args[:seek_permission])
+        end
+
+        def read_list_actions_params(r)
+          args = {}
+          label_count = r.read_varint
+          args[:labels] = label_count.times.map { r.read_utf8_string }
+
+          lqm_flag = r.read_int8
+          args[:label_query_mode] = case lqm_flag
+                                    when 1 then 'any'
+                                    when 2 then 'all'
+                                    end
+
+          LIST_ACTIONS_INCLUDE_FLAGS.each do |flag|
+            args[flag] = r.read_optional_bool
+          end
+
+          limit = r.read_signed_varint
+          args[:limit] = limit == -1 ? nil : limit
+          offset = r.read_signed_varint
+          args[:offset] = offset == -1 ? nil : offset
+          args[:seek_permission] = r.read_optional_bool
+          args
+        end
+
+        def write_list_actions_result(w, result)
+          actions = result[:actions] || []
+          w.write_varint(result[:total_actions] || actions.length)
+          actions.each do |action|
+            w.write_bytes([action[:txid]].pack('H*'))
+            w.write_varint(action[:satoshis].to_i)
+            status_code = {
+              'completed' => 1, 'unprocessed' => 2, 'sending' => 3,
+              'unproven' => 4, 'unsigned' => 5, 'nosend' => 6,
+              'nonfinal' => 7, 'failed' => 8
+            }[action[:status]] || -1
+            w.write_int8(status_code)
+            w.write_int8(action[:is_outgoing] ? 1 : 0)
+            w.write_utf8_string(action[:description].to_s)
+            w.write_string_array(action[:labels])
+            w.write_varint(action[:version].to_i)
+            w.write_varint(action[:lock_time].to_i)
+
+            inputs = action[:inputs]
+            if inputs.nil?
+              w.write_signed_varint(-1)
+            else
+              w.write_varint(inputs.length)
+              inputs.each do |inp|
+                write_outpoint_str(w, inp[:source_outpoint])
+                w.write_varint(inp[:source_satoshis].to_i)
+                w.write_optional_byte_array(inp[:source_locking_script] ? [inp[:source_locking_script]].pack('H*') : nil)
+                w.write_optional_byte_array(inp[:unlocking_script] ? [inp[:unlocking_script]].pack('H*') : nil)
+                w.write_utf8_string(inp[:input_description].to_s)
+                w.write_varint(inp[:sequence_number].to_i)
+              end
+            end
+
+            outputs = action[:outputs]
+            if outputs.nil?
+              w.write_signed_varint(-1)
+            else
+              w.write_varint(outputs.length)
+              outputs.each do |out|
+                w.write_varint(out[:output_index].to_i)
+                w.write_varint(out[:satoshis].to_i)
+                w.write_optional_byte_array(out[:locking_script] ? [out[:locking_script]].pack('H*') : nil)
+                w.write_int8(out[:spendable] ? 1 : 0)
+                w.write_utf8_string(out[:output_description].to_s)
+                w.write_optional_utf8_string(out[:basket])
+                w.write_string_array(out[:tags])
+                w.write_optional_utf8_string(out[:custom_instructions])
+              end
+            end
+          end
+        end
+
+        def read_list_actions_result(r)
+          total = r.read_varint
+          actions = total.times.map do
+            action = {}
+            action[:txid] = r.read_bytes(32).unpack1('H*')
+            action[:satoshis] = r.read_varint
+            action[:status] = {
+              1 => 'completed', 2 => 'unprocessed', 3 => 'sending',
+              4 => 'unproven', 5 => 'unsigned', 6 => 'nosend',
+              7 => 'nonfinal', 8 => 'failed'
+            }[r.read_int8]
+            action[:is_outgoing] = r.read_int8 == 1
+            action[:description] = r.read_utf8_string
+            action[:labels] = r.read_string_array
+            action[:version] = r.read_varint
+            action[:lock_time] = r.read_varint
+
+            inputs_count = r.read_signed_varint
+            action[:inputs] = if inputs_count == -1
+                                nil
+                              else
+                                inputs_count.times.map do
+                                  inp = {}
+                                  inp[:source_outpoint] = read_outpoint_str(r)
+                                  inp[:source_satoshis] = r.read_varint
+                                  sls = r.read_optional_byte_array
+                                  inp[:source_locking_script] = sls&.unpack1('H*')
+                                  us = r.read_optional_byte_array
+                                  inp[:unlocking_script] = us&.unpack1('H*')
+                                  inp[:input_description] = r.read_utf8_string
+                                  inp[:sequence_number] = r.read_varint
+                                  inp
+                                end
+                              end
+
+            outputs_count = r.read_signed_varint
+            action[:outputs] = if outputs_count == -1
+                                 nil
+                               else
+                                 outputs_count.times.map do
+                                   out = {}
+                                   out[:output_index] = r.read_varint
+                                   out[:satoshis] = r.read_varint
+                                   ls = r.read_optional_byte_array
+                                   out[:locking_script] = ls&.unpack1('H*')
+                                   out[:spendable] = r.read_int8 == 1
+                                   out[:output_description] = r.read_utf8_string
+                                   out[:basket] = r.read_optional_utf8_string
+                                   out[:tags] = r.read_string_array
+                                   out[:custom_instructions] = r.read_optional_utf8_string
+                                   out
+                                 end
+                               end
+
+            action
+          end
+
+          { total_actions: total, actions: actions }
+        end
+
+        # -----------------------------------------------------------------------
+        # 5. internalizeAction
+        # -----------------------------------------------------------------------
+
+        def write_internalize_action_params(w, args)
+          tx = args[:tx]
+          tx_bytes = tx.is_a?(Array) ? tx.pack('C*') : tx.to_s.b
+          w.write_varint(tx_bytes.bytesize)
+          w.write_bytes(tx_bytes)
+
+          outputs = args[:outputs] || []
+          w.write_varint(outputs.length)
+          outputs.each do |out|
+            w.write_varint(out[:output_index].to_i)
+            if out[:protocol] == 'wallet payment'
+              w.write_byte(1)
+              rem = out[:payment_remittance] || {}
+              w.write_bytes([rem[:sender_identity_key].to_s].pack('H*'))
+              require 'base64'
+              pref = Base64.strict_decode64(rem[:derivation_prefix].to_s)
+              w.write_varint(pref.bytesize)
+              w.write_bytes(pref)
+              suf = Base64.strict_decode64(rem[:derivation_suffix].to_s)
+              w.write_varint(suf.bytesize)
+              w.write_bytes(suf)
+            else
+              w.write_byte(2)
+              rem = out[:insertion_remittance] || {}
+              w.write_utf8_string(rem[:basket].to_s)
+              w.write_optional_utf8_string(rem[:custom_instructions])
+              tags = rem[:tags] || []
+              w.write_varint(tags.length)
+              tags.each { |t| w.write_utf8_string(t) }
+            end
+          end
+
+          w.write_string_array(args[:labels])
+          w.write_utf8_string(args[:description].to_s)
+          w.write_optional_bool(args[:seek_permission])
+        end
+
+        def read_internalize_action_params(r)
+          args = {}
+          tx_len = r.read_varint
+          args[:tx] = r.read_bytes(tx_len).bytes
+
+          outputs_count = r.read_varint
+          args[:outputs] = outputs_count.times.map do
+            out = {}
+            out[:output_index] = r.read_varint
+            proto_flag = r.read_byte
+            if proto_flag == 1
+              out[:protocol] = 'wallet payment'
+              rem = {}
+              rem[:sender_identity_key] = r.read_bytes(33).unpack1('H*')
+              pref_len = r.read_varint
+              rem[:derivation_prefix] = encode_base64(r.read_bytes(pref_len))
+              suf_len = r.read_varint
+              rem[:derivation_suffix] = encode_base64(r.read_bytes(suf_len))
+              out[:payment_remittance] = rem
+            else
+              out[:protocol] = 'basket insertion'
+              rem = {}
+              rem[:basket] = r.read_utf8_string
+              rem[:custom_instructions] = r.read_optional_utf8_string
+              tags_count = r.read_varint
+              rem[:tags] = tags_count.times.map { r.read_utf8_string }
+              out[:insertion_remittance] = rem
+            end
+            out
+          end
+
+          args[:labels] = r.read_string_array
+          args[:description] = r.read_utf8_string
+          args[:seek_permission] = r.read_optional_bool
+          args
+        end
+
+        def write_internalize_action_result(w, _result)
+          # No payload
+        end
+
+        def read_internalize_action_result(_r)
+          { accepted: true }
+        end
+
+        # -----------------------------------------------------------------------
+        # 6. listOutputs
+        # -----------------------------------------------------------------------
+
+        def write_list_outputs_params(w, args)
+          w.write_utf8_string(args[:basket].to_s)
+
+          tags = args[:tags]
+          if tags.nil? || tags.empty?
+            w.write_varint(0)
+          else
+            w.write_varint(tags.length)
+            tags.each { |t| w.write_utf8_string(t) }
+          end
+
+          tqm = args[:tag_query_mode]
+          if tqm == 'all'
+            w.write_int8(1)
+          elsif tqm == 'any'
+            w.write_int8(2)
+          else
+            w.write_int8(-1)
+          end
+
+          inc = args[:include]
+          if inc == 'locking scripts'
+            w.write_int8(1)
+          elsif inc == 'entire transactions'
+            w.write_int8(2)
+          else
+            w.write_int8(-1)
+          end
+
+          w.write_optional_bool(args[:include_custom_instructions])
+          w.write_optional_bool(args[:include_tags])
+          w.write_optional_bool(args[:include_labels])
+          w.write_signed_varint(args[:limit].nil? ? -1 : args[:limit])
+          w.write_signed_varint(args[:offset].nil? ? -1 : args[:offset])
+          w.write_optional_bool(args[:seek_permission])
+        end
+
+        def read_list_outputs_params(r)
+          args = {}
+          args[:basket] = r.read_utf8_string
+
+          tags_count = r.read_varint
+          args[:tags] = tags_count.zero? ? nil : tags_count.times.map { r.read_utf8_string }
+
+          tqm_flag = r.read_int8
+          args[:tag_query_mode] = case tqm_flag
+                                  when 1 then 'all'
+                                  when 2 then 'any'
+                                  end
+
+          inc_flag = r.read_int8
+          args[:include] = case inc_flag
+                           when 1 then 'locking scripts'
+                           when 2 then 'entire transactions'
+                           end
+
+          args[:include_custom_instructions] = r.read_optional_bool
+          args[:include_tags] = r.read_optional_bool
+          args[:include_labels] = r.read_optional_bool
+
+          limit = r.read_signed_varint
+          args[:limit] = limit == -1 ? nil : limit
+          offset = r.read_signed_varint
+          args[:offset] = offset == -1 ? nil : offset
+          args[:seek_permission] = r.read_optional_bool
+          args
+        end
+
+        def write_list_outputs_result(w, result)
+          outputs = result[:outputs] || []
+          w.write_varint(result[:total_outputs] || outputs.length)
+
+          beef = result[:beef]
+          if beef
+            beef_bytes = beef.is_a?(Array) ? beef.pack('C*') : beef
+            w.write_varint(beef_bytes.bytesize)
+            w.write_bytes(beef_bytes)
+          else
+            w.write_signed_varint(-1)
+          end
+
+          outputs.each do |out|
+            write_outpoint_str(w, out[:outpoint])
+            w.write_varint(out[:satoshis].to_i)
+            w.write_optional_byte_array(out[:locking_script] ? [out[:locking_script]].pack('H*') : nil)
+            w.write_optional_utf8_string(out[:custom_instructions])
+            w.write_string_array(out[:tags])
+            w.write_string_array(out[:labels])
+          end
+        end
+
+        def read_list_outputs_result(r)
+          total = r.read_varint
+          beef_raw = r.read_optional_byte_array
+          beef = beef_raw&.bytes
+
+          outputs = total.times.map do
+            out = {}
+            out[:outpoint] = read_outpoint_str(r)
+            out[:satoshis] = r.read_varint
+            ls = r.read_optional_byte_array
+            out[:locking_script] = ls&.unpack1('H*')
+            out[:custom_instructions] = r.read_optional_utf8_string
+            out[:tags] = r.read_string_array
+            out[:labels] = r.read_string_array
+            out
+          end
+
+          { total_outputs: total, beef: beef, outputs: outputs }
+        end
+
+        # -----------------------------------------------------------------------
+        # 7. relinquishOutput
+        # -----------------------------------------------------------------------
+
+        def write_relinquish_output_params(w, args)
+          w.write_utf8_string(args[:basket].to_s)
+          write_outpoint_str(w, args[:output].to_s)
+        end
+
+        def read_relinquish_output_params(r)
+          { basket: r.read_utf8_string, output: read_outpoint_str(r) }
+        end
+
+        def write_relinquish_output_result(w, _result); end
+
+        def read_relinquish_output_result(_r)
+          { relinquished: true }
+        end
+
+        # -----------------------------------------------------------------------
+        # 8. getPublicKey
+        # -----------------------------------------------------------------------
+
+        def write_get_public_key_params(w, args)
+          identity = args[:identity_key] ? 1 : 0
+          w.write_byte(identity)
+
+          if identity == 1
+            w.write_privileged(args[:privileged], args[:privileged_reason])
+          else
+            w.write_protocol_id(args[:protocol_id])
+            w.write_utf8_string(args[:key_id].to_s)
+            w.write_counterparty(args[:counterparty])
+            w.write_privileged(args[:privileged], args[:privileged_reason])
+            w.write_optional_bool(args[:for_self])
+          end
+
+          w.write_optional_bool(args[:seek_permission])
+        end
+
+        def read_get_public_key_params(r)
+          args = {}
+          identity_flag = r.read_byte
+          args[:identity_key] = identity_flag == 1
+
+          if args[:identity_key]
+            args[:privileged], args[:privileged_reason] = r.read_privileged
+          else
+            args[:protocol_id] = r.read_protocol_id
+            args[:key_id] = r.read_utf8_string
+            args[:counterparty] = r.read_counterparty
+            args[:privileged], args[:privileged_reason] = r.read_privileged
+            args[:for_self] = r.read_optional_bool
+          end
+
+          args[:seek_permission] = r.read_optional_bool
+          args
+        end
+
+        def write_get_public_key_result(w, result)
+          w.write_bytes([result[:public_key].to_s].pack('H*'))
+        end
+
+        def read_get_public_key_result(r)
+          { public_key: r.read_remaining.unpack1('H*') }
+        end
+
+        # -----------------------------------------------------------------------
+        # 9. revealCounterpartyKeyLinkage
+        # -----------------------------------------------------------------------
+
+        def write_reveal_counterparty_key_linkage_params(w, args)
+          w.write_privileged(args[:privileged], args[:privileged_reason])
+          w.write_bytes([args[:counterparty].to_s].pack('H*'))
+          w.write_bytes([args[:verifier].to_s].pack('H*'))
+        end
+
+        def read_reveal_counterparty_key_linkage_params(r)
+          privileged, privileged_reason = r.read_privileged
+          counterparty = r.read_bytes(33).unpack1('H*')
+          verifier = r.read_bytes(33).unpack1('H*')
+          { privileged: privileged, privileged_reason: privileged_reason,
+            counterparty: counterparty, verifier: verifier }
+        end
+
+        def write_reveal_counterparty_key_linkage_result(w, result)
+          w.write_bytes([result[:prover].to_s].pack('H*'))
+          w.write_bytes([result[:verifier].to_s].pack('H*'))
+          w.write_bytes([result[:counterparty].to_s].pack('H*'))
+          w.write_utf8_string(result[:revelation_time].to_s)
+          enc_link = result[:encrypted_linkage]
+          enc_link = enc_link.is_a?(Array) ? enc_link.pack('C*') : enc_link.to_s.b
+          w.write_varint(enc_link.bytesize)
+          w.write_bytes(enc_link)
+          enc_proof = result[:encrypted_linkage_proof]
+          enc_proof = enc_proof.is_a?(Array) ? enc_proof.pack('C*') : enc_proof.to_s.b
+          w.write_varint(enc_proof.bytesize)
+          w.write_bytes(enc_proof)
+        end
+
+        def read_reveal_counterparty_key_linkage_result(r)
+          prover = r.read_bytes(33).unpack1('H*')
+          verifier = r.read_bytes(33).unpack1('H*')
+          counterparty = r.read_bytes(33).unpack1('H*')
+          revelation_time = r.read_utf8_string
+          el_len = r.read_varint
+          encrypted_linkage = r.read_bytes(el_len).bytes
+          ep_len = r.read_varint
+          encrypted_linkage_proof = r.read_bytes(ep_len).bytes
+          { prover: prover, verifier: verifier, counterparty: counterparty,
+            revelation_time: revelation_time, encrypted_linkage: encrypted_linkage,
+            encrypted_linkage_proof: encrypted_linkage_proof }
+        end
+
+        # -----------------------------------------------------------------------
+        # 10. revealSpecificKeyLinkage
+        # -----------------------------------------------------------------------
+
+        def write_reveal_specific_key_linkage_params(w, args)
+          write_key_related_params(w, args)
+          w.write_bytes([args[:verifier].to_s].pack('H*'))
+        end
+
+        def read_reveal_specific_key_linkage_params(r)
+          args = read_key_related_from_reader(r)
+          args[:verifier] = r.read_bytes(33).unpack1('H*')
+          args
+        end
+
+        def write_reveal_specific_key_linkage_result(w, result)
+          w.write_bytes([result[:prover].to_s].pack('H*'))
+          w.write_bytes([result[:verifier].to_s].pack('H*'))
+          w.write_bytes([result[:counterparty].to_s].pack('H*'))
+          w.write_byte(result[:protocol_id][0].to_i)
+          w.write_utf8_string(result[:protocol_id][1].to_s)
+          w.write_utf8_string(result[:key_id].to_s)
+          el = result[:encrypted_linkage]
+          el = el.is_a?(Array) ? el.pack('C*') : el.to_s.b
+          w.write_varint(el.bytesize)
+          w.write_bytes(el)
+          ep = result[:encrypted_linkage_proof]
+          ep = ep.is_a?(Array) ? ep.pack('C*') : ep.to_s.b
+          w.write_varint(ep.bytesize)
+          w.write_bytes(ep)
+          w.write_byte(result[:proof_type].to_i)
+        end
+
+        def read_reveal_specific_key_linkage_result(r)
+          prover = r.read_bytes(33).unpack1('H*')
+          verifier = r.read_bytes(33).unpack1('H*')
+          counterparty = r.read_bytes(33).unpack1('H*')
+          level = r.read_byte
+          protocol = r.read_utf8_string
+          key_id = r.read_utf8_string
+          el_len = r.read_varint
+          encrypted_linkage = r.read_bytes(el_len).bytes
+          ep_len = r.read_varint
+          encrypted_linkage_proof = r.read_bytes(ep_len).bytes
+          proof_type = r.read_byte
+          { prover: prover, verifier: verifier, counterparty: counterparty,
+            protocol_id: [level, protocol], key_id: key_id,
+            encrypted_linkage: encrypted_linkage,
+            encrypted_linkage_proof: encrypted_linkage_proof,
+            proof_type: proof_type }
+        end
+
+        # -----------------------------------------------------------------------
+        # 11. encrypt
+        # -----------------------------------------------------------------------
+
+        def write_encrypt_params(w, args)
+          write_key_related_params(w, args)
+          pt = args[:plaintext]
+          pt_bytes = pt.is_a?(Array) ? pt.pack('C*') : pt.to_s.b
+          w.write_varint(pt_bytes.bytesize)
+          w.write_bytes(pt_bytes)
+          w.write_optional_bool(args[:seek_permission])
+        end
+
+        def read_encrypt_params(r)
+          args = read_key_related_from_reader(r)
+          pt_len = r.read_varint
+          args[:plaintext] = r.read_bytes(pt_len).bytes
+          args[:seek_permission] = r.read_optional_bool
+          args
+        end
+
+        def write_encrypt_result(w, result)
+          ct = result[:ciphertext]
+          ct_bytes = ct.is_a?(Array) ? ct.pack('C*') : ct.to_s.b
+          w.write_bytes(ct_bytes)
+        end
+
+        def read_encrypt_result(r)
+          { ciphertext: r.read_remaining.bytes }
+        end
+
+        # -----------------------------------------------------------------------
+        # 12. decrypt
+        # -----------------------------------------------------------------------
+
+        def write_decrypt_params(w, args)
+          write_key_related_params(w, args)
+          ct = args[:ciphertext]
+          ct_bytes = ct.is_a?(Array) ? ct.pack('C*') : ct.to_s.b
+          w.write_varint(ct_bytes.bytesize)
+          w.write_bytes(ct_bytes)
+          w.write_optional_bool(args[:seek_permission])
+        end
+
+        def read_decrypt_params(r)
+          args = read_key_related_from_reader(r)
+          ct_len = r.read_varint
+          args[:ciphertext] = r.read_bytes(ct_len).bytes
+          args[:seek_permission] = r.read_optional_bool
+          args
+        end
+
+        def write_decrypt_result(w, result)
+          pt = result[:plaintext]
+          pt_bytes = pt.is_a?(Array) ? pt.pack('C*') : pt.to_s.b
+          w.write_bytes(pt_bytes)
+        end
+
+        def read_decrypt_result(r)
+          { plaintext: r.read_remaining.bytes }
+        end
+
+        # -----------------------------------------------------------------------
+        # 13. createHmac
+        # -----------------------------------------------------------------------
+
+        def write_create_hmac_params(w, args)
+          write_key_related_params(w, args)
+          data = args[:data]
+          data_bytes = data.is_a?(Array) ? data.pack('C*') : data.to_s.b
+          w.write_varint(data_bytes.bytesize)
+          w.write_bytes(data_bytes)
+          w.write_optional_bool(args[:seek_permission])
+        end
+
+        def read_create_hmac_params(r)
+          args = read_key_related_from_reader(r)
+          data_len = r.read_varint
+          args[:data] = r.read_bytes(data_len).bytes
+          args[:seek_permission] = r.read_optional_bool
+          args
+        end
+
+        def write_create_hmac_result(w, result)
+          hmac = result[:hmac]
+          hmac_bytes = hmac.is_a?(Array) ? hmac.pack('C*') : hmac.to_s.b
+          w.write_bytes(hmac_bytes)
+        end
+
+        def read_create_hmac_result(r)
+          { hmac: r.read_remaining.bytes }
+        end
+
+        # -----------------------------------------------------------------------
+        # 14. verifyHmac
+        # -----------------------------------------------------------------------
+
+        def write_verify_hmac_params(w, args)
+          write_key_related_params(w, args)
+          hmac = args[:hmac]
+          hmac_bytes = hmac.is_a?(Array) ? hmac.pack('C*') : hmac.to_s.b
+          w.write_bytes(hmac_bytes) # fixed 32 bytes, no length prefix
+          data = args[:data]
+          data_bytes = data.is_a?(Array) ? data.pack('C*') : data.to_s.b
+          w.write_varint(data_bytes.bytesize)
+          w.write_bytes(data_bytes)
+          w.write_optional_bool(args[:seek_permission])
+        end
+
+        def read_verify_hmac_params(r)
+          args = read_key_related_from_reader(r)
+          args[:hmac] = r.read_bytes(32).bytes
+          data_len = r.read_varint
+          args[:data] = r.read_bytes(data_len).bytes
+          args[:seek_permission] = r.read_optional_bool
+          args
+        end
+
+        def write_verify_hmac_result(w, _result); end
+
+        def read_verify_hmac_result(_r)
+          { valid: true }
+        end
+
+        # -----------------------------------------------------------------------
+        # 15. createSignature
+        # -----------------------------------------------------------------------
+
+        def write_create_signature_params(w, args)
+          write_key_related_params(w, args)
+          if args[:data]
+            w.write_byte(1)
+            data = args[:data]
+            data_bytes = data.is_a?(Array) ? data.pack('C*') : data.to_s.b
+            w.write_varint(data_bytes.bytesize)
+            w.write_bytes(data_bytes)
+          elsif args[:hash_to_directly_sign]
+            w.write_byte(2)
+            hash = args[:hash_to_directly_sign]
+            hash_bytes = hash.is_a?(Array) ? hash.pack('C*') : hash.to_s.b
+            w.write_bytes(hash_bytes)
+          else
+            w.write_byte(0)
+          end
+          w.write_optional_bool(args[:seek_permission])
+        end
+
+        def read_create_signature_params(r)
+          args = read_key_related_from_reader(r)
+          data_type = r.read_byte
+          if data_type == 1
+            data_len = r.read_varint
+            args[:data] = r.read_bytes(data_len).bytes
+          elsif data_type == 2
+            args[:hash_to_directly_sign] = r.read_bytes(32).bytes
+          end
+          args[:seek_permission] = r.read_optional_bool
+          args
+        end
+
+        def write_create_signature_result(w, result)
+          sig = result[:signature]
+          sig_bytes = sig.is_a?(Array) ? sig.pack('C*') : sig.to_s.b
+          w.write_bytes(sig_bytes)
+        end
+
+        def read_create_signature_result(r)
+          { signature: r.read_remaining.bytes }
+        end
+
+        # -----------------------------------------------------------------------
+        # 16. verifySignature
+        # -----------------------------------------------------------------------
+
+        def write_verify_signature_params(w, args)
+          write_key_related_params(w, args)
+          w.write_optional_bool(args[:for_self])
+          sig = args[:signature]
+          sig_bytes = sig.is_a?(Array) ? sig.pack('C*') : sig.to_s.b
+          w.write_varint(sig_bytes.bytesize)
+          w.write_bytes(sig_bytes)
+          if args[:data]
+            w.write_byte(1)
+            data = args[:data]
+            data_bytes = data.is_a?(Array) ? data.pack('C*') : data.to_s.b
+            w.write_varint(data_bytes.bytesize)
+            w.write_bytes(data_bytes)
+          elsif args[:hash_to_directly_verify]
+            w.write_byte(2)
+            hash = args[:hash_to_directly_verify]
+            hash_bytes = hash.is_a?(Array) ? hash.pack('C*') : hash.to_s.b
+            w.write_bytes(hash_bytes)
+          else
+            w.write_byte(0)
+          end
+          w.write_optional_bool(args[:seek_permission])
+        end
+
+        def read_verify_signature_params(r)
+          args = read_key_related_from_reader(r)
+          args[:for_self] = r.read_optional_bool
+          sig_len = r.read_varint
+          args[:signature] = r.read_bytes(sig_len).bytes
+          data_type = r.read_byte
+          if data_type == 1
+            data_len = r.read_varint
+            args[:data] = r.read_bytes(data_len).bytes
+          elsif data_type == 2
+            args[:hash_to_directly_verify] = r.read_bytes(32).bytes
+          end
+          args[:seek_permission] = r.read_optional_bool
+          args
+        end
+
+        def write_verify_signature_result(w, _result); end
+
+        def read_verify_signature_result(_r)
+          { valid: true }
+        end
+
+        # -----------------------------------------------------------------------
+        # 17. acquireCertificate
+        # -----------------------------------------------------------------------
+
+        def write_acquire_certificate_params(w, args)
+          w.write_bytes(decode_base64_32(args[:type].to_s))
+          w.write_bytes([args[:certifier].to_s].pack('H*'))
+
+          fields = args[:fields] || {}
+          w.write_varint(fields.length)
+          fields.each do |k, v|
+            w.write_utf8_string(k.to_s)
+            w.write_utf8_string(v.to_s)
+          end
+
+          w.write_privileged(args[:privileged], args[:privileged_reason])
+
+          if args[:acquisition_protocol] == 'direct'
+            w.write_byte(1)
+            w.write_bytes(decode_base64_32(args[:serial_number].to_s))
+            write_outpoint_str(w, args[:revocation_outpoint].to_s)
+            sig_bytes = [args[:signature].to_s].pack('H*')
+            w.write_varint(sig_bytes.bytesize)
+            w.write_bytes(sig_bytes)
+
+            keyring_revealer = args[:keyring_revealer]
+            if keyring_revealer == 'certifier'
+              w.write_byte(11)
+            else
+              kr_bytes = [keyring_revealer.to_s].pack('H*')
+              w.write_bytes(kr_bytes)
+            end
+
+            keyring = args[:keyring_for_subject] || {}
+            w.write_varint(keyring.length)
+            keyring.each do |k, v|
+              w.write_utf8_string(k.to_s)
+              v_bytes = decode_base64_32_safe(v.to_s)
+              w.write_varint(v_bytes.bytesize)
+              w.write_bytes(v_bytes)
+            end
+          else
+            w.write_byte(2)
+            w.write_utf8_string(args[:certifier_url].to_s)
+          end
+        end
+
+        def read_acquire_certificate_params(r)
+          args = {}
+          args[:type] = encode_base64(r.read_bytes(32))
+          args[:certifier] = r.read_bytes(33).unpack1('H*')
+
+          fields_count = r.read_varint
+          args[:fields] = {}
+          fields_count.times do
+            k = r.read_utf8_string
+            args[:fields][k] = r.read_utf8_string
+          end
+
+          args[:privileged], args[:privileged_reason] = r.read_privileged
+
+          protocol_flag = r.read_byte
+          if protocol_flag == 1
+            args[:acquisition_protocol] = 'direct'
+            args[:serial_number] = encode_base64(r.read_bytes(32))
+            args[:revocation_outpoint] = read_outpoint_str(r)
+            sig_len = r.read_varint
+            args[:signature] = r.read_bytes(sig_len).unpack1('H*')
+            kr_flag = r.read_byte
+            if kr_flag == 11
+              args[:keyring_revealer] = 'certifier'
+            else
+              remaining = r.read_bytes(32)
+              args[:keyring_revealer] = ([kr_flag].pack('C') + remaining).unpack1('H*')
+            end
+            kr_count = r.read_varint
+            args[:keyring_for_subject] = {}
+            kr_count.times do
+              k = r.read_utf8_string
+              v_len = r.read_varint
+              args[:keyring_for_subject][k] = encode_base64(r.read_bytes(v_len))
+            end
+          else
+            args[:acquisition_protocol] = 'issuance'
+            args[:certifier_url] = r.read_utf8_string
+          end
+
+          args
+        end
+
+        def write_acquire_certificate_result(w, result)
+          write_certificate_fields(w, result)
+        end
+
+        def read_acquire_certificate_result(r)
+          read_cert_from_reader(r)
+        end
+
+        # -----------------------------------------------------------------------
+        # 18. listCertificates
+        # -----------------------------------------------------------------------
+
+        def write_list_certificates_params(w, args)
+          certifiers = args[:certifiers] || []
+          w.write_varint(certifiers.length)
+          certifiers.each { |c| w.write_bytes([c].pack('H*')) }
+
+          types = args[:types] || []
+          w.write_varint(types.length)
+          types.each { |t| w.write_bytes(decode_base64_32(t)) }
+
+          w.write_signed_varint(args[:limit].nil? ? -1 : args[:limit])
+          w.write_signed_varint(args[:offset].nil? ? -1 : args[:offset])
+          w.write_privileged(args[:privileged], args[:privileged_reason])
+        end
+
+        def read_list_certificates_params(r)
+          args = {}
+          cert_count = r.read_varint
+          args[:certifiers] = cert_count.times.map { r.read_bytes(33).unpack1('H*') }
+
+          types_count = r.read_varint
+          args[:types] = types_count.times.map { encode_base64(r.read_bytes(32)) }
+
+          limit = r.read_signed_varint
+          args[:limit] = limit == -1 ? nil : limit
+          offset = r.read_signed_varint
+          args[:offset] = offset == -1 ? nil : offset
+          args[:privileged], args[:privileged_reason] = r.read_privileged
+          args
+        end
+
+        def write_list_certificates_result(w, result)
+          certs = result[:certificates] || []
+          w.write_varint(result[:total_certificates] || certs.length)
+          certs.each do |cert|
+            cert_w = Writer.new
+            write_certificate_fields(cert_w, cert)
+            cert_bin = cert_w.to_binary
+            w.write_varint(cert_bin.bytesize)
+            w.write_bytes(cert_bin)
+
+            keyring = cert[:keyring]
+            if keyring && !keyring.empty?
+              w.write_int8(1)
+              w.write_varint(keyring.length)
+              keyring.each do |k, v|
+                w.write_utf8_string(k.to_s)
+                v_bytes = decode_base64_32_safe(v.to_s)
+                w.write_varint(v_bytes.bytesize)
+                w.write_bytes(v_bytes)
+              end
+            else
+              w.write_int8(0)
+            end
+
+            verifier_hex = cert[:verifier].to_s
+            verifier_bytes = verifier_hex.empty? ? ''.b : [verifier_hex].pack('H*')
+            w.write_varint(verifier_bytes.bytesize)
+            w.write_bytes(verifier_bytes)
+          end
+        end
+
+        def read_list_certificates_result(r)
+          total = r.read_varint
+          certs = total.times.map do
+            cert_len = r.read_varint
+            cert_r = Reader.new(r.read_bytes(cert_len))
+            cert = read_cert_from_reader(cert_r)
+
+            keyring_flag = r.read_int8
+            if keyring_flag == 1
+              kr_count = r.read_varint
+              keyring = {}
+              kr_count.times do
+                k = r.read_utf8_string
+                v_len = r.read_varint
+                keyring[k] = encode_base64(r.read_bytes(v_len))
+              end
+              cert[:keyring] = keyring
+            else
+              cert[:keyring] = {}
+            end
+
+            ver_len = r.read_varint
+            cert[:verifier] = ver_len.zero? ? nil : r.read_bytes(ver_len).unpack1('H*')
+            cert
+          end
+          { total_certificates: total, certificates: certs }
+        end
+
+        # -----------------------------------------------------------------------
+        # 19. proveCertificate
+        # -----------------------------------------------------------------------
+
+        def write_prove_certificate_params(w, args)
+          cert = args[:certificate] || {}
+          write_certificate_fields(w, cert)
+
+          fields_to_reveal = args[:fields_to_reveal] || []
+          w.write_varint(fields_to_reveal.length)
+          fields_to_reveal.each { |f| w.write_utf8_string(f) }
+
+          w.write_bytes([args[:verifier].to_s].pack('H*'))
+          w.write_privileged(args[:privileged], args[:privileged_reason])
+        end
+
+        def read_prove_certificate_params(r)
+          cert = read_cert_from_reader(r)
+
+          ftr_count = r.read_varint
+          fields_to_reveal = ftr_count.times.map { r.read_utf8_string }
+
+          verifier = r.read_bytes(33).unpack1('H*')
+          privileged, privileged_reason = r.read_privileged
+
+          { certificate: cert, fields_to_reveal: fields_to_reveal,
+            verifier: verifier, privileged: privileged, privileged_reason: privileged_reason }
+        end
+
+        def write_prove_certificate_result(w, result)
+          keyring = result[:keyring_for_verifier] || {}
+          w.write_varint(keyring.length)
+          keyring.each do |k, v|
+            w.write_utf8_string(k.to_s)
+            v_bytes = decode_base64_32_safe(v.to_s)
+            w.write_varint(v_bytes.bytesize)
+            w.write_bytes(v_bytes)
+          end
+        end
+
+        def read_prove_certificate_result(r)
+          kr_count = r.read_varint
+          keyring = {}
+          kr_count.times do
+            k = r.read_utf8_string
+            v_len = r.read_varint
+            keyring[k] = encode_base64(r.read_bytes(v_len))
+          end
+          { keyring_for_verifier: keyring }
+        end
+
+        # -----------------------------------------------------------------------
+        # 20. relinquishCertificate
+        # -----------------------------------------------------------------------
+
+        def write_relinquish_certificate_params(w, args)
+          w.write_bytes(decode_base64_32(args[:type].to_s))
+          w.write_bytes(decode_base64_32(args[:serial_number].to_s))
+          w.write_bytes([args[:certifier].to_s].pack('H*'))
+        end
+
+        def read_relinquish_certificate_params(r)
+          type = encode_base64(r.read_bytes(32))
+          serial_number = encode_base64(r.read_bytes(32))
+          certifier = r.read_bytes(33).unpack1('H*')
+          { type: type, serial_number: serial_number, certifier: certifier }
+        end
+
+        def write_relinquish_certificate_result(w, _result); end
+
+        def read_relinquish_certificate_result(_r)
+          { relinquished: true }
+        end
+
+        # -----------------------------------------------------------------------
+        # 21. discoverByIdentityKey
+        # -----------------------------------------------------------------------
+
+        def write_discover_by_identity_key_params(w, args)
+          w.write_bytes([args[:identity_key].to_s].pack('H*'))
+          w.write_signed_varint(args[:limit].nil? ? -1 : args[:limit])
+          w.write_signed_varint(args[:offset].nil? ? -1 : args[:offset])
+          w.write_optional_bool(args[:seek_permission])
+        end
+
+        def read_discover_by_identity_key_params(r)
+          identity_key = r.read_bytes(33).unpack1('H*')
+          limit = r.read_signed_varint
+          offset = r.read_signed_varint
+          seek_permission = r.read_optional_bool
+          { identity_key: identity_key,
+            limit: limit == -1 ? nil : limit,
+            offset: offset == -1 ? nil : offset,
+            seek_permission: seek_permission }
+        end
+
+        def write_discover_by_identity_key_result(w, result)
+          write_discovery_result(w, result)
+        end
+
+        def read_discover_by_identity_key_result(r)
+          read_discovery_result(r)
+        end
+
+        # -----------------------------------------------------------------------
+        # 22. discoverByAttributes
+        # -----------------------------------------------------------------------
+
+        def write_discover_by_attributes_params(w, args)
+          attributes = args[:attributes] || {}
+          w.write_varint(attributes.length)
+          attributes.each do |k, v|
+            w.write_utf8_string(k.to_s)
+            w.write_utf8_string(v.to_s)
+          end
+          w.write_signed_varint(args[:limit].nil? ? -1 : args[:limit])
+          w.write_signed_varint(args[:offset].nil? ? -1 : args[:offset])
+          w.write_optional_bool(args[:seek_permission])
+        end
+
+        def read_discover_by_attributes_params(r)
+          attr_count = r.read_varint
+          attributes = {}
+          attr_count.times do
+            k = r.read_utf8_string
+            attributes[k] = r.read_utf8_string
+          end
+          limit = r.read_signed_varint
+          offset = r.read_signed_varint
+          seek_permission = r.read_optional_bool
+          { attributes: attributes,
+            limit: limit == -1 ? nil : limit,
+            offset: offset == -1 ? nil : offset,
+            seek_permission: seek_permission }
+        end
+
+        def write_discover_by_attributes_result(w, result)
+          write_discovery_result(w, result)
+        end
+
+        def read_discover_by_attributes_result(r)
+          read_discovery_result(r)
+        end
+
+        # -----------------------------------------------------------------------
+        # 23. isAuthenticated  (no params)
+        # -----------------------------------------------------------------------
+
+        def write_is_authenticated_params(w, _args); end
+
+        def read_is_authenticated_params(_r)
+          {}
+        end
+
+        def write_is_authenticated_result(w, result)
+          w.write_byte(result[:authenticated] ? 1 : 0)
+        end
+
+        def read_is_authenticated_result(r)
+          { authenticated: r.read_byte == 1 }
+        end
+
+        # -----------------------------------------------------------------------
+        # 24. waitForAuthentication  (no params)
+        # -----------------------------------------------------------------------
+
+        def write_wait_for_authentication_params(w, _args); end
+
+        def read_wait_for_authentication_params(_r)
+          {}
+        end
+
+        def write_wait_for_authentication_result(w, _result); end
+
+        def read_wait_for_authentication_result(_r)
+          { authenticated: true }
+        end
+
+        # -----------------------------------------------------------------------
+        # 25. getHeight  (no params)
+        # -----------------------------------------------------------------------
+
+        def write_get_height_params(w, _args); end
+
+        def read_get_height_params(_r)
+          {}
+        end
+
+        def write_get_height_result(w, result)
+          w.write_varint(result[:height].to_i)
+        end
+
+        def read_get_height_result(r)
+          { height: r.read_varint }
+        end
+
+        # -----------------------------------------------------------------------
+        # 26. getHeaderForHeight
+        # -----------------------------------------------------------------------
+
+        def write_get_header_for_height_params(w, args)
+          w.write_varint(args[:height].to_i)
+        end
+
+        def read_get_header_for_height_params(r)
+          { height: r.read_varint }
+        end
+
+        def write_get_header_for_height_result(w, result)
+          header_bytes = [result[:header].to_s].pack('H*')
+          w.write_bytes(header_bytes)
+        end
+
+        def read_get_header_for_height_result(r)
+          { header: r.read_remaining.unpack1('H*') }
+        end
+
+        # -----------------------------------------------------------------------
+        # 27. getNetwork  (no params)
+        # -----------------------------------------------------------------------
+
+        def write_get_network_params(w, _args); end
+
+        def read_get_network_params(_r)
+          {}
+        end
+
+        def write_get_network_result(w, result)
+          w.write_byte(result[:network] == 'mainnet' ? 0 : 1)
+        end
+
+        def read_get_network_result(r)
+          { network: r.read_byte.zero? ? 'mainnet' : 'testnet' }
+        end
+
+        # -----------------------------------------------------------------------
+        # 28. getVersion  (no params)
+        # -----------------------------------------------------------------------
+
+        def write_get_version_params(w, _args); end
+
+        def read_get_version_params(_r)
+          {}
+        end
+
+        def write_get_version_result(w, result)
+          version_bytes = result[:version].to_s.encode('UTF-8').b
+          w.write_bytes(version_bytes)
+        end
+
+        def read_get_version_result(r)
+          { version: r.read_remaining.force_encoding('UTF-8') }
+        end
+      end
+    end
+  end
+end

--- a/lib/bsv/wallet_interface/wire/writer.rb
+++ b/lib/bsv/wallet_interface/wire/writer.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+module BSV
+  module Wallet
+    module Wire
+      # Builds a binary byte string using BRC-100 wire protocol encoding conventions.
+      #
+      # All multi-byte integers use little-endian order unless stated otherwise.
+      # VarInts follow Bitcoin encoding; -1 is encoded as the 9-byte MaxUint64 sentinel.
+      class Writer
+        # Maximum byte length for a PrivilegedReason string (Int8 length field).
+        MAX_PRIVILEGED_REASON = 127
+
+        def initialize
+          @buf = ''.b
+        end
+
+        # Returns the accumulated binary data.
+        #
+        # @return [String] binary string (encoding: ASCII-8BIT)
+        def to_binary
+          @buf
+        end
+
+        # Appends a single unsigned byte (0–255).
+        #
+        # @param val [Integer]
+        def write_byte(val)
+          @buf << [val & 0xFF].pack('C')
+        end
+
+        # Appends a signed 8-bit integer (-128–127).
+        # Negative values are encoded as their two's-complement byte.
+        #
+        # @param val [Integer]
+        def write_int8(val)
+          @buf << [val].pack('c')
+        end
+
+        # Appends an unsigned Bitcoin VarInt.
+        #
+        # @param val [Integer] non-negative integer
+        def write_varint(val)
+          @buf << if val < 0xFD
+                    [val].pack('C')
+                  elsif val <= 0xFFFF
+                    [0xFD, val].pack('Cv')
+                  elsif val <= 0xFFFF_FFFF
+                    [0xFE, val].pack('CV')
+                  else
+                    [0xFF, val].pack('CQ<')
+                  end
+        end
+
+        # Appends a signed VarInt where -1 is encoded as MaxUint64 (9 bytes: FF * 9).
+        #
+        # @param val [Integer] non-negative integer, or -1 to signal absence
+        def write_signed_varint(val)
+          if val == -1
+            @buf << "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF".b
+          else
+            write_varint(val)
+          end
+        end
+
+        # Appends raw bytes with no length prefix.
+        #
+        # @param data [String] binary string
+        def write_bytes(data)
+          @buf << data.b
+        end
+
+        # Appends a VarInt-prefixed byte array.
+        #
+        # @param data [String] binary string
+        def write_byte_array(data)
+          write_varint(data.bytesize)
+          write_bytes(data)
+        end
+
+        # Appends a VarInt-prefixed byte array, or the -1 sentinel if nil.
+        #
+        # @param data_or_nil [String, nil]
+        def write_optional_byte_array(data_or_nil)
+          if data_or_nil.nil?
+            write_signed_varint(-1)
+          else
+            write_byte_array(data_or_nil)
+          end
+        end
+
+        # Appends a VarInt-prefixed UTF-8 string.
+        #
+        # @param str [String]
+        def write_utf8_string(str)
+          bytes = str.encode('UTF-8').b
+          write_varint(bytes.bytesize)
+          write_bytes(bytes)
+        end
+
+        # Appends a VarInt-prefixed UTF-8 string, or the -1 sentinel if nil.
+        #
+        # @param str_or_nil [String, nil]
+        def write_optional_utf8_string(str_or_nil)
+          if str_or_nil.nil?
+            write_signed_varint(-1)
+          else
+            write_utf8_string(str_or_nil)
+          end
+        end
+
+        # Appends an optional boolean as a signed Int8: 1=true, 0=false, -1=nil.
+        #
+        # @param val_or_nil [Boolean, nil]
+        def write_optional_bool(val_or_nil)
+          if val_or_nil.nil?
+            write_int8(-1)
+          elsif val_or_nil
+            write_int8(1)
+          else
+            write_int8(0)
+          end
+        end
+
+        # Appends an outpoint: 32 bytes (txid in display order) + VarInt index.
+        #
+        # @param txid_hex [String] 64-character hex txid
+        # @param index [Integer] output index
+        def write_outpoint(txid_hex, index)
+          write_bytes([txid_hex].pack('H*'))
+          write_varint(index)
+        end
+
+        # Appends a counterparty value using the first-byte dispatch scheme.
+        #
+        # Encoding:
+        #   'self'   → 0x0B (11)
+        #   'anyone' → 0x0C (12)
+        #   nil      → 0x00 (0)
+        #   hex pubkey (33 bytes compressed) → 33 raw bytes
+        #
+        # @param val [String, nil] 'self', 'anyone', nil, or 66-char hex pubkey
+        def write_counterparty(val)
+          case val
+          when 'self'
+            write_byte(11)
+          when 'anyone'
+            write_byte(12)
+          when nil
+            write_byte(0)
+          else
+            write_bytes([val].pack('H*'))
+          end
+        end
+
+        # Appends a protocol ID: UInt8 security level + VarInt-prefixed UTF-8 name.
+        #
+        # @param protocol_id [Array] [Integer level, String name]
+        def write_protocol_id(protocol_id)
+          level, name = protocol_id
+          write_byte(level)
+          write_utf8_string(name)
+        end
+
+        # Appends an optional string array: VarInt count + strings, or -1 if nil.
+        #
+        # @param arr_or_nil [Array<String>, nil]
+        def write_string_array(arr_or_nil)
+          if arr_or_nil.nil?
+            write_signed_varint(-1)
+          else
+            write_varint(arr_or_nil.length)
+            arr_or_nil.each { |s| write_utf8_string(s) }
+          end
+        end
+
+        # Appends an optional string→string map: VarInt count + key/value pairs, or -1 if nil.
+        #
+        # @param hash_or_nil [Hash, nil]
+        def write_map(hash_or_nil)
+          if hash_or_nil.nil?
+            write_signed_varint(-1)
+          else
+            write_varint(hash_or_nil.length)
+            hash_or_nil.each do |key, value|
+              write_utf8_string(key.to_s)
+              write_utf8_string(value.to_s)
+            end
+          end
+        end
+
+        # Appends privileged parameters: optional bool + Int8-length reason string.
+        #
+        # PrivilegedReason uses Int8 for its length field (max 127 bytes), not VarInt.
+        # -1 (0xFF) means absent.
+        #
+        # @param privileged [Boolean, nil]
+        # @param privileged_reason [String, nil]
+        def write_privileged(privileged, privileged_reason)
+          write_optional_bool(privileged)
+          if privileged_reason.nil?
+            write_int8(-1)
+          else
+            reason_bytes = privileged_reason.encode('UTF-8').b
+            raise ArgumentError, 'privileged_reason exceeds 127 bytes' if reason_bytes.bytesize > MAX_PRIVILEGED_REASON
+
+            write_int8(reason_bytes.bytesize)
+            write_bytes(reason_bytes)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/bsv/wallet_interface/wire/primitives_spec.rb
+++ b/spec/bsv/wallet_interface/wire/primitives_spec.rb
@@ -1,0 +1,381 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+
+# Helper: write a value with Writer, read it back with Reader and return the result.
+def wire_roundtrip(write_method, read_method, *args)
+  w = BSV::Wallet::Wire::Writer.new
+  w.public_send(write_method, *args)
+  r = BSV::Wallet::Wire::Reader.new(w.to_binary)
+  r.public_send(read_method)
+end
+
+RSpec.describe 'BRC-100 wire protocol primitives' do
+  describe 'write_byte / read_byte' do
+    it 'round-trips 0' do
+      expect(wire_roundtrip(:write_byte, :read_byte, 0)).to eq(0)
+    end
+
+    it 'round-trips 255' do
+      expect(wire_roundtrip(:write_byte, :read_byte, 255)).to eq(255)
+    end
+
+    it 'round-trips 127' do
+      expect(wire_roundtrip(:write_byte, :read_byte, 127)).to eq(127)
+    end
+
+    it 'encodes a single byte (1 byte total)' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_byte(42)
+      expect(w.to_binary.bytesize).to eq(1)
+    end
+  end
+
+  describe 'write_int8 / read_int8' do
+    it 'round-trips 0' do
+      expect(wire_roundtrip(:write_int8, :read_int8, 0)).to eq(0)
+    end
+
+    it 'round-trips 127 (max positive)' do
+      expect(wire_roundtrip(:write_int8, :read_int8, 127)).to eq(127)
+    end
+
+    it 'round-trips -128 (min negative)' do
+      expect(wire_roundtrip(:write_int8, :read_int8, -128)).to eq(-128)
+    end
+
+    it 'round-trips -1' do
+      expect(wire_roundtrip(:write_int8, :read_int8, -1)).to eq(-1)
+    end
+
+    it 'encodes a single byte (1 byte total)' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_int8(-1)
+      expect(w.to_binary.bytesize).to eq(1)
+    end
+  end
+
+  describe 'write_varint / read_varint' do
+    it 'round-trips 0' do
+      expect(wire_roundtrip(:write_varint, :read_varint, 0)).to eq(0)
+    end
+
+    it 'round-trips 252 (largest 1-byte varint)' do
+      expect(wire_roundtrip(:write_varint, :read_varint, 252)).to eq(252)
+    end
+
+    it 'round-trips 253 using 3-byte encoding' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_varint(253)
+      expect(w.to_binary.bytesize).to eq(3)
+      r = BSV::Wallet::Wire::Reader.new(w.to_binary)
+      expect(r.read_varint).to eq(253)
+    end
+
+    it 'round-trips 0xFFFF using 3-byte encoding' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_varint(0xFFFF)
+      expect(w.to_binary.bytesize).to eq(3)
+      r = BSV::Wallet::Wire::Reader.new(w.to_binary)
+      expect(r.read_varint).to eq(0xFFFF)
+    end
+
+    it 'round-trips 0x10000 using 5-byte encoding' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_varint(0x10000)
+      expect(w.to_binary.bytesize).to eq(5)
+      r = BSV::Wallet::Wire::Reader.new(w.to_binary)
+      expect(r.read_varint).to eq(0x10000)
+    end
+
+    it 'round-trips 0xFFFF_FFFF using 5-byte encoding' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_varint(0xFFFF_FFFF)
+      expect(w.to_binary.bytesize).to eq(5)
+      r = BSV::Wallet::Wire::Reader.new(w.to_binary)
+      expect(r.read_varint).to eq(0xFFFF_FFFF)
+    end
+
+    it 'round-trips a large 9-byte value' do
+      val = 0x1_0000_0000
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_varint(val)
+      expect(w.to_binary.bytesize).to eq(9)
+      r = BSV::Wallet::Wire::Reader.new(w.to_binary)
+      expect(r.read_varint).to eq(val)
+    end
+  end
+
+  describe 'write_signed_varint / read_signed_varint' do
+    it 'round-trips 0' do
+      expect(wire_roundtrip(:write_signed_varint, :read_signed_varint, 0)).to eq(0)
+    end
+
+    it 'round-trips positive values identically to varint' do
+      expect(wire_roundtrip(:write_signed_varint, :read_signed_varint, 1000)).to eq(1000)
+    end
+
+    it 'round-trips -1 as the 9-byte MaxUint64 sentinel' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_signed_varint(-1)
+      expect(w.to_binary.bytesize).to eq(9)
+      expect(w.to_binary).to eq("\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF".b)
+      r = BSV::Wallet::Wire::Reader.new(w.to_binary)
+      expect(r.read_signed_varint).to eq(-1)
+    end
+  end
+
+  describe 'write_byte_array / read_byte_array' do
+    it 'round-trips an empty byte array' do
+      result = wire_roundtrip(:write_byte_array, :read_byte_array, ''.b)
+      expect(result).to eq(''.b)
+    end
+
+    it 'round-trips binary data' do
+      data = "\x00\x01\xFE\xFF".b
+      result = wire_roundtrip(:write_byte_array, :read_byte_array, data)
+      expect(result).to eq(data)
+    end
+
+    it 'round-trips 32 bytes (typical hash length)' do
+      data = ('ab' * 16).b
+      result = wire_roundtrip(:write_byte_array, :read_byte_array, data)
+      expect(result).to eq(data)
+    end
+
+    it 'prefixes with a varint length' do
+      data = 'hello'.b
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_byte_array(data)
+      expect(w.to_binary.bytesize).to eq(1 + data.bytesize)
+    end
+  end
+
+  describe 'write_optional_byte_array / read_optional_byte_array' do
+    it 'round-trips nil as the -1 sentinel' do
+      result = wire_roundtrip(:write_optional_byte_array, :read_optional_byte_array, nil)
+      expect(result).to be_nil
+    end
+
+    it 'round-trips an empty byte array as distinct from nil' do
+      result = wire_roundtrip(:write_optional_byte_array, :read_optional_byte_array, ''.b)
+      expect(result).to eq(''.b)
+    end
+
+    it 'round-trips binary data' do
+      data = "\xDE\xAD\xBE\xEF".b
+      result = wire_roundtrip(:write_optional_byte_array, :read_optional_byte_array, data)
+      expect(result).to eq(data)
+    end
+  end
+
+  describe 'write_utf8_string / read_utf8_string' do
+    it 'round-trips an empty string' do
+      result = wire_roundtrip(:write_utf8_string, :read_utf8_string, '')
+      expect(result).to eq('')
+    end
+
+    it 'round-trips an ASCII string' do
+      result = wire_roundtrip(:write_utf8_string, :read_utf8_string, 'hello world')
+      expect(result).to eq('hello world')
+    end
+
+    it 'round-trips a UTF-8 string with multibyte characters' do
+      str = "caf\u00E9"
+      result = wire_roundtrip(:write_utf8_string, :read_utf8_string, str)
+      expect(result).to eq(str)
+    end
+
+    it 'returns a UTF-8 encoded string' do
+      result = wire_roundtrip(:write_utf8_string, :read_utf8_string, 'test')
+      expect(result.encoding).to eq(Encoding::UTF_8)
+    end
+  end
+
+  describe 'write_optional_utf8_string / read_optional_utf8_string' do
+    it 'round-trips nil as the -1 sentinel' do
+      result = wire_roundtrip(:write_optional_utf8_string, :read_optional_utf8_string, nil)
+      expect(result).to be_nil
+    end
+
+    it 'round-trips an empty string as distinct from nil' do
+      result = wire_roundtrip(:write_optional_utf8_string, :read_optional_utf8_string, '')
+      expect(result).to eq('')
+    end
+
+    it 'round-trips a present string' do
+      result = wire_roundtrip(:write_optional_utf8_string, :read_optional_utf8_string, 'basket-name')
+      expect(result).to eq('basket-name')
+    end
+  end
+
+  describe 'write_optional_bool / read_optional_bool' do
+    it 'round-trips true as Int8 value 1' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_optional_bool(true)
+      expect(w.to_binary).to eq("\x01".b)
+      r = BSV::Wallet::Wire::Reader.new(w.to_binary)
+      expect(r.read_optional_bool).to be(true)
+    end
+
+    it 'round-trips false as Int8 value 0' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_optional_bool(false)
+      expect(w.to_binary).to eq("\x00".b)
+      r = BSV::Wallet::Wire::Reader.new(w.to_binary)
+      expect(r.read_optional_bool).to be(false)
+    end
+
+    it 'round-trips nil as Int8 value -1' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_optional_bool(nil)
+      expect(w.to_binary).to eq("\xFF".b)
+      r = BSV::Wallet::Wire::Reader.new(w.to_binary)
+      expect(r.read_optional_bool).to be_nil
+    end
+  end
+
+  describe 'write_outpoint / read_outpoint' do
+    let(:txid_hex) { 'ab' * 32 }
+
+    it 'round-trips a txid and index' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_outpoint(txid_hex, 3)
+      r = BSV::Wallet::Wire::Reader.new(w.to_binary)
+      txid_out, index_out = r.read_outpoint
+      expect(txid_out).to eq(txid_hex)
+      expect(index_out).to eq(3)
+    end
+
+    it 'round-trips index 0' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_outpoint(txid_hex, 0)
+      r = BSV::Wallet::Wire::Reader.new(w.to_binary)
+      _txid, index_out = r.read_outpoint
+      expect(index_out).to eq(0)
+    end
+
+    it 'encodes 32 bytes txid + 1 byte index (33 bytes total for small index)' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_outpoint(txid_hex, 0)
+      expect(w.to_binary.bytesize).to eq(33)
+    end
+
+    it 'preserves txid display order (not reversed)' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_outpoint(txid_hex, 0)
+      # First 32 bytes should be the raw txid hex decoded
+      expect(w.to_binary.byteslice(0, 32).unpack1('H*')).to eq(txid_hex)
+    end
+  end
+
+  describe 'write_counterparty / read_counterparty' do
+    it 'round-trips "self" as byte 11' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_counterparty('self')
+      expect(w.to_binary).to eq("\x0B".b)
+      r = BSV::Wallet::Wire::Reader.new(w.to_binary)
+      expect(r.read_counterparty).to eq('self')
+    end
+
+    it 'round-trips "anyone" as byte 12' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_counterparty('anyone')
+      expect(w.to_binary).to eq("\x0C".b)
+      r = BSV::Wallet::Wire::Reader.new(w.to_binary)
+      expect(r.read_counterparty).to eq('anyone')
+    end
+
+    it 'round-trips nil as byte 0' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_counterparty(nil)
+      expect(w.to_binary).to eq("\x00".b)
+      r = BSV::Wallet::Wire::Reader.new(w.to_binary)
+      expect(r.read_counterparty).to be_nil
+    end
+
+    it 'round-trips a compressed hex pubkey (33 bytes)' do
+      pubkey_hex = BSV::Primitives::PrivateKey.generate.public_key.to_hex
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_counterparty(pubkey_hex)
+      expect(w.to_binary.bytesize).to eq(33)
+      r = BSV::Wallet::Wire::Reader.new(w.to_binary)
+      expect(r.read_counterparty).to eq(pubkey_hex)
+    end
+  end
+
+  describe 'write_protocol_id / read_protocol_id' do
+    it 'round-trips [0, "hello world"]' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_protocol_id([0, 'hello world'])
+      r = BSV::Wallet::Wire::Reader.new(w.to_binary)
+      level, name = r.read_protocol_id
+      expect(level).to eq(0)
+      expect(name).to eq('hello world')
+    end
+
+    it 'round-trips [2, "hello world"] (security level 2)' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_protocol_id([2, 'hello world'])
+      r = BSV::Wallet::Wire::Reader.new(w.to_binary)
+      level, name = r.read_protocol_id
+      expect(level).to eq(2)
+      expect(name).to eq('hello world')
+    end
+
+    it 'encodes: 1 byte level + varint name length + name bytes' do
+      w = BSV::Wallet::Wire::Writer.new
+      w.write_protocol_id([1, 'ab'])
+      # 1 (level) + 1 (varint len=2) + 2 (bytes)
+      expect(w.to_binary.bytesize).to eq(4)
+    end
+  end
+
+  describe 'write_string_array / read_string_array' do
+    it 'round-trips nil as the -1 sentinel' do
+      result = wire_roundtrip(:write_string_array, :read_string_array, nil)
+      expect(result).to be_nil
+    end
+
+    it 'round-trips an empty array as distinct from nil' do
+      result = wire_roundtrip(:write_string_array, :read_string_array, [])
+      expect(result).to eq([])
+    end
+
+    it 'round-trips a populated array' do
+      arr = %w[alpha beta gamma]
+      result = wire_roundtrip(:write_string_array, :read_string_array, arr)
+      expect(result).to eq(arr)
+    end
+
+    it 'round-trips an array with a single element' do
+      result = wire_roundtrip(:write_string_array, :read_string_array, ['only'])
+      expect(result).to eq(['only'])
+    end
+  end
+
+  describe 'write_map / read_map' do
+    it 'round-trips nil as the -1 sentinel' do
+      result = wire_roundtrip(:write_map, :read_map, nil)
+      expect(result).to be_nil
+    end
+
+    it 'round-trips an empty hash as distinct from nil' do
+      result = wire_roundtrip(:write_map, :read_map, {})
+      expect(result).to eq({})
+    end
+
+    it 'round-trips a populated hash' do
+      map = { 'key1' => 'value1', 'key2' => 'value2' }
+      result = wire_roundtrip(:write_map, :read_map, map)
+      expect(result).to eq(map)
+    end
+
+    it 'coerces symbol keys to strings on write' do
+      map = { foo: 'bar' }
+      result = wire_roundtrip(:write_map, :read_map, map)
+      expect(result).to eq({ 'foo' => 'bar' })
+    end
+  end
+end

--- a/spec/bsv/wallet_interface/wire/serializer_spec.rb
+++ b/spec/bsv/wallet_interface/wire/serializer_spec.rb
@@ -1,0 +1,1094 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+require 'base64'
+
+# Helper: round-trip a request through serialize/deserialize and return [method, args, originator].
+def request_roundtrip(method, args, originator: 'example.com')
+  data = BSV::Wallet::Wire::Serializer.serialize_request(method, args, originator: originator)
+  BSV::Wallet::Wire::Serializer.deserialize_request(data)
+end
+
+# Shared assertion for method and originator identity.
+def assert_frame_header(method_out, originator_out, expected_method, expected_originator)
+  expect(method_out).to eq(expected_method)
+  expect(originator_out).to eq(expected_originator)
+end
+
+# Canonical test data — shared across multiple method tests.
+TXID_HEX    = ('ab' * 32).freeze
+OUTPOINT    = "#{TXID_HEX}.0"
+PROTOCOL_ID = [2, 'hello world'].freeze
+KEY_ID      = 'test key 1'
+CERT_TYPE   = Base64.strict_encode64(('ff' * 16).b).freeze
+SERIAL_NUM  = Base64.strict_encode64(('ee' * 16).b).freeze
+SIG_HEX     = ('cd' * 35).freeze
+
+def pubkey_hex
+  @pubkey_hex ||= BSV::Primitives::PrivateKey.generate.public_key.to_hex
+end
+
+def cert_fixture(extra = {})
+  {
+    type: CERT_TYPE,
+    subject: pubkey_hex,
+    serial_number: SERIAL_NUM,
+    certifier: pubkey_hex,
+    revocation_outpoint: OUTPOINT,
+    signature: SIG_HEX,
+    fields: { 'name' => 'Alice' }
+  }.merge(extra)
+end
+
+RSpec.describe BSV::Wallet::Wire::Serializer do
+  # -------------------------------------------------------------------------
+  # Frame basics
+  # -------------------------------------------------------------------------
+
+  describe 'serialize_request / deserialize_request — frame header' do
+    it 'preserves the originator string' do
+      _m, _a, orig = request_roundtrip(:get_height, {}, originator: 'wallet.example.com')
+      expect(orig).to eq('wallet.example.com')
+    end
+
+    it 'handles an empty originator' do
+      _m, _a, orig = request_roundtrip(:get_height, {}, originator: '')
+      expect(orig).to eq('')
+    end
+
+    it 'handles a nil originator (treated as empty string)' do
+      _m, _a, orig = request_roundtrip(:get_height, {}, originator: nil)
+      expect(orig).to eq('')
+    end
+
+    it 'raises on an unknown method' do
+      expect do
+        described_class.serialize_request(:unknown_method, {})
+      end.to raise_error(ArgumentError, /unknown method/)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Error frame
+  # -------------------------------------------------------------------------
+
+  describe 'serialize_error / deserialize_response' do
+    it 'encodes a non-zero error code and message' do
+      data = described_class.serialize_error(42, 'something went wrong')
+      expect do
+        described_class.deserialize_response(:get_height, data)
+      end.to raise_error(BSV::Wallet::WalletError, 'something went wrong')
+    end
+
+    it 'stores the error code on the raised exception' do
+      data = described_class.serialize_error(7, 'bad request')
+      begin
+        described_class.deserialize_response(:get_height, data)
+      rescue BSV::Wallet::WalletError => e
+        expect(e.code).to eq(7)
+      end
+    end
+
+    it 'includes a stack trace in the serialised frame (discarded on raise)' do
+      data = described_class.serialize_error(1, 'err', stack_trace: 'trace here')
+      expect(data.bytesize).to be > 10
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Transaction methods (1-6)
+  # -------------------------------------------------------------------------
+
+  describe 'createAction (1)' do
+    let(:args) do
+      {
+        description: 'pay someone',
+        inputs: [
+          {
+            outpoint: OUTPOINT,
+            unlocking_script: 'aabb',
+            input_description: 'spend utxo',
+            sequence_number: 0xFFFFFFFE
+          }
+        ],
+        outputs: [
+          {
+            locking_script: 'deadbeef',
+            satoshis: 1000,
+            output_description: 'change',
+            basket: 'default',
+            custom_instructions: nil,
+            tags: ['payment']
+          }
+        ],
+        lock_time: nil,
+        version: 1,
+        labels: ['my-label']
+      }
+    end
+
+    it 'round-trips the method and originator' do
+      m, _a, orig = request_roundtrip(:create_action, args)
+      assert_frame_header(m, orig, :create_action, 'example.com')
+    end
+
+    it 'preserves description' do
+      _m, a, = request_roundtrip(:create_action, args)
+      expect(a[:description]).to eq('pay someone')
+    end
+
+    it 'preserves inputs' do
+      _m, a, = request_roundtrip(:create_action, args)
+      expect(a[:inputs].length).to eq(1)
+      expect(a[:inputs][0][:outpoint]).to eq(OUTPOINT)
+      expect(a[:inputs][0][:unlocking_script]).to eq('aabb')
+      expect(a[:inputs][0][:sequence_number]).to eq(0xFFFFFFFE)
+    end
+
+    it 'preserves outputs' do
+      _m, a, = request_roundtrip(:create_action, args)
+      expect(a[:outputs].length).to eq(1)
+      expect(a[:outputs][0][:satoshis]).to eq(1000)
+      expect(a[:outputs][0][:basket]).to eq('default')
+      expect(a[:outputs][0][:tags]).to eq(['payment'])
+    end
+
+    it 'preserves version and nil lock_time' do
+      _m, a, = request_roundtrip(:create_action, args)
+      expect(a[:version]).to eq(1)
+      expect(a[:lock_time]).to be_nil
+    end
+
+    it 'preserves labels' do
+      _m, a, = request_roundtrip(:create_action, args)
+      expect(a[:labels]).to eq(['my-label'])
+    end
+
+    it 'round-trips nil inputs and outputs' do
+      minimal = { description: 'empty', inputs: nil, outputs: nil }
+      _m, a, = request_roundtrip(:create_action, minimal)
+      expect(a[:inputs]).to be_nil
+      expect(a[:outputs]).to be_nil
+    end
+
+    it 'round-trips an input with unlocking_script_length (no script yet)' do
+      with_len = args.merge(inputs: [
+                              {
+                                outpoint: OUTPOINT,
+                                unlocking_script: nil,
+                                unlocking_script_length: 107,
+                                input_description: 'unsigned input',
+                                sequence_number: nil
+                              }
+                            ])
+      _m, a, = request_roundtrip(:create_action, with_len)
+      expect(a[:inputs][0][:unlocking_script]).to be_nil
+      expect(a[:inputs][0][:unlocking_script_length]).to eq(107)
+      expect(a[:inputs][0][:sequence_number]).to be_nil
+    end
+
+    it 'round-trips options when present' do
+      with_opts = args.merge(options: {
+                               sign_and_process: true,
+                               accept_delayed_broadcast: nil,
+                               trust_self: 'known',
+                               known_txids: [TXID_HEX],
+                               return_txid_only: false,
+                               no_send: nil,
+                               no_send_change: nil,
+                               send_with: nil,
+                               randomize_outputs: nil
+                             })
+      _m, a, = request_roundtrip(:create_action, with_opts)
+      expect(a[:options][:sign_and_process]).to be(true)
+      expect(a[:options][:trust_self]).to eq('known')
+      expect(a[:options][:known_txids]).to eq([TXID_HEX])
+    end
+
+    it 'round-trips response: txid present' do
+      result = { txid: TXID_HEX, tx: nil, no_send_change: nil,
+                 send_with_results: nil, signable_transaction: nil }
+      data = described_class.serialize_response(:create_action, result)
+      out = described_class.deserialize_response(:create_action, data)
+      expect(out[:txid]).to eq(TXID_HEX)
+    end
+  end
+
+  describe 'signAction (2)' do
+    let(:ref_b64) { Base64.strict_encode64('reference-bytes') }
+    let(:args) do
+      {
+        spends: {
+          0 => { unlocking_script: 'aabbcc', sequence_number: nil }
+        },
+        reference: ref_b64,
+        options: nil
+      }
+    end
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:sign_action, args)
+      expect(m).to eq(:sign_action)
+    end
+
+    it 'preserves spends' do
+      _m, a, = request_roundtrip(:sign_action, args)
+      expect(a[:spends][0][:unlocking_script]).to eq('aabbcc')
+      expect(a[:spends][0][:sequence_number]).to be_nil
+    end
+
+    it 'preserves reference as base64' do
+      _m, a, = request_roundtrip(:sign_action, args)
+      expect(a[:reference]).to eq(ref_b64)
+    end
+
+    it 'round-trips options when present' do
+      with_opts = args.merge(options: {
+                               accept_delayed_broadcast: true,
+                               return_txid_only: false,
+                               no_send: nil,
+                               send_with: nil
+                             })
+      _m, a, = request_roundtrip(:sign_action, with_opts)
+      expect(a[:options][:accept_delayed_broadcast]).to be(true)
+    end
+  end
+
+  describe 'abortAction (3)' do
+    let(:ref_b64) { Base64.strict_encode64('abort-ref') }
+    let(:args) { { reference: ref_b64 } }
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:abort_action, args)
+      expect(m).to eq(:abort_action)
+    end
+
+    it 'preserves reference as base64' do
+      _m, a, = request_roundtrip(:abort_action, args)
+      expect(a[:reference]).to eq(ref_b64)
+    end
+
+    it 'round-trips response returning aborted: true' do
+      data = described_class.serialize_response(:abort_action, {})
+      out = described_class.deserialize_response(:abort_action, data)
+      expect(out[:aborted]).to be(true)
+    end
+  end
+
+  describe 'listActions (4)' do
+    let(:args) do
+      {
+        labels: %w[tag1 tag2],
+        label_query_mode: 'any',
+        include_labels: true,
+        include_inputs: false,
+        include_input_source_locking_scripts: nil,
+        include_input_unlocking_scripts: nil,
+        include_outputs: true,
+        include_output_locking_scripts: nil,
+        limit: 10,
+        offset: 0,
+        seek_permission: nil
+      }
+    end
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:list_actions, args)
+      expect(m).to eq(:list_actions)
+    end
+
+    it 'preserves labels' do
+      _m, a, = request_roundtrip(:list_actions, args)
+      expect(a[:labels]).to eq(%w[tag1 tag2])
+    end
+
+    it 'preserves label_query_mode' do
+      _m, a, = request_roundtrip(:list_actions, args)
+      expect(a[:label_query_mode]).to eq('any')
+    end
+
+    it 'preserves include flags' do
+      _m, a, = request_roundtrip(:list_actions, args)
+      expect(a[:include_labels]).to be(true)
+      expect(a[:include_inputs]).to be(false)
+      expect(a[:include_input_source_locking_scripts]).to be_nil
+    end
+
+    it 'preserves limit and offset' do
+      _m, a, = request_roundtrip(:list_actions, args)
+      expect(a[:limit]).to eq(10)
+      expect(a[:offset]).to eq(0)
+    end
+
+    it 'round-trips response with actions' do
+      result = {
+        total_actions: 1,
+        actions: [
+          {
+            txid: TXID_HEX,
+            satoshis: 5000,
+            status: 'completed',
+            is_outgoing: true,
+            description: 'test tx',
+            labels: nil,
+            version: 1,
+            lock_time: 0,
+            inputs: nil,
+            outputs: nil
+          }
+        ]
+      }
+      data = described_class.serialize_response(:list_actions, result)
+      out = described_class.deserialize_response(:list_actions, data)
+      expect(out[:total_actions]).to eq(1)
+      expect(out[:actions][0][:txid]).to eq(TXID_HEX)
+      expect(out[:actions][0][:status]).to eq('completed')
+    end
+  end
+
+  describe 'internalizeAction (5)' do
+    let(:sender_key) { pubkey_hex }
+    let(:args) do
+      {
+        tx: [1, 2, 3, 4],
+        outputs: [
+          {
+            output_index: 0,
+            protocol: 'wallet payment',
+            payment_remittance: {
+              sender_identity_key: sender_key,
+              derivation_prefix: Base64.strict_encode64('prefix'),
+              derivation_suffix: Base64.strict_encode64('suffix')
+            }
+          },
+          {
+            output_index: 1,
+            protocol: 'basket insertion',
+            insertion_remittance: {
+              basket: 'my-basket',
+              custom_instructions: 'abc',
+              tags: ['tag']
+            }
+          }
+        ],
+        labels: ['imported'],
+        description: 'internalize tx',
+        seek_permission: nil
+      }
+    end
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:internalize_action, args)
+      expect(m).to eq(:internalize_action)
+    end
+
+    it 'preserves wallet payment output' do
+      _m, a, = request_roundtrip(:internalize_action, args)
+      out = a[:outputs][0]
+      expect(out[:protocol]).to eq('wallet payment')
+      expect(out[:payment_remittance][:sender_identity_key]).to eq(sender_key)
+    end
+
+    it 'preserves basket insertion output' do
+      _m, a, = request_roundtrip(:internalize_action, args)
+      out = a[:outputs][1]
+      expect(out[:protocol]).to eq('basket insertion')
+      expect(out[:insertion_remittance][:basket]).to eq('my-basket')
+    end
+
+    it 'preserves description and labels' do
+      _m, a, = request_roundtrip(:internalize_action, args)
+      expect(a[:description]).to eq('internalize tx')
+      expect(a[:labels]).to eq(['imported'])
+    end
+  end
+
+  describe 'listOutputs (6)' do
+    let(:args) do
+      {
+        basket: 'default',
+        tags: ['payment'],
+        tag_query_mode: 'all',
+        include: 'locking scripts',
+        include_custom_instructions: true,
+        include_tags: nil,
+        include_labels: false,
+        limit: 25,
+        offset: nil,
+        seek_permission: nil
+      }
+    end
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:list_outputs, args)
+      expect(m).to eq(:list_outputs)
+    end
+
+    it 'preserves basket and tags' do
+      _m, a, = request_roundtrip(:list_outputs, args)
+      expect(a[:basket]).to eq('default')
+      expect(a[:tags]).to eq(['payment'])
+    end
+
+    it 'preserves tag_query_mode and include' do
+      _m, a, = request_roundtrip(:list_outputs, args)
+      expect(a[:tag_query_mode]).to eq('all')
+      expect(a[:include]).to eq('locking scripts')
+    end
+
+    it 'preserves nil offset' do
+      _m, a, = request_roundtrip(:list_outputs, args)
+      expect(a[:offset]).to be_nil
+    end
+  end
+
+  describe 'relinquishOutput (7)' do
+    let(:args) { { basket: 'default', output: OUTPOINT } }
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:relinquish_output, args)
+      expect(m).to eq(:relinquish_output)
+    end
+
+    it 'preserves basket and output outpoint' do
+      _m, a, = request_roundtrip(:relinquish_output, args)
+      expect(a[:basket]).to eq('default')
+      expect(a[:output]).to eq(OUTPOINT)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Key methods (8-10)
+  # -------------------------------------------------------------------------
+
+  describe 'getPublicKey (8)' do
+    context 'with identity_key: true' do
+      let(:args) { { identity_key: true, privileged: nil, privileged_reason: nil, seek_permission: nil } }
+
+      it 'round-trips the method' do
+        m, _a, = request_roundtrip(:get_public_key, args)
+        expect(m).to eq(:get_public_key)
+      end
+
+      it 'preserves identity_key flag' do
+        _m, a, = request_roundtrip(:get_public_key, args)
+        expect(a[:identity_key]).to be(true)
+      end
+    end
+
+    context 'with protocol/key derivation' do
+      let(:args) do
+        {
+          identity_key: false,
+          protocol_id: PROTOCOL_ID,
+          key_id: KEY_ID,
+          counterparty: 'self',
+          privileged: nil,
+          privileged_reason: nil,
+          for_self: true,
+          seek_permission: nil
+        }
+      end
+
+      it 'preserves protocol_id, key_id, and counterparty' do
+        _m, a, = request_roundtrip(:get_public_key, args)
+        expect(a[:protocol_id]).to eq(PROTOCOL_ID)
+        expect(a[:key_id]).to eq(KEY_ID)
+        expect(a[:counterparty]).to eq('self')
+        expect(a[:for_self]).to be(true)
+      end
+    end
+
+    it 'round-trips response with a public key' do
+      result = { public_key: pubkey_hex }
+      data = described_class.serialize_response(:get_public_key, result)
+      out = described_class.deserialize_response(:get_public_key, data)
+      expect(out[:public_key]).to eq(pubkey_hex)
+    end
+  end
+
+  describe 'revealCounterpartyKeyLinkage (9)' do
+    let(:prover_key) { pubkey_hex }
+    let(:verifier_key) { BSV::Primitives::PrivateKey.generate.public_key.to_hex }
+    let(:args) do
+      {
+        privileged: true,
+        privileged_reason: 'user consent',
+        counterparty: prover_key,
+        verifier: verifier_key
+      }
+    end
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:reveal_counterparty_key_linkage, args)
+      expect(m).to eq(:reveal_counterparty_key_linkage)
+    end
+
+    it 'preserves counterparty and verifier pubkeys' do
+      _m, a, = request_roundtrip(:reveal_counterparty_key_linkage, args)
+      expect(a[:counterparty]).to eq(prover_key)
+      expect(a[:verifier]).to eq(verifier_key)
+    end
+
+    it 'preserves privileged and privileged_reason' do
+      _m, a, = request_roundtrip(:reveal_counterparty_key_linkage, args)
+      expect(a[:privileged]).to be(true)
+      expect(a[:privileged_reason]).to eq('user consent')
+    end
+  end
+
+  describe 'revealSpecificKeyLinkage (10)' do
+    let(:verifier_key) { BSV::Primitives::PrivateKey.generate.public_key.to_hex }
+    let(:args) do
+      {
+        protocol_id: PROTOCOL_ID,
+        key_id: KEY_ID,
+        counterparty: 'self',
+        privileged: nil,
+        privileged_reason: nil,
+        verifier: verifier_key
+      }
+    end
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:reveal_specific_key_linkage, args)
+      expect(m).to eq(:reveal_specific_key_linkage)
+    end
+
+    it 'preserves verifier alongside key params' do
+      _m, a, = request_roundtrip(:reveal_specific_key_linkage, args)
+      expect(a[:verifier]).to eq(verifier_key)
+      expect(a[:protocol_id]).to eq(PROTOCOL_ID)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Crypto methods (11-16)
+  # -------------------------------------------------------------------------
+
+  describe 'encrypt (11)' do
+    let(:args) do
+      {
+        protocol_id: PROTOCOL_ID,
+        key_id: KEY_ID,
+        counterparty: 'self',
+        privileged: nil,
+        privileged_reason: nil,
+        plaintext: [104, 101, 108, 108, 111],
+        seek_permission: nil
+      }
+    end
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:encrypt, args)
+      expect(m).to eq(:encrypt)
+    end
+
+    it 'preserves plaintext bytes' do
+      _m, a, = request_roundtrip(:encrypt, args)
+      expect(a[:plaintext]).to eq([104, 101, 108, 108, 111])
+    end
+
+    it 'preserves key params' do
+      _m, a, = request_roundtrip(:encrypt, args)
+      expect(a[:protocol_id]).to eq(PROTOCOL_ID)
+      expect(a[:key_id]).to eq(KEY_ID)
+      expect(a[:counterparty]).to eq('self')
+    end
+
+    it 'round-trips response with ciphertext bytes' do
+      result = { ciphertext: [0xDE, 0xAD, 0xBE, 0xEF] }
+      data = described_class.serialize_response(:encrypt, result)
+      out = described_class.deserialize_response(:encrypt, data)
+      expect(out[:ciphertext]).to eq([0xDE, 0xAD, 0xBE, 0xEF])
+    end
+  end
+
+  describe 'decrypt (12)' do
+    let(:args) do
+      {
+        protocol_id: PROTOCOL_ID,
+        key_id: KEY_ID,
+        counterparty: 'self',
+        privileged: nil,
+        privileged_reason: nil,
+        ciphertext: [0xDE, 0xAD, 0xBE, 0xEF],
+        seek_permission: nil
+      }
+    end
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:decrypt, args)
+      expect(m).to eq(:decrypt)
+    end
+
+    it 'preserves ciphertext bytes' do
+      _m, a, = request_roundtrip(:decrypt, args)
+      expect(a[:ciphertext]).to eq([0xDE, 0xAD, 0xBE, 0xEF])
+    end
+  end
+
+  describe 'createHmac (13)' do
+    let(:args) do
+      {
+        protocol_id: PROTOCOL_ID,
+        key_id: KEY_ID,
+        counterparty: 'self',
+        privileged: nil,
+        privileged_reason: nil,
+        data: [1, 2, 3],
+        seek_permission: nil
+      }
+    end
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:create_hmac, args)
+      expect(m).to eq(:create_hmac)
+    end
+
+    it 'preserves data bytes' do
+      _m, a, = request_roundtrip(:create_hmac, args)
+      expect(a[:data]).to eq([1, 2, 3])
+    end
+  end
+
+  describe 'verifyHmac (14)' do
+    let(:hmac_bytes) { [0] * 32 }
+    let(:args) do
+      {
+        protocol_id: PROTOCOL_ID,
+        key_id: KEY_ID,
+        counterparty: 'self',
+        privileged: nil,
+        privileged_reason: nil,
+        hmac: hmac_bytes,
+        data: [10, 20, 30],
+        seek_permission: nil
+      }
+    end
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:verify_hmac, args)
+      expect(m).to eq(:verify_hmac)
+    end
+
+    it 'preserves hmac (fixed 32 bytes) and data' do
+      _m, a, = request_roundtrip(:verify_hmac, args)
+      expect(a[:hmac]).to eq(hmac_bytes)
+      expect(a[:data]).to eq([10, 20, 30])
+    end
+  end
+
+  describe 'createSignature (15)' do
+    context 'with data payload' do
+      let(:args) do
+        {
+          protocol_id: PROTOCOL_ID,
+          key_id: KEY_ID,
+          counterparty: 'self',
+          privileged: nil,
+          privileged_reason: nil,
+          data: [97, 98, 99],
+          seek_permission: nil
+        }
+      end
+
+      it 'round-trips the method' do
+        m, _a, = request_roundtrip(:create_signature, args)
+        expect(m).to eq(:create_signature)
+      end
+
+      it 'preserves data bytes' do
+        _m, a, = request_roundtrip(:create_signature, args)
+        expect(a[:data]).to eq([97, 98, 99])
+      end
+    end
+
+    context 'with hash_to_directly_sign (32 bytes)' do
+      let(:hash32) { [0xAB] * 32 }
+      let(:args) do
+        {
+          protocol_id: PROTOCOL_ID,
+          key_id: KEY_ID,
+          counterparty: 'self',
+          privileged: nil,
+          privileged_reason: nil,
+          hash_to_directly_sign: hash32,
+          seek_permission: nil
+        }
+      end
+
+      it 'preserves hash_to_directly_sign' do
+        _m, a, = request_roundtrip(:create_signature, args)
+        expect(a[:hash_to_directly_sign]).to eq(hash32)
+      end
+    end
+  end
+
+  describe 'verifySignature (16)' do
+    let(:sig_bytes) { [0x30] + ([0x01] * 70) }
+    let(:args) do
+      {
+        protocol_id: PROTOCOL_ID,
+        key_id: KEY_ID,
+        counterparty: 'self',
+        privileged: nil,
+        privileged_reason: nil,
+        for_self: nil,
+        signature: sig_bytes,
+        data: [1, 2, 3],
+        seek_permission: nil
+      }
+    end
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:verify_signature, args)
+      expect(m).to eq(:verify_signature)
+    end
+
+    it 'preserves signature bytes and data' do
+      _m, a, = request_roundtrip(:verify_signature, args)
+      expect(a[:signature]).to eq(sig_bytes)
+      expect(a[:data]).to eq([1, 2, 3])
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Certificate methods (17-20)
+  # -------------------------------------------------------------------------
+
+  describe 'acquireCertificate (17) — issuance protocol' do
+    let(:args) do
+      {
+        type: CERT_TYPE,
+        certifier: pubkey_hex,
+        fields: { 'email' => 'alice@example.com' },
+        privileged: nil,
+        privileged_reason: nil,
+        acquisition_protocol: 'issuance',
+        certifier_url: 'https://certifier.example.com'
+      }
+    end
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:acquire_certificate, args)
+      expect(m).to eq(:acquire_certificate)
+    end
+
+    it 'preserves type and certifier' do
+      _m, a, = request_roundtrip(:acquire_certificate, args)
+      expect(a[:type]).to eq(CERT_TYPE)
+      expect(a[:certifier]).to eq(pubkey_hex)
+    end
+
+    it 'preserves fields map' do
+      _m, a, = request_roundtrip(:acquire_certificate, args)
+      expect(a[:fields]).to eq({ 'email' => 'alice@example.com' })
+    end
+
+    it 'preserves acquisition_protocol and certifier_url' do
+      _m, a, = request_roundtrip(:acquire_certificate, args)
+      expect(a[:acquisition_protocol]).to eq('issuance')
+      expect(a[:certifier_url]).to eq('https://certifier.example.com')
+    end
+  end
+
+  describe 'acquireCertificate (17) — direct protocol' do
+    let(:args) do
+      {
+        type: CERT_TYPE,
+        certifier: pubkey_hex,
+        fields: {},
+        privileged: nil,
+        privileged_reason: nil,
+        acquisition_protocol: 'direct',
+        serial_number: SERIAL_NUM,
+        revocation_outpoint: OUTPOINT,
+        signature: SIG_HEX,
+        keyring_revealer: 'certifier',
+        keyring_for_subject: {}
+      }
+    end
+
+    it 'preserves direct protocol params' do
+      _m, a, = request_roundtrip(:acquire_certificate, args)
+      expect(a[:acquisition_protocol]).to eq('direct')
+      expect(a[:serial_number]).to eq(SERIAL_NUM)
+      expect(a[:revocation_outpoint]).to eq(OUTPOINT)
+      expect(a[:keyring_revealer]).to eq('certifier')
+    end
+  end
+
+  describe 'listCertificates (18)' do
+    let(:args) do
+      {
+        certifiers: [pubkey_hex],
+        types: [CERT_TYPE],
+        limit: 5,
+        offset: nil,
+        privileged: false,
+        privileged_reason: nil
+      }
+    end
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:list_certificates, args)
+      expect(m).to eq(:list_certificates)
+    end
+
+    it 'preserves certifiers and types' do
+      _m, a, = request_roundtrip(:list_certificates, args)
+      expect(a[:certifiers]).to eq([pubkey_hex])
+      expect(a[:types]).to eq([CERT_TYPE])
+    end
+
+    it 'preserves limit and nil offset' do
+      _m, a, = request_roundtrip(:list_certificates, args)
+      expect(a[:limit]).to eq(5)
+      expect(a[:offset]).to be_nil
+    end
+  end
+
+  describe 'proveCertificate (19)' do
+    let(:verifier_key) { BSV::Primitives::PrivateKey.generate.public_key.to_hex }
+    let(:args) do
+      {
+        certificate: cert_fixture,
+        fields_to_reveal: ['name'],
+        verifier: verifier_key,
+        privileged: nil,
+        privileged_reason: nil
+      }
+    end
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:prove_certificate, args)
+      expect(m).to eq(:prove_certificate)
+    end
+
+    it 'preserves fields_to_reveal and verifier' do
+      _m, a, = request_roundtrip(:prove_certificate, args)
+      expect(a[:fields_to_reveal]).to eq(['name'])
+      expect(a[:verifier]).to eq(verifier_key)
+    end
+
+    it 'preserves certificate core fields' do
+      _m, a, = request_roundtrip(:prove_certificate, args)
+      expect(a[:certificate][:type]).to eq(CERT_TYPE)
+      expect(a[:certificate][:subject]).to eq(pubkey_hex)
+    end
+  end
+
+  describe 'relinquishCertificate (20)' do
+    let(:args) do
+      {
+        type: CERT_TYPE,
+        serial_number: SERIAL_NUM,
+        certifier: pubkey_hex
+      }
+    end
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:relinquish_certificate, args)
+      expect(m).to eq(:relinquish_certificate)
+    end
+
+    it 'preserves type, serial_number, and certifier' do
+      _m, a, = request_roundtrip(:relinquish_certificate, args)
+      expect(a[:type]).to eq(CERT_TYPE)
+      expect(a[:serial_number]).to eq(SERIAL_NUM)
+      expect(a[:certifier]).to eq(pubkey_hex)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Discovery methods (21-22)
+  # -------------------------------------------------------------------------
+
+  describe 'discoverByIdentityKey (21)' do
+    let(:args) do
+      {
+        identity_key: pubkey_hex,
+        limit: nil,
+        offset: nil,
+        seek_permission: nil
+      }
+    end
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:discover_by_identity_key, args)
+      expect(m).to eq(:discover_by_identity_key)
+    end
+
+    it 'preserves identity_key' do
+      _m, a, = request_roundtrip(:discover_by_identity_key, args)
+      expect(a[:identity_key]).to eq(pubkey_hex)
+    end
+
+    it 'preserves nil limit and offset' do
+      _m, a, = request_roundtrip(:discover_by_identity_key, args)
+      expect(a[:limit]).to be_nil
+      expect(a[:offset]).to be_nil
+    end
+  end
+
+  describe 'discoverByAttributes (22)' do
+    let(:args) do
+      {
+        attributes: { 'name' => 'Alice', 'country' => 'AU' },
+        limit: 10,
+        offset: 0,
+        seek_permission: true
+      }
+    end
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:discover_by_attributes, args)
+      expect(m).to eq(:discover_by_attributes)
+    end
+
+    it 'preserves attributes map' do
+      _m, a, = request_roundtrip(:discover_by_attributes, args)
+      expect(a[:attributes]).to eq({ 'name' => 'Alice', 'country' => 'AU' })
+    end
+
+    it 'preserves limit, offset, seek_permission' do
+      _m, a, = request_roundtrip(:discover_by_attributes, args)
+      expect(a[:limit]).to eq(10)
+      expect(a[:offset]).to eq(0)
+      expect(a[:seek_permission]).to be(true)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Auth methods (23-24)
+  # -------------------------------------------------------------------------
+
+  describe 'isAuthenticated (23)' do
+    it 'round-trips the method with empty params' do
+      m, a, = request_roundtrip(:is_authenticated, {})
+      expect(m).to eq(:is_authenticated)
+      expect(a).to eq({})
+    end
+
+    it 'round-trips response: authenticated = true' do
+      data = described_class.serialize_response(:is_authenticated, { authenticated: true })
+      out = described_class.deserialize_response(:is_authenticated, data)
+      expect(out[:authenticated]).to be(true)
+    end
+
+    it 'round-trips response: authenticated = false' do
+      data = described_class.serialize_response(:is_authenticated, { authenticated: false })
+      out = described_class.deserialize_response(:is_authenticated, data)
+      expect(out[:authenticated]).to be(false)
+    end
+  end
+
+  describe 'waitForAuthentication (24)' do
+    it 'round-trips the method with empty params' do
+      m, a, = request_roundtrip(:wait_for_authentication, {})
+      expect(m).to eq(:wait_for_authentication)
+      expect(a).to eq({})
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Blockchain methods (25-28)
+  # -------------------------------------------------------------------------
+
+  describe 'getHeight (25)' do
+    it 'round-trips the method with empty params' do
+      m, a, = request_roundtrip(:get_height, {})
+      expect(m).to eq(:get_height)
+      expect(a).to eq({})
+    end
+
+    it 'round-trips response with block height' do
+      data = described_class.serialize_response(:get_height, { height: 900_000 })
+      out = described_class.deserialize_response(:get_height, data)
+      expect(out[:height]).to eq(900_000)
+    end
+  end
+
+  describe 'getHeaderForHeight (26)' do
+    let(:header_hex) { 'deadbeef' * 20 } # 80 bytes
+    let(:args) { { height: 830_000 } }
+
+    it 'round-trips the method' do
+      m, _a, = request_roundtrip(:get_header_for_height, args)
+      expect(m).to eq(:get_header_for_height)
+    end
+
+    it 'preserves height' do
+      _m, a, = request_roundtrip(:get_header_for_height, args)
+      expect(a[:height]).to eq(830_000)
+    end
+
+    it 'round-trips response with header hex' do
+      data = described_class.serialize_response(:get_header_for_height, { header: header_hex })
+      out = described_class.deserialize_response(:get_header_for_height, data)
+      expect(out[:header]).to eq(header_hex)
+    end
+  end
+
+  describe 'getNetwork (27)' do
+    it 'round-trips the method with empty params' do
+      m, a, = request_roundtrip(:get_network, {})
+      expect(m).to eq(:get_network)
+      expect(a).to eq({})
+    end
+
+    it 'round-trips response: mainnet' do
+      data = described_class.serialize_response(:get_network, { network: 'mainnet' })
+      out = described_class.deserialize_response(:get_network, data)
+      expect(out[:network]).to eq('mainnet')
+    end
+
+    it 'round-trips response: testnet' do
+      data = described_class.serialize_response(:get_network, { network: 'testnet' })
+      out = described_class.deserialize_response(:get_network, data)
+      expect(out[:network]).to eq('testnet')
+    end
+  end
+
+  describe 'getVersion (28)' do
+    it 'round-trips the method with empty params' do
+      m, a, = request_roundtrip(:get_version, {})
+      expect(m).to eq(:get_version)
+      expect(a).to eq({})
+    end
+
+    it 'round-trips response with version string' do
+      data = described_class.serialize_response(:get_version, { version: '0.3.1' })
+      out = described_class.deserialize_response(:get_version, data)
+      expect(out[:version]).to eq('0.3.1')
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # All 28 call codes exist and are symmetrical
+  # -------------------------------------------------------------------------
+
+  describe 'CALL_CODES / METHODS_BY_CODE' do
+    it 'defines exactly 28 methods' do
+      expect(BSV::Wallet::Wire::Serializer::CALL_CODES.length).to eq(28)
+    end
+
+    it 'has a unique code for every method' do
+      codes = BSV::Wallet::Wire::Serializer::CALL_CODES.values
+      expect(codes.uniq.length).to eq(28)
+    end
+
+    it 'covers codes 1 through 28 with no gaps' do
+      codes = BSV::Wallet::Wire::Serializer::CALL_CODES.values.sort
+      expect(codes).to eq((1..28).to_a)
+    end
+
+    it 'METHODS_BY_CODE is the exact inverse of CALL_CODES' do
+      BSV::Wallet::Wire::Serializer::CALL_CODES.each do |method, code|
+        expect(BSV::Wallet::Wire::Serializer::METHODS_BY_CODE[code]).to eq(method)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `BSV::Wallet::Wire` module — binary serialisation for all 28 BRC-100 wallet method calls
- `Writer`/`Reader` for all wire primitives (VarInt with -1 sentinel, counterparty dispatch, protocol IDs, outpoints, maps, etc.)
- `Serializer` with `serialize_request`/`deserialize_request`/`serialize_response`/`deserialize_response` for all 28 call codes
- Error frame handling (code + message + optional stack trace)
- 3,941 lines of implementation + tests

### Wire format matches ts-sdk/go-sdk:
- Bitcoin VarInt with signed -1 as MaxUint64
- Counterparty first-byte dispatch (0=nil, 11=self, 12=anyone, 0x02/0x03=pubkey)
- abortAction reference as raw payload (no length prefix)
- PrivilegedReason with Int8 length (not VarInt)
- TXID in display byte order

## Test plan

- [x] 156 wire protocol tests pass (55 primitives + 101 serialiser)
- [x] 2281 total project tests pass
- [x] Rubocop clean
- [x] Round-trip verified for all 28 methods (serialize → deserialize → compare)
- [x] Error frames tested

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)