### PR TITLE
feat: implement BRC-31 mutual authentication (Auth/Peer)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,6 +76,8 @@ Metrics/AbcSize:
     - 'lib/bsv/attest/**/*'
     - 'lib/bsv/wallet_interface.rb'
     - 'lib/bsv/wallet_interface/**/*'
+    - 'lib/bsv/auth.rb'
+    - 'lib/bsv/auth/**/*'
     - 'spec/**/*'
 
 Metrics/MethodLength:
@@ -89,6 +91,8 @@ Metrics/MethodLength:
     - 'lib/bsv/attest/**/*'
     - 'lib/bsv/wallet_interface.rb'
     - 'lib/bsv/wallet_interface/**/*'
+    - 'lib/bsv/auth.rb'
+    - 'lib/bsv/auth/**/*'
     - 'spec/**/*'
 
 Metrics/CyclomaticComplexity:
@@ -102,6 +106,8 @@ Metrics/CyclomaticComplexity:
     - 'lib/bsv/attest/**/*'
     - 'lib/bsv/wallet_interface.rb'
     - 'lib/bsv/wallet_interface/**/*'
+    - 'lib/bsv/auth.rb'
+    - 'lib/bsv/auth/**/*'
     - 'spec/**/*'
 
 Metrics/PerceivedComplexity:
@@ -115,6 +121,8 @@ Metrics/PerceivedComplexity:
     - 'lib/bsv/attest/**/*'
     - 'lib/bsv/wallet_interface.rb'
     - 'lib/bsv/wallet_interface/**/*'
+    - 'lib/bsv/auth.rb'
+    - 'lib/bsv/auth/**/*'
     - 'spec/**/*'
 
 Metrics/ModuleLength:
@@ -133,6 +141,7 @@ Metrics/ClassLength:
     - 'lib/bsv/transaction/merkle_path.rb'
     - 'lib/bsv/transaction/beef.rb'
     - 'lib/bsv/wallet_interface/**/*'
+    - 'lib/bsv/auth/**/*'
 
 Metrics/ParameterLists:
   Exclude:
@@ -166,6 +175,7 @@ RSpec/MultipleExpectations:
     - 'spec/bsv/wallet/**/*'
     - 'spec/bsv/attest_spec.rb'
     - 'spec/bsv/attest/**/*'
+    - 'spec/bsv/auth/**/*'
     - 'spec/bsv/wallet_interface/**/*'
     - 'spec/integration/**/*'
     - 'spec/conformance/**/*'
@@ -175,6 +185,7 @@ RSpec/MultipleMemoizedHelpers:
     - 'spec/bsv/primitives/**/*'
     - 'spec/bsv/script/**/*'
     - 'spec/bsv/transaction/**/*'
+    - 'spec/bsv/auth/**/*'
     - 'spec/conformance/**/*'
     - 'spec/bsv/wallet_interface/**/*'
 
@@ -187,6 +198,7 @@ RSpec/ExampleLength:
     - 'spec/bsv/wallet/**/*'
     - 'spec/bsv/attest_spec.rb'
     - 'spec/bsv/attest/**/*'
+    - 'spec/bsv/auth/**/*'
     - 'spec/bsv/wallet_interface/**/*'
     - 'spec/integration/**/*'
     - 'spec/conformance/**/*'

--- a/lib/bsv-sdk.rb
+++ b/lib/bsv-sdk.rb
@@ -8,4 +8,5 @@ module BSV
   autoload :Transaction, 'bsv/transaction'
   autoload :Network,     'bsv/network'
   autoload :Wallet,      'bsv/wallet'
+  autoload :Auth,        'bsv/auth'
 end

--- a/lib/bsv/auth.rb
+++ b/lib/bsv/auth.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module BSV
+  module Auth
+    autoload :AuthError,      'bsv/auth/auth_error'
+    autoload :Nonce,          'bsv/auth/nonce'
+    autoload :PeerSession,    'bsv/auth/peer_session'
+    autoload :SessionManager, 'bsv/auth/session_manager'
+    autoload :Transport,      'bsv/auth/transport'
+    autoload :Peer,           'bsv/auth/peer'
+
+    # Protocol version
+    AUTH_VERSION = '0.1'
+
+    # Message type string constants (matching ts-sdk/go-sdk)
+    MSG_INITIAL_REQUEST  = 'initialRequest'
+    MSG_INITIAL_RESPONSE = 'initialResponse'
+    MSG_CERT_REQUEST     = 'certificateRequest'
+    MSG_CERT_RESPONSE    = 'certificateResponse'
+    MSG_GENERAL          = 'general'
+  end
+end

--- a/lib/bsv/auth/auth_error.rb
+++ b/lib/bsv/auth/auth_error.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module BSV
+  module Auth
+    # Raised when a BRC-31 authentication protocol error occurs.
+    class AuthError < StandardError; end
+  end
+end

--- a/lib/bsv/auth/nonce.rb
+++ b/lib/bsv/auth/nonce.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'base64'
+require 'securerandom'
+
+module BSV
+  module Auth
+    # Nonce creation and verification for BRC-31 mutual authentication.
+    #
+    # A nonce is a 48-byte value: 16 random bytes concatenated with a 32-byte
+    # HMAC-SHA256 over those 16 bytes, base64-encoded. The HMAC is computed
+    # with the wallet using protocol [2, 'server hmac'] and the raw bytes as
+    # the key ID (decoded to a string). This makes nonces self-authenticating —
+    # only the wallet that created a nonce can verify it.
+    #
+    # The key ID is derived by decoding the 16 random bytes as UTF-8, replacing
+    # any invalid byte sequences with the Unicode replacement character (U+FFFD).
+    # This matches the ts-sdk behaviour (TextDecoder in non-fatal replacement mode).
+    # Since nonces are always self-verified (counterparty='self'), the key ID
+    # encoding does not need to be interoperable across SDK implementations.
+    module Nonce
+      PROTOCOL_ID  = [2, 'server hmac'].freeze
+      RANDOM_BYTES = 16
+
+      module_function
+
+      # Creates a self-authenticating nonce.
+      #
+      # @param wallet [BSV::Wallet::Interface] wallet with HMAC capability
+      # @param counterparty [String] counterparty ('self', 'anyone', or public key hex).
+      #   Defaults to 'self' — nonces are self-verified by the creating wallet.
+      # @return [String] base64-encoded nonce (48 bytes: 16 random + 32 HMAC)
+      def create(wallet, counterparty = 'self')
+        first_half = SecureRandom.random_bytes(RANDOM_BYTES)
+        key_id     = decode_as_utf8(first_half)
+
+        result = wallet.create_hmac({
+                                      data: first_half.bytes,
+                                      protocol_id: PROTOCOL_ID,
+                                      key_id: key_id,
+                                      counterparty: counterparty
+                                    })
+
+        nonce_bytes = first_half + result[:hmac].pack('C*')
+        ::Base64.strict_encode64(nonce_bytes)
+      end
+
+      # Verifies that a nonce was created by the given wallet.
+      #
+      # @param nonce [String] base64-encoded nonce to verify
+      # @param wallet [BSV::Wallet::Interface] wallet
+      # @param counterparty [String] counterparty — must match the value used
+      #   when the nonce was created (typically 'self')
+      # @return [Boolean] true if the nonce is valid
+      def verify(nonce, wallet, counterparty = 'self')
+        nonce_bytes = ::Base64.strict_decode64(nonce)
+        return false if nonce_bytes.bytesize <= RANDOM_BYTES
+
+        first_half = nonce_bytes.byteslice(0, RANDOM_BYTES)
+        hmac_bytes = nonce_bytes.byteslice(RANDOM_BYTES, nonce_bytes.bytesize - RANDOM_BYTES)
+        key_id     = decode_as_utf8(first_half)
+
+        wallet.verify_hmac({
+                             data: first_half.bytes,
+                             hmac: hmac_bytes.bytes,
+                             protocol_id: PROTOCOL_ID,
+                             key_id: key_id,
+                             counterparty: counterparty
+                           })
+
+        true
+      rescue BSV::Wallet::InvalidHmacError
+        false
+      end
+
+      # Decodes a binary string as UTF-8, replacing invalid byte sequences with
+      # the Unicode replacement character (U+FFFD). Used to derive the HMAC key
+      # ID from the random nonce bytes in a way consistent with the ts-sdk's
+      # use of TextDecoder (non-fatal mode).
+      #
+      # @param bytes [String] binary (ASCII-8BIT) string
+      # @return [String] UTF-8 encoded string
+      def decode_as_utf8(bytes)
+        bytes.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: "\uFFFD")
+      end
+    end
+  end
+end

--- a/lib/bsv/auth/peer.rb
+++ b/lib/bsv/auth/peer.rb
@@ -1,0 +1,317 @@
+# frozen_string_literal: true
+
+require 'base64'
+
+module BSV
+  module Auth
+    # BRC-31/BRC-103 mutual authentication peer.
+    #
+    # Manages the cryptographic handshake between two parties:
+    #
+    # 1. Alice calls {#initiate_handshake} — sends +initialRequest+ with her
+    #    session nonce and requested certificates.
+    # 2. Bob calls {#handle_incoming_message} — processes the request, creates
+    #    his own session nonce, signs +decode(alice_nonce) + decode(bob_nonce)+,
+    #    and sends +initialResponse+.
+    # 3. Alice processes +initialResponse+ — verifies the nonce is hers
+    #    (via HMAC), verifies Bob's signature, and marks the session authenticated.
+    # 4. Both parties may now exchange authenticated +general+ messages.
+    #
+    # Sessions are indexed by +session_nonce+ (our nonce), which is the primary
+    # key in the {SessionManager}.
+    #
+    # @example Using Peer with a custom transport
+    #   wallet_a = BSV::Wallet::ProtoWallet.new(BSV::Primitives::PrivateKey.generate)
+    #   wallet_b = BSV::Wallet::ProtoWallet.new(BSV::Primitives::PrivateKey.generate)
+    #
+    #   # Wire the two peers together with synchronous in-process transports
+    #   peer_a = BSV::Auth::Peer.new(wallet: wallet_a)
+    #   peer_b = BSV::Auth::Peer.new(wallet: wallet_b)
+    #
+    #   # Alice initiates; Bob responds; Alice completes
+    #   request  = peer_a.create_initial_request
+    #   response = peer_b.handle_incoming_message(request)
+    #   peer_a.handle_incoming_message(response)
+    class Peer
+      AUTH_PROTOCOL = [2, 'auth message signature'].freeze
+
+      attr_reader :wallet, :session_manager
+
+      # @param wallet [BSV::Wallet::Interface] wallet providing crypto operations
+      # @param transport [Transport, nil] optional transport for async usage
+      # @param session_manager [SessionManager, nil] optional custom session store
+      # @param certificates_to_request [Hash, nil] certificate set to request from peers
+      def initialize(wallet:, transport: nil, session_manager: nil, certificates_to_request: nil)
+        @wallet                  = wallet
+        @transport               = transport
+        @session_manager         = session_manager || SessionManager.new
+        @certificates_to_request = certificates_to_request || { certifiers: [], types: {} }
+        @identity_public_key     = nil
+
+        return unless @transport
+
+        @transport.on_data { |msg| handle_incoming_message(msg) }
+      end
+
+      # Returns our identity key (cached after first call).
+      #
+      # @return [String] compressed public key hex
+      def identity_key
+        @identity_key ||= @wallet.get_public_key({ identity_key: true })[:public_key]
+      end
+
+      # Checks whether we have an authenticated session with a peer.
+      #
+      # Accepts either a +session_nonce+ or +peer_identity_key+.
+      #
+      # @param identifier [String]
+      # @return [Boolean]
+      def authenticated?(identifier)
+        session = @session_manager.get_session(identifier)
+        session&.authenticated? || false
+      end
+
+      # --- Handshake initiation (we are the initiator) ---
+
+      # Builds an +initialRequest+ message and creates a pending session.
+      #
+      # @return [Hash] the message to send to the peer
+      def create_initial_request
+        session_nonce = Nonce.create(@wallet)
+
+        session = PeerSession.new(session_nonce: session_nonce)
+        session.certificates_required  = certifiers_present?
+        session.certificates_validated = !session.certificates_required
+
+        @session_manager.add_session(session)
+
+        {
+          version: AUTH_VERSION,
+          message_type: MSG_INITIAL_REQUEST,
+          identity_key: identity_key,
+          initial_nonce: session_nonce,
+          requested_certificates: @certificates_to_request
+        }
+      end
+
+      # --- Incoming message dispatch ---
+
+      # Processes any incoming auth message and returns a response (if applicable).
+      #
+      # @param message [Hash] the incoming auth message
+      # @return [Hash, nil] response message, or nil for messages requiring no reply
+      # @raise [AuthError] if the version is wrong or the message type is unknown
+      def handle_incoming_message(message)
+        version = message[:version] || message['version']
+        raise AuthError, "Unsupported auth version: #{version.inspect} (expected #{AUTH_VERSION})" unless version == AUTH_VERSION
+
+        type = message[:message_type] || message['message_type']
+
+        case type
+        when MSG_INITIAL_REQUEST  then process_initial_request(message)
+        when MSG_INITIAL_RESPONSE then process_initial_response(message)
+        when MSG_GENERAL          then process_general_message(message)
+        else
+          raise AuthError, "Unknown message type: #{type.inspect}"
+        end
+      end
+
+      # --- General message exchange (post-handshake) ---
+
+      # Creates an authenticated +general+ message to send to a peer.
+      #
+      # @param peer_identifier [String] peer's session nonce or identity key
+      # @param payload [Array<Integer>] byte array payload
+      # @return [Hash] the message to send
+      # @raise [AuthError] if not authenticated with this peer
+      def create_general_message(peer_identifier, payload)
+        session = @session_manager.get_session(peer_identifier)
+        raise AuthError, "Not authenticated with peer #{peer_identifier.inspect}" unless session&.authenticated?
+
+        # The receiver verifies `your_nonce` using their own wallet — so it must
+        # be the peer's nonce (the nonce THEY created during the handshake).
+        request_nonce = ::Base64.strict_encode64(SecureRandom.random_bytes(32))
+        key_id        = key_id_for(request_nonce, session.peer_nonce)
+
+        sig_result = @wallet.create_signature({
+                                                data: payload,
+                                                protocol_id: AUTH_PROTOCOL,
+                                                key_id: key_id,
+                                                counterparty: session.peer_identity_key
+                                              })
+
+        session.last_update = current_time_ms
+        @session_manager.update_session(session)
+
+        {
+          version: AUTH_VERSION,
+          message_type: MSG_GENERAL,
+          identity_key: identity_key,
+          nonce: request_nonce,
+          your_nonce: session.peer_nonce,
+          payload: payload,
+          signature: sig_result[:signature]
+        }
+      end
+
+      private
+
+      # --- Processing: initial request (we are the responder) ---
+
+      def process_initial_request(message)
+        peer_key        = fetch!(message, :identity_key)
+        their_nonce     = fetch!(message, :initial_nonce)
+
+        raise AuthError, 'initial_nonce must not be empty' if their_nonce.empty?
+
+        our_nonce = Nonce.create(@wallet)
+
+        session                        = PeerSession.new(session_nonce: our_nonce)
+        session.peer_identity_key      = peer_key
+        session.peer_nonce             = their_nonce
+        session.is_authenticated       = true
+        session.certificates_required  = certifiers_present?
+        session.certificates_validated = !session.certificates_required
+        session.last_update            = current_time_ms
+
+        @session_manager.add_session(session)
+
+        # Sign decode(their_nonce) + decode(our_nonce)
+        # Key ID: "their_nonce our_nonce"  (initiator_nonce responder_nonce)
+        sig_data = b64_decode(their_nonce) + b64_decode(our_nonce)
+        key_id   = key_id_for(their_nonce, our_nonce)
+
+        sig_result = @wallet.create_signature({
+                                                data: sig_data,
+                                                protocol_id: AUTH_PROTOCOL,
+                                                key_id: key_id,
+                                                counterparty: peer_key
+                                              })
+
+        {
+          version: AUTH_VERSION,
+          message_type: MSG_INITIAL_RESPONSE,
+          identity_key: identity_key,
+          initial_nonce: our_nonce,
+          your_nonce: their_nonce,
+          requested_certificates: @certificates_to_request,
+          signature: sig_result[:signature]
+        }
+      end
+
+      # --- Processing: initial response (we are the initiator) ---
+
+      def process_initial_response(message)
+        their_nonce = fetch!(message, :initial_nonce)  # responder's nonce
+        our_nonce   = fetch!(message, :your_nonce)     # our nonce echoed back
+        peer_key    = fetch!(message, :identity_key)
+        signature   = fetch!(message, :signature)
+
+        # Verify the echoed nonce is one we created
+        raise AuthError, "Nonce verification failed from peer: #{peer_key}" unless Nonce.verify(our_nonce, @wallet)
+
+        session = @session_manager.get_session(our_nonce)
+        raise AuthError, "No pending session for nonce: #{our_nonce.inspect}" unless session
+
+        # Verify responder's signature over decode(our_nonce) + decode(their_nonce)
+        # Key ID: "our_nonce their_nonce"  (initiator_nonce responder_nonce)
+        sig_data = b64_decode(our_nonce) + b64_decode(their_nonce)
+        key_id   = key_id_for(our_nonce, their_nonce)
+
+        @wallet.verify_signature({
+                                   data: sig_data,
+                                   signature: signature,
+                                   protocol_id: AUTH_PROTOCOL,
+                                   key_id: key_id,
+                                   counterparty: peer_key
+                                 })
+
+        # Authentication complete
+        session.peer_nonce        = their_nonce
+        session.peer_identity_key = peer_key
+        session.is_authenticated  = true
+        session.last_update       = current_time_ms
+
+        @session_manager.update_session(session)
+
+        nil
+      rescue BSV::Wallet::InvalidSignatureError
+        @session_manager.remove_session(session) if session
+        raise AuthError, "Initial response signature verification failed from peer: #{peer_key}"
+      end
+
+      # --- Processing: general message (we are the receiver) ---
+
+      def process_general_message(message)
+        our_nonce = fetch!(message, :your_nonce) # our session nonce echoed back
+        peer_key  = fetch!(message, :identity_key)
+        payload   = message[:payload] || message['payload'] || []
+        signature = fetch!(message, :signature)
+        msg_nonce = fetch!(message, :nonce)
+
+        # Verify the echoed nonce is one we created
+        raise AuthError, "Unable to verify nonce for general message from: #{peer_key}" unless Nonce.verify(our_nonce, @wallet)
+
+        session = @session_manager.get_session(our_nonce)
+        raise AuthError, "Session not found for nonce: #{our_nonce.inspect}" unless session
+
+        # Verify signature: signed over payload with key_id "msg_nonce session_nonce"
+        key_id = key_id_for(msg_nonce, session.session_nonce)
+
+        @wallet.verify_signature({
+                                   data: payload,
+                                   signature: signature,
+                                   protocol_id: AUTH_PROTOCOL,
+                                   key_id: key_id,
+                                   counterparty: session.peer_identity_key
+                                 })
+
+        session.last_update = current_time_ms
+        @session_manager.update_session(session)
+
+        { peer_identity_key: session.peer_identity_key, payload: payload }
+      rescue BSV::Wallet::InvalidSignatureError
+        raise AuthError, "General message signature verification failed from: #{peer_key}"
+      end
+
+      # --- Helpers ---
+
+      # Builds the key ID string: "prefix suffix".
+      # @param prefix [String] first nonce (base64)
+      # @param suffix [String] second nonce (base64)
+      # @return [String]
+      def key_id_for(prefix, suffix)
+        "#{prefix} #{suffix}"
+      end
+
+      # Decodes a base64 string to a byte array (Array<Integer>).
+      # @param b64 [String]
+      # @return [Array<Integer>]
+      def b64_decode(b64)
+        ::Base64.strict_decode64(b64).bytes
+      end
+
+      # Fetches a value from a message hash, trying both Symbol and String keys.
+      # @param message [Hash]
+      # @param key [Symbol]
+      # @return [Object]
+      # @raise [AuthError] if the key is missing or nil
+      def fetch!(message, key)
+        value = message[key] || message[key.to_s]
+        raise AuthError, "Missing required field: #{key}" if value.nil?
+        raise AuthError, "Field #{key} must not be empty" if value.respond_to?(:empty?) && value.empty?
+
+        value
+      end
+
+      def certifiers_present?
+        certs = @certificates_to_request[:certifiers] || @certificates_to_request['certifiers']
+        certs.is_a?(Array) && !certs.empty?
+      end
+
+      def current_time_ms
+        (Time.now.to_f * 1000).to_i
+      end
+    end
+  end
+end

--- a/lib/bsv/auth/peer_session.rb
+++ b/lib/bsv/auth/peer_session.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module BSV
+  module Auth
+    # Represents the state of an authentication session with a peer.
+    #
+    # Sessions are indexed by +session_nonce+ (our nonce for the session),
+    # which is the primary key in {SessionManager}. The +peer_identity_key+
+    # is a secondary index used to look up sessions by peer.
+    #
+    # @example Creating a session
+    #   session = PeerSession.new(session_nonce: nonce)
+    #   session.peer_identity_key = 'abc123...'
+    #   session.peer_nonce = 'xyz...'
+    class PeerSession
+      # @return [String] our nonce for this session (base64) — primary key
+      attr_reader :session_nonce
+
+      # @return [String, nil] the peer's identity key (public key hex)
+      attr_accessor :peer_identity_key
+
+      # @return [String, nil] the nonce we received from the peer (base64)
+      attr_accessor :peer_nonce
+
+      # @return [Boolean] whether mutual authentication is complete
+      attr_accessor :is_authenticated
+
+      # @return [Integer] Unix timestamp (milliseconds) of last update
+      attr_accessor :last_update
+
+      # @return [Boolean] whether certificates are required from this peer
+      attr_accessor :certificates_required
+
+      # @return [Boolean] whether required certificates have been validated
+      attr_accessor :certificates_validated
+
+      # @param session_nonce [String] our nonce for this session (base64)
+      def initialize(session_nonce:)
+        @session_nonce          = session_nonce
+        @peer_identity_key      = nil
+        @peer_nonce             = nil
+        @is_authenticated       = false
+        @last_update            = current_time_ms
+        @certificates_required  = false
+        @certificates_validated = true
+      end
+
+      # @return [Boolean]
+      def authenticated?
+        @is_authenticated
+      end
+
+      private
+
+      def current_time_ms
+        (Time.now.to_f * 1000).to_i
+      end
+    end
+  end
+end

--- a/lib/bsv/auth/session_manager.rb
+++ b/lib/bsv/auth/session_manager.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+module BSV
+  module Auth
+    # Thread-safe store for {PeerSession} objects.
+    #
+    # Supports dual-index lookup: by +session_nonce+ (primary) or by
+    # +peer_identity_key+ (secondary). Multiple concurrent sessions per
+    # peer identity key are supported — the most recently updated session
+    # is returned when looking up by identity key.
+    #
+    # Matches the ts-sdk SessionManager dual-index design.
+    class SessionManager
+      def initialize
+        # session_nonce -> PeerSession
+        @by_nonce    = {}
+        # peer_identity_key -> Set of session_nonces
+        @by_identity = {}
+        @mutex       = Mutex.new
+      end
+
+      # Adds a session to the manager.
+      #
+      # @param session [PeerSession]
+      # @raise [ArgumentError] if +session_nonce+ is blank
+      def add_session(session)
+        raise ArgumentError, 'session_nonce is required' unless session.session_nonce.is_a?(String) && !session.session_nonce.empty?
+
+        @mutex.synchronize do
+          @by_nonce[session.session_nonce] = session
+
+          if session.peer_identity_key.is_a?(String)
+            nonces = @by_identity[session.peer_identity_key] ||= []
+            nonces << session.session_nonce unless nonces.include?(session.session_nonce)
+          end
+        end
+      end
+
+      # Updates an existing session (removes old references and re-adds).
+      #
+      # @param session [PeerSession]
+      def update_session(session)
+        @mutex.synchronize do
+          remove_session_locked(session)
+          add_session_locked(session)
+        end
+      end
+
+      # Retrieves a session by +session_nonce+ or +peer_identity_key+.
+      #
+      # When the identifier is a session nonce, returns that exact session.
+      # When the identifier is a peer identity key, returns the most recently
+      # updated session for that peer.
+      #
+      # @param identifier [String]
+      # @return [PeerSession, nil]
+      def get_session(identifier)
+        @mutex.synchronize do
+          direct = @by_nonce[identifier]
+          return direct if direct
+
+          nonces = @by_identity[identifier]
+          return nil if nonces.nil? || nonces.empty?
+
+          best = nil
+          nonces.each do |nonce|
+            s = @by_nonce[nonce]
+            next if s.nil?
+
+            best = s if best.nil? || (s.last_update || 0) > (best.last_update || 0)
+          end
+          best
+        end
+      end
+
+      # Removes a session from the manager.
+      #
+      # @param session [PeerSession]
+      def remove_session(session)
+        @mutex.synchronize { remove_session_locked(session) }
+      end
+
+      # @param identifier [String] session nonce or identity key
+      # @return [Boolean]
+      def session?(identifier)
+        @mutex.synchronize do
+          return true if @by_nonce.key?(identifier)
+
+          nonces = @by_identity[identifier]
+          !nonces.nil? && !nonces.empty?
+        end
+      end
+
+      private
+
+      def add_session_locked(session)
+        return unless session.session_nonce.is_a?(String) && !session.session_nonce.empty?
+
+        @by_nonce[session.session_nonce] = session
+
+        return unless session.peer_identity_key.is_a?(String)
+
+        nonces = @by_identity[session.peer_identity_key] ||= []
+        nonces << session.session_nonce unless nonces.include?(session.session_nonce)
+      end
+
+      def remove_session_locked(session)
+        @by_nonce.delete(session.session_nonce)
+
+        return unless session.peer_identity_key.is_a?(String)
+
+        nonces = @by_identity[session.peer_identity_key]
+        return unless nonces
+
+        nonces.delete(session.session_nonce)
+        @by_identity.delete(session.peer_identity_key) if nonces.empty?
+      end
+    end
+  end
+end

--- a/lib/bsv/auth/transport.rb
+++ b/lib/bsv/auth/transport.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module BSV
+  module Auth
+    # Duck-typed interface for BRC-31 message transport.
+    #
+    # Concrete transports (HTTP, WebSocket, in-process, etc.) must implement
+    # both methods. Include this module to get the default +NotImplementedError+
+    # stubs — override in your implementation class.
+    #
+    # @example Minimal in-process transport for testing
+    #   class DirectTransport
+    #     include BSV::Auth::Transport
+    #
+    #     def initialize(peer)
+    #       @peer = peer
+    #     end
+    #
+    #     def send(message)
+    #       @peer.handle_incoming_message(message)
+    #     end
+    #
+    #     def on_data(&block)
+    #       @on_data = block
+    #     end
+    #   end
+    module Transport
+      # Sends a message to the remote peer.
+      #
+      # @param message [Hash] the serialised auth message
+      # @return [void]
+      def send(_message)
+        raise NotImplementedError, "#{self.class}#send not implemented"
+      end
+
+      # Registers a callback to be invoked when a message arrives.
+      #
+      # @yieldparam message [Hash] the incoming auth message
+      # @return [void]
+      def on_data(&_block)
+        raise NotImplementedError, "#{self.class}#on_data not implemented"
+      end
+    end
+  end
+end

--- a/spec/bsv/auth/nonce_spec.rb
+++ b/spec/bsv/auth/nonce_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+
+RSpec.describe BSV::Auth::Nonce do
+  let(:private_key) { BSV::Primitives::PrivateKey.generate }
+  let(:wallet) { BSV::Wallet::ProtoWallet.new(private_key) }
+
+  describe '.create' do
+    subject(:nonce) { described_class.create(wallet) }
+
+    it 'returns a non-empty string' do
+      expect(nonce).to be_a(String)
+      expect(nonce).not_to be_empty
+    end
+
+    it 'returns a valid base64-encoded string' do
+      expect { Base64.strict_decode64(nonce) }.not_to raise_error
+    end
+
+    it 'decodes to 48 bytes (16 random + 32 HMAC)' do
+      decoded = Base64.strict_decode64(nonce)
+      expect(decoded.bytesize).to eq(48)
+    end
+
+    it 'produces a unique nonce on each call' do
+      nonce2 = described_class.create(wallet)
+      expect(nonce).not_to eq(nonce2)
+    end
+
+    it 'uses counterparty "self" by default' do
+      expect { nonce }.not_to raise_error
+    end
+  end
+
+  describe '.verify' do
+    let(:nonce) { described_class.create(wallet) }
+
+    it 'returns true for a valid nonce from the same wallet' do
+      expect(described_class.verify(nonce, wallet)).to be(true)
+    end
+
+    it 'returns false when the HMAC suffix is tampered' do
+      decoded = Base64.strict_decode64(nonce)
+      tampered_bytes = decoded.dup.bytes
+      tampered_bytes[-1] ^= 0xFF
+      tampered_nonce = Base64.strict_encode64(tampered_bytes.pack('C*'))
+      expect(described_class.verify(tampered_nonce, wallet)).to be(false)
+    end
+
+    it 'returns false when the random prefix is altered' do
+      decoded = Base64.strict_decode64(nonce)
+      tampered_bytes = decoded.dup.bytes
+      tampered_bytes[0] ^= 0xFF
+      tampered_nonce = Base64.strict_encode64(tampered_bytes.pack('C*'))
+      expect(described_class.verify(tampered_nonce, wallet)).to be(false)
+    end
+
+    it 'returns false when verified against a different wallet' do
+      other_key    = BSV::Primitives::PrivateKey.generate
+      other_wallet = BSV::Wallet::ProtoWallet.new(other_key)
+      expect(described_class.verify(nonce, other_wallet)).to be(false)
+    end
+
+    it 'returns false for a nonce that is too short' do
+      short_nonce = Base64.strict_encode64('tooshort')
+      expect(described_class.verify(short_nonce, wallet)).to be(false)
+    end
+  end
+end

--- a/spec/bsv/auth/peer_spec.rb
+++ b/spec/bsv/auth/peer_spec.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+
+RSpec.describe BSV::Auth::Peer do
+  let(:alice_key)    { BSV::Primitives::PrivateKey.generate }
+  let(:bob_key)      { BSV::Primitives::PrivateKey.generate }
+  let(:alice_wallet) { BSV::Wallet::ProtoWallet.new(alice_key) }
+  let(:bob_wallet)   { BSV::Wallet::ProtoWallet.new(bob_key) }
+  let(:alice)        { described_class.new(wallet: alice_wallet) }
+  let(:bob)          { described_class.new(wallet: bob_wallet) }
+
+  # Performs the full three-step handshake and returns [request, response].
+  def perform_handshake(initiator, responder)
+    request  = initiator.create_initial_request
+    response = responder.handle_incoming_message(request)
+    initiator.handle_incoming_message(response)
+    [request, response]
+  end
+
+  describe '#identity_key' do
+    it 'returns the compressed public key hex for the wallet' do
+      expect(alice.identity_key).to eq(alice_key.public_key.to_hex)
+    end
+
+    it 'returns a 66-character hex string (compressed pubkey)' do
+      expect(alice.identity_key.length).to eq(66)
+    end
+
+    it 'returns a consistent value on repeated calls' do
+      first_call  = alice.identity_key
+      second_call = alice.identity_key
+      expect(first_call).to eq(second_call)
+    end
+
+    it 'returns different keys for different wallets' do
+      expect(alice.identity_key).not_to eq(bob.identity_key)
+    end
+  end
+
+  describe '#create_initial_request' do
+    subject(:request) { alice.create_initial_request }
+
+    it 'returns a hash with the expected keys' do
+      expect(request).to include(
+        version: BSV::Auth::AUTH_VERSION,
+        message_type: BSV::Auth::MSG_INITIAL_REQUEST,
+        identity_key: alice.identity_key
+      )
+    end
+
+    it 'includes a non-empty initial_nonce' do
+      expect(request[:initial_nonce]).to be_a(String)
+      expect(request[:initial_nonce]).not_to be_empty
+    end
+
+    it 'creates a pending session in the session manager' do
+      nonce = request[:initial_nonce]
+      expect(alice.session_manager.session?(nonce)).to be(true)
+    end
+
+    it 'generates a unique nonce on each call' do
+      second_request = alice.create_initial_request
+      expect(request[:initial_nonce]).not_to eq(second_request[:initial_nonce])
+    end
+  end
+
+  describe '#handle_incoming_message — full handshake round-trip' do
+    it 'authenticates Alice after processing the initial response' do
+      request  = alice.create_initial_request
+      response = bob.handle_incoming_message(request)
+      alice.handle_incoming_message(response)
+
+      expect(alice.authenticated?(request[:initial_nonce])).to be(true)
+    end
+
+    it 'authenticates Bob after processing the initial request' do
+      request  = alice.create_initial_request
+      response = bob.handle_incoming_message(request)
+      alice.handle_incoming_message(response)
+
+      # Bob's session is indexed by his own nonce (from the response)
+      expect(bob.authenticated?(response[:initial_nonce])).to be(true)
+    end
+
+    it 'returns nil when Alice processes the initial response (no further reply needed)' do
+      request  = alice.create_initial_request
+      response = bob.handle_incoming_message(request)
+      result   = alice.handle_incoming_message(response)
+
+      expect(result).to be_nil
+    end
+
+    it "includes Bob's identity key in the initial response" do
+      request  = alice.create_initial_request
+      response = bob.handle_incoming_message(request)
+
+      expect(response[:identity_key]).to eq(bob.identity_key)
+    end
+
+    it "echoes Alice's nonce back in the response" do
+      request  = alice.create_initial_request
+      response = bob.handle_incoming_message(request)
+
+      expect(response[:your_nonce]).to eq(request[:initial_nonce])
+    end
+  end
+
+  describe '#handle_incoming_message — version and type guards' do
+    it 'raises AuthError when the version is wrong' do
+      bad_msg = { version: '9.9', message_type: BSV::Auth::MSG_INITIAL_REQUEST }
+      expect { alice.handle_incoming_message(bad_msg) }.to raise_error(BSV::Auth::AuthError, /Unsupported auth version/)
+    end
+
+    it 'raises AuthError for an unknown message type' do
+      bad_msg = { version: BSV::Auth::AUTH_VERSION, message_type: 'mystery' }
+      expect { alice.handle_incoming_message(bad_msg) }.to raise_error(BSV::Auth::AuthError, /Unknown message type/)
+    end
+  end
+
+  describe '#create_general_message / #handle_incoming_message (general)' do
+    let(:payload) { [72, 101, 108, 108, 111] } # "Hello"
+
+    # Perform handshake and expose Alice's session nonce for use in examples.
+    let(:alice_session_nonce) do
+      perform_handshake(alice, bob)
+      alice.session_manager.instance_variable_get(:@by_nonce).keys.first
+    end
+
+    it 'can create a general message after authentication' do
+      msg = alice.create_general_message(alice_session_nonce, payload)
+      expect(msg[:message_type]).to eq(BSV::Auth::MSG_GENERAL)
+    end
+
+    it 'Bob can verify and read the payload sent by Alice' do
+      msg    = alice.create_general_message(alice_session_nonce, payload)
+      result = bob.handle_incoming_message(msg)
+
+      expect(result[:payload]).to eq(payload)
+      expect(result[:peer_identity_key]).to eq(alice.identity_key)
+    end
+  end
+
+  describe '#create_general_message — raises without auth' do
+    it 'raises AuthError when no session exists for the identifier' do
+      expect do
+        alice.create_general_message('no-such-nonce', [1, 2, 3])
+      end.to raise_error(BSV::Auth::AuthError, /Not authenticated/)
+    end
+  end
+
+  describe '#handle_incoming_message — tampered initial response' do
+    it 'raises AuthError when the signature has been tampered with' do
+      request = alice.create_initial_request
+      response = bob.handle_incoming_message(request)
+
+      # Flip the last byte of the signature to invalidate it
+      bad_sig = response[:signature].dup
+      bad_sig[-1] ^= 0xFF
+      tampered = response.merge(signature: bad_sig)
+
+      expect { alice.handle_incoming_message(tampered) }
+        .to raise_error(BSV::Auth::AuthError, /signature verification failed/)
+    end
+
+    it 'removes the pending session after a failed signature verification' do
+      request = alice.create_initial_request
+      our_nonce = request[:initial_nonce]
+
+      response = bob.handle_incoming_message(request)
+      bad_sig  = response[:signature].dup
+      bad_sig[-1] ^= 0xFF
+      tampered = response.merge(signature: bad_sig)
+
+      begin
+        alice.handle_incoming_message(tampered)
+      rescue BSV::Auth::AuthError
+        nil
+      end
+
+      expect(alice.session_manager.get_session(our_nonce)).to be_nil
+    end
+  end
+end

--- a/spec/bsv/auth/session_manager_spec.rb
+++ b/spec/bsv/auth/session_manager_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+
+RSpec.describe BSV::Auth::SessionManager do
+  subject(:manager) { described_class.new }
+
+  let(:session_nonce) { 'nonce-abc' }
+  let(:peer_key)      { "02#{'ab' * 32}" }
+
+  def build_session(nonce: session_nonce, peer_identity_key: nil, authenticated: false)
+    s = BSV::Auth::PeerSession.new(session_nonce: nonce)
+    s.peer_identity_key = peer_identity_key if peer_identity_key
+    s.is_authenticated  = authenticated
+    s
+  end
+
+  describe '#add_session / #get_session' do
+    it 'stores and retrieves a session by session_nonce' do
+      session = build_session
+      manager.add_session(session)
+      expect(manager.get_session(session_nonce)).to equal(session)
+    end
+
+    it 'returns nil for an unknown nonce' do
+      expect(manager.get_session('unknown-nonce')).to be_nil
+    end
+
+    it 'indexes by peer_identity_key when present' do
+      session = build_session(peer_identity_key: peer_key)
+      manager.add_session(session)
+      expect(manager.get_session(peer_key)).to equal(session)
+    end
+
+    it 'returns nil when looking up an unknown peer_identity_key' do
+      expect(manager.get_session(peer_key)).to be_nil
+    end
+
+    it 'raises ArgumentError when session_nonce is empty' do
+      session = build_session(nonce: '')
+      expect { manager.add_session(session) }.to raise_error(ArgumentError, /session_nonce is required/)
+    end
+  end
+
+  describe '#update_session' do
+    it 'reflects updated attributes after update_session' do
+      session = build_session(peer_identity_key: peer_key)
+      manager.add_session(session)
+
+      session.is_authenticated = true
+      manager.update_session(session)
+
+      retrieved = manager.get_session(session_nonce)
+      expect(retrieved.authenticated?).to be(true)
+    end
+
+    it 'updates the secondary identity-key index when peer key changes' do
+      session = build_session
+      manager.add_session(session)
+
+      session.peer_identity_key = peer_key
+      manager.update_session(session)
+
+      expect(manager.get_session(peer_key)).to equal(session)
+    end
+  end
+
+  describe '#remove_session' do
+    it 'removes the session so it cannot be retrieved by nonce' do
+      session = build_session
+      manager.add_session(session)
+      manager.remove_session(session)
+      expect(manager.get_session(session_nonce)).to be_nil
+    end
+
+    it 'removes the session from the identity-key index too' do
+      session = build_session(peer_identity_key: peer_key)
+      manager.add_session(session)
+      manager.remove_session(session)
+      expect(manager.get_session(peer_key)).to be_nil
+    end
+
+    it 'is idempotent for an unknown session' do
+      session = build_session
+      expect { manager.remove_session(session) }.not_to raise_error
+    end
+  end
+
+  describe '#session?' do
+    it 'returns true after a session is added' do
+      manager.add_session(build_session)
+      expect(manager.session?(session_nonce)).to be(true)
+    end
+
+    it 'returns false before any session is added' do
+      expect(manager.session?(session_nonce)).to be(false)
+    end
+
+    it 'returns false after the session is removed' do
+      session = build_session
+      manager.add_session(session)
+      manager.remove_session(session)
+      expect(manager.session?(session_nonce)).to be(false)
+    end
+  end
+
+  describe 'multiple sessions per peer identity key' do
+    it 'returns the most recently updated session when looking up by identity key' do
+      session_a = build_session(nonce: 'nonce-a', peer_identity_key: peer_key)
+      session_b = build_session(nonce: 'nonce-b', peer_identity_key: peer_key)
+
+      session_a.last_update = 1000
+      session_b.last_update = 2000
+
+      manager.add_session(session_a)
+      manager.add_session(session_b)
+
+      expect(manager.get_session(peer_key)).to equal(session_b)
+    end
+  end
+
+  describe 'authenticated? helper (via Peer)' do
+    it 'returns false when no session exists' do
+      expect(manager.get_session('no-such-nonce')).to be_nil
+    end
+
+    it 'reflects authentication state on the session' do
+      session = build_session(authenticated: true)
+      manager.add_session(session)
+      expect(manager.get_session(session_nonce).authenticated?).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `BSV::Auth` module — BRC-31 peer-to-peer mutual authentication
- `Peer` class: 3-step handshake (initial request → response → verify) + authenticated general messages
- `Nonce`: HMAC-based challenge creation/verification via wallet crypto
- `SessionManager`: thread-safe session lifecycle with dual-index lookup
- `Transport` duck-typed interface for pluggable message delivery
- Protocol follows go-sdk pattern (corrects known ts-sdk nonce concatenation bug)

## Components

| Class | Purpose |
|-------|---------|
| `BSV::Auth::Peer` | Main orchestrator — handshake + message exchange |
| `BSV::Auth::Nonce` | HMAC nonce creation/verification |
| `BSV::Auth::SessionManager` | Session lifecycle management |
| `BSV::Auth::PeerSession` | Per-peer session state |
| `BSV::Auth::Transport` | Message delivery interface |
| `BSV::Auth::AuthError` | Authentication exception |

## Test plan

- [x] 46 auth examples pass (nonce, session, peer handshake, general messages, error paths)
- [x] 2327 total project tests pass
- [x] Rubocop clean
- [x] Full handshake round-trip: Alice ↔ Bob mutual authentication verified
- [x] General message signed/verified after auth
- [x] Error paths: unauthenticated send, tampered signature, wrong version

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)