### PR TITLE
fix: PUSHDATA bounds check and extended key path validation

### DIFF
--- a/lib/bsv/primitives/extended_key.rb
+++ b/lib/bsv/primitives/extended_key.rb
@@ -212,7 +212,10 @@ module BSV
 
         components[1..].reduce(self) do |key, component|
           hardened = component.end_with?("'", 'H', 'h')
-          index = component.to_i
+          numeric_part = component.delete("'Hh")
+          raise ArgumentError, "invalid path component: '#{component}'" unless numeric_part.match?(/\A\d+\z/)
+
+          index = numeric_part.to_i
           index += HARDENED if hardened
           key.child(index)
         end

--- a/lib/bsv/script/script.rb
+++ b/lib/bsv/script/script.rb
@@ -692,6 +692,11 @@ module BSV
 
             len = raw.getbyte(pos)
             pos += 1
+            if pos + len > raw.bytesize
+              raise ArgumentError,
+                    "truncated script: OP_PUSHDATA1 needs #{len} data bytes at offset #{pos}, got #{raw.bytesize - pos}"
+            end
+
             data = raw.byteslice(pos, len)
             pos += len
             result << Chunk.new(opcode: opcode, data: data)
@@ -700,6 +705,11 @@ module BSV
 
             len = raw.byteslice(pos, 2).unpack1('v')
             pos += 2
+            if pos + len > raw.bytesize
+              raise ArgumentError,
+                    "truncated script: OP_PUSHDATA2 needs #{len} data bytes at offset #{pos}, got #{raw.bytesize - pos}"
+            end
+
             data = raw.byteslice(pos, len)
             pos += len
             result << Chunk.new(opcode: opcode, data: data)
@@ -708,6 +718,11 @@ module BSV
 
             len = raw.byteslice(pos, 4).unpack1('V')
             pos += 4
+            if pos + len > raw.bytesize
+              raise ArgumentError,
+                    "truncated script: OP_PUSHDATA4 needs #{len} data bytes at offset #{pos}, got #{raw.bytesize - pos}"
+            end
+
             data = raw.byteslice(pos, len)
             pos += len
             result << Chunk.new(opcode: opcode, data: data)


### PR DESCRIPTION
## Summary

- **B1**: Script parser now validates OP_PUSHDATA1/2/4 data length against remaining bytes. Previously, truncated scripts silently produced chunks with incomplete data — incorrect sighash computation → unspendable funds.
- **S1**: `ExtendedKey#derive_path` rejects non-numeric path components. Previously, `"m/44'/abc/0"` silently became `"m/44'/0/0"` — funds sent to wrong address.
- **B2 deferred**: OP_RETURN inside balanced conditionals interacts with edge cases in the script vector suite and needs deeper analysis.

## Test plan

- [x] 2327 tests pass, 0 failures
- [x] Rubocop clean
- [x] PUSHDATA1 truncation now raises ArgumentError
- [x] Invalid path component now raises ArgumentError
- [x] Valid paths still work
- [x] Script vector pass count unchanged (1205)

Fixes #225, fixes #227
From audit HLR #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)