### PR TITLE
feat(wallet): add FileStore as default storage adapter

### DIFF
--- a/lib/bsv/wallet_interface.rb
+++ b/lib/bsv/wallet_interface.rb
@@ -13,6 +13,7 @@ module BSV
     autoload :Validators,       'bsv/wallet_interface/validators'
     autoload :StorageAdapter,    'bsv/wallet_interface/storage_adapter'
     autoload :MemoryStore,       'bsv/wallet_interface/memory_store'
+    autoload :FileStore,         'bsv/wallet_interface/file_store'
     autoload :ChainProvider,     'bsv/wallet_interface/chain_provider'
     autoload :NullChainProvider, 'bsv/wallet_interface/null_chain_provider'
     autoload :WalletClient,      'bsv/wallet_interface/wallet_client'

--- a/lib/bsv/wallet_interface/file_store.rb
+++ b/lib/bsv/wallet_interface/file_store.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'fileutils'
+
+module BSV
+  module Wallet
+    # JSON file-backed storage adapter.
+    #
+    # Persists actions, outputs, and certificates as JSON files in a
+    # configurable directory (default: +~/.bsv-wallet/+). Data survives
+    # process restarts.
+    #
+    # Inherits all filtering and pagination logic from {MemoryStore} and
+    # adds load-on-init / save-on-mutation.
+    #
+    # @example Default location
+    #   store = BSV::Wallet::FileStore.new
+    #   # Data written to ~/.bsv-wallet/
+    #
+    # @example Custom directory
+    #   store = BSV::Wallet::FileStore.new(dir: '/var/lib/my-app/wallet')
+    class FileStore < MemoryStore
+      DEFAULT_DIR = File.expand_path('~/.bsv-wallet')
+
+      # @param dir [String] directory for JSON files
+      #   (default: +~/.bsv-wallet/+ or +BSV_WALLET_DIR+ env var)
+      def initialize(dir: nil)
+        super()
+        @dir = dir || ENV.fetch('BSV_WALLET_DIR', DEFAULT_DIR)
+        FileUtils.mkdir_p(@dir)
+        load_from_disk
+      end
+
+      # @return [String] the storage directory path
+      attr_reader :dir
+
+      # --- Mutations: delegate to super, then persist ---
+
+      def store_action(action_data)
+        result = super
+        save_actions
+        result
+      end
+
+      def store_output(output_data)
+        result = super
+        save_outputs
+        result
+      end
+
+      def delete_output(outpoint)
+        result = super
+        save_outputs if result
+        result
+      end
+
+      def store_certificate(cert_data)
+        result = super
+        save_certificates
+        result
+      end
+
+      def delete_certificate(type:, serial_number:, certifier:)
+        result = super
+        save_certificates if result
+        result
+      end
+
+      private
+
+      def actions_path
+        File.join(@dir, 'actions.json')
+      end
+
+      def outputs_path
+        File.join(@dir, 'outputs.json')
+      end
+
+      def certificates_path
+        File.join(@dir, 'certificates.json')
+      end
+
+      def load_from_disk
+        @actions = load_file(actions_path)
+        @outputs = load_file(outputs_path)
+        @certificates = load_file(certificates_path)
+      end
+
+      def load_file(path)
+        return [] unless File.exist?(path)
+
+        data = JSON.parse(File.read(path))
+        return [] unless data.is_a?(Array)
+
+        # Symbolise top-level keys for consistency with MemoryStore
+        data.map { |entry| symbolise_keys(entry) }
+      rescue JSON::ParserError
+        []
+      end
+
+      def save_actions
+        write_file(actions_path, @actions)
+      end
+
+      def save_outputs
+        write_file(outputs_path, @outputs)
+      end
+
+      def save_certificates
+        write_file(certificates_path, @certificates)
+      end
+
+      def write_file(path, data)
+        json = JSON.pretty_generate(stringify_keys_deep(data))
+        tmp = "#{path}.tmp"
+        File.write(tmp, json)
+        File.rename(tmp, path)
+      end
+
+      def symbolise_keys(hash)
+        return hash unless hash.is_a?(Hash)
+
+        hash.each_with_object({}) do |(k, v), result|
+          result[k.to_sym] = case v
+                             when Hash then symbolise_keys(v)
+                             when Array then v.map { |e| e.is_a?(Hash) ? symbolise_keys(e) : e }
+                             else v
+                             end
+        end
+      end
+
+      def stringify_keys_deep(obj)
+        case obj
+        when Hash
+          obj.each_with_object({}) do |(k, v), result|
+            result[k.to_s] = stringify_keys_deep(v)
+          end
+        when Array
+          obj.map { |e| stringify_keys_deep(e) }
+        else
+          obj
+        end
+      end
+    end
+  end
+end

--- a/lib/bsv/wallet_interface/wallet_client.rb
+++ b/lib/bsv/wallet_interface/wallet_client.rb
@@ -36,11 +36,12 @@ module BSV
       attr_reader :network
 
       # @param key [BSV::Primitives::PrivateKey, String, KeyDeriver] signing key
-      # @param storage [StorageAdapter] persistence adapter (default: MemoryStore)
+      # @param storage [StorageAdapter] persistence adapter (default: FileStore).
+      #   Use +storage: MemoryStore.new+ for tests.
       # @param network [String] 'mainnet' (default) or 'testnet'
       # @param chain_provider [ChainProvider] blockchain data provider (default: NullChainProvider)
       # @param http_client [#request, nil] injectable HTTP client for certificate issuance
-      def initialize(key, storage: MemoryStore.new, network: 'mainnet', chain_provider: NullChainProvider.new, http_client: nil)
+      def initialize(key, storage: FileStore.new, network: 'mainnet', chain_provider: NullChainProvider.new, http_client: nil)
         super(key)
         @storage = storage
         @network = network

--- a/spec/bsv/wallet_interface/certificate_spec.rb
+++ b/spec/bsv/wallet_interface/certificate_spec.rb
@@ -7,7 +7,7 @@ require 'base64'
 
 RSpec.describe 'WalletClient certificate methods' do
   let(:private_key) { BSV::Primitives::PrivateKey.generate }
-  let(:wallet) { BSV::Wallet::WalletClient.new(private_key) }
+  let(:wallet) { BSV::Wallet::WalletClient.new(private_key, storage: BSV::Wallet::MemoryStore.new) }
   let(:certifier_key) { BSV::Primitives::PrivateKey.generate }
   let(:certifier_hex) { certifier_key.public_key.to_hex }
 
@@ -84,7 +84,7 @@ RSpec.describe 'WalletClient certificate methods' do
       end
 
       let(:issuance_wallet) do
-        BSV::Wallet::WalletClient.new(private_key, http_client: mock_http)
+        BSV::Wallet::WalletClient.new(private_key, storage: BSV::Wallet::MemoryStore.new, http_client: mock_http)
       end
 
       let(:issuance_args) do
@@ -120,7 +120,7 @@ RSpec.describe 'WalletClient certificate methods' do
         failing_http = Class.new do
           define_method(:request) { |_uri, _req| Struct.new(:code, :body).new('500', 'error') }
         end.new
-        w = BSV::Wallet::WalletClient.new(private_key, http_client: failing_http)
+        w = BSV::Wallet::WalletClient.new(private_key, storage: BSV::Wallet::MemoryStore.new, http_client: failing_http)
         expect { w.acquire_certificate(issuance_args) }.to raise_error(BSV::Wallet::WalletError, /HTTP 500/)
       end
 
@@ -128,7 +128,7 @@ RSpec.describe 'WalletClient certificate methods' do
         bad_http = Class.new do
           define_method(:request) { |_uri, _req| Struct.new(:code, :body).new('200', 'not json') }
         end.new
-        w = BSV::Wallet::WalletClient.new(private_key, http_client: bad_http)
+        w = BSV::Wallet::WalletClient.new(private_key, storage: BSV::Wallet::MemoryStore.new, http_client: bad_http)
         expect { w.acquire_certificate(issuance_args) }.to raise_error(BSV::Wallet::WalletError, /invalid JSON/)
       end
     end
@@ -213,7 +213,7 @@ RSpec.describe 'WalletClient certificate methods' do
     end
 
     it 'allows the verifier to decrypt the keyring entry' do
-      verifier_wallet = BSV::Wallet::WalletClient.new(verifier_key)
+      verifier_wallet = BSV::Wallet::WalletClient.new(verifier_key, storage: BSV::Wallet::MemoryStore.new)
       prover_identity = wallet.key_deriver.identity_key
 
       result = wallet.prove_certificate({

--- a/spec/bsv/wallet_interface/file_store_spec.rb
+++ b/spec/bsv/wallet_interface/file_store_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+require 'tmpdir'
+
+RSpec.describe BSV::Wallet::FileStore do
+  let(:tmpdir) { Dir.mktmpdir('bsv-wallet-test') }
+  let(:store) { described_class.new(dir: tmpdir) }
+
+  after { FileUtils.rm_rf(tmpdir) }
+
+  describe '#initialize' do
+    it 'creates the directory if it does not exist' do
+      new_dir = File.join(tmpdir, 'nested', 'wallet')
+      described_class.new(dir: new_dir)
+      expect(Dir.exist?(new_dir)).to be true
+    end
+
+    it 'uses BSV_WALLET_DIR env var when no dir given' do
+      env_dir = File.join(tmpdir, 'from-env')
+      allow(ENV).to receive(:fetch).with('BSV_WALLET_DIR', anything).and_return(env_dir)
+      described_class.new
+      expect(Dir.exist?(env_dir)).to be true
+    end
+  end
+
+  describe 'persistence' do
+    it 'persists actions across instances' do
+      store.store_action({ labels: ['test'], txid: 'abc', description: 'test action here' })
+
+      reloaded = described_class.new(dir: tmpdir)
+      actions = reloaded.find_actions({ labels: ['test'] })
+      expect(actions.length).to eq(1)
+      expect(actions.first[:txid]).to eq('abc')
+    end
+
+    it 'persists outputs across instances' do
+      store.store_output({ basket: 'my test tokens', outpoint: 'def.0', satoshis: 1000, spendable: true })
+
+      reloaded = described_class.new(dir: tmpdir)
+      outputs = reloaded.find_outputs({ basket: 'my test tokens' })
+      expect(outputs.length).to eq(1)
+      expect(outputs.first[:satoshis]).to eq(1000)
+    end
+
+    it 'persists certificates across instances' do
+      store.store_certificate({ type: 'cert1', certifier: 'abc', serial_number: 's1', subject: 'xyz' })
+
+      reloaded = described_class.new(dir: tmpdir)
+      certs = reloaded.find_certificates({ certifiers: ['abc'] })
+      expect(certs.length).to eq(1)
+      expect(certs.first[:serial_number]).to eq('s1')
+    end
+
+    it 'persists output deletion' do
+      store.store_output({ basket: 'token vault', outpoint: 'aaa.0', spendable: true })
+      store.delete_output('aaa.0')
+
+      reloaded = described_class.new(dir: tmpdir)
+      outputs = reloaded.find_outputs({ basket: 'token vault' })
+      expect(outputs).to be_empty
+    end
+
+    it 'persists certificate deletion' do
+      store.store_certificate({ type: 't1', certifier: 'c1', serial_number: 's1' })
+      store.delete_certificate(type: 't1', serial_number: 's1', certifier: 'c1')
+
+      reloaded = described_class.new(dir: tmpdir)
+      certs = reloaded.find_certificates({ certifiers: ['c1'], types: ['t1'] })
+      expect(certs).to be_empty
+    end
+  end
+
+  describe 'corrupt file handling' do
+    it 'recovers from invalid JSON' do
+      File.write(File.join(tmpdir, 'actions.json'), 'not json{{{')
+
+      reloaded = described_class.new(dir: tmpdir)
+      expect(reloaded.find_actions({})).to be_empty
+    end
+
+    it 'recovers from non-array JSON' do
+      File.write(File.join(tmpdir, 'outputs.json'), '{"not": "an array"}')
+
+      reloaded = described_class.new(dir: tmpdir)
+      expect(reloaded.find_outputs({ basket: 'anything' })).to be_empty
+    end
+  end
+
+  describe 'atomic writes' do
+    it 'does not leave .tmp files after write' do
+      store.store_action({ labels: ['test'], txid: 'abc', description: 'atomicity test' })
+
+      tmp_files = Dir.glob(File.join(tmpdir, '*.tmp'))
+      expect(tmp_files).to be_empty
+    end
+  end
+
+  describe 'filtering and pagination' do
+    it 'supports the same queries as MemoryStore' do
+      store.store_action({ labels: %w[payment urgent], txid: 'tx1' })
+      store.store_action({ labels: ['payment'], txid: 'tx2' })
+
+      any_results = store.find_actions({ labels: ['urgent'] })
+      expect(any_results.length).to eq(1)
+
+      all_results = store.find_actions({ labels: %w[payment urgent], label_query_mode: 'all' })
+      expect(all_results.length).to eq(1)
+      expect(all_results.first[:txid]).to eq('tx1')
+    end
+
+    it 'counts correctly' do
+      3.times { |i| store.store_output({ basket: 'count test', outpoint: "tx.#{i}", spendable: true }) }
+      expect(store.count_outputs({ basket: 'count test' })).to eq(3)
+    end
+  end
+end

--- a/spec/bsv/wallet_interface/wallet_client_spec.rb
+++ b/spec/bsv/wallet_interface/wallet_client_spec.rb
@@ -8,7 +8,7 @@ require 'base64'
 RSpec.describe BSV::Wallet::WalletClient do
   let(:private_key) { BSV::Primitives::PrivateKey.generate }
   let(:pub_key) { private_key.public_key }
-  let(:wallet) { described_class.new(private_key) }
+  let(:wallet) { described_class.new(private_key, storage: BSV::Wallet::MemoryStore.new) }
 
   # P2PKH locking script for the wallet's own public key
   let(:locking_script_hex) { BSV::Script::Script.p2pkh_lock(pub_key.hash160).to_hex }
@@ -207,7 +207,7 @@ RSpec.describe BSV::Wallet::WalletClient do
 
       # Run enough times that shuffling is virtually certain to swap at least once
       10.times do |i|
-        w = described_class.new(private_key)
+        w = described_class.new(private_key, storage: BSV::Wallet::MemoryStore.new)
         w.create_action({
                           description: "shuffle test #{i} check",
                           outputs: [untracked, tracked]


### PR DESCRIPTION
## Summary

- Adds `BSV::Wallet::FileStore` — JSON file-backed persistent storage (default: `~/.bsv-wallet/`)
- **FileStore is now the default** for `WalletClient.new(key)` — data survives process restarts
- `MemoryStore` becomes explicit opt-in for tests: `storage: MemoryStore.new`
- Atomic writes (tmp + rename), graceful recovery from corrupt files
- Configurable via `dir:` parameter or `BSV_WALLET_DIR` env var

## Why

A wallet that forgets your money when you restart is not a wallet. The previous default (MemoryStore) silently lost all tracked outputs, labels, and certificates on process restart.

## Test plan

- [x] 2339 tests pass (12 new FileStore tests)
- [x] Rubocop clean
- [x] Persistence verified: store → restart → reload → data present
- [x] Corrupt file recovery: invalid JSON → empty state, no crash
- [x] Existing tests updated to use explicit MemoryStore

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)