### PR TITLE
feat: align fee rate defaults with ecosystem (100 sat/kB)

### DIFF
--- a/lib/bsv/transaction/fee_models/live_policy.rb
+++ b/lib/bsv/transaction/fee_models/live_policy.rb
@@ -32,12 +32,24 @@ module BSV
         # @return [Integer] cache TTL in seconds
         attr_reader :cache_ttl
 
+        DEFAULT_ARC_URL = 'https://arc.gorillapool.io'
+        DEFAULT_FALLBACK_RATE = 100
+
+        # Returns a LivePolicy with sensible defaults (GorillaPool ARC,
+        # 100 sat/kB fallback, 5-minute cache).
+        #
+        # @param api_key [String, nil] optional ARC API key
+        # @return [LivePolicy]
+        def self.default(api_key: nil)
+          new(arc_url: DEFAULT_ARC_URL, fallback_rate: DEFAULT_FALLBACK_RATE, api_key: api_key)
+        end
+
         # @param arc_url [String] ARC base URL (e.g. 'https://arc.gorillapool.io')
-        # @param fallback_rate [Integer] sat/kB to use when fetch fails (default: 50)
+        # @param fallback_rate [Integer] sat/kB to use when fetch fails (default: 100)
         # @param cache_ttl [Integer] seconds to cache a fetched rate (default: 300)
         # @param api_key [String, nil] optional Bearer token for ARC authentication
         # @param http_client [#request, nil] injectable HTTP client for testing
-        def initialize(arc_url:, fallback_rate: 50, cache_ttl: DEFAULT_CACHE_TTL, api_key: nil, http_client: nil)
+        def initialize(arc_url:, fallback_rate: DEFAULT_FALLBACK_RATE, cache_ttl: DEFAULT_CACHE_TTL, api_key: nil, http_client: nil)
           super()
           @arc_url = arc_url.chomp('/')
           @fallback_rate = fallback_rate

--- a/lib/bsv/transaction/fee_models/satoshis_per_kilobyte.rb
+++ b/lib/bsv/transaction/fee_models/satoshis_per_kilobyte.rb
@@ -15,8 +15,8 @@ module BSV
         # @return [Integer] satoshis per kilobyte rate
         attr_reader :value
 
-        # @param value [Integer] satoshis per kilobyte (default: 50)
-        def initialize(value: 50)
+        # @param value [Integer] satoshis per kilobyte (default: 100)
+        def initialize(value: 100)
           super()
           @value = value
         end

--- a/lib/bsv/wallet/wallet.rb
+++ b/lib/bsv/wallet/wallet.rb
@@ -25,7 +25,7 @@ module BSV
         @provider.fetch_utxos(address(network: network)).sum(&:satoshis)
       end
 
-      def fund(tx, network: :mainnet, satoshis_per_byte: 0.5)
+      def fund(tx, network: :mainnet, satoshis_per_byte: 0.1)
         utxos = @provider.fetch_utxos(address(network: network))
         output_total = tx.total_output_satoshis
 
@@ -66,7 +66,7 @@ module BSV
         tx.sign_all(@private_key)
       end
 
-      def fund_and_sign(tx, network: :mainnet, satoshis_per_byte: 0.5)
+      def fund_and_sign(tx, network: :mainnet, satoshis_per_byte: 0.1)
         fund(tx, network: network, satoshis_per_byte: satoshis_per_byte)
         sign(tx)
       end

--- a/spec/bsv/transaction/fee_models/satoshis_per_kilobyte_spec.rb
+++ b/spec/bsv/transaction/fee_models/satoshis_per_kilobyte_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe BSV::Transaction::FeeModels::SatoshisPerKilobyte do
       tx = instance_double(BSV::Transaction::Transaction, estimated_size: 1000)
       model = described_class.new
 
-      expect(model.compute_fee(tx)).to eq(50) # 1000/1000 * 50
+      expect(model.compute_fee(tx)).to eq(100) # 1000/1000 * 100
     end
 
     it 'computes fee for a 250 byte transaction at default rate' do
       tx = instance_double(BSV::Transaction::Transaction, estimated_size: 250)
       model = described_class.new
 
-      expect(model.compute_fee(tx)).to eq(13) # ceil(250/1000 * 50) = ceil(12.5) = 13
+      expect(model.compute_fee(tx)).to eq(25) # ceil(250/1000 * 100) = 25
     end
 
     it 'computes fee with custom rate' do
@@ -39,8 +39,8 @@ RSpec.describe BSV::Transaction::FeeModels::SatoshisPerKilobyte do
   end
 
   describe '#value' do
-    it 'defaults to 50 sat/kB' do
-      expect(described_class.new.value).to eq(50)
+    it 'defaults to 100 sat/kB' do
+      expect(described_class.new.value).to eq(100)
     end
 
     it 'accepts a custom rate' do

--- a/spec/bsv/wallet/wallet_spec.rb
+++ b/spec/bsv/wallet/wallet_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe BSV::Wallet::Wallet do
           prev_tx_out_index: 0
         )
       )
-      fee_with_change = dummy_tx.estimated_fee(satoshis_per_byte: 0.5)
+      fee_with_change = dummy_tx.estimated_fee(satoshis_per_byte: 0.1)
 
       # UTXO covers output + fee (with change) exactly — no room for actual change
       utxos = [make_utxo(10_000 + fee_with_change)]

--- a/spec/conformance/fee_model_spec.rb
+++ b/spec/conformance/fee_model_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe BSV::Transaction::FeeModels::SatoshisPerKilobyte do # rubocop:dis
     expect(described_class.new.compute_fee(tx)).to be_an(Integer)
   end
 
-  it 'defaults to 50 sat/kB matching reference SDKs' do
-    expect(described_class.new.value).to eq(50)
+  it 'defaults to 100 sat/kB matching reference SDK fallback' do
+    expect(described_class.new.value).to eq(100)
   end
 end
 


### PR DESCRIPTION
## Summary

- `SatoshisPerKilobyte` default: 50 → 100 sat/kB (matches ts-sdk LivePolicy fallback)
- `Wallet#fund` default: 0.5 → 0.1 sat/byte (was overpaying 5x vs ecosystem)
- `LivePolicy.default` — one-line convenience for live fee queries via GorillaPool ARC
- No API breaking changes — only default values

## Test plan

- [x] 2353 tests pass, 0 failures
- [x] Rubocop clean
- [x] Fee model, wallet, and conformance specs updated for new defaults

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)