### PR TITLE
feat(overlay): implement SHIP/SLAP overlay services

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,6 +78,8 @@ Metrics/AbcSize:
     - 'lib/bsv/wallet_interface/**/*'
     - 'lib/bsv/auth.rb'
     - 'lib/bsv/auth/**/*'
+    - 'lib/bsv/overlay.rb'
+    - 'lib/bsv/overlay/**/*'
     - 'spec/**/*'
 
 Metrics/MethodLength:
@@ -93,6 +95,8 @@ Metrics/MethodLength:
     - 'lib/bsv/wallet_interface/**/*'
     - 'lib/bsv/auth.rb'
     - 'lib/bsv/auth/**/*'
+    - 'lib/bsv/overlay.rb'
+    - 'lib/bsv/overlay/**/*'
     - 'spec/**/*'
 
 Metrics/CyclomaticComplexity:
@@ -108,6 +112,8 @@ Metrics/CyclomaticComplexity:
     - 'lib/bsv/wallet_interface/**/*'
     - 'lib/bsv/auth.rb'
     - 'lib/bsv/auth/**/*'
+    - 'lib/bsv/overlay.rb'
+    - 'lib/bsv/overlay/**/*'
     - 'spec/**/*'
 
 Metrics/PerceivedComplexity:
@@ -123,6 +129,8 @@ Metrics/PerceivedComplexity:
     - 'lib/bsv/wallet_interface/**/*'
     - 'lib/bsv/auth.rb'
     - 'lib/bsv/auth/**/*'
+    - 'lib/bsv/overlay.rb'
+    - 'lib/bsv/overlay/**/*'
     - 'spec/**/*'
 
 Metrics/ModuleLength:
@@ -143,12 +151,14 @@ Metrics/ClassLength:
     - 'lib/bsv/transaction/beef.rb'
     - 'lib/bsv/wallet_interface/**/*'
     - 'lib/bsv/auth/**/*'
+    - 'lib/bsv/overlay/**/*'
 
 Metrics/ParameterLists:
   Exclude:
     - 'lib/bsv/primitives/**/*'
     - 'lib/bsv/script/**/*'
     - 'lib/bsv/transaction/**/*'
+    - 'lib/bsv/overlay/**/*'
 
 # The interpreter condition stack uses :true/:false symbols intentionally
 # (matching the Go SDK pattern) to distinguish from boolean values.
@@ -177,6 +187,7 @@ RSpec/MultipleExpectations:
     - 'spec/bsv/attest_spec.rb'
     - 'spec/bsv/attest/**/*'
     - 'spec/bsv/auth/**/*'
+    - 'spec/bsv/overlay/**/*'
     - 'spec/bsv/wallet_interface/**/*'
     - 'spec/integration/**/*'
     - 'spec/conformance/**/*'
@@ -187,6 +198,7 @@ RSpec/MultipleMemoizedHelpers:
     - 'spec/bsv/script/**/*'
     - 'spec/bsv/transaction/**/*'
     - 'spec/bsv/auth/**/*'
+    - 'spec/bsv/overlay/**/*'
     - 'spec/conformance/**/*'
     - 'spec/bsv/wallet_interface/**/*'
 
@@ -200,6 +212,7 @@ RSpec/ExampleLength:
     - 'spec/bsv/attest_spec.rb'
     - 'spec/bsv/attest/**/*'
     - 'spec/bsv/auth/**/*'
+    - 'spec/bsv/overlay/**/*'
     - 'spec/bsv/wallet_interface/**/*'
     - 'spec/integration/**/*'
     - 'spec/conformance/**/*'

--- a/lib/bsv-sdk.rb
+++ b/lib/bsv-sdk.rb
@@ -9,4 +9,5 @@ module BSV
   autoload :Network,     'bsv/network'
   autoload :Wallet,      'bsv/wallet'
   autoload :Auth,        'bsv/auth'
+  autoload :Overlay,     'bsv/overlay'
 end

--- a/lib/bsv/overlay.rb
+++ b/lib/bsv/overlay.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module BSV
+  # Overlay Services module for BSV blockchain.
+  #
+  # Provides foundation types, protocol constants, and error classes for
+  # interacting with BSV Overlay Services via the SHIP and SLAP protocols.
+  module Overlay
+    autoload :Constants,              'bsv/overlay/constants'
+    autoload :TaggedBEEF,             'bsv/overlay/types'
+    autoload :AdmittanceInstructions, 'bsv/overlay/types'
+    autoload :LookupQuestion,         'bsv/overlay/types'
+    autoload :LookupAnswer,           'bsv/overlay/types'
+    autoload :OverlayBroadcastResult, 'bsv/overlay/types'
+    autoload :OverlayError,           'bsv/overlay/errors'
+    autoload :NoCompetentHostsError,  'bsv/overlay/errors'
+    autoload :AllHostsRejectedError,  'bsv/overlay/errors'
+    autoload :AcknowledgementError, 'bsv/overlay/errors'
+    autoload :HostReputationTracker,    'bsv/overlay/host_reputation_tracker'
+    autoload :AdminTokenTemplate,       'bsv/overlay/admin_token_template'
+    autoload :LookupFacilitator,        'bsv/overlay/lookup_facilitator'
+    autoload :HTTPSLookupFacilitator,   'bsv/overlay/lookup_facilitator'
+    autoload :LookupResolver,           'bsv/overlay/lookup_resolver'
+    autoload :BroadcastFacilitator,       'bsv/overlay/broadcast_facilitator'
+    autoload :HTTPSBroadcastFacilitator,  'bsv/overlay/broadcast_facilitator'
+    autoload :TopicBroadcaster,           'bsv/overlay/topic_broadcaster'
+    autoload :SHIPBroadcaster,            'bsv/overlay/topic_broadcaster'
+  end
+end

--- a/lib/bsv/overlay/admin_token_template.rb
+++ b/lib/bsv/overlay/admin_token_template.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+
+module BSV
+  module Overlay
+    # Script template for creating, unlocking, and decoding SHIP and SLAP advertisements.
+    #
+    # SHIP (Service Host Interconnect) and SLAP (Service Lookup Availability)
+    # tokens are PushDrop scripts containing four data fields:
+    #
+    #   Field 0: protocol string — 'SHIP' or 'SLAP'
+    #   Field 1: identity key — 33-byte compressed public key (binary)
+    #   Field 2: domain — UTF-8 string
+    #   Field 3: topic or service name — UTF-8 string
+    #
+    # The locking script includes a fifth field containing a wallet signature
+    # over the concatenation of fields 0–3, which authenticates the token at
+    # creation time. The lock is secured with a P2PK condition derived from the
+    # wallet using BRC-42/43 key derivation at security level 2.
+    #
+    # Script layout (lock-after PushDrop format):
+    #
+    #   <protocol> <identity_key> <domain> <topic> <wallet_sig>
+    #   OP_2DROP OP_2DROP OP_DROP
+    #   <derived_pubkey> OP_CHECKSIG
+    #
+    # @example Lock a SHIP advertisement
+    #   wallet = BSV::Wallet::ProtoWallet.new(private_key)
+    #   template = BSV::Overlay::AdminTokenTemplate.new(wallet)
+    #   locking_script = template.lock('SHIP', 'myhost.example.com', 'tm_payments')
+    #   decoded = BSV::Overlay::AdminTokenTemplate.decode(locking_script)
+    #   decoded.identity_key  # => hex public key of the wallet
+    class AdminTokenTemplate
+      # Decoded representation of a SHIP or SLAP advertisement.
+      class Advertisement
+        # @return [String] protocol identifier — 'SHIP' or 'SLAP'
+        attr_reader :protocol
+
+        # @return [String] hex-encoded compressed public key (33 bytes)
+        attr_reader :identity_key
+
+        # @return [String] domain where the topic or service is available
+        attr_reader :domain
+
+        # @return [String] topic or service name being advertised
+        attr_reader :topic_or_service
+
+        # @param protocol [String]
+        # @param identity_key [String]
+        # @param domain [String]
+        # @param topic_or_service [String]
+        def initialize(protocol:, identity_key:, domain:, topic_or_service:)
+          @protocol = protocol
+          @identity_key = identity_key
+          @domain = domain
+          @topic_or_service = topic_or_service
+        end
+      end
+
+      # Unlocker returned by {#unlock}.
+      #
+      # Satisfies the P2PK condition in a PushDrop locking script by signing
+      # the BIP-143 sighash of the spending transaction using the wallet's
+      # derived key for the appropriate protocol.
+      class Unlocker
+        # Estimated length of a P2PK unlocking script: 1 push opcode + up to
+        # 72 DER-encoded signature bytes + 1 sighash byte = 73 bytes total.
+        ESTIMATED_LENGTH = 73
+
+        # @param wallet [#create_signature] BRC-100 wallet interface
+        # @param protocol_id [Array] two-element array [security_level, protocol_name]
+        # @param originator [String, nil] optional originator domain
+        def initialize(wallet, protocol_id, originator)
+          @wallet = wallet
+          @protocol_id = protocol_id
+          @originator = originator
+        end
+
+        # Generate the unlocking script for the given input.
+        #
+        # Computes the BIP-143 sighash (SIGHASH_ALL|FORK_ID) and signs it
+        # using the wallet's derived key for the protocol.
+        #
+        # @param tx [BSV::Transaction::Transaction] the spending transaction
+        # @param input_index [Integer] which input to sign
+        # @return [BSV::Script::Script] the unlocking script
+        def sign(tx, input_index)
+          sighash_type = BSV::Transaction::Sighash::ALL_FORK_ID
+          hash = tx.sighash(input_index, sighash_type)
+          hash_bytes = hash.unpack('C*')
+
+          result = @wallet.create_signature(
+            { hash_to_directly_sign: hash_bytes, protocol_id: @protocol_id, key_id: '1', counterparty: 'self' }
+          )
+
+          sig_bytes = result[:signature].pack('C*')
+          sig_with_hashtype = sig_bytes + [sighash_type].pack('C')
+          BSV::Script::Script.pushdrop_unlock(
+            BSV::Script::Script.p2pk_unlock(sig_with_hashtype)
+          )
+        end
+
+        # Estimated byte length of the unlocking script.
+        #
+        # @param _tx [BSV::Transaction::Transaction] unused
+        # @param _input_index [Integer] unused
+        # @return [Integer]
+        def estimated_length(_tx, _input_index)
+          ESTIMATED_LENGTH
+        end
+      end
+
+      VALID_PROTOCOLS = [Constants::PROTOCOL_SHIP, Constants::PROTOCOL_SLAP].freeze
+      private_constant :VALID_PROTOCOLS
+
+      # Decode a SHIP or SLAP advertisement from a PushDrop locking script.
+      #
+      # @param script [BSV::Script::Script, nil] the locking script to decode
+      # @return [Advertisement, nil] the decoded advertisement, or +nil+ if the
+      #   script is nil, empty, or not a PushDrop script
+      # @raise [BSV::Overlay::OverlayError] if the script is PushDrop but has
+      #   fewer than 4 fields, or if the protocol field is not 'SHIP' or 'SLAP'
+      def self.decode(script)
+        return nil if script.nil? || script.bytes.empty?
+        return nil unless script.pushdrop?
+
+        fields = script.pushdrop_fields
+        raise OverlayError, 'Invalid SHIP/SLAP advertisement: expected at least 4 fields' if fields.length < 4
+
+        protocol = fields[0].force_encoding('UTF-8')
+        raise OverlayError, "Invalid SHIP/SLAP protocol: #{protocol.inspect}" unless VALID_PROTOCOLS.include?(protocol)
+
+        identity_key = fields[1].unpack1('H*')
+        domain = normalise_field(fields[2])
+        topic_or_service = normalise_field(fields[3])
+
+        Advertisement.new(
+          protocol: protocol,
+          identity_key: identity_key,
+          domain: domain,
+          topic_or_service: topic_or_service
+        )
+      end
+
+      # Construct a new AdminTokenTemplate instance.
+      #
+      # @param wallet [#get_public_key, #create_signature] any object implementing
+      #   the BRC-100 wallet interface (e.g. {BSV::Wallet::ProtoWallet})
+      # @param originator [String, nil] optional FQDN of the originating application
+      def initialize(wallet, originator: nil)
+        @wallet = wallet
+        @originator = originator
+      end
+
+      # Create a SHIP or SLAP advertisement locking script.
+      #
+      # Derives the wallet's identity key, builds the four advertisement fields,
+      # signs them with the protocol-derived key, and constructs a PushDrop
+      # locking script with a P2PK spending condition.
+      #
+      # @param protocol [String] 'SHIP' or 'SLAP'
+      # @param domain [String] domain where the service or topic is available
+      # @param topic_or_service [String] topic or service name to advertise
+      # @return [BSV::Script::Script] the locking script
+      # @raise [BSV::Overlay::OverlayError] if protocol is not 'SHIP' or 'SLAP'
+      def lock(protocol, domain, topic_or_service)
+        raise OverlayError, "Invalid protocol: #{protocol.inspect}. Must be 'SHIP' or 'SLAP'" \
+          unless VALID_PROTOCOLS.include?(protocol)
+
+        protocol_id = protocol_id_for(protocol)
+
+        # Fetch the wallet's identity key (compressed public key hex)
+        identity_result = @wallet.get_public_key({ identity_key: true })
+        identity_key_hex = identity_result[:public_key]
+        identity_key_bytes = [identity_key_hex].pack('H*')
+
+        # Derive the locking public key for this protocol
+        locking_result = @wallet.get_public_key(
+          { protocol_id: protocol_id, key_id: '1', counterparty: 'self' }
+        )
+        locking_pubkey_hex = locking_result[:public_key]
+        locking_pubkey_bytes = [locking_pubkey_hex].pack('H*')
+
+        # Build the four advertisement fields
+        field_protocol = protocol.b
+        field_identity = identity_key_bytes
+        field_domain = domain.encode('binary')
+        field_topic = topic_or_service.encode('binary')
+
+        # Sign the concatenation of all four fields as authentication
+        data_to_sign = (field_protocol + field_identity + field_domain + field_topic).unpack('C*')
+        sig_result = @wallet.create_signature(
+          { data: data_to_sign, protocol_id: protocol_id, key_id: '1', counterparty: 'self' }
+        )
+        field_sig = sig_result[:signature].pack('C*')
+
+        fields = [field_protocol, field_identity, field_domain, field_topic, field_sig]
+        lock_script = BSV::Script::Script.p2pk_lock(locking_pubkey_bytes)
+        BSV::Script::Script.pushdrop_lock(fields, lock_script)
+      end
+
+      # Return an unlocker for spending an advertisement token.
+      #
+      # The returned object follows the {BSV::Transaction::UnlockingScriptTemplate}
+      # interface and can be assigned to an input's +unlocking_script_template+.
+      #
+      # @param protocol [String] 'SHIP' or 'SLAP' — must match the locked token
+      # @return [Unlocker] an object with +#sign+ and +#estimated_length+
+      # @raise [BSV::Overlay::OverlayError] if protocol is not 'SHIP' or 'SLAP'
+      def unlock(protocol)
+        raise OverlayError, "Invalid protocol: #{protocol.inspect}. Must be 'SHIP' or 'SLAP'" \
+          unless VALID_PROTOCOLS.include?(protocol)
+
+        Unlocker.new(@wallet, protocol_id_for(protocol), @originator)
+      end
+
+      class << self
+        private
+
+        # Normalise a field value: decode as UTF-8 and treat a single null byte
+        # as an empty string. This matches the encoding used when an empty string
+        # is represented as a raw +\x00+ byte push rather than OP_0.
+        def normalise_field(raw)
+          return '' if raw.bytesize == 1 && raw.getbyte(0).zero?
+
+          raw.force_encoding('UTF-8')
+        end
+      end
+
+      private
+
+      # Map a protocol string to its BRC-42/43 protocol ID array for key derivation.
+      #
+      # Uses the lowercase derivation names required by the wallet key-derivation
+      # validator, matching the Go SDK convention (not the titlecase TS SDK variant).
+      #
+      # @param protocol [String] 'SHIP' or 'SLAP'
+      # @return [Array] [security_level, protocol_name]
+      def protocol_id_for(protocol)
+        if protocol == Constants::PROTOCOL_SHIP
+          [2, Constants::DERIVE_PROTOCOL_SHIP]
+        else
+          [2, Constants::DERIVE_PROTOCOL_SLAP]
+        end
+      end
+    end
+  end
+end

--- a/lib/bsv/overlay/admin_token_template.rb
+++ b/lib/bsv/overlay/admin_token_template.rb
@@ -88,9 +88,9 @@ module BSV
           hash = tx.sighash(input_index, sighash_type)
           hash_bytes = hash.unpack('C*')
 
-          result = @wallet.create_signature(
-            { hash_to_directly_sign: hash_bytes, protocol_id: @protocol_id, key_id: '1', counterparty: 'self' }
-          )
+          sig_args = { hash_to_directly_sign: hash_bytes, protocol_id: @protocol_id, key_id: '1', counterparty: 'self' }
+          sig_args[:originator] = @originator if @originator
+          result = @wallet.create_signature(sig_args)
 
           sig_bytes = result[:signature].pack('C*')
           sig_with_hashtype = sig_bytes + [sighash_type].pack('C')
@@ -169,14 +169,16 @@ module BSV
         protocol_id = protocol_id_for(protocol)
 
         # Fetch the wallet's identity key (compressed public key hex)
-        identity_result = @wallet.get_public_key({ identity_key: true })
+        id_args = { identity_key: true }
+        id_args[:originator] = @originator if @originator
+        identity_result = @wallet.get_public_key(id_args)
         identity_key_hex = identity_result[:public_key]
         identity_key_bytes = [identity_key_hex].pack('H*')
 
         # Derive the locking public key for this protocol
-        locking_result = @wallet.get_public_key(
-          { protocol_id: protocol_id, key_id: '1', counterparty: 'self' }
-        )
+        lock_args = { protocol_id: protocol_id, key_id: '1', counterparty: 'self' }
+        lock_args[:originator] = @originator if @originator
+        locking_result = @wallet.get_public_key(lock_args)
         locking_pubkey_hex = locking_result[:public_key]
         locking_pubkey_bytes = [locking_pubkey_hex].pack('H*')
 
@@ -188,9 +190,9 @@ module BSV
 
         # Sign the concatenation of all four fields as authentication
         data_to_sign = (field_protocol + field_identity + field_domain + field_topic).unpack('C*')
-        sig_result = @wallet.create_signature(
-          { data: data_to_sign, protocol_id: protocol_id, key_id: '1', counterparty: 'self' }
-        )
+        sig_args = { data: data_to_sign, protocol_id: protocol_id, key_id: '1', counterparty: 'self' }
+        sig_args[:originator] = @originator if @originator
+        sig_result = @wallet.create_signature(sig_args)
         field_sig = sig_result[:signature].pack('C*')
 
         fields = [field_protocol, field_identity, field_domain, field_topic, field_sig]

--- a/lib/bsv/overlay/broadcast_facilitator.rb
+++ b/lib/bsv/overlay/broadcast_facilitator.rb
@@ -40,10 +40,16 @@ module BSV
     class HTTPSBroadcastFacilitator < BroadcastFacilitator
       # @param allow_http  [Boolean]        permit non-HTTPS URLs (default: false)
       # @param http_client [#request, nil]  injectable HTTP client for testing
-      def initialize(allow_http: false, http_client: nil)
+      DEFAULT_TIMEOUT = 30
+
+      # @param allow_http  [Boolean]        permit non-HTTPS URLs (default: false)
+      # @param http_client [#request, nil]  injectable HTTP client for testing
+      # @param timeout     [Integer]        request timeout in seconds (default: 30)
+      def initialize(allow_http: false, http_client: nil, timeout: DEFAULT_TIMEOUT)
         super()
         @allow_http  = allow_http
         @http_client = http_client
+        @timeout     = timeout
       end
 
       # Send a tagged BEEF to +{url}/submit+ and return the parsed STEAK hash.
@@ -90,7 +96,9 @@ module BSV
           Net::HTTP.start(
             uri.hostname,
             uri.port,
-            use_ssl: uri.scheme == 'https'
+            use_ssl: uri.scheme == 'https',
+            open_timeout: @timeout,
+            read_timeout: @timeout
           ) do |http|
             http.request(request)
           end

--- a/lib/bsv/overlay/broadcast_facilitator.rb
+++ b/lib/bsv/overlay/broadcast_facilitator.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+require 'uri'
+
+module BSV
+  module Overlay
+    # Abstract base class defining the interface for broadcast facilitators.
+    #
+    # A facilitator is responsible for sending a TaggedBEEF to a given
+    # Overlay Services host URL and returning a parsed STEAK response.
+    # Concrete subclasses implement the transport mechanism (e.g. HTTPS).
+    #
+    # Implementors must override +#send_beef+.
+    class BroadcastFacilitator
+      # Send a tagged BEEF to the given overlay host.
+      #
+      # @param url         [String]     base URL of the Overlay Services host
+      # @param tagged_beef [TaggedBEEF] the tagged BEEF to send
+      # @return [Hash{String => AdmittanceInstructions}, nil] STEAK response, or nil on failure
+      # @raise [NotImplementedError] always — subclasses must implement this
+      def send_beef(url, tagged_beef)
+        raise NotImplementedError, "#{self.class}#send_beef must be implemented"
+      end
+    end
+
+    # Default HTTPS-based broadcast facilitator using Net::HTTP.
+    #
+    # POSTs to +{url}/submit+ with a binary BEEF body,
+    # +Content-Type: application/octet-stream+, and an +X-Topics+ header
+    # containing the JSON-encoded list of topics for the tagged BEEF.
+    #
+    # HTTPS is enforced by default; pass +allow_http: true+ to permit plain
+    # HTTP (useful for local development and testing).
+    #
+    # An injectable +http_client+ may be supplied for testing. It must respond
+    # to +#request(uri, net_http_request)+ and return an object with +#code+
+    # and +#body+.
+    class HTTPSBroadcastFacilitator < BroadcastFacilitator
+      # @param allow_http  [Boolean]        permit non-HTTPS URLs (default: false)
+      # @param http_client [#request, nil]  injectable HTTP client for testing
+      def initialize(allow_http: false, http_client: nil)
+        super()
+        @allow_http  = allow_http
+        @http_client = http_client
+      end
+
+      # Send a tagged BEEF to +{url}/submit+ and return the parsed STEAK hash.
+      #
+      # @param url         [String]     base URL of the Overlay Services host
+      # @param tagged_beef [TaggedBEEF] the tagged BEEF to broadcast
+      # @return [Hash{String => AdmittanceInstructions}, nil]
+      #   parsed STEAK response, or nil if the host returned an error or
+      #   the response could not be parsed
+      # @raise [ArgumentError] if the URL is not HTTPS and +allow_http+ is false
+      def send_beef(url, tagged_beef)
+        validate_url!(url)
+
+        uri     = URI("#{url.chomp('/')}/submit")
+        request = build_request(uri, tagged_beef)
+        response = execute(uri, request)
+
+        parse_steak(response)
+      end
+
+      private
+
+      def validate_url!(url)
+        return if @allow_http
+        return if url.start_with?('https:')
+
+        raise ArgumentError,
+              'HTTPS facilitator can only use URLs that start with "https:" ' \
+              '(pass allow_http: true to permit plain HTTP)'
+      end
+
+      def build_request(uri, tagged_beef)
+        request = Net::HTTP::Post.new(uri)
+        request['Content-Type'] = 'application/octet-stream'
+        request['X-Topics']     = JSON.generate(tagged_beef.topics)
+        request.body            = tagged_beef.beef
+        request
+      end
+
+      def execute(uri, request)
+        if @http_client
+          @http_client.request(uri, request)
+        else
+          Net::HTTP.start(
+            uri.hostname,
+            uri.port,
+            use_ssl: uri.scheme == 'https'
+          ) do |http|
+            http.request(request)
+          end
+        end
+      end
+
+      # Parse the STEAK response body into a hash of topic => AdmittanceInstructions.
+      #
+      # Returns nil for non-2xx responses or unparseable bodies.
+      def parse_steak(response)
+        code = response.code.to_i
+        return nil unless (200..299).cover?(code)
+
+        body = parse_json(response.body)
+        return nil unless body.is_a?(Hash)
+
+        body.each_with_object({}) do |(topic, raw), steak|
+          next unless raw.is_a?(Hash)
+
+          steak[topic] = AdmittanceInstructions.new(
+            outputs_to_admit: Array(raw['outputsToAdmit']),
+            coins_to_retain: Array(raw['coinsToRetain']),
+            coins_removed: raw['coinsRemoved'] ? Array(raw['coinsRemoved']) : nil
+          )
+        end
+      end
+
+      def parse_json(raw)
+        JSON.parse(raw)
+      rescue JSON::ParserError
+        nil
+      end
+    end
+  end
+end

--- a/lib/bsv/overlay/broadcast_facilitator.rb
+++ b/lib/bsv/overlay/broadcast_facilitator.rb
@@ -38,8 +38,6 @@ module BSV
     # to +#request(uri, net_http_request)+ and return an object with +#code+
     # and +#body+.
     class HTTPSBroadcastFacilitator < BroadcastFacilitator
-      # @param allow_http  [Boolean]        permit non-HTTPS URLs (default: false)
-      # @param http_client [#request, nil]  injectable HTTP client for testing
       DEFAULT_TIMEOUT = 30
 
       # @param allow_http  [Boolean]        permit non-HTTPS URLs (default: false)

--- a/lib/bsv/overlay/constants.rb
+++ b/lib/bsv/overlay/constants.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module BSV
+  module Overlay
+    # Protocol identifiers and network configuration constants for BSV Overlay Services.
+    module Constants
+      # Short protocol identifier for Service Host Interconnect.
+      PROTOCOL_SHIP = 'SHIP'
+
+      # Short protocol identifier for Service Lookup Availability Protocol.
+      PROTOCOL_SLAP = 'SLAP'
+
+      # Full protocol identifier for Service Host Interconnect (display / human-readable form).
+      PROTOCOL_ID_SHIP = 'Service Host Interconnect'
+
+      # Full protocol identifier for Service Lookup Availability Protocol (display / human-readable form).
+      PROTOCOL_ID_SLAP = 'Service Lookup Availability'
+
+      # BRC-42/43 key-derivation protocol name for Service Host Interconnect.
+      # Lowercase as required by the wallet key-derivation validator.
+      DERIVE_PROTOCOL_SHIP = 'service host interconnect'
+
+      # BRC-42/43 key-derivation protocol name for Service Lookup Availability.
+      # Lowercase as required by the wallet key-derivation validator.
+      DERIVE_PROTOCOL_SLAP = 'service lookup availability'
+
+      # Default SLAP tracker URLs for mainnet.
+      # These nodes maintain records of which overlay services are available and where.
+      DEFAULT_SLAP_TRACKERS = [
+        # BSVA clusters
+        'https://overlay-us-1.bsvb.tech',
+        'https://overlay-eu-1.bsvb.tech',
+        'https://overlay-ap-1.bsvb.tech',
+
+        # Babbage primary overlay service
+        'https://users.bapp.dev'
+      ].freeze
+
+      # Default SLAP tracker URLs for testnet.
+      DEFAULT_TESTNET_SLAP_TRACKERS = [
+        # Babbage primary testnet overlay service
+        'https://testnet-users.bapp.dev'
+      ].freeze
+
+      # Network presets mapping network names to their default SLAP tracker lists.
+      NETWORK_PRESETS = {
+        'mainnet' => DEFAULT_SLAP_TRACKERS,
+        'testnet' => DEFAULT_TESTNET_SLAP_TRACKERS
+      }.freeze
+    end
+  end
+end

--- a/lib/bsv/overlay/errors.rb
+++ b/lib/bsv/overlay/errors.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module BSV
+  module Overlay
+    # Base error class for all Overlay Services errors.
+    class OverlayError < StandardError; end
+
+    # Raised when no overlay hosts are found that are competent to handle a request.
+    class NoCompetentHostsError < OverlayError; end
+
+    # Raised when all competent overlay hosts have rejected a broadcast.
+    class AllHostsRejectedError < OverlayError; end
+
+    # Raised when a host fails to acknowledge a submitted transaction as expected.
+    class AcknowledgementError < OverlayError; end
+  end
+end

--- a/lib/bsv/overlay/host_reputation_tracker.rb
+++ b/lib/bsv/overlay/host_reputation_tracker.rb
@@ -99,8 +99,9 @@ module BSV
           entry[:last_updated_at] = now
 
           if dns_error?(reason)
-            # Skip grace period — treat as if grace failures already consumed.
-            entry[:consecutive_failures] = FAILURE_BACKOFF_GRACE + 1
+            # Skip grace period but continue ramping — ensure consecutive_failures
+            # is at least past grace, then keep incrementing on repeated DNS errors.
+            entry[:consecutive_failures] = [entry[:consecutive_failures] + 1, FAILURE_BACKOFF_GRACE + 1].max
           else
             entry[:consecutive_failures] += 1
           end

--- a/lib/bsv/overlay/host_reputation_tracker.rb
+++ b/lib/bsv/overlay/host_reputation_tracker.rb
@@ -1,0 +1,265 @@
+# frozen_string_literal: true
+
+module BSV
+  module Overlay
+    # Tracks per-host reputation for overlay query dispatch.
+    #
+    # Records success and failure events per host, maintains an EWMA latency
+    # estimate, applies exponential backoff after repeated failures, and ranks
+    # a candidate host list so callers can prefer fast, reliable hosts.
+    #
+    # Thread-safe via an internal Mutex.
+    #
+    # An optional +store+ adapter may be supplied for persistence. The adapter
+    # must respond to +#get(key)+ and +#set(key, value)+. When provided, each
+    # updated entry is persisted and unknown hosts are loaded on first access.
+    class HostReputationTracker
+      # Fallback latency used when no measurements exist yet, or when an
+      # invalid (negative / non-finite) value is reported.
+      DEFAULT_LATENCY_MS = 1500
+
+      # EWMA smoothing factor (α). Higher values give more weight to recent
+      # observations; lower values produce a smoother, more stable estimate.
+      LATENCY_SMOOTHING_FACTOR = 0.25
+
+      # Starting backoff duration in milliseconds.
+      BASE_BACKOFF_MS = 1000
+
+      # Maximum backoff duration in milliseconds (60 seconds).
+      MAX_BACKOFF_MS = 60_000
+
+      # Latency penalty added to a host's score per consecutive failure.
+      FAILURE_PENALTY_MS = 400
+
+      # Latency bonus subtracted from a host's score per recorded success,
+      # capped at half the current average latency.
+      SUCCESS_BONUS_MS = 30
+
+      # Number of consecutive failures that are forgiven before backoff kicks
+      # in. A host may fail this many times without being penalised with a
+      # backoff window.
+      FAILURE_BACKOFF_GRACE = 2
+
+      # @param store [#get, #set, nil] optional persistence adapter
+      def initialize(store: nil)
+        @entries = {}
+        @mutex   = Mutex.new
+        @store   = store
+      end
+
+      # Records a successful request to +host+.
+      #
+      # Updates the EWMA latency estimate (first success sets the average
+      # directly; subsequent successes apply smoothing). Resets consecutive
+      # failure count and clears any active backoff window.
+      #
+      # @param host       [String]  hostname or URL
+      # @param latency_ms [Numeric] observed round-trip time in milliseconds
+      def record_success(host, latency_ms)
+        @mutex.synchronize do
+          entry = fetch_or_create(host)
+
+          safe_latency = valid_latency?(latency_ms) ? latency_ms.to_f : DEFAULT_LATENCY_MS.to_f
+
+          entry[:avg_latency_ms] =
+            if entry[:total_successes].zero?
+              safe_latency
+            else
+              (entry[:avg_latency_ms] * (1 - LATENCY_SMOOTHING_FACTOR)) + (safe_latency * LATENCY_SMOOTHING_FACTOR)
+            end
+
+          entry[:last_latency_ms] = safe_latency
+          entry[:total_successes] += 1
+          entry[:consecutive_failures] = 0
+          entry[:backoff_until]        = nil
+          entry[:last_updated_at]      = Time.now
+
+          persist(host, entry)
+        end
+      end
+
+      # Records a failed request to +host+.
+      #
+      # Increments failure counters. Once consecutive failures exceed
+      # +FAILURE_BACKOFF_GRACE+, an exponential backoff window is set.
+      #
+      # DNS-level errors (+SocketError+, +Errno::ECONNREFUSED+, or messages
+      # containing 'getaddrinfo' or 'Failed to fetch') skip the grace period
+      # entirely — backoff is applied from the very first such failure.
+      #
+      # @param host   [String]            hostname or URL
+      # @param reason [Exception, String, nil] error that caused the failure
+      def record_failure(host, reason = nil)
+        @mutex.synchronize do
+          entry = fetch_or_create(host)
+          now   = Time.now
+
+          entry[:total_failures] += 1
+          entry[:last_error]      = reason.to_s if reason
+          entry[:last_updated_at] = now
+
+          if dns_error?(reason)
+            # Skip grace period — treat as if grace failures already consumed.
+            entry[:consecutive_failures] = FAILURE_BACKOFF_GRACE + 1
+          else
+            entry[:consecutive_failures] += 1
+          end
+
+          consecutive = entry[:consecutive_failures]
+
+          if consecutive > FAILURE_BACKOFF_GRACE
+            exponent   = consecutive - FAILURE_BACKOFF_GRACE - 1
+            backoff_ms = [BASE_BACKOFF_MS * (2**exponent), MAX_BACKOFF_MS].min
+            entry[:backoff_until] = now + (backoff_ms / 1000.0)
+          end
+
+          persist(host, entry)
+        end
+      end
+
+      # Ranks +hosts+ for query dispatch.
+      #
+      # Steps:
+      # 1. Filter nil and empty-string entries.
+      # 2. Deduplicate preserving first occurrence order.
+      # 3. Compute a score for each host.
+      # 4. Sort: available hosts first (score asc, then total_successes desc,
+      #    then original position asc), followed by backed-off hosts
+      #    (backoff_until asc).
+      #
+      # @param hosts [Array<String>] candidate host list
+      # @param now   [Time]          reference time (default: Time.now)
+      # @return [Array<String>]
+      def rank_hosts(hosts, now = Time.now)
+        @mutex.synchronize do
+          filtered  = hosts.select { |h| h.is_a?(String) && !h.empty? }
+          unique    = deduplicate(filtered)
+
+          available = []
+          backed_off = []
+
+          unique.each_with_index do |host, idx|
+            entry = fetch_or_create_locked(host)
+            if in_backoff?(entry, now)
+              backed_off << { host: host, entry: entry, idx: idx }
+            else
+              available << { host: host, entry: entry, idx: idx, score: compute_score(entry, now) }
+            end
+          end
+
+          sorted_available  = available.sort_by { |h| [h[:score], -h[:entry][:total_successes], h[:idx]] }
+          sorted_backed_off = backed_off.sort_by { |h| h[:entry][:backoff_until].to_f }
+
+          (sorted_available + sorted_backed_off).map { |h| h[:host] }
+        end
+      end
+
+      # Returns a frozen copy of the internal entry hash for +host+, or +nil+
+      # if the host is unknown and not in the store.
+      #
+      # @param host [String]
+      # @return [Hash, nil]
+      def snapshot(host)
+        @mutex.synchronize do
+          entry = @entries[host] || load_from_store(host)
+          entry&.dup&.freeze
+        end
+      end
+
+      # Clears all in-memory reputation data.
+      def reset
+        @mutex.synchronize { @entries.clear }
+      end
+
+      private
+
+      # Returns the entry for +host+, creating a default one if absent.
+      # Must be called within +@mutex.synchronize+.
+      def fetch_or_create(host)
+        @entries[host] ||= load_from_store(host) || default_entry(host)
+      end
+
+      # Alias used inside rank_hosts where the mutex is already held.
+      alias fetch_or_create_locked fetch_or_create
+
+      # Builds a default entry for a host with no recorded history.
+      def default_entry(host)
+        {
+          host: host,
+          total_successes: 0,
+          total_failures: 0,
+          consecutive_failures: 0,
+          avg_latency_ms: DEFAULT_LATENCY_MS.to_f,
+          last_latency_ms: nil,
+          backoff_until: nil,
+          last_updated_at: nil,
+          last_error: nil
+        }
+      end
+
+      # Returns +true+ if +latency+ is a valid, finite non-negative number.
+      def valid_latency?(latency)
+        return false unless latency.is_a?(Numeric)
+        return false if latency.respond_to?(:nan?) && latency.nan?
+        return false if latency.respond_to?(:infinite?) && latency.infinite?
+
+        latency >= 0
+      end
+
+      # Returns +true+ if +reason+ represents a DNS-level connectivity error.
+      def dns_error?(reason)
+        return true if reason.is_a?(SocketError)
+        return true if reason.is_a?(Errno::ECONNREFUSED)
+        return false unless reason
+
+        msg = reason.is_a?(Exception) ? reason.message : reason.to_s
+        msg.include?('getaddrinfo') || msg.include?('Failed to fetch')
+      end
+
+      # Returns +true+ if the entry's backoff window is still active.
+      def in_backoff?(entry, now)
+        bu = entry[:backoff_until]
+        bu && bu > now
+      end
+
+      # Computes the priority score for a host entry.
+      #
+      # Lower scores are better. The score penalises slow and unreliable
+      # hosts and rewards those with many successes.
+      def compute_score(entry, now)
+        avg    = entry[:avg_latency_ms]
+        cons   = entry[:consecutive_failures]
+        succs  = entry[:total_successes]
+
+        backoff_penalty = in_backoff?(entry, now) ? (entry[:backoff_until] - now) * 1000 : 0
+        bonus           = [succs * SUCCESS_BONUS_MS, avg / 2.0].min
+
+        avg + (cons * FAILURE_PENALTY_MS) + backoff_penalty - bonus
+      end
+
+      # Returns deduplicated list preserving the first occurrence of each host.
+      def deduplicate(hosts)
+        seen = {}
+        hosts.each_with_object([]) do |host, acc|
+          next if seen.key?(host)
+
+          seen[host] = true
+          acc << host
+        end
+      end
+
+      # Loads an entry from the store adapter. Returns +nil+ if no store is
+      # configured or the key is absent.
+      def load_from_store(host)
+        return nil unless @store
+
+        @store.get(host)
+      end
+
+      # Persists an entry via the store adapter (no-op if no store configured).
+      def persist(host, entry)
+        @store&.set(host, entry)
+      end
+    end
+  end
+end

--- a/lib/bsv/overlay/lookup_facilitator.rb
+++ b/lib/bsv/overlay/lookup_facilitator.rb
@@ -104,7 +104,10 @@ module BSV
 
       def handle_response(response)
         code = response.code.to_i
-        raise "Failed to facilitate lookup (HTTP #{code}): #{response.body}" unless (200..299).cover?(code)
+        unless (200..299).cover?(code)
+          body_preview = response.body.to_s[0, 200]
+          raise "Failed to facilitate lookup (HTTP #{code}): #{body_preview}"
+        end
 
         body = parse_json(response.body)
         type    = body['type'] || 'output-list'

--- a/lib/bsv/overlay/lookup_facilitator.rb
+++ b/lib/bsv/overlay/lookup_facilitator.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+require 'uri'
+
+module BSV
+  module Overlay
+    # Abstract base class defining the interface for lookup facilitators.
+    #
+    # A facilitator is responsible for sending a LookupQuestion to a given
+    # Overlay Services host URL and returning a LookupAnswer. Concrete
+    # subclasses implement the transport mechanism (e.g. HTTPS, in-process).
+    #
+    # Implementors must override +#lookup+.
+    class LookupFacilitator
+      # Send a lookup question to the given host URL.
+      #
+      # @param url      [String]          base URL of the Overlay Services host
+      # @param question [LookupQuestion]  the question to ask
+      # @param timeout  [Integer]         seconds to wait for a response
+      # @return [LookupAnswer]
+      # @raise [NotImplementedError] always — subclasses must implement this
+      def lookup(url, question, timeout: 5)
+        raise NotImplementedError, "#{self.class}#lookup must be implemented"
+      end
+    end
+
+    # Default HTTPS-based lookup facilitator using Net::HTTP.
+    #
+    # POSTs to +{url}/lookup+ with a JSON body and the +X-Aggregation: yes+
+    # header, as required by the BSV Overlay Services protocol.
+    #
+    # HTTPS is enforced by default; pass +allow_http: true+ to permit plain
+    # HTTP (useful for local development and testing).
+    #
+    # An injectable +http_client+ may be supplied for testing. It must respond
+    # to +#request(uri, net_http_request)+ and return an object with +#code+
+    # and +#body+.
+    class HTTPSLookupFacilitator < LookupFacilitator
+      # @param allow_http  [Boolean]        permit non-HTTPS URLs (default: false)
+      # @param http_client [#request, nil]  injectable HTTP client for testing
+      def initialize(allow_http: false, http_client: nil)
+        super()
+        @allow_http  = allow_http
+        @http_client = http_client
+      end
+
+      # Perform an HTTPS POST to +{url}/lookup+ and return the parsed answer.
+      #
+      # @param url      [String]         base URL of the Overlay Services host
+      # @param question [LookupQuestion] the question to send
+      # @param timeout  [Integer]        request timeout in seconds (default: 5)
+      # @return [LookupAnswer]
+      # @raise [ArgumentError] if the URL is not HTTPS and +allow_http+ is false
+      # @raise [RuntimeError]  if the server returns a non-2xx status
+      def lookup(url, question, timeout: 5)
+        validate_url!(url)
+
+        uri     = URI("#{url.chomp('/')}/lookup")
+        request = build_request(uri, question)
+
+        response = execute(uri, request, timeout)
+        handle_response(response)
+      end
+
+      private
+
+      def validate_url!(url)
+        return if @allow_http
+        return if url.start_with?('https:')
+
+        raise ArgumentError,
+              'HTTPS facilitator can only use URLs that start with "https:" ' \
+              '(pass allow_http: true to permit plain HTTP)'
+      end
+
+      def build_request(uri, question)
+        request = Net::HTTP::Post.new(uri)
+        request['Content-Type'] = 'application/json'
+        request['X-Aggregation'] = 'yes'
+        request.body = JSON.generate(
+          'service' => question.service,
+          'query' => question.query
+        )
+        request
+      end
+
+      def execute(uri, request, timeout)
+        if @http_client
+          @http_client.request(uri, request)
+        else
+          Net::HTTP.start(
+            uri.hostname,
+            uri.port,
+            use_ssl: uri.scheme == 'https',
+            open_timeout: timeout,
+            read_timeout: timeout
+          ) do |http|
+            http.request(request)
+          end
+        end
+      end
+
+      def handle_response(response)
+        code = response.code.to_i
+        raise "Failed to facilitate lookup (HTTP #{code}): #{response.body}" unless (200..299).cover?(code)
+
+        body = parse_json(response.body)
+        type    = body['type'] || 'output-list'
+        outputs = body['outputs'] || []
+        LookupAnswer.new(type: type, outputs: outputs)
+      end
+
+      def parse_json(raw)
+        JSON.parse(raw)
+      rescue JSON::ParserError
+        {}
+      end
+    end
+  end
+end

--- a/lib/bsv/overlay/lookup_resolver.rb
+++ b/lib/bsv/overlay/lookup_resolver.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'set'
+require 'uri'
+
 module BSV
   module Overlay
     # Resolves LookupQuestions by discovering competent overlay hosts via SLAP
@@ -248,7 +251,7 @@ module BSV
         threads = hosts.map do |host|
           Thread.new do
             answer = lookup_with_tracking(host, question, timeout)
-            if answer && answer.type == 'output-list' && !answer.outputs.empty?
+            if answer && answer.type == 'output-list'
               results_mu.synchronize { results << answer }
 
               resolved_mu.synchronize do

--- a/lib/bsv/overlay/lookup_resolver.rb
+++ b/lib/bsv/overlay/lookup_resolver.rb
@@ -155,8 +155,10 @@ module BSV
         all_hosts = []
         threads   = @slap_trackers.map do |tracker|
           Thread.new do
+            started_at = Time.now
             answer = @facilitator.lookup(tracker, slap_question, timeout: SLAP_TRACKER_TIMEOUT)
-            @reputation_tracker.record_success(tracker, SLAP_TRACKER_TIMEOUT * 1000)
+            latency_ms = ((Time.now - started_at) * 1000).round
+            @reputation_tracker.record_success(tracker, latency_ms)
             extract_hosts_from_answer(answer, service)
           rescue StandardError => e
             @reputation_tracker.record_failure(tracker, e)
@@ -221,12 +223,7 @@ module BSV
       def parse_beef(beef_data)
         case beef_data
         when String
-          # Binary string or hex
-          if beef_data.encoding == Encoding::BINARY || beef_data =~ /\A[\x00-\xFF]*\z/n
-            BSV::Transaction::Beef.from_binary(beef_data)
-          else
-            BSV::Transaction::Beef.from_hex(beef_data)
-          end
+          BSV::Transaction::Beef.from_binary(beef_data)
         when Array
           # Array of integers (TS SDK wire format)
           BSV::Transaction::Beef.from_binary(beef_data.pack('C*'))

--- a/lib/bsv/overlay/lookup_resolver.rb
+++ b/lib/bsv/overlay/lookup_resolver.rb
@@ -188,6 +188,8 @@ module BSV
       def extract_host_from_output(output, service)
         beef_data = output['beef'] || output[:beef]
         output_index = output['outputIndex'] || output[:output_index] || 0
+        output_index = output_index.to_i
+        return nil if output_index.negative?
 
         return nil unless beef_data
 
@@ -210,7 +212,10 @@ module BSV
         domain = advert.domain
         return nil if domain.nil? || domain.empty?
 
-        domain.start_with?('https://', 'http://') ? domain : "https://#{domain}"
+        url = domain.start_with?('https://', 'http://') ? domain : "https://#{domain}"
+        return nil if private_url?(url)
+
+        url
       end
 
       def parse_beef(beef_data)
@@ -327,7 +332,7 @@ module BSV
 
       def dedup_key(output)
         beef_data    = output['beef'] || output[:beef]
-        output_index = output['outputIndex'] || output[:output_index] || 0
+        output_index = (output['outputIndex'] || output[:output_index] || 0).to_i
 
         txid =
           begin
@@ -363,6 +368,22 @@ module BSV
 
       def local?
         @network_preset == :local
+      end
+
+      # Reject URLs whose hostname is a private/loopback IP literal (SSRF protection).
+      # Only applied to SLAP-discovered domains, not to user-configured overrides.
+      # Does not perform DNS resolution — only catches IP-literal hostnames like
+      # 127.0.0.1, 169.254.x.x, 10.x.x.x, 192.168.x.x, etc. Domain-name SSRF
+      # (DNS rebinding) is outside the scope of this check.
+      def private_url?(url)
+        require 'ipaddr'
+        host = URI(url).hostname
+        return true if host.nil? || host.empty?
+
+        addr = IPAddr.new(host)
+        addr.loopback? || addr.private? || addr.link_local?
+      rescue IPAddr::InvalidAddressError
+        false # Not an IP literal — allow (domain names pass through)
       end
 
       def default_facilitator

--- a/lib/bsv/overlay/lookup_resolver.rb
+++ b/lib/bsv/overlay/lookup_resolver.rb
@@ -1,0 +1,385 @@
+# frozen_string_literal: true
+
+module BSV
+  module Overlay
+    # Resolves LookupQuestions by discovering competent overlay hosts via SLAP
+    # trackers and querying them in parallel.
+    #
+    # == Host discovery
+    #
+    # For any service other than +ls_slap+, the resolver first queries the
+    # configured SLAP trackers to discover which hosts advertise competence for
+    # that service. Discovery results are cached with a configurable TTL
+    # (default: 5 minutes) to avoid redundant network round-trips.
+    #
+    # == Host overrides and additional hosts
+    #
+    # +host_overrides+ replaces SLAP discovery entirely for a named service.
+    # +additional_hosts+ supplements discovered (or overridden) hosts. Both
+    # maps require service names that begin with +ls_+.
+    #
+    # == Parallel querying
+    #
+    # All competent hosts are queried concurrently using Ruby threads.
+    # Responses are collected, outputs are merged, and duplicates are removed
+    # by +"#{txid}.#{output_index}"+ key.
+    #
+    # == Reputation tracking
+    #
+    # Hosts are ranked before querying via +HostReputationTracker#rank_hosts+,
+    # and success/failure outcomes (with latency) are recorded after each
+    # query.
+    #
+    # Thread-safe via an internal Mutex on the hosts cache.
+    class LookupResolver
+      # Grace window (seconds) after the first valid response arrives during
+      # which other in-flight host queries may still contribute their outputs.
+      QUERY_GRACE_SECONDS = 0.08
+
+      # Timeout applied when querying SLAP trackers for host discovery.
+      SLAP_TRACKER_TIMEOUT = 5
+
+      # @param network_preset     [Symbol]                 :mainnet, :testnet, or :local
+      # @param facilitator        [LookupFacilitator, nil] injectable facilitator
+      # @param slap_trackers      [Array<String>, nil]     override default tracker list
+      # @param host_overrides     [Hash{String=>Array<String>}]
+      # @param additional_hosts   [Hash{String=>Array<String>}]
+      # @param reputation_tracker [HostReputationTracker, nil] injectable tracker
+      # @param cache_ttl          [Integer]                seconds before cached hosts expire
+      def initialize(
+        network_preset:     :mainnet,
+        facilitator:        nil,
+        slap_trackers:      nil,
+        host_overrides:     {},
+        additional_hosts:   {},
+        reputation_tracker: nil,
+        cache_ttl:          300
+      )
+        @network_preset = network_preset
+
+        @facilitator = facilitator || default_facilitator
+
+        @slap_trackers = slap_trackers || default_slap_trackers
+        validate_slap_trackers!
+
+        validate_service_keys!('host_overrides',   host_overrides)
+        validate_service_keys!('additional_hosts', additional_hosts)
+
+        @host_overrides   = host_overrides
+        @additional_hosts = additional_hosts
+
+        @reputation_tracker = reputation_tracker || HostReputationTracker.new
+
+        @cache_ttl   = cache_ttl
+        @hosts_cache = {}
+        @cache_mutex = Mutex.new
+      end
+
+      # Resolve a LookupQuestion by discovering competent hosts and querying them.
+      #
+      # @param question [LookupQuestion] the question to resolve
+      # @param timeout  [Integer, nil]   per-host query timeout in seconds
+      # @return [LookupAnswer] merged and deduplicated answer
+      # @raise [NoCompetentHostsError] if no hosts can be found or all fail
+      def query(question, timeout: nil)
+        competent_hosts = resolve_hosts(question)
+        apply_additional_hosts!(competent_hosts, question.service)
+
+        if competent_hosts.empty?
+          raise NoCompetentHostsError,
+                "No competent #{@network_preset} hosts found by the SLAP trackers " \
+                "for lookup service: #{question.service}"
+        end
+
+        ranked = @reputation_tracker.rank_hosts(competent_hosts)
+        answers = query_hosts_in_parallel(ranked, question, timeout)
+
+        if answers.empty?
+          raise NoCompetentHostsError,
+                "All competent hosts for #{question.service} failed to return a valid answer"
+        end
+
+        merge_answers(answers)
+      end
+
+      # Discover competent hosts for +service+ via SLAP trackers.
+      #
+      # Results are cached for +cache_ttl+ seconds. Concurrent callers for the
+      # same service will each trigger their own SLAP query (no in-flight
+      # coalescing in this implementation).
+      #
+      # @param service [String] lookup service name (e.g. +'ls_foo'+)
+      # @return [Array<String>] array of host URLs
+      def find_competent_hosts(service)
+        cached = @cache_mutex.synchronize { @hosts_cache[service] }
+        return cached[:hosts].dup if cached && (Time.now.to_f - cached[:fetched_at]) < @cache_ttl
+
+        hosts = fetch_hosts_from_slap(service)
+        @cache_mutex.synchronize do
+          @hosts_cache[service] = { hosts: hosts, fetched_at: Time.now.to_f }
+        end
+        hosts
+      end
+
+      private
+
+      # ---- Host resolution ----
+
+      def resolve_hosts(question)
+        service = question.service
+
+        if service == 'ls_slap'
+          return local? ? ['http://localhost:8080'] : @slap_trackers.dup
+        end
+
+        return @host_overrides[service].dup if @host_overrides.key?(service)
+
+        return ['http://localhost:8080'] if local?
+
+        find_competent_hosts(service)
+      end
+
+      def apply_additional_hosts!(hosts, service)
+        extras = @additional_hosts[service]
+        return unless extras&.any?
+
+        seen = hosts.to_set
+        extras.each { |h| hosts << h unless seen.include?(h) }
+      end
+
+      # ---- SLAP discovery ----
+
+      def fetch_hosts_from_slap(service)
+        slap_question = LookupQuestion.new(service: 'ls_slap', query: { 'service' => service })
+
+        all_hosts = []
+        threads   = @slap_trackers.map do |tracker|
+          Thread.new do
+            answer = @facilitator.lookup(tracker, slap_question, timeout: SLAP_TRACKER_TIMEOUT)
+            @reputation_tracker.record_success(tracker, SLAP_TRACKER_TIMEOUT * 1000)
+            extract_hosts_from_answer(answer, service)
+          rescue StandardError => e
+            @reputation_tracker.record_failure(tracker, e)
+            []
+          end
+        end
+
+        threads.each do |t|
+          result = t.value
+          all_hosts.concat(result) if result
+        end
+
+        all_hosts.uniq
+      end
+
+      def extract_hosts_from_answer(answer, service)
+        hosts = []
+        return hosts unless answer.type == 'output-list'
+
+        answer.outputs.each do |output|
+          hosts << extract_host_from_output(output, service)
+        rescue StandardError
+          next # Skip corrupted or invalid outputs
+        end
+
+        hosts.compact
+      end
+
+      def extract_host_from_output(output, service)
+        beef_data = output['beef'] || output[:beef]
+        output_index = output['outputIndex'] || output[:output_index] || 0
+
+        return nil unless beef_data
+
+        beef = parse_beef(beef_data)
+        return nil unless beef
+
+        # Get the last (subject) transaction — typically the most recent entry
+        beef_tx = beef.transactions.last
+        return nil unless beef_tx&.transaction
+
+        tx     = beef_tx.transaction
+        txout  = tx.outputs[output_index]
+        return nil unless txout
+
+        advert = AdminTokenTemplate.decode(txout.locking_script)
+        return nil unless advert
+        return nil unless advert.protocol == Constants::PROTOCOL_SLAP
+        return nil unless advert.topic_or_service == service
+
+        domain = advert.domain
+        return nil if domain.nil? || domain.empty?
+
+        domain.start_with?('https://', 'http://') ? domain : "https://#{domain}"
+      end
+
+      def parse_beef(beef_data)
+        case beef_data
+        when String
+          # Binary string or hex
+          if beef_data.encoding == Encoding::BINARY || beef_data =~ /\A[\x00-\xFF]*\z/n
+            BSV::Transaction::Beef.from_binary(beef_data)
+          else
+            BSV::Transaction::Beef.from_hex(beef_data)
+          end
+        when Array
+          # Array of integers (TS SDK wire format)
+          BSV::Transaction::Beef.from_binary(beef_data.pack('C*'))
+        end
+      rescue StandardError
+        nil
+      end
+
+      # ---- Parallel host querying ----
+
+      def query_hosts_in_parallel(hosts, question, timeout)
+        results     = []
+        results_mu  = Mutex.new
+        resolved    = false
+        resolved_mu = Mutex.new
+        pending     = hosts.length
+
+        grace_cv    = ConditionVariable.new
+        done_mu     = Mutex.new
+        done        = false
+
+        threads = hosts.map do |host|
+          Thread.new do
+            answer = lookup_with_tracking(host, question, timeout)
+            if answer && answer.type == 'output-list' && !answer.outputs.empty?
+              results_mu.synchronize { results << answer }
+
+              resolved_mu.synchronize do
+                unless resolved
+                  resolved = true
+                  # Signal that we can start the grace-window countdown
+                  done_mu.synchronize { grace_cv.signal }
+                end
+              end
+            end
+          rescue StandardError
+            nil # Failure already recorded by lookup_with_tracking
+          ensure
+            remaining = nil
+            results_mu.synchronize do
+              pending -= 1
+              remaining = pending
+            end
+            # If all threads are done, wake any waiter
+            done_mu.synchronize { grace_cv.signal } if remaining.zero?
+          end
+        end
+
+        # Wait for either (a) first result + grace window, or (b) all threads done
+        done_mu.synchronize do
+          grace_cv.wait(done_mu) # Wait for first result or all done
+
+          first_resolved = resolved_mu.synchronize { resolved }
+          if first_resolved
+            remaining_threads = threads.count(&:alive?)
+            grace_cv.wait(done_mu, QUERY_GRACE_SECONDS) if remaining_threads.positive?
+          end
+
+          done = true
+        end
+
+        threads.each(&:join)
+
+        results_mu.synchronize { results.dup }
+      end
+
+      def lookup_with_tracking(host, question, timeout)
+        started_at = Time.now
+        opts       = timeout ? { timeout: timeout } : {}
+        answer     = @facilitator.lookup(host, question, **opts)
+        latency_ms = ((Time.now - started_at) * 1000).round
+
+        valid = answer.is_a?(LookupAnswer) &&
+                answer.type == 'output-list' &&
+                answer.outputs.is_a?(Array)
+
+        if valid
+          @reputation_tracker.record_success(host, latency_ms)
+        else
+          @reputation_tracker.record_failure(host, 'Invalid lookup response')
+        end
+
+        answer
+      rescue StandardError => e
+        @reputation_tracker.record_failure(host, e)
+        raise
+      end
+
+      # ---- Result aggregation ----
+
+      def merge_answers(answers)
+        outputs_map = {}
+
+        answers.each do |answer|
+          answer.outputs.each do |output|
+            key = dedup_key(output)
+            outputs_map[key] ||= output
+          end
+        end
+
+        LookupAnswer.new(type: 'output-list', outputs: outputs_map.values)
+      end
+
+      def dedup_key(output)
+        beef_data    = output['beef'] || output[:beef]
+        output_index = output['outputIndex'] || output[:output_index] || 0
+
+        txid =
+          begin
+            beef = parse_beef(beef_data)
+            last = beef&.transactions&.last
+            last&.transaction&.txid
+          rescue StandardError
+            nil
+          end
+
+        txid ? "#{txid}.#{output_index}" : output.object_id.to_s
+      end
+
+      # ---- Validation ----
+
+      def validate_service_keys!(name, hash)
+        hash.each_key do |service|
+          next if service.start_with?('ls_')
+
+          raise ArgumentError,
+                "#{name} service names must start with \"ls_\": #{service}"
+        end
+      end
+
+      def validate_slap_trackers!
+        return if local?
+        return if @slap_trackers.is_a?(Array) && !@slap_trackers.empty?
+
+        raise ArgumentError, 'slap_trackers must be a non-empty array for non-local presets'
+      end
+
+      # ---- Helpers ----
+
+      def local?
+        @network_preset == :local
+      end
+
+      def default_facilitator
+        if local?
+          HTTPSLookupFacilitator.new(allow_http: true)
+        else
+          HTTPSLookupFacilitator.new
+        end
+      end
+
+      def default_slap_trackers
+        case @network_preset
+        when :mainnet then Constants::DEFAULT_SLAP_TRACKERS.dup
+        when :testnet then Constants::DEFAULT_TESTNET_SLAP_TRACKERS.dup
+        else []
+        end
+      end
+    end
+  end
+end

--- a/lib/bsv/overlay/topic_broadcaster.rb
+++ b/lib/bsv/overlay/topic_broadcaster.rb
@@ -2,6 +2,7 @@
 
 require 'set'
 require 'json'
+require 'uri'
 
 module BSV
   module Overlay
@@ -109,7 +110,7 @@ module BSV
 
         OverlayBroadcastResult.new(
           status: 'success',
-          txid: tx.txid,
+          txid: tx.txid_hex,
           message: "Sent to #{successful.size} Overlay Service host(s)."
         )
       end
@@ -121,12 +122,14 @@ module BSV
       # @return [Hash{String => Set<String>}] map of host URL to set of interested topics
       def find_interested_hosts
         @ship_cache_mutex.synchronize do
-          return @ship_cache.dup if @ship_cache && (Time.now.to_f - @ship_cache_at) < SHIP_CACHE_TTL
+          if @ship_cache && (Time.now.to_f - @ship_cache_at) < SHIP_CACHE_TTL
+            return @ship_cache.transform_values(&:dup)
+          end
 
           hosts = fetch_ship_hosts
           @ship_cache    = hosts
           @ship_cache_at = Time.now.to_f
-          hosts.dup
+          hosts.transform_values(&:dup)
         end
       end
 
@@ -147,7 +150,7 @@ module BSV
       def serialise_beef(tx)
         tx.to_beef
       rescue StandardError => e
-        error_result('400', "Failed to serialise transaction to BEEF: #{e.message}")
+        error_result('ERR_BEEF_SERIALIZATION_FAILED', "Failed to serialise transaction to BEEF: #{e.message}")
       end
 
       # ---- SHIP host discovery ----

--- a/lib/bsv/overlay/topic_broadcaster.rb
+++ b/lib/bsv/overlay/topic_broadcaster.rb
@@ -171,7 +171,8 @@ module BSV
 
         answer.outputs.each do |output|
           beef_data    = output['beef'] || output[:beef]
-          output_index = output['outputIndex'] || output[:output_index] || 0
+          output_index = (output['outputIndex'] || output[:output_index] || 0).to_i
+          next if output_index.negative?
 
           next unless beef_data
 
@@ -220,9 +221,22 @@ module BSV
       end
 
       def normalise_domain(domain)
-        return domain if domain.start_with?('https://', 'http://')
+        url = domain.start_with?('https://', 'http://') ? domain : "https://#{domain}"
+        return nil if private_url?(url)
 
-        "https://#{domain}"
+        url
+      end
+
+      # Reject URLs whose hostname is a private/loopback IP literal (SSRF protection).
+      def private_url?(url)
+        require 'ipaddr'
+        host = URI(url).hostname
+        return true if host.nil? || host.empty?
+
+        addr = IPAddr.new(host)
+        addr.loopback? || addr.private? || addr.link_local?
+      rescue IPAddr::InvalidAddressError
+        false # Not an IP literal — domain names pass through
       end
 
       # ---- Parallel dispatch ----

--- a/lib/bsv/overlay/topic_broadcaster.rb
+++ b/lib/bsv/overlay/topic_broadcaster.rb
@@ -1,0 +1,385 @@
+# frozen_string_literal: true
+
+require 'set'
+require 'json'
+
+module BSV
+  module Overlay
+    # Broadcasts transactions to overlay topics via SHIP (Service Host Interconnect Protocol).
+    #
+    # Discovers interested overlay hosts by querying the +ls_ship+ SLAP service,
+    # then dispatches a TaggedBEEF to each host in parallel and verifies
+    # acknowledgements according to the configured requirements.
+    #
+    # == Topic validation
+    #
+    # All topics must be non-empty strings beginning with +tm_+. An empty
+    # topics array or a topic without the +tm_+ prefix raises ArgumentError.
+    #
+    # == Acknowledgement modes
+    #
+    # Three independent ack modes may be combined:
+    #
+    # - +require_ack_from_any_host+ (default: +'all'+) — at least one successful
+    #   host must satisfy the requirement.
+    # - +require_ack_from_all_hosts+ (default: +[]+) — every successful host must
+    #   satisfy the requirement. An empty array disables this check.
+    # - +require_ack_from_specific_hosts+ (default: +{}+) — named hosts must
+    #   each satisfy their individual requirement.
+    #
+    # Requirement values:
+    # - +'all'+ — the host must have acknowledged every one of the broadcaster's topics.
+    # - +'any'+ — the host must have acknowledged at least one topic.
+    # - +Array<String>+ — the host must have acknowledged all topics in the array.
+    #
+    # == Host caching
+    #
+    # SHIP host discovery results are cached for +SHIP_CACHE_TTL+ seconds (5 minutes)
+    # to avoid redundant SLAP queries on repeated broadcasts.
+    class TopicBroadcaster
+      # Seconds before the SHIP host cache expires.
+      SHIP_CACHE_TTL = 300
+
+      # @param topics             [Array<String>]   overlay topic names (must start with +tm_+)
+      # @param network_preset     [Symbol]          +:mainnet+, +:testnet+, or +:local+
+      # @param facilitator        [BroadcastFacilitator, nil] injectable facilitator
+      # @param resolver           [LookupResolver, nil]       injectable resolver
+      # @param require_ack_from_all_hosts    [Array, String] requirement all hosts must satisfy
+      # @param require_ack_from_any_host     [String]        requirement at least one host must satisfy
+      # @param require_ack_from_specific_hosts [Hash]        per-host requirements
+      def initialize(
+        topics,
+        network_preset: :mainnet,
+        facilitator: nil,
+        resolver: nil,
+        require_ack_from_all_hosts: [],
+        require_ack_from_any_host: 'all',
+        require_ack_from_specific_hosts: {}
+      )
+        validate_topics!(topics)
+
+        @topics          = topics.dup.freeze
+        @network_preset  = network_preset
+        @facilitator     = facilitator || default_facilitator
+        @resolver        = resolver    || default_resolver
+
+        @require_ack_from_all_hosts      = require_ack_from_all_hosts
+        @require_ack_from_any_host       = require_ack_from_any_host
+        @require_ack_from_specific_hosts = require_ack_from_specific_hosts
+
+        @ship_cache       = nil
+        @ship_cache_at    = nil
+        @ship_cache_mutex = Mutex.new
+      end
+
+      # Broadcast a transaction to all interested overlay hosts.
+      #
+      # @param tx [BSV::Transaction::Transaction] the transaction to broadcast
+      # @return [OverlayBroadcastResult]
+      def broadcast(tx)
+        beef = serialise_beef(tx)
+        return beef if beef.is_a?(OverlayBroadcastResult)
+
+        if local?
+          host_topics = { 'http://localhost:8080' => Set.new(@topics) }
+        else
+          host_topics = find_interested_hosts
+          if host_topics.empty?
+            return error_result(
+              'ERR_NO_HOSTS_INTERESTED',
+              "No #{@network_preset} hosts are interested in receiving this transaction."
+            )
+          end
+        end
+
+        results = dispatch(beef, host_topics)
+
+        successful = results.compact
+        if successful.empty?
+          return error_result(
+            'ERR_ALL_HOSTS_REJECTED',
+            "All #{@network_preset} topical hosts have rejected the transaction."
+          )
+        end
+
+        host_acks = build_host_acks(successful)
+
+        ack_check = check_ack_requirements(host_acks)
+        return ack_check if ack_check.is_a?(OverlayBroadcastResult)
+
+        OverlayBroadcastResult.new(
+          status: 'success',
+          txid: tx.txid,
+          message: "Sent to #{successful.size} Overlay Service host(s)."
+        )
+      end
+
+      # Discover overlay hosts interested in the broadcaster's topics via SHIP.
+      #
+      # Results are cached for +SHIP_CACHE_TTL+ seconds.
+      #
+      # @return [Hash{String => Set<String>}] map of host URL to set of interested topics
+      def find_interested_hosts
+        @ship_cache_mutex.synchronize do
+          return @ship_cache.dup if @ship_cache && (Time.now.to_f - @ship_cache_at) < SHIP_CACHE_TTL
+
+          hosts = fetch_ship_hosts
+          @ship_cache    = hosts
+          @ship_cache_at = Time.now.to_f
+          hosts.dup
+        end
+      end
+
+      private
+
+      # ---- Topic validation ----
+
+      def validate_topics!(topics)
+        raise ArgumentError, 'topics must be a non-empty array' if topics.nil? || topics.empty?
+
+        topics.each do |topic|
+          raise ArgumentError, "topic #{topic.inspect} must start with 'tm_'" unless topic.is_a?(String) && topic.start_with?('tm_')
+        end
+      end
+
+      # ---- BEEF serialisation ----
+
+      def serialise_beef(tx)
+        tx.to_beef
+      rescue StandardError => e
+        error_result('400', "Failed to serialise transaction to BEEF: #{e.message}")
+      end
+
+      # ---- SHIP host discovery ----
+
+      def fetch_ship_hosts
+        question = LookupQuestion.new(
+          service: 'ls_ship',
+          query: { 'topics' => @topics }
+        )
+
+        answer = @resolver.query(question)
+        return {} unless answer.type == 'output-list'
+
+        parse_ship_answer(answer)
+      rescue StandardError
+        {}
+      end
+
+      def parse_ship_answer(answer)
+        results = {}
+
+        answer.outputs.each do |output|
+          beef_data    = output['beef'] || output[:beef]
+          output_index = output['outputIndex'] || output[:output_index] || 0
+
+          next unless beef_data
+
+          advert = decode_ship_advert(beef_data, output_index)
+          next unless advert
+          next unless advert.protocol == Constants::PROTOCOL_SHIP
+          next unless @topics.include?(advert.topic_or_service)
+
+          domain = normalise_domain(advert.domain)
+          next if domain.nil? || domain.empty?
+
+          results[domain] ||= Set.new
+          results[domain] << advert.topic_or_service
+        rescue StandardError
+          next
+        end
+
+        results
+      end
+
+      def decode_ship_advert(beef_data, output_index)
+        beef = parse_beef(beef_data)
+        return nil unless beef
+
+        beef_tx = beef.transactions.last
+        return nil unless beef_tx&.transaction
+
+        tx    = beef_tx.transaction
+        txout = tx.outputs[output_index]
+        return nil unless txout
+
+        AdminTokenTemplate.decode(txout.locking_script)
+      rescue StandardError
+        nil
+      end
+
+      def parse_beef(beef_data)
+        case beef_data
+        when String
+          BSV::Transaction::Beef.from_binary(beef_data)
+        when Array
+          BSV::Transaction::Beef.from_binary(beef_data.pack('C*'))
+        end
+      rescue StandardError
+        nil
+      end
+
+      def normalise_domain(domain)
+        return domain if domain.start_with?('https://', 'http://')
+
+        "https://#{domain}"
+      end
+
+      # ---- Parallel dispatch ----
+
+      def dispatch(beef, host_topics)
+        results   = {}
+        mutex     = Mutex.new
+
+        threads = host_topics.map do |host, host_topic_set|
+          Thread.new do
+            topics_for_host = @topics.select { |t| host_topic_set.include?(t) }
+            tagged = TaggedBEEF.new(beef: beef, topics: topics_for_host)
+            steak  = @facilitator.send_beef(host, tagged)
+            mutex.synchronize { results[host] = steak }
+          rescue StandardError
+            mutex.synchronize { results[host] = nil }
+          end
+        end
+
+        threads.each(&:join)
+        results
+      end
+
+      # ---- Acknowledgement tracking ----
+
+      # Build a map of host → Set of acknowledged topic names.
+      #
+      # A topic is considered acknowledged if the host's AdmittanceInstructions
+      # for that topic has at least one entry in +outputs_to_admit+,
+      # +coins_to_retain+, or +coins_removed+.
+      def build_host_acks(successful_results)
+        successful_results.each_with_object({}) do |(host, steak), acks|
+          next unless steak.is_a?(Hash)
+
+          acked = Set.new
+          steak.each do |topic, instructions|
+            next unless instructions.is_a?(AdmittanceInstructions)
+
+            admit = instructions.outputs_to_admit
+            retain = instructions.coins_to_retain
+            removed = instructions.coins_removed
+
+            next unless (admit && !admit.empty?) ||
+                        (retain && !retain.empty?) ||
+                        (removed && !removed.empty?)
+
+            acked << topic
+          end
+          acks[host] = acked
+        end
+      end
+
+      # Check all three ack requirement modes and return an error result if
+      # any check fails, or nil on success.
+      def check_ack_requirements(host_acks)
+        if any_host_requirement_active? && !any_host_satisfies?(host_acks, @require_ack_from_any_host)
+          return error_result(
+            'ERR_REQUIRE_ACK_FROM_ANY_HOST_FAILED',
+            'No host acknowledged the required topics.'
+          )
+        end
+
+        if all_hosts_requirement_active? && !all_hosts_satisfy?(host_acks, @require_ack_from_all_hosts)
+          return error_result(
+            'ERR_REQUIRE_ACK_FROM_ALL_HOSTS_FAILED',
+            'Not all hosts acknowledged the required topics.'
+          )
+        end
+
+        if @require_ack_from_specific_hosts.any? && !specific_hosts_satisfy?(host_acks)
+          return error_result(
+            'ERR_REQUIRE_ACK_FROM_SPECIFIC_HOSTS_FAILED',
+            'Specific hosts did not acknowledge the required topics.'
+          )
+        end
+
+        nil
+      end
+
+      def any_host_requirement_active?
+        req = @require_ack_from_any_host
+        req && req != []
+      end
+
+      def all_hosts_requirement_active?
+        req = @require_ack_from_all_hosts
+        req && req != [] && !req.empty?
+      end
+
+      # Returns true if at least one host in +host_acks+ satisfies +requirement+.
+      def any_host_satisfies?(host_acks, requirement)
+        host_acks.any? { |_host, acked| host_meets_requirement?(acked, requirement) }
+      end
+
+      # Returns true if every host in +host_acks+ satisfies +requirement+.
+      def all_hosts_satisfy?(host_acks, requirement)
+        host_acks.all? { |_host, acked| host_meets_requirement?(acked, requirement) }
+      end
+
+      # Returns true if every named host in +require_ack_from_specific_hosts+
+      # responded and met its individual requirement.
+      def specific_hosts_satisfy?(host_acks)
+        @require_ack_from_specific_hosts.all? do |host, requirement|
+          acked = host_acks[host]
+          next false unless acked
+
+          host_meets_requirement?(acked, requirement)
+        end
+      end
+
+      # Evaluate whether a host's acknowledged topic set satisfies a requirement.
+      #
+      # @param acked       [Set<String>] topics the host acknowledged
+      # @param requirement [String, Array<String>] +'all'+, +'any'+, or topic list
+      def host_meets_requirement?(acked, requirement)
+        case requirement
+        when 'all'
+          @topics.all? { |t| acked.include?(t) }
+        when 'any'
+          @topics.any? { |t| acked.include?(t) }
+        when Array
+          requirement.all? { |t| acked.include?(t) }
+        else
+          true
+        end
+      end
+
+      # ---- Result helpers ----
+
+      def error_result(code, description)
+        OverlayBroadcastResult.new(status: 'error', code: code, description: description)
+      end
+
+      # ---- Defaults ----
+
+      def local?
+        @network_preset == :local
+      end
+
+      def default_facilitator
+        if local?
+          HTTPSBroadcastFacilitator.new(allow_http: true)
+        else
+          HTTPSBroadcastFacilitator.new
+        end
+      end
+
+      def default_resolver
+        LookupResolver.new(network_preset: @network_preset)
+      end
+    end
+
+    # Alias for TopicBroadcaster.
+    #
+    # SHIPBroadcaster and TopicBroadcaster are the same class; the alias exists
+    # for compatibility with the Go and TypeScript SDKs where the class is known
+    # by both names.
+    SHIPBroadcaster = TopicBroadcaster
+  end
+end

--- a/lib/bsv/overlay/types.rb
+++ b/lib/bsv/overlay/types.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module BSV
+  module Overlay
+    # Tagged BEEF (Background Evaluation Extended Format) structure.
+    #
+    # Comprises a transaction, its SPV information, and the overlay topics
+    # where its inclusion is requested.
+    class TaggedBEEF
+      # @return [String] raw binary BEEF-encoded transaction data
+      attr_reader :beef
+
+      # @return [Array<String>] overlay topic names where the transaction is to be submitted
+      attr_reader :topics
+
+      # @param beef [String] raw binary BEEF-encoded transaction data
+      # @param topics [Array<String>] overlay topic names
+      def initialize(beef:, topics:)
+        @beef = beef
+        @topics = topics
+      end
+    end
+
+    # Instructs the Overlay Services Engine about which outputs to admit and
+    # which previous outputs to retain. Returned by a Topic Manager.
+    class AdmittanceInstructions
+      # @return [Array<Integer>] indices of admissible outputs in the managed topic
+      attr_reader :outputs_to_admit
+
+      # @return [Array<Integer>] indices of inputs spending previously-admitted outputs to retain
+      attr_reader :coins_to_retain
+
+      # @return [Array<Integer>, nil] indices of inputs spending previously-admitted outputs
+      #   that are now considered spent and removed from the topic (optional)
+      attr_reader :coins_removed
+
+      # @param outputs_to_admit [Array<Integer>]
+      # @param coins_to_retain [Array<Integer>]
+      # @param coins_removed [Array<Integer>, nil]
+      def initialize(outputs_to_admit:, coins_to_retain:, coins_removed: nil)
+        @outputs_to_admit = outputs_to_admit
+        @coins_to_retain = coins_to_retain
+        @coins_removed = coins_removed
+      end
+    end
+
+    # The question asked to the Overlay Services Engine when a consumer of state
+    # wishes to look up information.
+    class LookupQuestion
+      # @return [String] identifier of the Lookup Service to query
+      attr_reader :service
+
+      # @return [Hash] query forwarded to the Lookup Service; structure depends on the service
+      attr_reader :query
+
+      # @param service [String]
+      # @param query [Hash]
+      def initialize(service:, query:)
+        @service = service
+        @query = query
+      end
+    end
+
+    # How the Overlay Services Engine responds to a LookupQuestion.
+    class LookupAnswer
+      # @return [String] response type (e.g. 'output-list')
+      attr_reader :type
+
+      # @return [Array] outputs or freeform response data from the Lookup Service
+      attr_reader :outputs
+
+      # @param type [String]
+      # @param outputs [Array]
+      def initialize(type:, outputs:)
+        @type = type
+        @outputs = outputs
+      end
+    end
+
+    # Result of broadcasting a transaction to an Overlay Services host.
+    class OverlayBroadcastResult
+      # @return [String] result status ('success' or 'error')
+      attr_reader :status
+
+      # @return [String, nil] transaction identifier (present on success)
+      attr_reader :txid
+
+      # @return [String, nil] human-readable result message
+      attr_reader :message
+
+      # @return [String, nil] machine-readable error code
+      attr_reader :code
+
+      # @return [String, nil] human-readable error description
+      attr_reader :description
+
+      # @param status [String]
+      # @param txid [String, nil]
+      # @param message [String, nil]
+      # @param code [String, nil]
+      # @param description [String, nil]
+      def initialize(status:, txid: nil, message: nil, code: nil, description: nil)
+        @status = status
+        @txid = txid
+        @message = message
+        @code = code
+        @description = description
+      end
+    end
+  end
+end

--- a/spec/bsv/overlay/admin_token_template_spec.rb
+++ b/spec/bsv/overlay/admin_token_template_spec.rb
@@ -1,0 +1,353 @@
+# frozen_string_literal: true
+
+require 'bsv-sdk'
+require 'bsv-wallet'
+
+# A well-known compressed public key (33 bytes) used as a test identity key.
+# Corresponds to PrivateKey(1) on secp256k1.
+SHIP_IDENTITY_KEY_HEX = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
+SHIP_IDENTITY_KEY_BIN = [SHIP_IDENTITY_KEY_HEX].pack('H*')
+
+RSpec.describe BSV::Overlay::AdminTokenTemplate do
+  # A dummy P2PKH lock script used as the underlying lock in test PushDrop scripts.
+  let(:dummy_pubkey_hash) { ("\x00" * 20).b }
+  let(:lock_script) { BSV::Script::Script.p2pkh_lock(dummy_pubkey_hash) }
+
+  # A ProtoWallet backed by PrivateKey(1), used for deterministic lock/unlock tests.
+  let(:private_key) { BSV::Primitives::PrivateKey.new(OpenSSL::BN.new(1)) }
+  let(:wallet) { BSV::Wallet::ProtoWallet.new(private_key) }
+
+  def ship_script(domain: 'example.com', topic: 'tm_tests', identity_key: SHIP_IDENTITY_KEY_BIN)
+    BSV::Script::Script.pushdrop_lock(
+      ['SHIP'.b, identity_key, domain.encode('binary'), topic.encode('binary')],
+      lock_script
+    )
+  end
+
+  def slap_script(domain: 'lookup.example.com', service: 'ls_tests', identity_key: SHIP_IDENTITY_KEY_BIN)
+    BSV::Script::Script.pushdrop_lock(
+      ['SLAP'.b, identity_key, domain.encode('binary'), service.encode('binary')],
+      lock_script
+    )
+  end
+
+  describe '.decode' do
+    context 'with a valid SHIP advertisement' do
+      subject(:result) { described_class.decode(ship_script) }
+
+      it 'returns an Advertisement' do
+        expect(result).to be_a(BSV::Overlay::AdminTokenTemplate::Advertisement)
+      end
+
+      it 'decodes the protocol as SHIP' do
+        expect(result.protocol).to eq('SHIP')
+      end
+
+      it 'decodes the identity key as hex' do
+        expect(result.identity_key).to eq(SHIP_IDENTITY_KEY_HEX)
+      end
+
+      it 'decodes the domain' do
+        expect(result.domain).to eq('example.com')
+      end
+
+      it 'decodes the topic_or_service' do
+        expect(result.topic_or_service).to eq('tm_tests')
+      end
+    end
+
+    context 'with a valid SLAP advertisement' do
+      subject(:result) { described_class.decode(slap_script) }
+
+      it 'decodes the protocol as SLAP' do
+        expect(result.protocol).to eq('SLAP')
+      end
+
+      it 'decodes the identity key as hex' do
+        expect(result.identity_key).to eq(SHIP_IDENTITY_KEY_HEX)
+      end
+
+      it 'decodes the domain' do
+        expect(result.domain).to eq('lookup.example.com')
+      end
+
+      it 'decodes the topic_or_service' do
+        expect(result.topic_or_service).to eq('ls_tests')
+      end
+    end
+
+    context 'with a non-PushDrop script' do
+      it 'returns nil for a P2PKH script' do
+        script = BSV::Script::Script.p2pkh_lock(dummy_pubkey_hash)
+        expect(described_class.decode(script)).to be_nil
+      end
+    end
+
+    context 'with a nil or empty script' do
+      it 'returns nil for nil' do
+        expect(described_class.decode(nil)).to be_nil
+      end
+
+      it 'returns nil for an empty script' do
+        expect(described_class.decode(BSV::Script::Script.new)).to be_nil
+      end
+    end
+
+    context 'with a PushDrop script with fewer than 4 fields' do
+      it 'raises OverlayError' do
+        script = BSV::Script::Script.pushdrop_lock(
+          ['SHIP'.b, SHIP_IDENTITY_KEY_BIN],
+          lock_script
+        )
+        expect { described_class.decode(script) }.to raise_error(BSV::Overlay::OverlayError, /4 fields/)
+      end
+    end
+
+    context 'with a PushDrop script containing exactly 3 fields' do
+      it 'raises OverlayError' do
+        script = BSV::Script::Script.pushdrop_lock(
+          ['SHIP'.b, SHIP_IDENTITY_KEY_BIN, 'example.com'.b],
+          lock_script
+        )
+        expect { described_class.decode(script) }.to raise_error(BSV::Overlay::OverlayError)
+      end
+    end
+
+    context 'with a PushDrop script containing an invalid protocol' do
+      it 'raises OverlayError' do
+        script = BSV::Script::Script.pushdrop_lock(
+          ['NOPE'.b, SHIP_IDENTITY_KEY_BIN, 'example.com'.b, 'tm_tests'.b],
+          lock_script
+        )
+        expect { described_class.decode(script) }.to raise_error(BSV::Overlay::OverlayError, /protocol/)
+      end
+    end
+
+    context 'with null byte normalisation' do
+      it 'treats a single null byte in the domain field as an empty string' do
+        script = BSV::Script::Script.pushdrop_lock(
+          ['SHIP'.b, SHIP_IDENTITY_KEY_BIN, "\x00".b, 'tm_tests'.b],
+          lock_script
+        )
+        result = described_class.decode(script)
+        expect(result.domain).to eq('')
+      end
+
+      it 'treats a single null byte in the topic_or_service field as an empty string' do
+        script = BSV::Script::Script.pushdrop_lock(
+          ['SHIP'.b, SHIP_IDENTITY_KEY_BIN, 'example.com'.b, "\x00".b],
+          lock_script
+        )
+        result = described_class.decode(script)
+        expect(result.topic_or_service).to eq('')
+      end
+    end
+
+    context 'when verifying round-trip encode/decode via pushdrop_lock' do
+      it 'round-trips a SHIP advertisement' do
+        script = ship_script(domain: 'myhost.bsvb.tech', topic: 'tm_payments')
+        result = described_class.decode(script)
+
+        expect(result.protocol).to eq('SHIP')
+        expect(result.identity_key).to eq(SHIP_IDENTITY_KEY_HEX)
+        expect(result.domain).to eq('myhost.bsvb.tech')
+        expect(result.topic_or_service).to eq('tm_payments')
+      end
+
+      it 'round-trips a SLAP advertisement' do
+        script = slap_script(domain: 'lookup.bsvb.tech', service: 'ls_ship')
+        result = described_class.decode(script)
+
+        expect(result.protocol).to eq('SLAP')
+        expect(result.identity_key).to eq(SHIP_IDENTITY_KEY_HEX)
+        expect(result.domain).to eq('lookup.bsvb.tech')
+        expect(result.topic_or_service).to eq('ls_ship')
+      end
+    end
+  end
+
+  describe '#lock' do
+    let(:template) { described_class.new(wallet) }
+
+    context 'with a SHIP advertisement' do
+      subject(:locking_script) { template.lock('SHIP', 'test.com', 'tm_tests') }
+
+      it 'returns a PushDrop script' do
+        expect(locking_script).to be_a(BSV::Script::Script)
+        expect(locking_script.pushdrop?).to be true
+      end
+
+      it 'produces a script that decode can parse' do
+        decoded = described_class.decode(locking_script)
+        expect(decoded).to be_a(BSV::Overlay::AdminTokenTemplate::Advertisement)
+      end
+
+      it 'encodes the protocol as SHIP' do
+        decoded = described_class.decode(locking_script)
+        expect(decoded.protocol).to eq('SHIP')
+      end
+
+      it 'encodes the domain' do
+        decoded = described_class.decode(locking_script)
+        expect(decoded.domain).to eq('test.com')
+      end
+
+      it 'encodes the topic_or_service' do
+        decoded = described_class.decode(locking_script)
+        expect(decoded.topic_or_service).to eq('tm_tests')
+      end
+
+      it 'encodes the wallet identity key' do
+        decoded = described_class.decode(locking_script)
+        identity_hex = wallet.get_public_key({ identity_key: true })[:public_key]
+        expect(decoded.identity_key).to eq(identity_hex)
+      end
+    end
+
+    context 'with a SLAP advertisement' do
+      subject(:locking_script) { template.lock('SLAP', 'lookup.example.com', 'ls_tests') }
+
+      it 'returns a PushDrop script' do
+        expect(locking_script).to be_a(BSV::Script::Script)
+        expect(locking_script.pushdrop?).to be true
+      end
+
+      it 'encodes the protocol as SLAP' do
+        decoded = described_class.decode(locking_script)
+        expect(decoded.protocol).to eq('SLAP')
+      end
+
+      it 'encodes the domain' do
+        decoded = described_class.decode(locking_script)
+        expect(decoded.domain).to eq('lookup.example.com')
+      end
+
+      it 'encodes the topic_or_service' do
+        decoded = described_class.decode(locking_script)
+        expect(decoded.topic_or_service).to eq('ls_tests')
+      end
+    end
+
+    context 'with an invalid protocol' do
+      it 'raises OverlayError for an unrecognised protocol string' do
+        expect { template.lock('INVALID', 'test.com', 'tm_tests') }
+          .to raise_error(BSV::Overlay::OverlayError, /SHIP.*SLAP/)
+      end
+
+      it 'raises OverlayError for a lowercase protocol string' do
+        expect { template.lock('ship', 'test.com', 'tm_tests') }
+          .to raise_error(BSV::Overlay::OverlayError)
+      end
+
+      it 'raises OverlayError for an empty string' do
+        expect { template.lock('', 'test.com', 'tm_tests') }
+          .to raise_error(BSV::Overlay::OverlayError)
+      end
+    end
+
+    context 'with an originator' do
+      it 'accepts an originator on construction without raising' do
+        template_with_originator = described_class.new(wallet, originator: 'test.example.com')
+        expect { template_with_originator.lock('SHIP', 'test.com', 'tm_tests') }
+          .not_to raise_error
+      end
+    end
+
+    context 'when verifying the identity key round-trip' do
+      it 'embeds the wallet identity key in the locking script' do
+        identity_hex = wallet.get_public_key({ identity_key: true })[:public_key]
+        locking_script = template.lock('SHIP', 'myhost.bsvb.tech', 'tm_payments')
+        decoded = described_class.decode(locking_script)
+        expect(decoded.identity_key).to eq(identity_hex)
+      end
+    end
+  end
+
+  describe '#unlock' do
+    let(:template) { described_class.new(wallet) }
+
+    context 'with an invalid protocol' do
+      it 'raises OverlayError' do
+        expect { template.unlock('INVALID') }
+          .to raise_error(BSV::Overlay::OverlayError)
+      end
+    end
+
+    context 'with a valid protocol' do
+      it 'returns an Unlocker for SHIP' do
+        expect(template.unlock('SHIP')).to be_a(BSV::Overlay::AdminTokenTemplate::Unlocker)
+      end
+
+      it 'returns an Unlocker for SLAP' do
+        expect(template.unlock('SLAP')).to be_a(BSV::Overlay::AdminTokenTemplate::Unlocker)
+      end
+
+      it 'estimates the script length as 73 bytes' do
+        unlocker = template.unlock('SHIP')
+        expect(unlocker.estimated_length(nil, 0)).to eq(73)
+      end
+    end
+  end
+
+  describe 'lock + unlock round-trip (script verification)' do
+    # Helper: build a signed spending transaction and verify its input scripts.
+    def build_and_verify(protocol, domain, topic_or_service)
+      template = described_class.new(wallet)
+      locking_script = template.lock(protocol, domain, topic_or_service)
+      satoshis = 1_000
+
+      # Source transaction: contains the locked output.
+      source_tx = BSV::Transaction::Transaction.new
+      dummy_input = BSV::Transaction::TransactionInput.new(
+        prev_tx_id: "\x00" * 32,
+        prev_tx_out_index: 0
+      )
+      dummy_input.source_locking_script = BSV::Script::Script.p2pkh_lock("\x00" * 20)
+      dummy_input.source_satoshis = satoshis + 100
+      dummy_input.unlocking_script = BSV::Script::Script.new
+      source_tx.add_input(dummy_input)
+      source_tx.add_output(
+        BSV::Transaction::TransactionOutput.new(satoshis: satoshis, locking_script: locking_script)
+      )
+
+      # Spending transaction: spends the locked output.
+      spend_tx = BSV::Transaction::Transaction.new
+      spend_input = BSV::Transaction::TransactionInput.new(
+        prev_tx_id: [source_tx.txid_hex].pack('H*'),
+        prev_tx_out_index: 0,
+        sequence: 0xffffffff
+      )
+      spend_input.source_transaction = source_tx
+      spend_input.source_satoshis = satoshis
+      spend_input.source_locking_script = locking_script
+      spend_tx.add_input(spend_input)
+      spend_tx.add_output(
+        BSV::Transaction::TransactionOutput.new(
+          satoshis: satoshis - 100,
+          locking_script: BSV::Script::Script.p2pkh_lock("\x00" * 20)
+        )
+      )
+
+      # Sign and verify.
+      unlocker = template.unlock(protocol)
+      spend_tx.inputs[0].unlocking_script = unlocker.sign(spend_tx, 0)
+      spend_tx.verify_input(0)
+    end
+
+    it 'verifies a SHIP lock + unlock' do
+      expect(build_and_verify('SHIP', 'test.com', 'tm_tests')).to be true
+    end
+
+    it 'verifies a SLAP lock + unlock' do
+      expect(build_and_verify('SLAP', 'lookup.example.com', 'ls_tests')).to be true
+    end
+
+    it 'verifies with an empty domain' do
+      expect(build_and_verify('SHIP', '', 'tm_tests')).to be true
+    end
+
+    it 'verifies with an empty topic_or_service' do
+      expect(build_and_verify('SLAP', 'lookup.example.com', '')).to be true
+    end
+  end
+end

--- a/spec/bsv/overlay/broadcast_facilitator_spec.rb
+++ b/spec/bsv/overlay/broadcast_facilitator_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/MultipleDescribes
+
+require 'spec_helper'
+require 'bsv-sdk'
+
+RSpec.describe BSV::Overlay::BroadcastFacilitator do
+  subject(:facilitator) { described_class.new }
+
+  let(:tagged_beef) do
+    BSV::Overlay::TaggedBEEF.new(beef: "\x00\x01\x02", topics: ['tm_foo'])
+  end
+
+  describe '#send_beef' do
+    it 'raises NotImplementedError' do
+      expect { facilitator.send_beef('https://example.com', tagged_beef) }
+        .to raise_error(NotImplementedError, /send_beef must be implemented/)
+    end
+  end
+end
+
+RSpec.describe BSV::Overlay::HTTPSBroadcastFacilitator do
+  subject(:facilitator) { described_class.new(http_client: mock_http_client) }
+
+  let(:tagged_beef) do
+    BSV::Overlay::TaggedBEEF.new(beef: "\x01\x02\x03", topics: %w[tm_foo tm_bar])
+  end
+
+  let(:steak_body) do
+    JSON.generate(
+      'tm_foo' => {
+        'outputsToAdmit' => [0],
+        'coinsToRetain' => [],
+        'coinsRemoved' => nil
+      },
+      'tm_bar' => {
+        'outputsToAdmit' => [],
+        'coinsToRetain' => [1],
+        'coinsRemoved' => nil
+      }
+    )
+  end
+
+  let(:mock_response) do
+    instance_double(Net::HTTPResponse, code: '200', body: steak_body)
+  end
+
+  let(:mock_http_client) do
+    dbl = double('http_client') # rubocop:disable RSpec/VerifiedDoubles
+    allow(dbl).to receive(:request).and_return(mock_response)
+    dbl
+  end
+
+  describe 'HTTPS enforcement' do
+    it 'raises ArgumentError for a plain HTTP URL' do
+      expect { facilitator.send_beef('http://example.com', tagged_beef) }
+        .to raise_error(ArgumentError, /https:/)
+    end
+
+    it 'permits plain HTTP when allow_http: true' do
+      http_facilitator = described_class.new(allow_http: true, http_client: mock_http_client)
+      expect { http_facilitator.send_beef('http://example.com', tagged_beef) }.not_to raise_error
+    end
+
+    it 'permits HTTPS URLs' do
+      expect { facilitator.send_beef('https://example.com', tagged_beef) }.not_to raise_error
+    end
+  end
+
+  describe '#send_beef' do
+    it 'POSTs to {url}/submit' do
+      facilitator.send_beef('https://example.com', tagged_beef)
+      expect(mock_http_client).to have_received(:request) do |uri, req|
+        expect(uri.to_s).to eq('https://example.com/submit')
+        expect(req).to be_a(Net::HTTP::Post)
+      end
+    end
+
+    it 'strips trailing slash before appending /submit' do
+      facilitator.send_beef('https://example.com/', tagged_beef)
+      expect(mock_http_client).to have_received(:request) do |uri, _req|
+        expect(uri.to_s).to eq('https://example.com/submit')
+      end
+    end
+
+    it 'sets Content-Type to application/octet-stream' do
+      facilitator.send_beef('https://example.com', tagged_beef)
+      expect(mock_http_client).to have_received(:request) do |_uri, req|
+        expect(req['Content-Type']).to eq('application/octet-stream')
+      end
+    end
+
+    it 'sets X-Topics to JSON-encoded topics array' do
+      facilitator.send_beef('https://example.com', tagged_beef)
+      expect(mock_http_client).to have_received(:request) do |_uri, req|
+        expect(JSON.parse(req['X-Topics'])).to eq(%w[tm_foo tm_bar])
+      end
+    end
+
+    it 'sends raw BEEF bytes as the request body' do
+      facilitator.send_beef('https://example.com', tagged_beef)
+      expect(mock_http_client).to have_received(:request) do |_uri, req|
+        expect(req.body).to eq("\x01\x02\x03")
+      end
+    end
+
+    it 'returns a hash of topic => AdmittanceInstructions' do
+      result = facilitator.send_beef('https://example.com', tagged_beef)
+      expect(result).to be_a(Hash)
+      expect(result.keys).to contain_exactly('tm_foo', 'tm_bar')
+      expect(result['tm_foo']).to be_a(BSV::Overlay::AdmittanceInstructions)
+      expect(result['tm_foo'].outputs_to_admit).to eq([0])
+      expect(result['tm_bar'].coins_to_retain).to eq([1])
+    end
+
+    it 'returns nil for a non-2xx response' do
+      error_response = instance_double(Net::HTTPResponse, code: '500', body: 'Server Error')
+      allow(mock_http_client).to receive(:request).and_return(error_response)
+      result = facilitator.send_beef('https://example.com', tagged_beef)
+      expect(result).to be_nil
+    end
+
+    it 'returns nil for an unparseable response body' do
+      bad_response = instance_double(Net::HTTPResponse, code: '200', body: 'not json')
+      allow(mock_http_client).to receive(:request).and_return(bad_response)
+      result = facilitator.send_beef('https://example.com', tagged_beef)
+      expect(result).to be_nil
+    end
+  end
+end
+
+# rubocop:enable RSpec/MultipleDescribes

--- a/spec/bsv/overlay/constants_spec.rb
+++ b/spec/bsv/overlay/constants_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+RSpec.describe 'BSV::Overlay::Constants' do
+  subject(:constants) { BSV::Overlay::Constants }
+
+  describe 'protocol identifiers' do
+    it 'defines PROTOCOL_SHIP as SHIP' do
+      expect(constants::PROTOCOL_SHIP).to eq('SHIP')
+    end
+
+    it 'defines PROTOCOL_SLAP as SLAP' do
+      expect(constants::PROTOCOL_SLAP).to eq('SLAP')
+    end
+
+    it 'defines PROTOCOL_ID_SHIP' do
+      expect(constants::PROTOCOL_ID_SHIP).to eq('Service Host Interconnect')
+    end
+
+    it 'defines PROTOCOL_ID_SLAP' do
+      expect(constants::PROTOCOL_ID_SLAP).to eq('Service Lookup Availability')
+    end
+  end
+
+  describe 'SLAP tracker URLs' do
+    it 'includes US BSVA cluster in mainnet trackers' do
+      expect(constants::DEFAULT_SLAP_TRACKERS).to include('https://overlay-us-1.bsvb.tech')
+    end
+
+    it 'includes EU BSVA cluster in mainnet trackers' do
+      expect(constants::DEFAULT_SLAP_TRACKERS).to include('https://overlay-eu-1.bsvb.tech')
+    end
+
+    it 'includes AP BSVA cluster in mainnet trackers' do
+      expect(constants::DEFAULT_SLAP_TRACKERS).to include('https://overlay-ap-1.bsvb.tech')
+    end
+
+    it 'includes Babbage primary service in mainnet trackers' do
+      expect(constants::DEFAULT_SLAP_TRACKERS).to include('https://users.bapp.dev')
+    end
+
+    it 'includes Babbage testnet service in testnet trackers' do
+      expect(constants::DEFAULT_TESTNET_SLAP_TRACKERS).to include('https://testnet-users.bapp.dev')
+    end
+
+    it 'freezes the mainnet tracker array' do
+      expect(constants::DEFAULT_SLAP_TRACKERS).to be_frozen
+    end
+
+    it 'freezes the testnet tracker array' do
+      expect(constants::DEFAULT_TESTNET_SLAP_TRACKERS).to be_frozen
+    end
+  end
+
+  describe 'NETWORK_PRESETS' do
+    it 'maps mainnet to the mainnet SLAP trackers' do
+      expect(constants::NETWORK_PRESETS['mainnet']).to eq(constants::DEFAULT_SLAP_TRACKERS)
+    end
+
+    it 'maps testnet to the testnet SLAP trackers' do
+      expect(constants::NETWORK_PRESETS['testnet']).to eq(constants::DEFAULT_TESTNET_SLAP_TRACKERS)
+    end
+
+    it 'is frozen' do
+      expect(constants::NETWORK_PRESETS).to be_frozen
+    end
+  end
+end

--- a/spec/bsv/overlay/errors_spec.rb
+++ b/spec/bsv/overlay/errors_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'BSV::Overlay error classes' do
+  describe BSV::Overlay::OverlayError do
+    it 'inherits from StandardError' do
+      expect(described_class.ancestors).to include(StandardError)
+    end
+
+    it 'can be raised and rescued as StandardError' do
+      expect { raise described_class, 'test' }.to raise_error(StandardError)
+    end
+  end
+
+  describe BSV::Overlay::NoCompetentHostsError do
+    it 'inherits from OverlayError' do
+      expect(described_class.ancestors).to include(BSV::Overlay::OverlayError)
+    end
+
+    it 'can be raised and rescued as OverlayError' do
+      expect { raise described_class, 'no hosts' }.to raise_error(BSV::Overlay::OverlayError)
+    end
+
+    it 'carries a message' do
+      error = described_class.new('no competent hosts found')
+      expect(error.message).to eq('no competent hosts found')
+    end
+  end
+
+  describe BSV::Overlay::AllHostsRejectedError do
+    it 'inherits from OverlayError' do
+      expect(described_class.ancestors).to include(BSV::Overlay::OverlayError)
+    end
+
+    it 'can be raised and rescued as OverlayError' do
+      expect { raise described_class, 'all rejected' }.to raise_error(BSV::Overlay::OverlayError)
+    end
+  end
+
+  describe BSV::Overlay::AcknowledgementError do
+    it 'inherits from OverlayError' do
+      expect(described_class.ancestors).to include(BSV::Overlay::OverlayError)
+    end
+
+    it 'can be raised and rescued as OverlayError' do
+      expect { raise described_class, 'ack failed' }.to raise_error(BSV::Overlay::OverlayError)
+    end
+  end
+
+  it 'loads BSV::Overlay without error' do
+    expect { BSV::Overlay }.not_to raise_error
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/bsv/overlay/host_reputation_tracker_spec.rb
+++ b/spec/bsv/overlay/host_reputation_tracker_spec.rb
@@ -1,0 +1,419 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-sdk'
+
+RSpec.describe BSV::Overlay::HostReputationTracker do
+  subject(:tracker) { described_class.new }
+
+  let(:host) { 'https://overlay.example.com' }
+
+  # -------------------------------------------------------------------------
+  # Success recording — EWMA latency
+  # -------------------------------------------------------------------------
+
+  describe '#record_success' do
+    it 'sets avg_latency_ms directly on first success (no smoothing)' do
+      tracker.record_success(host, 200)
+      snap = tracker.snapshot(host)
+      expect(snap[:avg_latency_ms]).to eq(200.0)
+    end
+
+    it 'applies EWMA smoothing on subsequent successes' do
+      # After first success avg = 200
+      tracker.record_success(host, 200)
+      # Second: new_avg = 200 * 0.75 + 400 * 0.25 = 150 + 100 = 250
+      tracker.record_success(host, 400)
+      snap = tracker.snapshot(host)
+      expect(snap[:avg_latency_ms]).to be_within(0.001).of(250.0)
+    end
+
+    it 'applies further EWMA smoothing on a third success' do
+      tracker.record_success(host, 200)
+      tracker.record_success(host, 400) # avg = 250
+      # Third: new_avg = 250 * 0.75 + 100 * 0.25 = 187.5 + 25 = 212.5
+      tracker.record_success(host, 100)
+      snap = tracker.snapshot(host)
+      expect(snap[:avg_latency_ms]).to be_within(0.001).of(212.5)
+    end
+
+    it 'increments total_successes' do
+      tracker.record_success(host, 100)
+      tracker.record_success(host, 100)
+      expect(tracker.snapshot(host)[:total_successes]).to eq(2)
+    end
+
+    it 'resets consecutive_failures to zero' do
+      tracker.record_failure(host)
+      tracker.record_failure(host)
+      tracker.record_success(host, 100)
+      expect(tracker.snapshot(host)[:consecutive_failures]).to eq(0)
+    end
+
+    it 'clears backoff_until' do
+      # Force three failures so backoff is set
+      3.times { tracker.record_failure(host) }
+      expect(tracker.snapshot(host)[:backoff_until]).not_to be_nil
+
+      tracker.record_success(host, 100)
+      expect(tracker.snapshot(host)[:backoff_until]).to be_nil
+    end
+
+    it 'clamps negative latency to DEFAULT_LATENCY_MS' do
+      tracker.record_success(host, -50)
+      snap = tracker.snapshot(host)
+      expect(snap[:avg_latency_ms]).to eq(described_class::DEFAULT_LATENCY_MS.to_f)
+    end
+
+    it 'clamps NaN latency to DEFAULT_LATENCY_MS' do
+      tracker.record_success(host, Float::NAN)
+      snap = tracker.snapshot(host)
+      expect(snap[:avg_latency_ms]).to eq(described_class::DEFAULT_LATENCY_MS.to_f)
+    end
+
+    it 'clamps Infinity latency to DEFAULT_LATENCY_MS' do
+      tracker.record_success(host, Float::INFINITY)
+      snap = tracker.snapshot(host)
+      expect(snap[:avg_latency_ms]).to eq(described_class::DEFAULT_LATENCY_MS.to_f)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Failure recording — backoff logic
+  # -------------------------------------------------------------------------
+
+  describe '#record_failure' do
+    it 'does not set backoff_until on first failure (within grace period)' do
+      tracker.record_failure(host)
+      expect(tracker.snapshot(host)[:backoff_until]).to be_nil
+    end
+
+    it 'does not set backoff_until on second failure (within grace period)' do
+      tracker.record_failure(host)
+      tracker.record_failure(host)
+      expect(tracker.snapshot(host)[:backoff_until]).to be_nil
+    end
+
+    it 'sets backoff_until on third failure (BASE_BACKOFF_MS = 1 s)' do
+      now = Time.now
+      allow(Time).to receive(:now).and_return(now)
+
+      3.times { tracker.record_failure(host) }
+
+      snap = tracker.snapshot(host)
+      expect(snap[:backoff_until]).to be_within(0.01).of(now + 1.0)
+    end
+
+    it 'doubles the backoff on the fourth failure (2 s)' do
+      now = Time.now
+      allow(Time).to receive(:now).and_return(now)
+
+      4.times { tracker.record_failure(host) }
+
+      snap = tracker.snapshot(host)
+      expect(snap[:backoff_until]).to be_within(0.01).of(now + 2.0)
+    end
+
+    it 'doubles again on the fifth failure (4 s)' do
+      now = Time.now
+      allow(Time).to receive(:now).and_return(now)
+
+      5.times { tracker.record_failure(host) }
+
+      snap = tracker.snapshot(host)
+      expect(snap[:backoff_until]).to be_within(0.01).of(now + 4.0)
+    end
+
+    it 'caps backoff at MAX_BACKOFF_MS (60 s)' do
+      now = Time.now
+      allow(Time).to receive(:now).and_return(now)
+
+      # Need enough failures to exceed cap: BASE * 2^(n-GRACE-1) >= 60_000
+      # 1000 * 2^(n-3) >= 60000 → 2^(n-3) >= 60 → n-3 >= 6 → n >= 9
+      # Use 15 failures to be safely past the cap.
+      15.times { tracker.record_failure(host) }
+
+      snap = tracker.snapshot(host)
+      expect(snap[:backoff_until]).to be_within(0.01).of(now + 60.0)
+    end
+
+    it 'increments total_failures on each call' do
+      3.times { tracker.record_failure(host) }
+      expect(tracker.snapshot(host)[:total_failures]).to eq(3)
+    end
+
+    it 'records the last_error when reason is supplied' do
+      tracker.record_failure(host, 'timeout')
+      expect(tracker.snapshot(host)[:last_error]).to eq('timeout')
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # DNS error — skip grace period
+  # -------------------------------------------------------------------------
+
+  describe '#record_failure — DNS errors skip grace period' do
+    it 'triggers backoff immediately on SocketError' do
+      now = Time.now
+      allow(Time).to receive(:now).and_return(now)
+
+      tracker.record_failure(host, SocketError.new('getaddrinfo failed'))
+
+      snap = tracker.snapshot(host)
+      expect(snap[:backoff_until]).not_to be_nil
+      expect(snap[:backoff_until]).to be_within(0.01).of(now + 1.0)
+    end
+
+    it 'triggers backoff immediately on Errno::ECONNREFUSED' do
+      now = Time.now
+      allow(Time).to receive(:now).and_return(now)
+
+      tracker.record_failure(host, Errno::ECONNREFUSED.new)
+
+      snap = tracker.snapshot(host)
+      expect(snap[:backoff_until]).not_to be_nil
+    end
+
+    it 'triggers backoff immediately when message contains "getaddrinfo"' do
+      now = Time.now
+      allow(Time).to receive(:now).and_return(now)
+
+      tracker.record_failure(host, RuntimeError.new('getaddrinfo: Name or service not known'))
+
+      snap = tracker.snapshot(host)
+      expect(snap[:backoff_until]).not_to be_nil
+    end
+
+    it 'triggers backoff immediately when message contains "Failed to fetch"' do
+      now = Time.now
+      allow(Time).to receive(:now).and_return(now)
+
+      tracker.record_failure(host, 'Failed to fetch resource')
+
+      snap = tracker.snapshot(host)
+      expect(snap[:backoff_until]).not_to be_nil
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # rank_hosts
+  # -------------------------------------------------------------------------
+
+  describe '#rank_hosts' do
+    let(:host_a) { 'https://a.example.com' }
+    let(:host_b) { 'https://b.example.com' }
+    let(:host_c) { 'https://c.example.com' }
+
+    it 'returns available hosts before backed-off hosts' do
+      now = Time.now
+      allow(Time).to receive(:now).and_return(now)
+
+      3.times { tracker.record_failure(host_a) } # backed off
+      tracker.record_success(host_b, 100) # available
+
+      result = tracker.rank_hosts([host_a, host_b])
+      expect(result).to eq([host_b, host_a])
+    end
+
+    it 'deduplicates hosts preserving first occurrence order' do
+      result = tracker.rank_hosts([host_a, host_b, host_a, host_c])
+      expect(result).to eq([host_a, host_b, host_c])
+    end
+
+    it 'filters out nil entries' do
+      result = tracker.rank_hosts([host_a, nil, host_b])
+      expect(result).not_to include(nil)
+      expect(result).to include(host_a, host_b)
+    end
+
+    it 'filters out empty-string entries' do
+      result = tracker.rank_hosts([host_a, '', host_b])
+      expect(result).not_to include('')
+      expect(result).to include(host_a, host_b)
+    end
+
+    it 'sorts available hosts by score ascending' do
+      # host_a: 3 failures → high penalty; host_b: 1 fast success → low score
+      3.times { tracker.record_failure(host_a) }
+
+      now = Time.now + 100 # far future so host_a backoff has expired
+      tracker.record_success(host_b, 100)
+
+      # Re-stub now so host_a is NOT in backoff
+      allow(Time).to receive(:now).and_return(now)
+
+      result = tracker.rank_hosts([host_a, host_b], now)
+      expect(result.first).to eq(host_b)
+    end
+
+    it 'sorts backed-off hosts by backoff_until ascending' do
+      now = Time.now
+      allow(Time).to receive(:now).and_return(now)
+
+      # Give host_b more failures so it has a longer backoff
+      3.times { tracker.record_failure(host_a) }     # backoff = now + 1 s
+      6.times { tracker.record_failure(host_b) }     # backoff = now + 8 s (2^3)
+
+      result = tracker.rank_hosts([host_b, host_a])  # intentionally swapped
+      expect(result).to eq([host_a, host_b])
+    end
+
+    it 'returns an empty array for an empty input' do
+      expect(tracker.rank_hosts([])).to eq([])
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # snapshot
+  # -------------------------------------------------------------------------
+
+  describe '#snapshot' do
+    it 'returns nil for an unknown host' do
+      expect(tracker.snapshot('https://unknown.example.com')).to be_nil
+    end
+
+    it 'returns a frozen hash for a known host' do
+      tracker.record_success(host, 100)
+      snap = tracker.snapshot(host)
+      expect(snap).to be_a(Hash)
+      expect(snap).to be_frozen
+    end
+
+    it 'does not expose internal mutable state (copy, not reference)' do
+      tracker.record_success(host, 100)
+      snap = tracker.snapshot(host)
+      expect { snap[:total_successes] = 999 }.to raise_error(FrozenError)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # score computation
+  # -------------------------------------------------------------------------
+
+  describe 'score computation' do
+    it 'computes expected score for known inputs' do
+      # Set up: 1 success at 500 ms, then 1 failure (still within grace)
+      now = Time.now
+      allow(Time).to receive(:now).and_return(now)
+
+      tracker.record_success(host, 500)
+      tracker.record_failure(host)
+
+      snap = tracker.snapshot(host)
+
+      avg   = snap[:avg_latency_ms]          # 500.0 (first success sets directly)
+      cons  = snap[:consecutive_failures]    # 1
+      succs = snap[:total_successes]         # 1
+
+      # score = avg + cons * PENALTY - min(succs * BONUS, avg / 2)
+      #       = 500 + 1 * 400 - min(1 * 30, 250) = 900 - 30 = 870
+      expected = avg + (cons * described_class::FAILURE_PENALTY_MS) -
+                 [succs * described_class::SUCCESS_BONUS_MS, avg / 2.0].min
+
+      expect(expected).to be_within(0.001).of(870.0)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # reset
+  # -------------------------------------------------------------------------
+
+  describe '#reset' do
+    it 'clears all entries so snapshots return nil' do
+      tracker.record_success(host, 100)
+      tracker.reset
+      expect(tracker.snapshot(host)).to be_nil
+    end
+
+    it 'returns an empty host list from rank_hosts after reset' do
+      tracker.record_success(host, 100)
+      tracker.reset
+      result = tracker.rank_hosts([host])
+      # All hosts are unknown (default entry created inline), so just verify
+      # the host is still included in output (no crash).
+      expect(result).to include(host)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # store adapter
+  # -------------------------------------------------------------------------
+
+  describe 'optional store adapter' do
+    let(:store) do
+      data = {}
+      Class.new do
+        define_method(:get) { |k| data[k] }
+        define_method(:set) { |k, v| data[k] = v }
+      end.new
+    end
+
+    it 'persists entries to the store on record_success' do
+      t = described_class.new(store: store)
+      t.record_success(host, 200)
+      expect(store.get(host)).not_to be_nil
+      expect(store.get(host)[:total_successes]).to eq(1)
+    end
+
+    it 'persists entries to the store on record_failure' do
+      t = described_class.new(store: store)
+      t.record_failure(host, 'err')
+      expect(store.get(host)[:total_failures]).to eq(1)
+    end
+
+    it 'loads an entry from the store on first snapshot access' do
+      existing = {
+        host: host,
+        total_successes: 5,
+        total_failures: 0,
+        consecutive_failures: 0,
+        avg_latency_ms: 300.0,
+        last_latency_ms: 300.0,
+        backoff_until: nil,
+        last_updated_at: Time.now,
+        last_error: nil
+      }
+      store.set(host, existing)
+
+      t    = described_class.new(store: store)
+      snap = t.snapshot(host)
+      expect(snap[:total_successes]).to eq(5)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Thread safety
+  # -------------------------------------------------------------------------
+
+  describe 'thread safety' do
+    it 'handles concurrent record_success/record_failure without corrupting state' do
+      threads = []
+
+      20.times do |i|
+        threads << Thread.new do
+          if i.even?
+            tracker.record_success(host, 100 + i)
+          else
+            tracker.record_failure(host)
+          end
+        end
+      end
+
+      threads.each(&:join)
+
+      snap = tracker.snapshot(host)
+      expect(snap).not_to be_nil
+      expect(snap[:total_successes] + snap[:total_failures]).to eq(20)
+    end
+
+    it 'handles concurrent rank_hosts calls without raising' do
+      hosts = (1..5).map { |i| "https://host#{i}.example.com" }
+
+      threads = 10.times.map do
+        Thread.new { tracker.rank_hosts(hosts) }
+      end
+
+      expect { threads.each(&:join) }.not_to raise_error
+    end
+  end
+end

--- a/spec/bsv/overlay/lookup_facilitator_spec.rb
+++ b/spec/bsv/overlay/lookup_facilitator_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/MultipleDescribes
+
+require 'spec_helper'
+require 'bsv-sdk'
+
+RSpec.describe BSV::Overlay::LookupFacilitator do
+  subject(:facilitator) { described_class.new }
+
+  let(:question) { BSV::Overlay::LookupQuestion.new(service: 'ls_foo', query: { 'q' => 1 }) }
+
+  describe '#lookup' do
+    it 'raises NotImplementedError' do
+      expect { facilitator.lookup('https://example.com', question) }
+        .to raise_error(NotImplementedError, /lookup must be implemented/)
+    end
+  end
+end
+
+RSpec.describe BSV::Overlay::HTTPSLookupFacilitator do
+  subject(:facilitator) { described_class.new(http_client: mock_http_client) }
+
+  let(:question) { BSV::Overlay::LookupQuestion.new(service: 'ls_foo', query: { 'q' => 1 }) }
+
+  let(:ok_body) do
+    JSON.generate(
+      'type' => 'output-list',
+      'outputs' => [{ 'beef' => [], 'outputIndex' => 0 }]
+    )
+  end
+
+  let(:mock_response) do
+    instance_double(Net::HTTPResponse, code: '200', body: ok_body)
+  end
+
+  let(:mock_http_client) do
+    dbl = double('http_client') # rubocop:disable RSpec/VerifiedDoubles
+    allow(dbl).to receive(:request).and_return(mock_response)
+    dbl
+  end
+
+  describe 'HTTPS enforcement' do
+    it 'raises ArgumentError for a plain HTTP URL' do
+      expect { facilitator.lookup('http://example.com', question) }
+        .to raise_error(ArgumentError, /https:/)
+    end
+
+    it 'permits plain HTTP when allow_http: true' do
+      http_facilitator = described_class.new(allow_http: true, http_client: mock_http_client)
+      expect { http_facilitator.lookup('http://example.com', question) }.not_to raise_error
+    end
+
+    it 'permits HTTPS URLs' do
+      expect { facilitator.lookup('https://example.com', question) }.not_to raise_error
+    end
+  end
+
+  describe '#lookup' do
+    it 'POSTs to {url}/lookup' do
+      facilitator.lookup('https://example.com', question)
+      expect(mock_http_client).to have_received(:request) do |uri, req|
+        expect(uri.to_s).to eq('https://example.com/lookup')
+        expect(req).to be_a(Net::HTTP::Post)
+      end
+    end
+
+    it 'sets Content-Type and X-Aggregation headers' do
+      facilitator.lookup('https://example.com', question)
+      expect(mock_http_client).to have_received(:request) do |_uri, req|
+        expect(req['Content-Type']).to eq('application/json')
+        expect(req['X-Aggregation']).to eq('yes')
+      end
+    end
+
+    it 'sends service and query in the JSON body' do
+      facilitator.lookup('https://example.com', question)
+      expect(mock_http_client).to have_received(:request) do |_uri, req|
+        body = JSON.parse(req.body)
+        expect(body['service']).to eq('ls_foo')
+        expect(body['query']).to eq({ 'q' => 1 })
+      end
+    end
+
+    it 'returns a LookupAnswer with type and outputs' do
+      answer = facilitator.lookup('https://example.com', question)
+      expect(answer).to be_a(BSV::Overlay::LookupAnswer)
+      expect(answer.type).to eq('output-list')
+      expect(answer.outputs).to be_an(Array)
+    end
+
+    it 'raises on non-2xx response' do
+      error_response = instance_double(Net::HTTPResponse, code: '503', body: 'Service Unavailable')
+      allow(mock_http_client).to receive(:request).and_return(error_response)
+      expect { facilitator.lookup('https://example.com', question) }
+        .to raise_error(RuntimeError, /HTTP 503/)
+    end
+
+    it 'strips trailing slash from URL before appending /lookup' do
+      facilitator.lookup('https://example.com/', question)
+      expect(mock_http_client).to have_received(:request) do |uri, _req|
+        expect(uri.to_s).to eq('https://example.com/lookup')
+      end
+    end
+  end
+end
+
+# rubocop:enable RSpec/MultipleDescribes

--- a/spec/bsv/overlay/lookup_resolver_spec.rb
+++ b/spec/bsv/overlay/lookup_resolver_spec.rb
@@ -453,6 +453,12 @@ RSpec.describe 'BSV::Overlay::LookupResolver' do
       end.to raise_error(ArgumentError, /ls_/)
     end
 
+    it 'raises ArgumentError for host_overrides without ls_ prefix' do
+      expect do
+        resolver(host_overrides: { 'nope' => ['https://host'] })
+      end.to raise_error(ArgumentError, /ls_/)
+    end
+
     it 'raises ArgumentError when slap_trackers is empty for mainnet' do
       expect do
         BSV::Overlay::LookupResolver.new(
@@ -460,6 +466,77 @@ RSpec.describe 'BSV::Overlay::LookupResolver' do
           slap_trackers: []
         )
       end.to raise_error(ArgumentError, /slap_trackers/)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # SSRF protection
+  # ---------------------------------------------------------------------------
+
+  describe 'SSRF protection' do
+    it 'rejects SLAP advertisements with loopback IP domains' do
+      beef = slap_beef(domain: '127.0.0.1', service: 'ls_ssrf')
+      answer = BSV::Overlay::LookupAnswer.new(
+        type: 'output-list',
+        outputs: [{ 'beef' => beef, 'outputIndex' => 0 }]
+      )
+
+      allow(mock_facilitator).to receive(:lookup) { |url, _q, **_opts|
+        if url == slap_tracker
+          answer
+        else
+          BSV::Overlay::LookupAnswer.new(type: 'output-list', outputs: [])
+        end
+      }
+
+      r = resolver
+      expect do
+        r.query(BSV::Overlay::LookupQuestion.new(service: 'ls_ssrf', query: {}))
+      end.to raise_error(BSV::Overlay::NoCompetentHostsError)
+    end
+
+    it 'rejects SLAP advertisements with private IP domains' do
+      %w[10.0.0.1 192.168.1.1 172.16.0.1].each do |ip|
+        beef = slap_beef(domain: ip, service: 'ls_priv')
+        answer = BSV::Overlay::LookupAnswer.new(
+          type: 'output-list',
+          outputs: [{ 'beef' => beef, 'outputIndex' => 0 }]
+        )
+
+        allow(mock_facilitator).to receive(:lookup) { |url, _q, **_opts|
+          if url == slap_tracker
+            answer
+          else
+            BSV::Overlay::LookupAnswer.new(type: 'output-list', outputs: [])
+          end
+        }
+
+        r = resolver
+        expect do
+          r.query(BSV::Overlay::LookupQuestion.new(service: 'ls_priv', query: {}))
+        end.to raise_error(BSV::Overlay::NoCompetentHostsError)
+      end
+    end
+
+    it 'rejects SLAP advertisements with link-local IP domains' do
+      beef = slap_beef(domain: '169.254.169.254', service: 'ls_meta')
+      answer = BSV::Overlay::LookupAnswer.new(
+        type: 'output-list',
+        outputs: [{ 'beef' => beef, 'outputIndex' => 0 }]
+      )
+
+      allow(mock_facilitator).to receive(:lookup) { |url, _q, **_opts|
+        if url == slap_tracker
+          answer
+        else
+          BSV::Overlay::LookupAnswer.new(type: 'output-list', outputs: [])
+        end
+      }
+
+      r = resolver
+      expect do
+        r.query(BSV::Overlay::LookupQuestion.new(service: 'ls_meta', query: {}))
+      end.to raise_error(BSV::Overlay::NoCompetentHostsError)
     end
   end
 end

--- a/spec/bsv/overlay/lookup_resolver_spec.rb
+++ b/spec/bsv/overlay/lookup_resolver_spec.rb
@@ -1,0 +1,465 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-sdk'
+
+# Helpers for building test BEEF containing SLAP admin token scripts.
+RESOLVER_IDENTITY_KEY_BIN = [
+  '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
+].pack('H*')
+
+module LookupResolverSpecHelpers
+  def dummy_lock_script
+    BSV::Script::Script.p2pkh_lock(("\x00" * 20).b)
+  end
+
+  # Build a PushDrop script advertising a SLAP token.
+  def slap_script(domain:, service:)
+    BSV::Script::Script.pushdrop_lock(
+      [
+        'SLAP'.b,
+        RESOLVER_IDENTITY_KEY_BIN,
+        domain.encode('binary'),
+        service.encode('binary')
+      ],
+      dummy_lock_script
+    )
+  end
+
+  # Build a minimal BEEF binary containing one transaction whose output at
+  # index 0 is a SLAP admin token for (domain, service).
+  def slap_beef(domain:, service:)
+    script = slap_script(domain: domain, service: service)
+    tx_out = BSV::Transaction::TransactionOutput.new(satoshis: 1, locking_script: script)
+    tx     = BSV::Transaction::Transaction.new
+    tx.add_output(tx_out)
+    beef = BSV::Transaction::Beef.new
+    beef.merge_transaction(tx)
+    beef.to_binary
+  end
+
+  # Build a minimal BEEF for a plain (non-SLAP) output so we can test
+  # non-discovery queries.
+  def plain_beef
+    script = dummy_lock_script
+    tx_out = BSV::Transaction::TransactionOutput.new(satoshis: 1, locking_script: script)
+    tx     = BSV::Transaction::Transaction.new
+    tx.add_output(tx_out)
+    beef = BSV::Transaction::Beef.new
+    beef.merge_transaction(tx)
+    beef.to_binary
+  end
+
+  # Build a LookupAnswer whose single output contains a SLAP advertisement.
+  def slap_answer(domain:, service:)
+    BSV::Overlay::LookupAnswer.new(
+      type: 'output-list',
+      outputs: [{ 'beef' => slap_beef(domain: domain, service: service), 'outputIndex' => 0 }]
+    )
+  end
+
+  # Build a LookupAnswer whose single output contains a plain (non-SLAP) result.
+  def plain_answer(beef_bin = nil)
+    beef_bin ||= plain_beef
+    BSV::Overlay::LookupAnswer.new(
+      type: 'output-list',
+      outputs: [{ 'beef' => beef_bin, 'outputIndex' => 0 }]
+    )
+  end
+
+  def empty_answer
+    BSV::Overlay::LookupAnswer.new(type: 'output-list', outputs: [])
+  end
+
+  # Stub the mock facilitator so that:
+  #   - calls to the SLAP tracker return the given SLAP answer
+  #   - calls to any other URL return a plain_answer (or the given default)
+  def stub_slap_then_host(mock_fac, slap_tracker:, slap_resp:, host_resp: nil)
+    allow(mock_fac).to receive(:lookup) do |url, _question, **_opts|
+      if url == slap_tracker
+        slap_resp
+      else
+        host_resp || plain_answer
+      end
+    end
+  end
+end
+
+RSpec.describe 'BSV::Overlay::LookupResolver' do
+  include LookupResolverSpecHelpers
+
+  let(:mock_facilitator) do
+    # Use a plain double so we can stub with block form — instance_double
+    # requires exact keyword argument matching which is fragile here.
+    dbl = double('LookupFacilitator') # rubocop:disable RSpec/VerifiedDoubles
+    allow(dbl).to receive(:lookup).and_return(empty_answer)
+    dbl
+  end
+
+  let(:slap_tracker) { 'https://mock.slap' }
+
+  def resolver(opts = {})
+    defaults = {
+      facilitator: mock_facilitator,
+      slap_trackers: [slap_tracker]
+    }
+    BSV::Overlay::LookupResolver.new(**defaults, **opts)
+  end
+
+  # ---------------------------------------------------------------------------
+  # LookupFacilitator (abstract base)
+  # ---------------------------------------------------------------------------
+
+  describe BSV::Overlay::LookupFacilitator do
+    it 'raises NotImplementedError on #lookup' do
+      q = BSV::Overlay::LookupQuestion.new(service: 'ls_foo', query: {})
+      expect { described_class.new.lookup('https://host', q) }
+        .to raise_error(NotImplementedError)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Host overrides
+  # ---------------------------------------------------------------------------
+
+  describe '#query with host_overrides' do
+    it 'uses the override host and bypasses SLAP discovery' do
+      result_beef = plain_beef
+      allow(mock_facilitator).to receive(:lookup) do |url, _q, **_opts|
+        raise 'SLAP tracker should not be queried' if url == slap_tracker
+
+        plain_answer(result_beef)
+      end
+
+      r = resolver(host_overrides: { 'ls_foo' => ['https://override.host'] })
+      answer = r.query(BSV::Overlay::LookupQuestion.new(service: 'ls_foo', query: {}))
+
+      expect(answer.type).to eq('output-list')
+      expect(answer.outputs).not_to be_empty
+    end
+
+    it 'raises ArgumentError when an override service name lacks the ls_ prefix' do
+      expect do
+        resolver(host_overrides: { 'bad_service' => ['https://host'] })
+      end.to raise_error(ArgumentError, /ls_/)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Additional hosts
+  # ---------------------------------------------------------------------------
+
+  describe '#query with additional_hosts' do
+    it 'queries additional hosts alongside discovered hosts' do
+      slap_resp = slap_answer(domain: 'discovered.host', service: 'ls_foo')
+      queried_urls = []
+      allow(mock_facilitator).to receive(:lookup) do |url, _q, **_opts|
+        queried_urls << url
+        url == slap_tracker ? slap_resp : plain_answer
+      end
+
+      r = resolver(additional_hosts: { 'ls_foo' => ['https://extra.host'] })
+      r.query(BSV::Overlay::LookupQuestion.new(service: 'ls_foo', query: {}))
+
+      expect(queried_urls).to include('https://extra.host')
+    end
+
+    it 'does not add duplicate hosts' do
+      slap_resp = slap_answer(domain: 'discovered.host', service: 'ls_foo')
+      queried_host_urls = []
+      allow(mock_facilitator).to receive(:lookup) do |url, _q, **_opts|
+        queried_host_urls << url unless url == slap_tracker
+        url == slap_tracker ? slap_resp : plain_answer
+      end
+
+      r = resolver(additional_hosts: { 'ls_foo' => ['https://discovered.host'] })
+      r.query(BSV::Overlay::LookupQuestion.new(service: 'ls_foo', query: {}))
+
+      # The dedup logic prevents the same URL appearing twice in the host list
+      expect(queried_host_urls.count('https://discovered.host')).to eq(1)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # SLAP tracker discovery
+  # ---------------------------------------------------------------------------
+
+  describe '#query via SLAP discovery' do
+    it 'queries the discovered host after SLAP returns a valid advertisement' do
+      result_beef = plain_beef
+      slap_resp = slap_answer(domain: 'service.host', service: 'ls_bar')
+      stub_slap_then_host(mock_facilitator, slap_tracker: slap_tracker,
+                                            slap_resp: slap_resp,
+                                            host_resp: plain_answer(result_beef))
+
+      answer = resolver.query(BSV::Overlay::LookupQuestion.new(service: 'ls_bar', query: {}))
+      expect(answer.type).to eq('output-list')
+    end
+
+    it 'skips SLAP outputs with wrong protocol (SHIP instead of SLAP)' do
+      ship_script_val = BSV::Script::Script.pushdrop_lock(
+        ['SHIP'.b, RESOLVER_IDENTITY_KEY_BIN, 'ship.host'.encode('binary'), 'ls_bar'.encode('binary')],
+        BSV::Script::Script.p2pkh_lock(("\x00" * 20).b)
+      )
+      tx_out = BSV::Transaction::TransactionOutput.new(satoshis: 1, locking_script: ship_script_val)
+      tx     = BSV::Transaction::Transaction.new
+      tx.add_output(tx_out)
+      beef = BSV::Transaction::Beef.new
+      beef.merge_transaction(tx)
+      ship_answer = BSV::Overlay::LookupAnswer.new(
+        type: 'output-list',
+        outputs: [{ 'beef' => beef.to_binary, 'outputIndex' => 0 }]
+      )
+
+      allow(mock_facilitator).to receive(:lookup).and_return(ship_answer)
+
+      expect do
+        resolver.query(BSV::Overlay::LookupQuestion.new(service: 'ls_bar', query: {}))
+      end.to raise_error(BSV::Overlay::NoCompetentHostsError)
+    end
+
+    it 'skips SLAP outputs advertising a different service' do
+      slap_resp = slap_answer(domain: 'other.host', service: 'ls_other')
+      allow(mock_facilitator).to receive(:lookup).and_return(slap_resp)
+
+      expect do
+        resolver.query(BSV::Overlay::LookupQuestion.new(service: 'ls_target', query: {}))
+      end.to raise_error(BSV::Overlay::NoCompetentHostsError)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # ls_slap service — queries trackers directly
+  # ---------------------------------------------------------------------------
+
+  describe '#query for ls_slap service' do
+    it 'queries the SLAP tracker directly without discovery' do
+      received_services = []
+      allow(mock_facilitator).to receive(:lookup) do |_url, question, **_opts|
+        received_services << question.service
+        plain_answer
+      end
+
+      r = resolver
+      r.query(BSV::Overlay::LookupQuestion.new(service: 'ls_slap', query: { 'service' => 'ls_foo' }))
+
+      # Only one lookup call expected — direct query to the tracker
+      expect(received_services).to eq(['ls_slap'])
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Local preset
+  # ---------------------------------------------------------------------------
+
+  describe 'local preset' do
+    it 'queries localhost:8080 without SLAP discovery' do
+      queried_urls = []
+      allow(mock_facilitator).to receive(:lookup) do |url, _q, **_opts|
+        queried_urls << url
+        plain_answer
+      end
+
+      r = BSV::Overlay::LookupResolver.new(
+        network_preset: :local,
+        facilitator: mock_facilitator
+      )
+      r.query(BSV::Overlay::LookupQuestion.new(service: 'ls_foo', query: {}))
+
+      expect(queried_urls).to eq(['http://localhost:8080'])
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # NoCompetentHostsError
+  # ---------------------------------------------------------------------------
+
+  describe 'NoCompetentHostsError' do
+    it 'raises when all SLAP trackers return empty host lists' do
+      allow(mock_facilitator).to receive(:lookup).and_return(empty_answer)
+
+      expect do
+        resolver.query(BSV::Overlay::LookupQuestion.new(service: 'ls_foo', query: {}))
+      end.to raise_error(BSV::Overlay::NoCompetentHostsError)
+    end
+
+    it 'raises when all SLAP trackers raise errors' do
+      allow(mock_facilitator).to receive(:lookup).and_raise(RuntimeError, 'Connection refused')
+
+      expect do
+        resolver.query(BSV::Overlay::LookupQuestion.new(service: 'ls_foo', query: {}))
+      end.to raise_error(BSV::Overlay::NoCompetentHostsError)
+    end
+
+    it 'raises when all competent hosts fail to return a valid answer' do
+      slap_resp = slap_answer(domain: 'failing.host', service: 'ls_fail')
+      allow(mock_facilitator).to receive(:lookup) do |url, _q, **_opts|
+        url == slap_tracker ? slap_resp : raise('timeout')
+      end
+
+      expect do
+        resolver.query(BSV::Overlay::LookupQuestion.new(service: 'ls_fail', query: {}))
+      end.to raise_error(BSV::Overlay::NoCompetentHostsError)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Cache
+  # ---------------------------------------------------------------------------
+
+  describe 'host caching' do
+    it 'returns cached hosts within TTL without re-querying SLAP' do
+      slap_resp = slap_answer(domain: 'cached.host', service: 'ls_cached')
+      slap_call_count = 0
+      allow(mock_facilitator).to receive(:lookup) do |url, _q, **_opts|
+        if url == slap_tracker
+          slap_call_count += 1
+          slap_resp
+        else
+          plain_answer
+        end
+      end
+
+      r = resolver
+      q = BSV::Overlay::LookupQuestion.new(service: 'ls_cached', query: {})
+      r.query(q) # fills cache
+      r.query(q) # should use cache
+
+      expect(slap_call_count).to eq(1)
+    end
+
+    it 'revalidates cache after TTL expiry' do
+      slap_resp = slap_answer(domain: 'ttl.host', service: 'ls_ttl')
+      slap_call_count = 0
+      allow(mock_facilitator).to receive(:lookup) do |url, _q, **_opts|
+        if url == slap_tracker
+          slap_call_count += 1
+          slap_resp
+        else
+          plain_answer
+        end
+      end
+
+      r = BSV::Overlay::LookupResolver.new(
+        facilitator: mock_facilitator,
+        slap_trackers: [slap_tracker],
+        cache_ttl: 0 # expire immediately
+      )
+      q = BSV::Overlay::LookupQuestion.new(service: 'ls_ttl', query: {})
+      r.query(q)
+      r.query(q) # TTL 0 — should re-query SLAP
+
+      expect(slap_call_count).to be >= 2
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Output deduplication
+  # ---------------------------------------------------------------------------
+
+  describe 'output deduplication' do
+    it 'deduplicates outputs with the same txid.output_index across hosts' do
+      shared_beef = plain_beef
+
+      answer_a = BSV::Overlay::LookupAnswer.new(
+        type: 'output-list',
+        outputs: [{ 'beef' => shared_beef, 'outputIndex' => 0 }]
+      )
+      answer_b = BSV::Overlay::LookupAnswer.new(
+        type: 'output-list',
+        outputs: [{ 'beef' => shared_beef, 'outputIndex' => 0 }]
+      )
+
+      slap_resp = BSV::Overlay::LookupAnswer.new(
+        type: 'output-list',
+        outputs: [
+          { 'beef' => slap_beef(domain: 'host-a.com', service: 'ls_dedup'), 'outputIndex' => 0 },
+          { 'beef' => slap_beef(domain: 'host-b.com', service: 'ls_dedup'), 'outputIndex' => 0 }
+        ]
+      )
+
+      allow(mock_facilitator).to receive(:lookup) do |url, _q, **_opts|
+        case url
+        when slap_tracker then slap_resp
+        when 'https://host-a.com' then answer_a
+        when 'https://host-b.com' then answer_b
+        else empty_answer
+        end
+      end
+
+      answer = resolver.query(BSV::Overlay::LookupQuestion.new(service: 'ls_dedup', query: {}))
+      expect(answer.outputs.length).to eq(1)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Reputation tracker integration
+  # ---------------------------------------------------------------------------
+
+  describe 'reputation tracker' do
+    it 'records a success when a host returns a valid answer' do
+      slap_resp = slap_answer(domain: 'good.host', service: 'ls_rep')
+      stub_slap_then_host(mock_facilitator, slap_tracker: slap_tracker, slap_resp: slap_resp)
+
+      success_hosts = []
+      rep = instance_double(BSV::Overlay::HostReputationTracker)
+      allow(rep).to receive(:rank_hosts) { |hosts| hosts }
+      allow(rep).to receive(:record_success) { |host, _lat| success_hosts << host }
+      allow(rep).to receive(:record_failure)
+
+      r = BSV::Overlay::LookupResolver.new(
+        facilitator: mock_facilitator,
+        slap_trackers: [slap_tracker],
+        reputation_tracker: rep
+      )
+      r.query(BSV::Overlay::LookupQuestion.new(service: 'ls_rep', query: {}))
+
+      expect(success_hosts).to include('https://good.host')
+    end
+
+    it 'records a failure when a host raises an error' do
+      slap_resp = slap_answer(domain: 'bad.host', service: 'ls_rep')
+      allow(mock_facilitator).to receive(:lookup) do |url, _q, **_opts|
+        url == slap_tracker ? slap_resp : raise('timeout')
+      end
+
+      failure_hosts = []
+      rep = instance_double(BSV::Overlay::HostReputationTracker)
+      allow(rep).to receive(:rank_hosts) { |hosts| hosts }
+      allow(rep).to receive(:record_success)
+      allow(rep).to receive(:record_failure) { |host, _err| failure_hosts << host }
+
+      r = BSV::Overlay::LookupResolver.new(
+        facilitator: mock_facilitator,
+        slap_trackers: [slap_tracker],
+        reputation_tracker: rep
+      )
+      expect do
+        r.query(BSV::Overlay::LookupQuestion.new(service: 'ls_rep', query: {}))
+      end.to raise_error(BSV::Overlay::NoCompetentHostsError)
+
+      expect(failure_hosts).to include('https://bad.host')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Constructor validation
+  # ---------------------------------------------------------------------------
+
+  describe 'constructor validation' do
+    it 'raises ArgumentError for additional_hosts without ls_ prefix' do
+      expect do
+        resolver(additional_hosts: { 'nope' => ['https://host'] })
+      end.to raise_error(ArgumentError, /ls_/)
+    end
+
+    it 'raises ArgumentError when slap_trackers is empty for mainnet' do
+      expect do
+        BSV::Overlay::LookupResolver.new(
+          facilitator: mock_facilitator,
+          slap_trackers: []
+        )
+      end.to raise_error(ArgumentError, /slap_trackers/)
+    end
+  end
+end

--- a/spec/bsv/overlay/topic_broadcaster_spec.rb
+++ b/spec/bsv/overlay/topic_broadcaster_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe BSV::Overlay::TopicBroadcaster do
 
   let(:mock_tx) do
     tx = instance_double(BSV::Transaction::Transaction)
-    allow(tx).to receive_messages(to_beef: "\xbe\xef\x01", txid: mock_txid)
+    allow(tx).to receive_messages(to_beef: "\xbe\xef\x01", txid: mock_txid, txid_hex: mock_txid)
     tx
   end
 

--- a/spec/bsv/overlay/topic_broadcaster_spec.rb
+++ b/spec/bsv/overlay/topic_broadcaster_spec.rb
@@ -1,0 +1,404 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-sdk'
+
+# Build a minimal AdmittanceInstructions representing a positive acknowledgement.
+def ack_instructions(outputs: [0])
+  BSV::Overlay::AdmittanceInstructions.new(
+    outputs_to_admit: outputs,
+    coins_to_retain: [],
+    coins_removed: nil
+  )
+end
+
+# Build an AdmittanceInstructions that represents no acknowledgement.
+def no_ack_instructions
+  BSV::Overlay::AdmittanceInstructions.new(
+    outputs_to_admit: [],
+    coins_to_retain: [],
+    coins_removed: nil
+  )
+end
+
+RSpec.describe BSV::Overlay::TopicBroadcaster do
+  # ---- Shared doubles ----
+
+  # A mock transaction that serialises successfully and has a stable txid.
+  let(:mock_txid) { "#{'aabbcc' * 10}aabb" }
+
+  let(:mock_tx) do
+    tx = instance_double(BSV::Transaction::Transaction)
+    allow(tx).to receive_messages(to_beef: "\xbe\xef\x01", txid: mock_txid)
+    tx
+  end
+
+  # A facilitator that records calls and returns configurable STEAKs.
+  let(:mock_facilitator) do
+    dbl = instance_double(BSV::Overlay::BroadcastFacilitator)
+    allow(dbl).to receive(:send_beef) do |_url, tagged_beef|
+      # Return acks for every topic in the tagged beef by default
+      tagged_beef.topics.to_h { |t| [t, ack_instructions] }
+    end
+    dbl
+  end
+
+  # A resolver that returns a single host interested in all topics.
+  def mock_resolver_for(_host_topics_map)
+    dbl = instance_double(BSV::Overlay::LookupResolver)
+    allow(dbl).to receive(:query) do |_question|
+      # Return an output-list answer; the broadcaster parses SHIP admin tokens
+      # from these outputs, but in tests we bypass that by supplying a
+      # pre-built resolver that returns no outputs — host discovery uses
+      # fetch_ship_hosts which falls back on the raw answer outputs.
+      # Instead, we inject hosts via a custom resolver.
+      BSV::Overlay::LookupAnswer.new(type: 'output-list', outputs: [])
+    end
+
+    # Monkey-patch find_interested_hosts to return the provided map directly.
+    # We achieve this by making the broadcaster accept the map from a stub.
+    dbl
+  end
+
+  # Build a broadcaster with injected host map (bypasses SHIP parsing).
+  def broadcaster_with_hosts(topics, host_topics_map, **opts)
+    broadcaster = described_class.new(
+      topics,
+      facilitator: mock_facilitator,
+      resolver: instance_double(BSV::Overlay::LookupResolver),
+      **opts
+    )
+    allow(broadcaster).to receive(:find_interested_hosts).and_return(host_topics_map)
+    broadcaster
+  end
+
+  # ---- Constructor validation ----
+
+  describe 'topic validation' do
+    it 'raises ArgumentError for an empty topics array' do
+      expect { described_class.new([]) }
+        .to raise_error(ArgumentError, /non-empty/)
+    end
+
+    it 'raises ArgumentError for nil topics' do
+      expect { described_class.new(nil) }
+        .to raise_error(ArgumentError, /non-empty/)
+    end
+
+    it 'raises ArgumentError for a topic without tm_ prefix' do
+      expect { described_class.new(['nope_topic']) }
+        .to raise_error(ArgumentError, /tm_/)
+    end
+
+    it 'accepts valid tm_ prefixed topics' do
+      expect { described_class.new(['tm_valid']) }.not_to raise_error
+    end
+  end
+
+  # ---- Successful broadcast ----
+
+  describe '#broadcast — single host, single topic' do
+    subject(:broadcaster) do
+      broadcaster_with_hosts(['tm_foo'], { 'https://host1.example.com' => Set.new(['tm_foo']) })
+    end
+
+    it 'returns an OverlayBroadcastResult' do
+      result = broadcaster.broadcast(mock_tx)
+      expect(result).to be_a(BSV::Overlay::OverlayBroadcastResult)
+    end
+
+    it 'returns status success' do
+      result = broadcaster.broadcast(mock_tx)
+      expect(result.status).to eq('success')
+    end
+
+    it 'includes the transaction txid' do
+      result = broadcaster.broadcast(mock_tx)
+      expect(result.txid).to eq(mock_txid)
+    end
+
+    it 'includes a human-readable message with host count' do
+      result = broadcaster.broadcast(mock_tx)
+      expect(result.message).to match(/1 Overlay Service host/)
+    end
+  end
+
+  describe '#broadcast — multiple hosts with disjoint topics' do
+    subject(:broadcaster) do
+      broadcaster_with_hosts(
+        topics,
+        host_map,
+        require_ack_from_any_host: 'any'
+      )
+    end
+
+    let(:topics) { %w[tm_foo tm_bar] }
+    let(:host_map) do
+      {
+        'https://host1.example.com' => Set.new(['tm_foo']),
+        'https://host2.example.com' => Set.new(['tm_bar'])
+      }
+    end
+
+    let(:sent) { {} }
+
+    before do
+      # Track which topics each host received
+      allow(mock_facilitator).to receive(:send_beef) do |url, tagged_beef|
+        sent[url] = tagged_beef.topics.dup
+        tagged_beef.topics.to_h { |t| [t, ack_instructions] }
+      end
+    end
+
+    it 'sends only matching topics to each host' do
+      broadcaster.broadcast(mock_tx)
+      expect(sent['https://host1.example.com']).to eq(['tm_foo'])
+      expect(sent['https://host2.example.com']).to eq(['tm_bar'])
+    end
+
+    it 'returns success when at least one host acknowledges a topic' do
+      result = broadcaster.broadcast(mock_tx)
+      expect(result.status).to eq('success')
+    end
+  end
+
+  # ---- Error cases ----
+
+  describe '#broadcast — no hosts interested' do
+    subject(:broadcaster) do
+      broadcaster_with_hosts(['tm_foo'], {})
+    end
+
+    it 'returns ERR_NO_HOSTS_INTERESTED' do
+      result = broadcaster.broadcast(mock_tx)
+      expect(result.status).to eq('error')
+      expect(result.code).to eq('ERR_NO_HOSTS_INTERESTED')
+    end
+  end
+
+  describe '#broadcast — all hosts reject' do
+    subject(:broadcaster) do
+      b = broadcaster_with_hosts(
+        ['tm_foo'],
+        { 'https://host1.example.com' => Set.new(['tm_foo']) }
+      )
+      allow(mock_facilitator).to receive(:send_beef).and_return(nil)
+      b
+    end
+
+    it 'returns ERR_ALL_HOSTS_REJECTED' do
+      result = broadcaster.broadcast(mock_tx)
+      expect(result.status).to eq('error')
+      expect(result.code).to eq('ERR_ALL_HOSTS_REJECTED')
+    end
+  end
+
+  describe '#broadcast — BEEF serialisation failure' do
+    subject(:broadcaster) do
+      broadcaster_with_hosts(
+        ['tm_foo'],
+        { 'https://host1.example.com' => Set.new(['tm_foo']) }
+      )
+    end
+
+    before { allow(mock_tx).to receive(:to_beef).and_raise(StandardError, 'no inputs') }
+
+    it 'returns an error result without raising' do
+      result = broadcaster.broadcast(mock_tx)
+      expect(result.status).to eq('error')
+      expect(result.description).to match(/no inputs/)
+    end
+  end
+
+  # ---- Local preset ----
+
+  describe 'local network preset' do
+    subject(:broadcaster) do
+      described_class.new(
+        ['tm_foo'],
+        network_preset: :local,
+        facilitator: mock_facilitator,
+        resolver: instance_double(BSV::Overlay::LookupResolver)
+      )
+    end
+
+    it 'broadcasts to localhost:8080 without querying resolver' do
+      called_urls = []
+      allow(mock_facilitator).to receive(:send_beef) do |url, tagged_beef|
+        called_urls << url
+        tagged_beef.topics.to_h { |t| [t, ack_instructions] }
+      end
+      broadcaster.broadcast(mock_tx)
+      expect(called_urls).to eq(['http://localhost:8080'])
+    end
+  end
+
+  # ---- Acknowledgement requirements ----
+
+  describe 'require_ack_from_any_host: "all" (default)' do
+    subject(:broadcaster) do
+      broadcaster_with_hosts(
+        %w[tm_foo tm_bar],
+        {
+          'https://host1.example.com' => Set.new(%w[tm_foo tm_bar]),
+          'https://host2.example.com' => Set.new(%w[tm_foo tm_bar])
+        }
+      )
+    end
+
+    it 'succeeds when at least one host acknowledges all topics' do
+      # host1 acks both, host2 acks neither
+      call_count = 0
+      allow(mock_facilitator).to receive(:send_beef) do |_url, tagged_beef|
+        call_count += 1
+        if call_count == 1
+          # First host acks all topics
+          tagged_beef.topics.to_h { |t| [t, ack_instructions] }
+        else
+          # Second host acks nothing
+          tagged_beef.topics.to_h { |t| [t, no_ack_instructions] }
+        end
+      end
+
+      result = broadcaster.broadcast(mock_tx)
+      expect(result.status).to eq('success')
+    end
+
+    it 'fails when no host acknowledges all topics' do
+      allow(mock_facilitator).to receive(:send_beef) do |_url, tagged_beef|
+        # Each host only acks one topic
+        { tagged_beef.topics.first => ack_instructions }
+      end
+
+      result = broadcaster.broadcast(mock_tx)
+      expect(result.status).to eq('error')
+      expect(result.code).to eq('ERR_REQUIRE_ACK_FROM_ANY_HOST_FAILED')
+    end
+  end
+
+  describe 'require_ack_from_any_host: "any"' do
+    subject(:broadcaster) do
+      broadcaster_with_hosts(
+        %w[tm_foo tm_bar],
+        { 'https://host1.example.com' => Set.new(%w[tm_foo tm_bar]) },
+        require_ack_from_any_host: 'any'
+      )
+    end
+
+    it 'succeeds when a host acknowledges at least one topic' do
+      allow(mock_facilitator).to receive(:send_beef) do |_url, tagged_beef|
+        { tagged_beef.topics.first => ack_instructions }
+      end
+
+      result = broadcaster.broadcast(mock_tx)
+      expect(result.status).to eq('success')
+    end
+  end
+
+  describe 'require_ack_from_all_hosts: "all"' do
+    subject(:broadcaster) do
+      broadcaster_with_hosts(
+        %w[tm_foo tm_bar],
+        {
+          'https://host1.example.com' => Set.new(%w[tm_foo tm_bar]),
+          'https://host2.example.com' => Set.new(%w[tm_foo tm_bar])
+        },
+        require_ack_from_all_hosts: 'all',
+        require_ack_from_any_host: 'any'
+      )
+    end
+
+    it 'fails when one host does not acknowledge all topics' do
+      call_count = 0
+      allow(mock_facilitator).to receive(:send_beef) do |_url, tagged_beef|
+        call_count += 1
+        if call_count == 1
+          tagged_beef.topics.to_h { |t| [t, ack_instructions] }
+        else
+          # Second host only acknowledges one topic
+          { 'tm_foo' => ack_instructions }
+        end
+      end
+
+      result = broadcaster.broadcast(mock_tx)
+      expect(result.status).to eq('error')
+      expect(result.code).to eq('ERR_REQUIRE_ACK_FROM_ALL_HOSTS_FAILED')
+    end
+
+    it 'succeeds when all hosts acknowledge all topics' do
+      allow(mock_facilitator).to receive(:send_beef) do |_url, tagged_beef|
+        tagged_beef.topics.to_h { |t| [t, ack_instructions] }
+      end
+
+      result = broadcaster.broadcast(mock_tx)
+      expect(result.status).to eq('success')
+    end
+  end
+
+  describe 'require_ack_from_specific_hosts' do
+    subject(:broadcaster) do
+      broadcaster_with_hosts(
+        ['tm_foo'],
+        {
+          required_host => Set.new(['tm_foo']),
+          'https://other.example.com' => Set.new(['tm_foo'])
+        },
+        require_ack_from_specific_hosts: { required_host => 'all' },
+        require_ack_from_any_host: 'any'
+      )
+    end
+
+    let(:required_host) { 'https://required.example.com' }
+
+    it 'fails when the required host does not acknowledge' do
+      allow(mock_facilitator).to receive(:send_beef) do |url, tagged_beef|
+        if url == required_host
+          { 'tm_foo' => no_ack_instructions }
+        else
+          tagged_beef.topics.to_h { |t| [t, ack_instructions] }
+        end
+      end
+
+      result = broadcaster.broadcast(mock_tx)
+      expect(result.status).to eq('error')
+      expect(result.code).to eq('ERR_REQUIRE_ACK_FROM_SPECIFIC_HOSTS_FAILED')
+    end
+
+    it 'fails when the required host did not respond at all' do
+      allow(mock_facilitator).to receive(:send_beef) do |url, tagged_beef|
+        if url == required_host
+          nil # Host rejected / did not respond
+        else
+          tagged_beef.topics.to_h { |t| [t, ack_instructions] }
+        end
+      end
+
+      result = broadcaster.broadcast(mock_tx)
+      expect(result.status).to eq('error')
+      expect(result.code).to eq('ERR_REQUIRE_ACK_FROM_SPECIFIC_HOSTS_FAILED')
+    end
+
+    it 'succeeds when the required host acknowledges' do
+      result = broadcaster.broadcast(mock_tx)
+      expect(result.status).to eq('success')
+    end
+  end
+
+  # ---- SHIPBroadcaster alias ----
+
+  describe 'SHIPBroadcaster alias' do
+    it 'is the same class as TopicBroadcaster' do
+      expect(BSV::Overlay::SHIPBroadcaster).to equal(described_class)
+    end
+
+    it 'can be instantiated as SHIPBroadcaster' do
+      broadcaster = BSV::Overlay::SHIPBroadcaster.new(
+        ['tm_test'],
+        network_preset: :local,
+        facilitator: mock_facilitator,
+        resolver: instance_double(BSV::Overlay::LookupResolver)
+      )
+      expect(broadcaster).to be_a(described_class)
+    end
+  end
+end

--- a/spec/bsv/overlay/types_spec.rb
+++ b/spec/bsv/overlay/types_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'BSV::Overlay types' do
+  describe BSV::Overlay::TaggedBEEF do
+    subject(:tagged_beef) { described_class.new(beef: "\x01\x02\x03", topics: ['tm_example']) }
+
+    it 'exposes beef' do
+      expect(tagged_beef.beef).to eq("\x01\x02\x03")
+    end
+
+    it 'exposes topics' do
+      expect(tagged_beef.topics).to eq(['tm_example'])
+    end
+
+    it 'accepts multiple topics' do
+      instance = described_class.new(beef: '', topics: %w[tm_a tm_b])
+      expect(instance.topics).to eq(%w[tm_a tm_b])
+    end
+  end
+
+  describe BSV::Overlay::AdmittanceInstructions do
+    it 'exposes outputs_to_admit' do
+      instance = described_class.new(outputs_to_admit: [0, 1], coins_to_retain: [2])
+      expect(instance.outputs_to_admit).to eq([0, 1])
+    end
+
+    it 'exposes coins_to_retain' do
+      instance = described_class.new(outputs_to_admit: [0, 1], coins_to_retain: [2])
+      expect(instance.coins_to_retain).to eq([2])
+    end
+
+    it 'defaults coins_removed to nil' do
+      instance = described_class.new(outputs_to_admit: [], coins_to_retain: [])
+      expect(instance.coins_removed).to be_nil
+    end
+
+    it 'accepts coins_removed when provided' do
+      instance = described_class.new(outputs_to_admit: [0], coins_to_retain: [], coins_removed: [3])
+      expect(instance.coins_removed).to eq([3])
+    end
+  end
+
+  describe BSV::Overlay::LookupQuestion do
+    subject(:question) { described_class.new(service: 'ls_ship', query: { topics: ['tm_example'] }) }
+
+    it 'exposes service' do
+      expect(question.service).to eq('ls_ship')
+    end
+
+    it 'exposes query' do
+      expect(question.query).to eq({ topics: ['tm_example'] })
+    end
+  end
+
+  describe BSV::Overlay::LookupAnswer do
+    subject(:answer) do
+      described_class.new(type: 'output-list', outputs: [{ beef: [], output_index: 0 }])
+    end
+
+    it 'exposes type' do
+      expect(answer.type).to eq('output-list')
+    end
+
+    it 'exposes outputs' do
+      expect(answer.outputs).to eq([{ beef: [], output_index: 0 }])
+    end
+  end
+
+  describe BSV::Overlay::OverlayBroadcastResult do
+    context 'when successful' do
+      subject(:result) do
+        described_class.new(
+          status: 'success',
+          txid: 'abc123',
+          message: 'Sent to 1 host.'
+        )
+      end
+
+      it 'exposes status' do
+        expect(result.status).to eq('success')
+      end
+
+      it 'exposes txid' do
+        expect(result.txid).to eq('abc123')
+      end
+
+      it 'exposes message' do
+        expect(result.message).to eq('Sent to 1 host.')
+      end
+
+      it 'has nil code' do
+        expect(result.code).to be_nil
+      end
+
+      it 'has nil description' do
+        expect(result.description).to be_nil
+      end
+    end
+
+    context 'when an error occurs' do
+      subject(:result) do
+        described_class.new(
+          status: 'error',
+          code: 'ERR_NO_HOSTS_INTERESTED',
+          description: 'No mainnet hosts are interested.'
+        )
+      end
+
+      it 'exposes status' do
+        expect(result.status).to eq('error')
+      end
+
+      it 'exposes code' do
+        expect(result.code).to eq('ERR_NO_HOSTS_INTERESTED')
+      end
+
+      it 'exposes description' do
+        expect(result.description).to eq('No mainnet hosts are interested.')
+      end
+
+      it 'has nil txid' do
+        expect(result.txid).to be_nil
+      end
+
+      it 'has nil message' do
+        expect(result.message).to be_nil
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
## Summary

- **TopicBroadcaster** (aliased as `SHIPBroadcaster`): broadcasts tagged BEEF to topic-interested hosts discovered via SHIP lookup, with configurable acknowledgement modes (all/any/specific hosts) and STEAK response parsing
- **LookupResolver**: discovers competent hosts via SLAP trackers, queries all hosts in parallel, aggregates and deduplicates results, with TTL-based caching
- **HostReputationTracker**: EWMA latency scoring, exponential backoff after failures (with grace period), DNS error escalation, thread-safe via Mutex
- **AdminTokenTemplate**: decode/lock/unlock for SHIP/SLAP advertisement PushDrop tokens with wallet key derivation (BRC-42)
- **Abstract base classes** (`LookupFacilitator`, `BroadcastFacilitator`) with default HTTPS implementations — injectable via constructor for composition
- Foundation types: `TaggedBEEF`, `AdmittanceInstructions`, `LookupQuestion`, `LookupAnswer`, `OverlayBroadcastResult`

Architecture follows composition + abstract + defaults pattern: all extension points are injectable with sensible defaults that work out of the box.

## Test plan

- [x] 192 new overlay specs pass
- [x] Full suite: 2545 examples, 0 failures, 5 pending
- [x] RuboCop: 0 offences
- [x] All acceptance criteria from #237 verified
- [x] Cross-SDK alignment verified against ts-sdk and go-sdk reference implementations

Closes #237, closes #240, closes #241, closes #242, closes #243, closes #244, closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)