### PR TITLE
feat(identity): implement Identity client

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -161,6 +161,7 @@ Metrics/ClassLength:
     - 'lib/bsv/wallet_interface/**/*'
     - 'lib/bsv/auth/**/*'
     - 'lib/bsv/overlay/**/*'
+    - 'lib/bsv/identity/**/*'
 
 Metrics/ParameterLists:
   Exclude:
@@ -210,6 +211,7 @@ RSpec/MultipleMemoizedHelpers:
     - 'spec/bsv/transaction/**/*'
     - 'spec/bsv/auth/**/*'
     - 'spec/bsv/overlay/**/*'
+    - 'spec/bsv/identity/**/*'
     - 'spec/conformance/**/*'
     - 'spec/bsv/wallet_interface/**/*'
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,6 +80,8 @@ Metrics/AbcSize:
     - 'lib/bsv/auth/**/*'
     - 'lib/bsv/overlay.rb'
     - 'lib/bsv/overlay/**/*'
+    - 'lib/bsv/identity.rb'
+    - 'lib/bsv/identity/**/*'
     - 'spec/**/*'
 
 Metrics/MethodLength:
@@ -97,6 +99,8 @@ Metrics/MethodLength:
     - 'lib/bsv/auth/**/*'
     - 'lib/bsv/overlay.rb'
     - 'lib/bsv/overlay/**/*'
+    - 'lib/bsv/identity.rb'
+    - 'lib/bsv/identity/**/*'
     - 'spec/**/*'
 
 Metrics/CyclomaticComplexity:
@@ -114,6 +118,8 @@ Metrics/CyclomaticComplexity:
     - 'lib/bsv/auth/**/*'
     - 'lib/bsv/overlay.rb'
     - 'lib/bsv/overlay/**/*'
+    - 'lib/bsv/identity.rb'
+    - 'lib/bsv/identity/**/*'
     - 'spec/**/*'
 
 Metrics/PerceivedComplexity:
@@ -131,6 +137,8 @@ Metrics/PerceivedComplexity:
     - 'lib/bsv/auth/**/*'
     - 'lib/bsv/overlay.rb'
     - 'lib/bsv/overlay/**/*'
+    - 'lib/bsv/identity.rb'
+    - 'lib/bsv/identity/**/*'
     - 'spec/**/*'
 
 Metrics/ModuleLength:
@@ -140,6 +148,7 @@ Metrics/ModuleLength:
     - 'lib/bsv/script/opcodes.rb'
     - 'lib/bsv/script/interpreter/operations/**/*'
     - 'lib/bsv/wallet_interface/wire/**/*'
+    - 'lib/bsv/identity/**/*'
     - 'spec/**/*'
 
 Metrics/ClassLength:
@@ -159,6 +168,7 @@ Metrics/ParameterLists:
     - 'lib/bsv/script/**/*'
     - 'lib/bsv/transaction/**/*'
     - 'lib/bsv/overlay/**/*'
+    - 'lib/bsv/identity/**/*'
 
 # The interpreter condition stack uses :true/:false symbols intentionally
 # (matching the Go SDK pattern) to distinguish from boolean values.
@@ -188,6 +198,7 @@ RSpec/MultipleExpectations:
     - 'spec/bsv/attest/**/*'
     - 'spec/bsv/auth/**/*'
     - 'spec/bsv/overlay/**/*'
+    - 'spec/bsv/identity/**/*'
     - 'spec/bsv/wallet_interface/**/*'
     - 'spec/integration/**/*'
     - 'spec/conformance/**/*'
@@ -213,6 +224,7 @@ RSpec/ExampleLength:
     - 'spec/bsv/attest/**/*'
     - 'spec/bsv/auth/**/*'
     - 'spec/bsv/overlay/**/*'
+    - 'spec/bsv/identity/**/*'
     - 'spec/bsv/wallet_interface/**/*'
     - 'spec/integration/**/*'
     - 'spec/conformance/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -173,6 +173,12 @@ Metrics/ParameterLists:
 
 # The interpreter condition stack uses :true/:false symbols intentionally
 # (matching the Go SDK pattern) to distinguish from boolean values.
+# ProtoWallet implements the WalletInterface but intentionally ignores the
+# originator: keyword on all methods (local-only wallet, no originator policy).
+Lint/UnusedMethodArgument:
+  Exclude:
+    - 'lib/bsv/wallet_interface/proto_wallet.rb'
+
 Lint/BooleanSymbol:
   Exclude:
     - 'lib/bsv/script/interpreter/**/*'

--- a/lib/bsv-sdk.rb
+++ b/lib/bsv-sdk.rb
@@ -10,4 +10,5 @@ module BSV
   autoload :Wallet,      'bsv/wallet'
   autoload :Auth,        'bsv/auth'
   autoload :Overlay,     'bsv/overlay'
+  autoload :Identity,    'bsv/identity'
 end

--- a/lib/bsv/identity.rb
+++ b/lib/bsv/identity.rb
@@ -13,5 +13,6 @@ module BSV
     autoload :ClientOptions,        'bsv/identity/types'
     autoload :Constants,            'bsv/identity/constants'
     autoload :IdentityParser,       'bsv/identity/identity_parser'
+    autoload :Client,               'bsv/identity/client'
   end
 end

--- a/lib/bsv/identity.rb
+++ b/lib/bsv/identity.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module BSV
+  # Identity module for BSV blockchain.
+  #
+  # Provides data structures and constants for resolving and displaying
+  # identity information associated with BSV public keys, backed by
+  # verifiable certificates managed through the BSV overlay network.
+  module Identity
+    autoload :DisplayableIdentity,  'bsv/identity/types'
+    autoload :CertifierInfo,        'bsv/identity/types'
+    autoload :IdentityCertificate,  'bsv/identity/types'
+    autoload :ClientOptions,        'bsv/identity/types'
+    autoload :Constants,            'bsv/identity/constants'
+    autoload :IdentityParser,       'bsv/identity/identity_parser'
+  end
+end

--- a/lib/bsv/identity/client.rb
+++ b/lib/bsv/identity/client.rb
@@ -236,12 +236,15 @@ module BSV
           key_id: @options.key_id,
           counterparty: 'anyone'
         )
-        unlocking_script = unlocker.sign(partial_tx, output_idx)
+        # Sign the first (and only) input in the spending transaction.
+        # output_idx is the index in the *source* tx; the spending tx input is always 0.
+        spending_input_idx = 0
+        unlocking_script = unlocker.sign(partial_tx, spending_input_idx)
 
         sign_result = @wallet.sign_action(
           {
             reference: signable[:reference],
-            spends: { output_idx => { unlocking_script: unlocking_script.to_hex } },
+            spends: { spending_input_idx => { unlocking_script: unlocking_script.to_hex } },
             options: { no_send: true }
           },
           originator: @originator
@@ -341,14 +344,8 @@ module BSV
 
       # Returns the default ClientOptions.
       #
-      # Calling +Constants.name+ triggers the autoload of constants.rb, which
-      # reopens ClientOptions to define +ClientOptions::DEFAULT+.
-      #
       # @return [ClientOptions]
       def default_options
-        # Calling a method on Constants forces its autoload (constants.rb), which
-        # reopens ClientOptions and defines ClientOptions::DEFAULT.
-        Constants.name
         ClientOptions::DEFAULT
       end
     end

--- a/lib/bsv/identity/client.rb
+++ b/lib/bsv/identity/client.rb
@@ -1,0 +1,333 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module BSV
+  module Identity
+    # Client for resolving and publishing identity information on the BSV overlay network.
+    #
+    # Wraps wallet discovery and overlay broadcasting to provide a high-level
+    # interface for the BSV Identity protocol:
+    #
+    # - Resolve identities by key or attributes via {#resolve_by_identity_key} and
+    #   {#resolve_by_attributes}.
+    # - Publicly reveal certificate fields on-chain via {#publicly_reveal_attributes}.
+    # - Revoke an existing revelation via {#revoke_certificate_revelation}.
+    #
+    # All overlay dependencies (broadcaster, resolver) are injectable for testing.
+    #
+    # @example Resolve an identity
+    #   client = BSV::Identity::Client.new(wallet: my_wallet)
+    #   identities = client.resolve_by_identity_key(identity_key: pubkey_hex)
+    #
+    # @example Publicly reveal certificate fields
+    #   client = BSV::Identity::Client.new(wallet: my_wallet, broadcaster: my_broadcaster)
+    #   result = client.publicly_reveal_attributes(certificate, fields_to_reveal: ['email'])
+    class Client
+      # Default certificate verifier — raises NotImplementedError because certificate
+      # verification depends on BSV::Auth::Certificate, which is a separate HLR.
+      DEFAULT_VERIFIER = lambda do |_certificate|
+        raise NotImplementedError,
+              'Certificate verification requires BSV::Auth::Certificate (not yet implemented)'
+      end
+
+      # @param wallet [#discover_by_identity_key, #discover_by_attributes,
+      #   #prove_certificate, #create_action, #get_network] BRC-100 wallet interface
+      # @param options [ClientOptions, nil] identity protocol options (default: ClientOptions::DEFAULT)
+      # @param originator [String, nil] optional FQDN of the originating application
+      # @param certificate_verifier [#call, nil] callable that verifies a certificate;
+      #   defaults to a lambda that raises NotImplementedError
+      # @param broadcaster [BSV::Overlay::TopicBroadcaster, nil] injectable broadcaster;
+      #   built from the wallet's network preset when nil
+      # @param resolver [BSV::Overlay::LookupResolver, nil] injectable lookup resolver;
+      #   built from the wallet's network preset when nil
+      def initialize(
+        wallet:,
+        options: nil,
+        originator: nil,
+        certificate_verifier: nil,
+        broadcaster: nil,
+        resolver: nil
+      )
+        @wallet               = wallet
+        @options              = options || default_options
+        @originator           = originator
+        @certificate_verifier = certificate_verifier || DEFAULT_VERIFIER
+        @broadcaster          = broadcaster
+        @resolver             = resolver
+      end
+
+      # Resolves displayable identities issued to a given identity key.
+      #
+      # Delegates to the wallet's +discover_by_identity_key+ and maps each
+      # returned certificate through {IdentityParser.parse}.
+      #
+      # @param identity_key [String] compressed public key hex
+      # @param limit [Integer, nil] maximum number of certificates to return
+      # @param offset [Integer, nil] number of certificates to skip
+      # @return [Array<DisplayableIdentity>]
+      def resolve_by_identity_key(identity_key:, limit: nil, offset: nil)
+        args = { identity_key: identity_key }
+        args[:limit]  = limit  unless limit.nil?
+        args[:offset] = offset unless offset.nil?
+
+        result = @wallet.discover_by_identity_key(args, originator: @originator)
+        parse_certificates(result)
+      end
+
+      # Resolves displayable identities matching specific certificate attribute values.
+      #
+      # Delegates to the wallet's +discover_by_attributes+ and maps each
+      # returned certificate through {IdentityParser.parse}.
+      #
+      # @param attributes [Hash] field name/value pairs to match
+      # @param limit [Integer, nil] maximum number of certificates to return
+      # @param offset [Integer, nil] number of certificates to skip
+      # @return [Array<DisplayableIdentity>]
+      def resolve_by_attributes(attributes:, limit: nil, offset: nil)
+        args = { attributes: attributes }
+        args[:limit]  = limit  unless limit.nil?
+        args[:offset] = offset unless offset.nil?
+
+        result = @wallet.discover_by_attributes(args, originator: @originator)
+        parse_certificates(result)
+      end
+
+      # Publicly reveals selected fields from a certificate by creating an
+      # on-chain identity token and broadcasting it to the overlay network.
+      #
+      # The certificate is first optionally verified via the injected verifier,
+      # then the wallet proves the selected fields to the "anyone" verifier
+      # (PrivateKey(1) public key). A PushDrop locking script is constructed from
+      # the certificate JSON plus keyring, and the resulting transaction is
+      # broadcast to +tm_identity+.
+      #
+      # @param certificate [Hash] wallet certificate hash
+      # @param fields_to_reveal [Array<String>] field names to include in the revelation
+      # @return [BSV::Overlay::OverlayBroadcastResult]
+      # @raise [ArgumentError] if the certificate has no fields or fields_to_reveal is empty
+      # @raise [RuntimeError] if certificate verification fails or create_action returns no tx
+      def publicly_reveal_attributes(certificate, fields_to_reveal:)
+        fields = certificate[:fields] || certificate['fields'] || {}
+        raise ArgumentError, 'Public reveal failed: Certificate has no fields to reveal!' if fields.empty?
+        raise ArgumentError, 'Public reveal failed: You must reveal at least one field!' if fields_to_reveal.empty?
+
+        verify_certificate(certificate)
+
+        # Prove the certificate to the "anyone" verifier (PrivateKey(1) public key)
+        anyone_pubkey = BSV::Script::PushDropTemplate::GENERATOR_PUBKEY_HEX
+        prove_result  = @wallet.prove_certificate(
+          { certificate: certificate, fields_to_reveal: fields_to_reveal, verifier: anyone_pubkey },
+          originator: @originator
+        )
+        keyring = prove_result[:keyring_for_verifier]
+
+        # Build the PushDrop payload: certificate fields merged with the keyring
+        payload = JSON.generate(certificate.merge(keyring: keyring))
+
+        # Construct the locking script via PushDropTemplate
+        template = BSV::Script::PushDropTemplate.new(wallet: @wallet, originator: @originator)
+        locking_script = template.lock(
+          fields: [payload],
+          protocol_id: @options.protocol_id,
+          key_id: @options.key_id,
+          counterparty: 'anyone'
+        )
+
+        # Create the transaction
+        create_result = @wallet.create_action(
+          {
+            description: 'Create a new Identity Token',
+            outputs: [
+              {
+                satoshis: @options.token_amount,
+                locking_script: locking_script.to_hex,
+                output_description: 'Identity Token'
+              }
+            ],
+            options: { randomize_outputs: false }
+          },
+          originator: @originator
+        )
+
+        raise 'Public reveal failed: failed to create action!' if create_result[:tx].nil?
+
+        tx = BSV::Transaction::Transaction.from_beef(create_result[:tx])
+        broadcaster_for_action.broadcast(tx)
+      end
+
+      # Revokes a publicly revealed certificate by spending the identity token.
+      #
+      # Queries the +ls_identity+ lookup service for the revelation output identified
+      # by +serial_number+, then creates a spending transaction via the wallet and
+      # broadcasts it to +tm_identity+.
+      #
+      # @param serial_number [String] Base64 serial number of the certificate revelation to revoke
+      # @return [void]
+      # @raise [RuntimeError] if the revelation cannot be found or the transaction cannot be created
+      def revoke_certificate_revelation(serial_number)
+        question = BSV::Overlay::LookupQuestion.new(
+          service: Constants::SERVICE,
+          query: { serial_number: serial_number }
+        )
+        answer = resolver_for_action.query(question)
+
+        raise 'Revoke failed: could not find revelation output' unless answer.type == 'output-list'
+        raise 'Revoke failed: no outputs found for serial number' if answer.outputs.empty?
+
+        output     = answer.outputs.first
+        beef_bytes = output['beef'] || output[:beef]
+        output_idx = (output['outputIndex'] || output[:output_index] || @options.output_index).to_i
+
+        tx      = BSV::Transaction::Beef.from_binary(beef_bytes).transactions.last.transaction
+        txid    = tx.txid_hex
+        outpoint = "#{txid}.#{output_idx}"
+
+        # Create a spending transaction; use unlocking_script_length so the wallet
+        # produces a signable transaction that can then be signed and broadcast.
+        create_result = @wallet.create_action(
+          {
+            description: 'Spend certificate revelation token',
+            input_beef: beef_bytes,
+            inputs: [
+              {
+                input_description: 'Revelation token',
+                outpoint: outpoint,
+                unlocking_script_length: BSV::Script::PushDropTemplate::Unlocker::ESTIMATED_LENGTH
+              }
+            ],
+            options: { randomize_outputs: false, no_send: true }
+          },
+          originator: @originator
+        )
+
+        raise 'Revoke failed: failed to create signable transaction' if create_result[:signable_transaction].nil?
+
+        signable = create_result[:signable_transaction]
+        partial_tx = BSV::Transaction::Transaction.from_beef(signable[:tx])
+
+        # Unlock via PushDrop
+        template = BSV::Script::PushDropTemplate.new(wallet: @wallet, originator: @originator)
+        unlocker = template.unlock(
+          protocol_id: @options.protocol_id,
+          key_id: @options.key_id,
+          counterparty: 'anyone'
+        )
+        unlocking_script = unlocker.sign(partial_tx, output_idx)
+
+        sign_result = @wallet.sign_action(
+          {
+            reference: signable[:reference],
+            spends: { output_idx => { unlocking_script: unlocking_script.to_hex } },
+            options: { no_send: true }
+          },
+          originator: @originator
+        )
+
+        raise 'Revoke failed: failed to sign transaction' if sign_result[:tx].nil?
+
+        signed_tx = BSV::Transaction::Transaction.from_beef(sign_result[:tx])
+        broadcaster_for_action.broadcast(signed_tx)
+      end
+
+      private
+
+      # Maps an array of raw certificate hashes to DisplayableIdentity objects.
+      #
+      # Each certificate hash (as returned by the wallet's discovery methods) is
+      # wrapped in an IdentityCertificate and parsed via IdentityParser.
+      #
+      # @param result [Hash, nil] wallet discovery result with :certificates key
+      # @return [Array<DisplayableIdentity>]
+      def parse_certificates(result)
+        certs = result && result[:certificates]
+        return [] if certs.nil? || certs.empty?
+
+        certs.map { |cert| IdentityParser.parse(wrap_certificate(cert)) }
+      end
+
+      # Wraps a raw certificate hash in an IdentityCertificate, extracting
+      # decrypted_fields and certifier_info where present.
+      #
+      # @param cert [Hash] raw certificate hash from the wallet
+      # @return [IdentityCertificate]
+      def wrap_certificate(cert)
+        decrypted   = cert[:decrypted_fields] || cert['decrypted_fields'] || {}
+        certifier_h = cert[:certifier_info]   || cert['certifier_info']   || {}
+
+        certifier_info = if certifier_h && !certifier_h.empty?
+                           CertifierInfo.new(
+                             name: certifier_h[:name] || certifier_h['name'] || '',
+                             icon_url: certifier_h[:icon_url] || certifier_h['icon_url']
+                           )
+                         end
+
+        IdentityCertificate.new(
+          certificate: cert,
+          decrypted_fields: decrypted,
+          certifier_info: certifier_info
+        )
+      end
+
+      # Calls the injected certificate verifier, wrapping any errors in a
+      # standardised RuntimeError message.
+      #
+      # @param certificate [Hash]
+      # @raise [RuntimeError] if verification fails
+      def verify_certificate(certificate)
+        @certificate_verifier.call(certificate)
+      rescue NotImplementedError
+        raise
+      rescue StandardError => e
+        raise "Public reveal failed: Certificate verification failed! (#{e.message})"
+      end
+
+      # Returns the broadcaster to use for overlay actions, building one from
+      # the wallet's network when no injectable broadcaster was provided.
+      #
+      # @return [BSV::Overlay::TopicBroadcaster]
+      def broadcaster_for_action
+        return @broadcaster if @broadcaster
+
+        network = wallet_network
+        BSV::Overlay::TopicBroadcaster.new(
+          [Constants::TOPIC],
+          network_preset: network
+        )
+      end
+
+      # Returns the lookup resolver to use for overlay queries, building one from
+      # the wallet's network when no injectable resolver was provided.
+      #
+      # @return [BSV::Overlay::LookupResolver]
+      def resolver_for_action
+        return @resolver if @resolver
+
+        network = wallet_network
+        BSV::Overlay::LookupResolver.new(network_preset: network)
+      end
+
+      # Queries the wallet for the current network and converts the string to a symbol.
+      #
+      # @return [Symbol] :mainnet or :testnet
+      def wallet_network
+        result = @wallet.get_network({}, originator: @originator)
+        net_str = result[:network] || result['network'] || 'mainnet'
+        net_str.to_sym
+      end
+
+      # Returns the default ClientOptions.
+      #
+      # Calling +Constants.name+ triggers the autoload of constants.rb, which
+      # reopens ClientOptions to define +ClientOptions::DEFAULT+.
+      #
+      # @return [ClientOptions]
+      def default_options
+        # Calling a method on Constants forces its autoload (constants.rb), which
+        # reopens ClientOptions and defines ClientOptions::DEFAULT.
+        Constants.name
+        ClientOptions::DEFAULT
+      end
+    end
+  end
+end

--- a/lib/bsv/identity/client.rb
+++ b/lib/bsv/identity/client.rb
@@ -122,8 +122,22 @@ module BSV
         )
         keyring = prove_result[:keyring_for_verifier]
 
-        # Build the PushDrop payload: certificate fields merged with the keyring
-        payload = JSON.generate(certificate.merge(keyring: keyring))
+        # Build the PushDrop payload with ONLY the revealed fields — never
+        # broadcast the full certificate (encrypted values for unrevealed
+        # fields must not be written on-chain).
+        revealed_fields = fields_to_reveal.each_with_object({}) do |name, h|
+          h[name] = fields[name.to_s] || fields[name.to_sym]
+        end
+
+        payload = JSON.generate(
+          type: certificate[:type] || certificate['type'],
+          serialNumber: certificate[:serial_number] || certificate['serial_number'] || certificate[:serialNumber] || certificate['serialNumber'],
+          subject: certificate[:subject] || certificate['subject'],
+          certifier: certificate[:certifier] || certificate['certifier'],
+          revocationOutpoint: certificate[:revocation_outpoint] || certificate['revocation_outpoint'] || certificate[:revocationOutpoint] || certificate['revocationOutpoint'],
+          fields: revealed_fields,
+          keyring: keyring
+        )
 
         # Construct the locking script via PushDropTemplate
         template = BSV::Script::PushDropTemplate.new(wallet: @wallet, originator: @originator)
@@ -177,9 +191,18 @@ module BSV
 
         output     = answer.outputs.first
         beef_bytes = output['beef'] || output[:beef]
-        output_idx = (output['outputIndex'] || output[:output_index] || @options.output_index).to_i
+        raise 'Revoke failed: overlay response missing BEEF data' unless beef_bytes
 
-        tx      = BSV::Transaction::Beef.from_binary(beef_bytes).transactions.last.transaction
+        raw_idx = output['outputIndex'] || output[:output_index]
+        raise 'Revoke failed: overlay response missing outputIndex' if raw_idx.nil?
+
+        output_idx = raw_idx.to_i
+        raise 'Revoke failed: invalid outputIndex from overlay' if output_idx.negative?
+
+        beef = BSV::Transaction::Beef.from_binary(beef_bytes)
+        tx   = beef.transactions.last&.transaction
+        raise 'Revoke failed: no transaction found in BEEF' unless tx
+        raise 'Revoke failed: outputIndex out of range' if output_idx >= tx.outputs.length
         txid    = tx.txid_hex
         outpoint = "#{txid}.#{output_idx}"
 

--- a/lib/bsv/identity/constants.rb
+++ b/lib/bsv/identity/constants.rb
@@ -37,15 +37,5 @@ module BSV
         badge_click_url: 'https://projectbabbage.com/docs/unknown-identity'
       ).freeze
     end
-
-    class ClientOptions
-      # Default options matching the TS SDK DEFAULT_IDENTITY_CLIENT_OPTIONS constant.
-      DEFAULT = new(
-        protocol_id: [1, 'identity'].freeze,
-        key_id: '1',
-        token_amount: 1,
-        output_index: 0
-      ).freeze
-    end
   end
 end

--- a/lib/bsv/identity/constants.rb
+++ b/lib/bsv/identity/constants.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module BSV
+  module Identity
+    # Protocol constants and well-known values for the BSV Identity system.
+    module Constants
+      # Overlay topic name for identity transactions.
+      TOPIC = 'tm_identity'
+
+      # Lookup service identifier for identity queries.
+      SERVICE = 'ls_identity'
+
+      # Maps symbolic names to their Base64-encoded 32-byte certificate type identifiers.
+      #
+      # Values are byte-exact matches with the TS SDK (ts-sdk/src/identity/types/index.ts)
+      # and Go SDK (go-sdk/identity/types.go).
+      KNOWN_IDENTITY_TYPES = {
+        x_cert: 'vdDWvftf1H+5+ZprUw123kjHlywH+v20aPQTuXgMpNc=',
+        discord_cert: '2TgqRC35B1zehGmB21xveZNc7i5iqHc0uxMb+1NMPW4=',
+        phone_cert: 'mffUklUzxbHr65xLohn0hRL0Tq2GjW1GYF/OPfzqJ6A=',
+        email_cert: 'exOl3KM0dIJ04EW5pZgbZmPag6MdJXd3/a1enmUU/BA=',
+        identi_cert: 'z40BOInXkI8m7f/wBrv4MJ09bZfzZbTj2fJqCtONqCY=',
+        registrant: 'YoPsbfR6YQczjzPdHCoGC7nJsOdPQR50+SYqcWpJ0y0=',
+        cool_cert: 'AGfk/WrT1eBDXpz3mcw386Zww2HmqcIn3uY6x4Af1eo=',
+        anyone: 'mfkOMfLDQmrr3SBxBQ5WeE+6Hy3VJRFq6w4A5Ljtlis=',
+        self: 'Hkge6X5JRxt1cWXtHLCrSTg6dCVTxjQJJ48iOYd7n3g='
+      }.freeze
+
+      # Fallback identity used when no verified identity information is available.
+      DEFAULT_IDENTITY = DisplayableIdentity.new(
+        name: 'Unknown Identity',
+        avatar_url: 'XUUB8bbn9fEthk15Ge3zTQXypUShfC94vFjp65v7u5CQ8qkpxzst',
+        abbreviated_key: '',
+        identity_key: '',
+        badge_icon_url: 'XUUV39HVPkpmMzYNTx7rpKzJvXfeiVyQWg2vfSpjBAuhunTCA9uG',
+        badge_label: 'Not verified by anyone you trust.',
+        badge_click_url: 'https://projectbabbage.com/docs/unknown-identity'
+      ).freeze
+    end
+
+    class ClientOptions
+      # Default options matching the TS SDK DEFAULT_IDENTITY_CLIENT_OPTIONS constant.
+      DEFAULT = new(
+        protocol_id: [1, 'identity'].freeze,
+        key_id: '1',
+        token_amount: 1,
+        output_index: 0
+      ).freeze
+    end
+  end
+end

--- a/lib/bsv/identity/identity_parser.rb
+++ b/lib/bsv/identity/identity_parser.rb
@@ -127,7 +127,15 @@ module BSV
       private_class_method :parse_phone_cert
 
       def self.parse_identi_cert(fields, certifier)
-        name        = "#{fields['firstName']} #{fields['lastName']}"
+        first = fields['firstName']
+        last  = fields['lastName']
+        name  = if present?(first) && present?(last)
+                  "#{first} #{last}"
+                elsif present?(first)
+                  first
+                elsif present?(last)
+                  last
+                end
         avatar_url  = fields['profilePhoto']
         badge_label = "Government ID certified by #{certifier&.name}"
         badge_icon  = certifier&.icon_url

--- a/lib/bsv/identity/identity_parser.rb
+++ b/lib/bsv/identity/identity_parser.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+
+module BSV
+  module Identity
+    # Parses an {IdentityCertificate} into a {DisplayableIdentity} suitable for
+    # presentation in a user interface.
+    #
+    # Handles all 9 well-known certificate types (xCert, discordCert, phoneCert,
+    # emailCert, identiCert, registrant, coolCert, anyone, self) with type-specific
+    # field extraction that matches the TS SDK implementation exactly. Unknown
+    # certificate types fall through to a generic field-name heuristic.
+    module IdentityParser
+      # Well-known avatar opaque strings used by specific certificate types.
+      EMAIL_AVATAR  = 'XUTZxep7BBghAJbSBwTjNfmcsDdRFs5EaGEgkESGSgjJVYgMEizu'
+      PHONE_AVATAR  = 'XUTLxtX3ELNUwRhLwL7kWNGbdnFM8WG2eSLv84J7654oH8HaJWrU'
+      ANYONE_AVATAR = 'XUT4bpQ6cpBaXi1oMzZsXfpkWGbtp2JTUYAoN7PzhStFJ6wLfoeR'
+      SELF_AVATAR   = 'XUT9jHGk2qace148jeCX5rDsMftkSGYKmigLwU2PLLBc7Hm63VYR'
+      BADGE_ICON    = 'XUUV39HVPkpmMzYNTx7rpKzJvXfeiVyQWg2vfSpjBAuhunTCA9uG'
+
+      # Parses an {IdentityCertificate} and returns a {DisplayableIdentity}.
+      #
+      # @param identity_certificate [IdentityCertificate]
+      # @return [DisplayableIdentity]
+      def self.parse(identity_certificate)
+        fields       = identity_certificate.decrypted_fields
+        certifier    = identity_certificate.certifier_info
+        type_b64     = identity_certificate.certificate[:type]
+
+        name, avatar_url, badge_label, badge_icon_url, badge_click_url =
+          extract_fields(type_b64, fields, certifier)
+
+        subject       = identity_certificate.certificate[:subject].to_s
+        identity_key  = subject
+        abbreviated   = abbreviated_key(subject)
+
+        DisplayableIdentity.new(
+          name: name,
+          avatar_url: avatar_url,
+          abbreviated_key: abbreviated,
+          identity_key: identity_key,
+          badge_icon_url: badge_icon_url,
+          badge_label: badge_label,
+          badge_click_url: badge_click_url
+        )
+      end
+
+      # -----------------------------------------------------------------------
+      # Private helpers
+      # -----------------------------------------------------------------------
+
+      # Returns true when +val+ is a non-nil, non-empty string.
+      def self.present?(val)
+        val.is_a?(String) && !val.empty?
+      end
+      private_class_method :present?
+
+      # Returns the first 10 characters of the subject followed by '...',
+      # or the subject itself when it is shorter than 10 characters.
+      def self.abbreviated_key(subject)
+        return '' unless present?(subject)
+        return subject if subject.length < 10
+
+        "#{subject[0, 10]}..."
+      end
+      private_class_method :abbreviated_key
+
+      # Dispatches to per-type extraction logic and returns a 5-element array:
+      # [name, avatar_url, badge_label, badge_icon_url, badge_click_url]
+      def self.extract_fields(type_b64, fields, certifier)
+        types = Constants::KNOWN_IDENTITY_TYPES
+
+        case type_b64
+        when types[:x_cert]       then parse_x_cert(fields, certifier)
+        when types[:discord_cert] then parse_discord_cert(fields, certifier)
+        when types[:email_cert]   then parse_email_cert(fields, certifier)
+        when types[:phone_cert]   then parse_phone_cert(fields, certifier)
+        when types[:identi_cert]  then parse_identi_cert(fields, certifier)
+        when types[:registrant]   then parse_registrant(fields, certifier)
+        when types[:cool_cert]    then parse_cool_cert(fields)
+        when types[:anyone]       then parse_anyone
+        when types[:self]         then parse_self
+        else                           parse_generic(type_b64, fields, certifier)
+        end
+      end
+      private_class_method :extract_fields
+
+      # -- Known-type parsers --------------------------------------------------
+
+      def self.parse_x_cert(fields, certifier)
+        name          = fields['userName']
+        avatar_url    = fields['profilePhoto']
+        badge_label   = "X account certified by #{certifier&.name}"
+        badge_icon    = certifier&.icon_url
+        badge_click   = 'https://socialcert.net'
+        [name, avatar_url, badge_label, badge_icon, badge_click]
+      end
+      private_class_method :parse_x_cert
+
+      def self.parse_discord_cert(fields, certifier)
+        name          = fields['userName']
+        avatar_url    = fields['profilePhoto']
+        badge_label   = "Discord account certified by #{certifier&.name}"
+        badge_icon    = certifier&.icon_url
+        badge_click   = 'https://socialcert.net'
+        [name, avatar_url, badge_label, badge_icon, badge_click]
+      end
+      private_class_method :parse_discord_cert
+
+      def self.parse_email_cert(fields, certifier)
+        name        = fields['email']
+        avatar_url  = EMAIL_AVATAR
+        badge_label = "Email certified by #{certifier&.name}"
+        badge_icon  = certifier&.icon_url
+        badge_click = 'https://socialcert.net'
+        [name, avatar_url, badge_label, badge_icon, badge_click]
+      end
+      private_class_method :parse_email_cert
+
+      def self.parse_phone_cert(fields, certifier)
+        name        = fields['phoneNumber']
+        avatar_url  = PHONE_AVATAR
+        badge_label = "Phone certified by #{certifier&.name}"
+        badge_icon  = certifier&.icon_url
+        badge_click = 'https://socialcert.net'
+        [name, avatar_url, badge_label, badge_icon, badge_click]
+      end
+      private_class_method :parse_phone_cert
+
+      def self.parse_identi_cert(fields, certifier)
+        name        = "#{fields['firstName']} #{fields['lastName']}"
+        avatar_url  = fields['profilePhoto']
+        badge_label = "Government ID certified by #{certifier&.name}"
+        badge_icon  = certifier&.icon_url
+        badge_click = 'https://identicert.me'
+        [name, avatar_url, badge_label, badge_icon, badge_click]
+      end
+      private_class_method :parse_identi_cert
+
+      def self.parse_registrant(fields, certifier)
+        name        = fields['name']
+        avatar_url  = fields['icon']
+        badge_label = "Entity certified by #{certifier&.name}"
+        badge_icon  = certifier&.icon_url
+        badge_click = 'https://projectbabbage.com/docs/registrant'
+        [name, avatar_url, badge_label, badge_icon, badge_click]
+      end
+      private_class_method :parse_registrant
+
+      def self.parse_cool_cert(fields)
+        name = fields['cool'] == 'true' ? 'Cool Person!' : 'Not cool!'
+        [name, nil, nil, nil, nil]
+      end
+      private_class_method :parse_cool_cert
+
+      def self.parse_anyone
+        [
+          'Anyone',
+          ANYONE_AVATAR,
+          'Represents the ability for anyone to access this information.',
+          BADGE_ICON,
+          'https://projectbabbage.com/docs/anyone-identity'
+        ]
+      end
+      private_class_method :parse_anyone
+
+      def self.parse_self
+        [
+          'You',
+          SELF_AVATAR,
+          'Represents your ability to access this information.',
+          BADGE_ICON,
+          'https://projectbabbage.com/docs/self-identity'
+        ]
+      end
+      private_class_method :parse_self
+
+      # -- Generic fallback ---------------------------------------------------
+
+      # Attempts to extract identity fields from an unknown certificate type by
+      # checking commonly used field names in order of preference.
+      def self.parse_generic(type_b64, fields, certifier)
+        default = Constants::DEFAULT_IDENTITY
+
+        name      = resolve_generic_name(fields, default)
+        avatar    = resolve_generic_avatar(fields, default)
+        b_label   = resolve_generic_badge_label(type_b64, certifier, default)
+        b_icon    = present?(certifier&.icon_url) ? certifier.icon_url : default.badge_icon_url
+        b_click   = default.badge_click_url
+
+        [name, avatar, b_label, b_icon, b_click]
+      end
+      private_class_method :parse_generic
+
+      def self.resolve_generic_name(fields, default)
+        return fields['name']     if present?(fields['name'])
+        return fields['userName'] if present?(fields['userName'])
+
+        full_name = compose_full_name(fields)
+        return full_name if present?(full_name)
+
+        return fields['email'] if present?(fields['email'])
+
+        default.name
+      end
+      private_class_method :resolve_generic_name
+
+      def self.compose_full_name(fields)
+        first = fields['firstName']
+        last  = fields['lastName']
+
+        if present?(first) && present?(last)
+          "#{first} #{last}"
+        elsif present?(first)
+          first
+        elsif present?(last)
+          last
+        end
+      end
+      private_class_method :compose_full_name
+
+      def self.resolve_generic_avatar(fields, default)
+        return fields['profilePhoto'] if present?(fields['profilePhoto'])
+        return fields['avatar']       if present?(fields['avatar'])
+        return fields['icon']         if present?(fields['icon'])
+        return fields['photo']        if present?(fields['photo'])
+
+        default.avatar_url
+      end
+      private_class_method :resolve_generic_avatar
+
+      def self.resolve_generic_badge_label(type_b64, certifier, default)
+        return "#{type_b64} certified by #{certifier.name}" if present?(certifier&.name)
+
+        default.badge_label
+      end
+      private_class_method :resolve_generic_badge_label
+    end
+  end
+end

--- a/lib/bsv/identity/types.rb
+++ b/lib/bsv/identity/types.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module BSV
+  module Identity
+    # Formatted identity information for display in user interfaces.
+    class DisplayableIdentity
+      # @return [String] human-readable display name
+      attr_reader :name
+
+      # @return [String] URL or opaque string for the identity avatar image
+      attr_reader :avatar_url
+
+      # @return [String] shortened version of the identity key for compact display
+      attr_reader :abbreviated_key
+
+      # @return [String] full identity public key
+      attr_reader :identity_key
+
+      # @return [String, nil] URL or opaque string for a trust badge icon
+      attr_reader :badge_icon_url
+
+      # @return [String, nil] human-readable badge label (e.g. certifier name)
+      attr_reader :badge_label
+
+      # @return [String, nil] URL to open when the badge is clicked
+      attr_reader :badge_click_url
+
+      # @param name [String]
+      # @param avatar_url [String]
+      # @param abbreviated_key [String]
+      # @param identity_key [String]
+      # @param badge_icon_url [String, nil]
+      # @param badge_label [String, nil]
+      # @param badge_click_url [String, nil]
+      def initialize(name:, avatar_url:, abbreviated_key:, identity_key:,
+                     badge_icon_url: nil, badge_label: nil, badge_click_url: nil)
+        @name            = name
+        @avatar_url      = avatar_url
+        @abbreviated_key = abbreviated_key
+        @identity_key    = identity_key
+        @badge_icon_url  = badge_icon_url
+        @badge_label     = badge_label
+        @badge_click_url = badge_click_url
+      end
+    end
+
+    # Certifier metadata attached to a certificate for display purposes.
+    class CertifierInfo
+      # @return [String] certifier's display name
+      attr_reader :name
+
+      # @return [String, nil] URL or opaque string for the certifier's icon
+      attr_reader :icon_url
+
+      # @param name [String]
+      # @param icon_url [String, nil]
+      def initialize(name:, icon_url: nil)
+        @name     = name
+        @icon_url = icon_url
+      end
+    end
+
+    # A certificate together with its decrypted field values and optional certifier info.
+    class IdentityCertificate
+      # @return [Hash] raw certificate data (type, subject, fields, etc.)
+      attr_reader :certificate
+
+      # @return [Hash] certificate field values after decryption
+      attr_reader :decrypted_fields
+
+      # @return [CertifierInfo, nil] display information about the certifier
+      attr_reader :certifier_info
+
+      # @param certificate [Hash]
+      # @param decrypted_fields [Hash]
+      # @param certifier_info [CertifierInfo, nil]
+      def initialize(certificate:, decrypted_fields:, certifier_info: nil)
+        @certificate      = certificate
+        @decrypted_fields = decrypted_fields
+        @certifier_info   = certifier_info
+      end
+    end
+
+    # Configuration options for an IdentityClient instance.
+    class ClientOptions
+      # @return [Array] BRC-42/43 wallet protocol identifier, e.g. [1, 'identity']
+      attr_reader :protocol_id
+
+      # @return [String] key identifier within the protocol
+      attr_reader :key_id
+
+      # @return [Integer] token amount in satoshis for identity operations
+      attr_reader :token_amount
+
+      # @return [Integer] output index within the token transaction
+      attr_reader :output_index
+
+      # @param protocol_id [Array]
+      # @param key_id [String]
+      # @param token_amount [Integer]
+      # @param output_index [Integer]
+      def initialize(protocol_id:, key_id:, token_amount:, output_index:)
+        @protocol_id  = protocol_id
+        @key_id       = key_id
+        @token_amount = token_amount
+        @output_index = output_index
+      end
+    end
+  end
+end

--- a/lib/bsv/identity/types.rb
+++ b/lib/bsv/identity/types.rb
@@ -105,6 +105,14 @@ module BSV
         @token_amount = token_amount
         @output_index = output_index
       end
+
+      # Default options matching the TS SDK DEFAULT_IDENTITY_CLIENT_OPTIONS constant.
+      DEFAULT = new(
+        protocol_id: [1, 'identity'].freeze,
+        key_id: '1',
+        token_amount: 1,
+        output_index: 0
+      ).freeze
     end
   end
 end

--- a/lib/bsv/script.rb
+++ b/lib/bsv/script.rb
@@ -12,9 +12,11 @@ module BSV
     autoload :Builder, 'bsv/script/builder'
     autoload :Script,  'bsv/script/script'
 
-    autoload :Interpreter,  'bsv/script/interpreter/interpreter'
-    autoload :ScriptError,  'bsv/script/interpreter/error'
-    autoload :ScriptNumber, 'bsv/script/interpreter/script_number'
-    autoload :Stack,        'bsv/script/interpreter/stack'
+    autoload :Interpreter,       'bsv/script/interpreter/interpreter'
+    autoload :ScriptError,       'bsv/script/interpreter/error'
+    autoload :ScriptNumber,      'bsv/script/interpreter/script_number'
+    autoload :Stack,             'bsv/script/interpreter/stack'
+
+    autoload :PushDropTemplate, 'bsv/script/push_drop_template'
   end
 end

--- a/lib/bsv/script/push_drop_template.rb
+++ b/lib/bsv/script/push_drop_template.rb
@@ -107,16 +107,15 @@ module BSV
             key_id: @key_id,
             counterparty: @counterparty
           }
-          sig_args[:originator] = @originator if @originator
-          result = @wallet.create_signature(sig_args)
+          orig_kw = @originator ? { originator: @originator } : {}
+          result = @wallet.create_signature(sig_args, **orig_kw)
 
           sig_bytes = result[:signature].pack('C*')
           sig_with_hashtype = sig_bytes + [sighash_type].pack('C')
 
           # Fetch the derived public key so the P2PKH unlock can include it
           pub_args = { protocol_id: @protocol_id, key_id: @key_id, counterparty: @counterparty }
-          pub_args[:originator] = @originator if @originator
-          pub_result = @wallet.get_public_key(pub_args)
+          pub_result = @wallet.get_public_key(pub_args, **orig_kw)
           pubkey_bytes = [pub_result[:public_key]].pack('H*')
 
           BSV::Script::Script.pushdrop_unlock(
@@ -168,8 +167,8 @@ module BSV
                          [GENERATOR_PUBKEY_HEX].pack('H*')
                        else
                          pub_args = { protocol_id: protocol_id, key_id: key_id, counterparty: counterparty }
-                         pub_args[:originator] = @originator if @originator
-                         pub_result = @wallet.get_public_key(pub_args)
+                         orig_kw = @originator ? { originator: @originator } : {}
+                         pub_result = @wallet.get_public_key(pub_args, **orig_kw)
                          [pub_result[:public_key]].pack('H*')
                        end
 
@@ -179,8 +178,8 @@ module BSV
         if include_signature
           data_to_sign = all_fields.reduce(''.b) { |acc, f| acc + f }.unpack('C*')
           sig_args = { data: data_to_sign, protocol_id: protocol_id, key_id: key_id, counterparty: counterparty }
-          sig_args[:originator] = @originator if @originator
-          sig_result = @wallet.create_signature(sig_args)
+          orig_kw = @originator ? { originator: @originator } : {}
+          sig_result = @wallet.create_signature(sig_args, **orig_kw)
           all_fields << sig_result[:signature].pack('C*')
         end
 

--- a/lib/bsv/script/push_drop_template.rb
+++ b/lib/bsv/script/push_drop_template.rb
@@ -8,6 +8,13 @@ module BSV
     # derives a locking key from the wallet, optionally signs the data fields,
     # and wraps everything in a PushDrop script backed by a P2PKH condition.
     #
+    # == Note: P2PKH vs P2PK
+    #
+    # This template uses P2PKH as the underlying spending condition. The
+    # {BSV::Overlay::AdminTokenTemplate} uses P2PK (matching the TS/Go SDKs'
+    # overlay admin token convention). The two lock types are not
+    # interchangeable — tokens locked by one cannot be unlocked by the other.
+    #
     # PushDrop scripts embed arbitrary token data inline in a spendable output:
     #
     #   <field0> <field1> ... <fieldN> [OP_2DROP...] [OP_DROP?]

--- a/lib/bsv/script/push_drop_template.rb
+++ b/lib/bsv/script/push_drop_template.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+module BSV
+  module Script
+    # Wallet-integrated PushDrop template for any protocol.
+    #
+    # Generalises the pattern used by {BSV::Overlay::AdminTokenTemplate} —
+    # derives a locking key from the wallet, optionally signs the data fields,
+    # and wraps everything in a PushDrop script backed by a P2PKH condition.
+    #
+    # PushDrop scripts embed arbitrary token data inline in a spendable output:
+    #
+    #   <field0> <field1> ... <fieldN> [OP_2DROP...] [OP_DROP?]
+    #   OP_DUP OP_HASH160 <hash160(derived_pubkey)> OP_EQUALVERIFY OP_CHECKSIG
+    #
+    # When +include_signature: true+ (the default), an ECDSA signature over the
+    # concatenation of all fields is appended as a final field. This
+    # authenticates the token at creation time using the same derived key.
+    #
+    # @example Lock a token
+    #   wallet   = BSV::Wallet::ProtoWallet.new(private_key)
+    #   template = BSV::Script::PushDropTemplate.new(wallet:)
+    #   script   = template.lock(
+    #     fields:       ['hello'.b, 'world'.b],
+    #     protocol_id:  [1, 'my-protocol'],
+    #     key_id:       '1',
+    #     counterparty: 'self'
+    #   )
+    #   script.pushdrop? #=> true
+    #
+    # @example Unlock a token
+    #   unlocker = template.unlock(
+    #     protocol_id:  [1, 'my-protocol'],
+    #     key_id:       '1',
+    #     counterparty: 'self'
+    #   )
+    #   input.unlocking_script_template = unlocker
+    class PushDropTemplate
+      # Public key for PrivateKey(1) — the generator point G.
+      # Used when +counterparty: 'anyone'+ so any party can verify.
+      GENERATOR_PUBKEY_HEX =
+        '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
+
+      # Unlocking template returned by {#unlock}.
+      #
+      # Satisfies the P2PKH condition embedded in a PushDrop locking script
+      # by computing the BIP-143 sighash and signing it with the wallet's
+      # derived key.
+      class Unlocker
+        # Estimated unlocking script length in bytes.
+        #
+        # P2PKH unlock is 1 + ~72 (DER sig + hashtype) + 1 + 33 (pubkey) = 107 bytes.
+        # In PushDrop context the unlock wraps P2PKH, so the estimate is the same.
+        ESTIMATED_LENGTH = 107
+
+        # @param wallet [#create_signature, #get_public_key] BRC-100 wallet interface
+        # @param protocol_id [Array] two-element [security_level, protocol_name]
+        # @param key_id [String] key identifier
+        # @param counterparty [String] 'self', 'anyone', or a hex public key
+        # @param originator [String, nil] optional originator domain
+        def initialize(wallet, protocol_id, key_id, counterparty, originator)
+          @wallet = wallet
+          @protocol_id = protocol_id
+          @key_id = key_id
+          @counterparty = counterparty
+          @originator = originator
+        end
+
+        # Generate the unlocking script for the given input.
+        #
+        # Computes the BIP-143 sighash (SIGHASH_ALL|FORK_ID), signs it with
+        # the wallet's derived key, then returns a P2PKH unlock wrapped in a
+        # PushDrop unlock (which is a pass-through).
+        #
+        # @param tx [BSV::Transaction::Transaction] the spending transaction
+        # @param input_index [Integer] which input to sign
+        # @return [BSV::Script::Script] the unlocking script
+        def sign(tx, input_index)
+          sighash_type = BSV::Transaction::Sighash::ALL_FORK_ID
+          hash = tx.sighash(input_index, sighash_type)
+          hash_bytes = hash.unpack('C*')
+
+          sig_args = {
+            hash_to_directly_sign: hash_bytes,
+            protocol_id: @protocol_id,
+            key_id: @key_id,
+            counterparty: @counterparty
+          }
+          sig_args[:originator] = @originator if @originator
+          result = @wallet.create_signature(sig_args)
+
+          sig_bytes = result[:signature].pack('C*')
+          sig_with_hashtype = sig_bytes + [sighash_type].pack('C')
+
+          # Fetch the derived public key so the P2PKH unlock can include it
+          pub_args = { protocol_id: @protocol_id, key_id: @key_id, counterparty: @counterparty }
+          pub_args[:originator] = @originator if @originator
+          pub_result = @wallet.get_public_key(pub_args)
+          pubkey_bytes = [pub_result[:public_key]].pack('H*')
+
+          BSV::Script::Script.pushdrop_unlock(
+            BSV::Script::Script.p2pkh_unlock(sig_with_hashtype, pubkey_bytes)
+          )
+        end
+
+        # Estimated byte length of the unlocking script.
+        #
+        # @param _tx [BSV::Transaction::Transaction] unused
+        # @param _input_index [Integer] unused
+        # @return [Integer]
+        def estimated_length(_tx, _input_index)
+          ESTIMATED_LENGTH
+        end
+      end
+
+      # @param wallet [#get_public_key, #create_signature] BRC-100 wallet interface
+      # @param originator [String, nil] optional FQDN of the originating application
+      def initialize(wallet:, originator: nil)
+        @wallet = wallet
+        @originator = originator
+      end
+
+      # Create a PushDrop locking script for the given data fields.
+      #
+      # Derives a public key from the wallet using the supplied protocol
+      # parameters, then builds a P2PKH locking condition from it. When
+      # +include_signature: true+ (the default), signs the concatenation of all
+      # fields and appends the DER signature as an additional field.
+      #
+      # When +counterparty+ is +'anyone'+, the generator point (PrivateKey(1)
+      # public key) is used directly as the locking key. This is the convention
+      # for tokens that any party can verify.
+      #
+      # @param fields [Array<String>] data payloads to embed (binary strings)
+      # @param protocol_id [Array] two-element [security_level, protocol_name]
+      # @param key_id [String] key identifier
+      # @param counterparty [String] 'self', 'anyone', or a hex public key
+      # @param include_signature [Boolean] whether to append an ECDSA field signature
+      # @return [BSV::Script::Script] the PushDrop locking script
+      # @raise [ArgumentError] if fields is empty
+      def lock(fields:, protocol_id:, key_id:, counterparty:, include_signature: true)
+        raise ArgumentError, 'fields must not be empty' if fields.empty?
+
+        # When counterparty is 'anyone', use the generator point directly as the
+        # locking key — this is the "anyone can verify" convention.
+        pubkey_bytes = if counterparty == 'anyone'
+                         [GENERATOR_PUBKEY_HEX].pack('H*')
+                       else
+                         pub_args = { protocol_id: protocol_id, key_id: key_id, counterparty: counterparty }
+                         pub_args[:originator] = @originator if @originator
+                         pub_result = @wallet.get_public_key(pub_args)
+                         [pub_result[:public_key]].pack('H*')
+                       end
+
+        # Build all fields, optionally appending a signature over their concatenation
+        all_fields = fields.map(&:b)
+
+        if include_signature
+          data_to_sign = all_fields.reduce(''.b) { |acc, f| acc + f }.unpack('C*')
+          sig_args = { data: data_to_sign, protocol_id: protocol_id, key_id: key_id, counterparty: counterparty }
+          sig_args[:originator] = @originator if @originator
+          sig_result = @wallet.create_signature(sig_args)
+          all_fields << sig_result[:signature].pack('C*')
+        end
+
+        # Build P2PKH lock from the derived pubkey's Hash160
+        pubkey_hash = BSV::Primitives::Digest.hash160(pubkey_bytes)
+        p2pkh_lock = BSV::Script::Script.p2pkh_lock(pubkey_hash)
+
+        BSV::Script::Script.pushdrop_lock(all_fields, p2pkh_lock)
+      end
+
+      # Return an unlocker for spending a PushDrop token output.
+      #
+      # The returned {Unlocker} follows the unlocking template interface and
+      # can be assigned to an input's +unlocking_script_template+.
+      #
+      # @param protocol_id [Array] two-element [security_level, protocol_name]
+      # @param key_id [String] key identifier
+      # @param counterparty [String] 'self', 'anyone', or a hex public key
+      # @return [Unlocker] object with +#sign+ and +#estimated_length+
+      def unlock(protocol_id:, key_id:, counterparty:)
+        Unlocker.new(@wallet, protocol_id, key_id, counterparty, @originator)
+      end
+    end
+  end
+end

--- a/lib/bsv/script/push_drop_template.rb
+++ b/lib/bsv/script/push_drop_template.rb
@@ -17,6 +17,20 @@ module BSV
     # concatenation of all fields is appended as a final field. This
     # authenticates the token at creation time using the same derived key.
     #
+    # == Security note: +counterparty: 'anyone'+ tokens
+    #
+    # When +counterparty+ is +'anyone'+, the locking key is derived from the
+    # secp256k1 generator point G (PrivateKey(1)). This is a publicly known
+    # scalar, meaning:
+    #
+    # 1. The output is **publicly spendable** — any party can sign with
+    #    PrivateKey(1) and spend the token. This is by design for overlay
+    #    tokens where public revocability is desired.
+    # 2. The field signature (+include_signature: true+) provides **no
+    #    authenticity guarantee** — anyone can produce a valid signature with
+    #    the known key. Rely on higher-level mechanisms (e.g. certificate
+    #    keyrings from +prove_certificate+) for field-level integrity.
+    #
     # @example Lock a token
     #   wallet   = BSV::Wallet::ProtoWallet.new(private_key)
     #   template = BSV::Script::PushDropTemplate.new(wallet:)

--- a/lib/bsv/wallet_interface/proto_wallet.rb
+++ b/lib/bsv/wallet_interface/proto_wallet.rb
@@ -45,7 +45,7 @@ module BSV
       # @option args [Boolean] :for_self derive from own identity
       # @param originator [String, nil] FQDN of the originating application
       # @return [Hash] { public_key: String } hex-encoded compressed public key
-      def get_public_key(args, _originator: nil)
+      def get_public_key(args, originator: nil)
         if args[:identity_key]
           { public_key: @key_deriver.identity_key }
         else
@@ -69,7 +69,7 @@ module BSV
       # @option args [String] :counterparty public key hex, 'self', or 'anyone'
       # @param originator [String, nil] FQDN of the originating application
       # @return [Hash] { ciphertext: Array<Integer> }
-      def encrypt(args, _originator: nil)
+      def encrypt(args, originator: nil)
         sym_key = derive_sym_key(args)
         ciphertext = sym_key.encrypt(bytes_to_string(args[:plaintext]))
         { ciphertext: string_to_bytes(ciphertext) }
@@ -84,7 +84,7 @@ module BSV
       # @option args [String] :counterparty public key hex, 'self', or 'anyone'
       # @param originator [String, nil] FQDN of the originating application
       # @return [Hash] { plaintext: Array<Integer> }
-      def decrypt(args, _originator: nil)
+      def decrypt(args, originator: nil)
         sym_key = derive_sym_key(args)
         plaintext = sym_key.decrypt(bytes_to_string(args[:ciphertext]))
         { plaintext: string_to_bytes(plaintext) }
@@ -99,7 +99,7 @@ module BSV
       # @option args [String] :counterparty public key hex, 'self', or 'anyone'
       # @param originator [String, nil] FQDN of the originating application
       # @return [Hash] { hmac: Array<Integer> }
-      def create_hmac(args, _originator: nil)
+      def create_hmac(args, originator: nil)
         sym_key = derive_sym_key(args)
         hmac = BSV::Primitives::Digest.hmac_sha256(sym_key.to_bytes, bytes_to_string(args[:data]))
         { hmac: string_to_bytes(hmac) }
@@ -116,7 +116,7 @@ module BSV
       # @param originator [String, nil] FQDN of the originating application
       # @return [Hash] { valid: true }
       # @raise [InvalidHmacError] if the HMAC does not match
-      def verify_hmac(args, _originator: nil)
+      def verify_hmac(args, originator: nil)
         sym_key = derive_sym_key(args)
         expected = BSV::Primitives::Digest.hmac_sha256(sym_key.to_bytes, bytes_to_string(args[:data]))
         provided = bytes_to_string(args[:hmac])
@@ -140,7 +140,7 @@ module BSV
       # @option args [String] :counterparty public key hex, 'self', or 'anyone'
       # @param originator [String, nil] FQDN of the originating application
       # @return [Hash] { signature: Array<Integer> } DER-encoded signature as byte array
-      def create_signature(args, _originator: nil)
+      def create_signature(args, originator: nil)
         counterparty = args[:counterparty] || 'self'
         priv_key = @key_deriver.derive_private_key(args[:protocol_id], args[:key_id], counterparty)
 
@@ -170,7 +170,7 @@ module BSV
       # @param originator [String, nil] FQDN of the originating application
       # @return [Hash] { valid: true }
       # @raise [InvalidSignatureError] if the signature does not verify
-      def verify_signature(args, _originator: nil)
+      def verify_signature(args, originator: nil)
         counterparty = args[:counterparty] || 'self'
         for_self = args[:for_self] || false
 
@@ -208,7 +208,7 @@ module BSV
       # @param originator [String, nil] FQDN of the originating application
       # @return [Hash] with :prover, :verifier, :counterparty, :revelation_time,
       #   :encrypted_linkage, :encrypted_linkage_proof
-      def reveal_counterparty_key_linkage(args, _originator: nil)
+      def reveal_counterparty_key_linkage(args, originator: nil)
         counterparty = args[:counterparty]
         verifier = args[:verifier]
 
@@ -270,7 +270,7 @@ module BSV
       # @param originator [String, nil] FQDN of the originating application
       # @return [Hash] with :prover, :verifier, :counterparty, :protocol_id, :key_id,
       #   :encrypted_linkage, :encrypted_linkage_proof, :proof_type
-      def reveal_specific_key_linkage(args, _originator: nil)
+      def reveal_specific_key_linkage(args, originator: nil)
         counterparty = args[:counterparty]
         verifier = args[:verifier]
         protocol_id = args[:protocol_id]

--- a/spec/bsv/identity/client_spec.rb
+++ b/spec/bsv/identity/client_spec.rb
@@ -318,7 +318,8 @@ RSpec.describe 'BSV::Identity::Client' do
     let(:broadcaster) { instance_double(BSV::Overlay::TopicBroadcaster) }
 
     # Minimal BEEF-like stub: just needs to respond to .transactions.last.transaction
-    let(:inner_tx) { instance_double(BSV::Transaction::Transaction, txid_hex: 'deadbeef01') }
+    let(:mock_output) { instance_double(BSV::Transaction::TransactionOutput) }
+    let(:inner_tx) { instance_double(BSV::Transaction::Transaction, txid_hex: 'deadbeef01', outputs: [mock_output]) }
     let(:beef_tx) { instance_double(BSV::Transaction::Beef::BeefTx, transaction: inner_tx) }
     let(:beef_obj) { instance_double(BSV::Transaction::Beef, transactions: [beef_tx]) }
     let(:beef_bytes) { 'fake_beef' }

--- a/spec/bsv/identity/client_spec.rb
+++ b/spec/bsv/identity/client_spec.rb
@@ -1,0 +1,390 @@
+# frozen_string_literal: true
+
+# Constants used across the describe blocks — defined at spec-file scope
+# to avoid Lint/ConstantDefinitionInBlock.
+IDENTITY_CLIENT_SPEC_PUBKEY = "02#{'ab' * 32}"
+IDENTITY_CLIENT_SPEC_CERTIFIER = "03#{'cd' * 32}"
+
+RSpec.describe 'BSV::Identity::Client' do
+  subject(:client) { described_class.new(wallet: wallet) }
+
+  let(:described_class) { BSV::Identity::Client }
+  # Use a plain double — the wallet is duck-typed and Interface is not loaded by default.
+  let(:wallet) { double('wallet') } # rubocop:disable RSpec/VerifiedDoubles
+
+  # Minimal certificate hash as returned by the wallet's discover methods.
+  def raw_cert(
+    type_key: :email_cert,
+    subject: IDENTITY_CLIENT_SPEC_PUBKEY,
+    decrypted_fields: { 'email' => 'alice@example.com' },
+    certifier_info: { name: 'TrustCo', icon_url: 'https://tc.example.com/icon.png' }
+  )
+    {
+      type: BSV::Identity::Constants::KNOWN_IDENTITY_TYPES[type_key],
+      subject: subject,
+      fields: { 'email' => 'encrypted_value' },
+      serial_number: 'AAABBBCCC==',
+      certifier: IDENTITY_CLIENT_SPEC_CERTIFIER,
+      decrypted_fields: decrypted_fields,
+      certifier_info: certifier_info
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Part 1 — Resolution methods
+  # ---------------------------------------------------------------------------
+
+  describe '#resolve_by_identity_key' do
+    context 'with one matching certificate' do
+      before do
+        allow(wallet).to receive(:discover_by_identity_key)
+          .with({ identity_key: IDENTITY_CLIENT_SPEC_PUBKEY }, originator: nil)
+          .and_return({ total_certificates: 1, certificates: [raw_cert] })
+      end
+
+      it 'returns an array of DisplayableIdentity' do
+        results = client.resolve_by_identity_key(identity_key: IDENTITY_CLIENT_SPEC_PUBKEY)
+        expect(results).to all(be_a(BSV::Identity::DisplayableIdentity))
+      end
+
+      it 'parses the email from the certificate' do
+        result = client.resolve_by_identity_key(identity_key: IDENTITY_CLIENT_SPEC_PUBKEY).first
+        expect(result.name).to eq('alice@example.com')
+      end
+
+      it 'sets identity_key from the subject field' do
+        result = client.resolve_by_identity_key(identity_key: IDENTITY_CLIENT_SPEC_PUBKEY).first
+        expect(result.identity_key).to eq(IDENTITY_CLIENT_SPEC_PUBKEY)
+      end
+    end
+
+    context 'with multiple certificates' do
+      let(:email_cert)   { raw_cert(decrypted_fields: { 'email' => 'alice@example.com' }) }
+      let(:x_cert_entry) { raw_cert(type_key: :x_cert, decrypted_fields: { 'userName' => '@alice', 'profilePhoto' => nil }) }
+
+      before do
+        allow(wallet).to receive(:discover_by_identity_key)
+          .with({ identity_key: IDENTITY_CLIENT_SPEC_PUBKEY }, originator: nil)
+          .and_return({ total_certificates: 2, certificates: [email_cert, x_cert_entry] })
+      end
+
+      it 'returns one DisplayableIdentity per certificate' do
+        results = client.resolve_by_identity_key(identity_key: IDENTITY_CLIENT_SPEC_PUBKEY)
+        expect(results.length).to eq(2)
+      end
+    end
+
+    context 'with no results' do
+      before do
+        allow(wallet).to receive(:discover_by_identity_key)
+          .with({ identity_key: IDENTITY_CLIENT_SPEC_PUBKEY }, originator: nil)
+          .and_return({ total_certificates: 0, certificates: [] })
+      end
+
+      it 'returns an empty array' do
+        expect(client.resolve_by_identity_key(identity_key: IDENTITY_CLIENT_SPEC_PUBKEY)).to eq([])
+      end
+    end
+
+    context 'with nil result' do
+      before do
+        allow(wallet).to receive(:discover_by_identity_key)
+          .with({ identity_key: IDENTITY_CLIENT_SPEC_PUBKEY }, originator: nil)
+          .and_return(nil)
+      end
+
+      it 'returns an empty array' do
+        expect(client.resolve_by_identity_key(identity_key: IDENTITY_CLIENT_SPEC_PUBKEY)).to eq([])
+      end
+    end
+
+    context 'with limit and offset' do
+      before do
+        allow(wallet).to receive(:discover_by_identity_key)
+          .with({ identity_key: IDENTITY_CLIENT_SPEC_PUBKEY, limit: 5, offset: 10 }, originator: nil)
+          .and_return({ total_certificates: 0, certificates: [] })
+      end
+
+      it 'passes limit and offset to the wallet' do
+        client.resolve_by_identity_key(identity_key: IDENTITY_CLIENT_SPEC_PUBKEY, limit: 5, offset: 10)
+        expect(wallet).to have_received(:discover_by_identity_key)
+          .with({ identity_key: IDENTITY_CLIENT_SPEC_PUBKEY, limit: 5, offset: 10 }, originator: nil)
+      end
+    end
+
+    context 'with an originator' do
+      subject(:client) { described_class.new(wallet: wallet, originator: 'myapp.example.com') }
+
+      before do
+        allow(wallet).to receive(:discover_by_identity_key)
+          .with({ identity_key: IDENTITY_CLIENT_SPEC_PUBKEY }, originator: 'myapp.example.com')
+          .and_return({ total_certificates: 0, certificates: [] })
+      end
+
+      it 'passes the originator through to the wallet' do
+        client.resolve_by_identity_key(identity_key: IDENTITY_CLIENT_SPEC_PUBKEY)
+        expect(wallet).to have_received(:discover_by_identity_key)
+          .with({ identity_key: IDENTITY_CLIENT_SPEC_PUBKEY }, originator: 'myapp.example.com')
+      end
+    end
+  end
+
+  describe '#resolve_by_attributes' do
+    let(:attributes) { { 'email' => 'alice@example.com' } }
+
+    context 'with one matching certificate' do
+      before do
+        allow(wallet).to receive(:discover_by_attributes)
+          .with({ attributes: attributes }, originator: nil)
+          .and_return({ total_certificates: 1, certificates: [raw_cert] })
+      end
+
+      it 'returns an array of DisplayableIdentity' do
+        results = client.resolve_by_attributes(attributes: attributes)
+        expect(results).to all(be_a(BSV::Identity::DisplayableIdentity))
+      end
+
+      it 'parses the certificate correctly' do
+        result = client.resolve_by_attributes(attributes: attributes).first
+        expect(result.name).to eq('alice@example.com')
+      end
+    end
+
+    context 'with no results' do
+      before do
+        allow(wallet).to receive(:discover_by_attributes)
+          .with({ attributes: attributes }, originator: nil)
+          .and_return({ total_certificates: 0, certificates: [] })
+      end
+
+      it 'returns an empty array' do
+        expect(client.resolve_by_attributes(attributes: attributes)).to eq([])
+      end
+    end
+
+    context 'with nil result' do
+      before do
+        allow(wallet).to receive(:discover_by_attributes)
+          .with({ attributes: attributes }, originator: nil)
+          .and_return(nil)
+      end
+
+      it 'returns an empty array' do
+        expect(client.resolve_by_attributes(attributes: attributes)).to eq([])
+      end
+    end
+
+    context 'with limit and offset' do
+      before do
+        allow(wallet).to receive(:discover_by_attributes)
+          .with({ attributes: attributes, limit: 3, offset: 6 }, originator: nil)
+          .and_return({ total_certificates: 0, certificates: [] })
+      end
+
+      it 'passes limit and offset to the wallet' do
+        client.resolve_by_attributes(attributes: attributes, limit: 3, offset: 6)
+        expect(wallet).to have_received(:discover_by_attributes)
+          .with({ attributes: attributes, limit: 3, offset: 6 }, originator: nil)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Part 2 — publicly_reveal_attributes
+  # ---------------------------------------------------------------------------
+
+  describe '#publicly_reveal_attributes' do
+    subject(:client) do
+      described_class.new(wallet: wallet, broadcaster: broadcaster, certificate_verifier: verifier)
+    end
+
+    let(:verifier) { ->(cert) { cert } } # no-op verifier
+    let(:certificate) do
+      {
+        type: BSV::Identity::Constants::KNOWN_IDENTITY_TYPES[:email_cert],
+        serial_number: 'AAABBBCCC==',
+        subject: IDENTITY_CLIENT_SPEC_PUBKEY,
+        certifier: IDENTITY_CLIENT_SPEC_CERTIFIER,
+        revocation_outpoint: 'abc123.0',
+        fields: { 'email' => 'encrypted' },
+        signature: 'deadbeef'
+      }
+    end
+    let(:keyring) { { 'email' => [1, 2, 3, 4] } }
+    let(:locking_hex) { "76a914#{'ff' * 20}88ac" }
+    let(:mock_script) { instance_double(BSV::Script::Script, to_hex: locking_hex) }
+    let(:mock_template) { instance_double(BSV::Script::PushDropTemplate, lock: mock_script) }
+    let(:beef_bytes) { 'fake_beef_bytes' }
+    let(:broadcaster) { instance_double(BSV::Overlay::TopicBroadcaster) }
+    let(:broadcast_result) do
+      BSV::Overlay::OverlayBroadcastResult.new(status: 'success', txid: 'abc123', message: 'ok')
+    end
+
+    before do
+      allow(BSV::Script::PushDropTemplate).to receive(:new).and_return(mock_template)
+      allow(wallet).to receive_messages(
+        prove_certificate: { keyring_for_verifier: keyring },
+        create_action: { tx: beef_bytes, txid: 'abc123' }
+      )
+      allow(BSV::Transaction::Transaction).to receive(:from_beef)
+        .and_return(instance_double(BSV::Transaction::Transaction, txid_hex: 'abc123'))
+      allow(broadcaster).to receive(:broadcast).and_return(broadcast_result)
+    end
+
+    it 'returns an OverlayBroadcastResult' do
+      result = client.publicly_reveal_attributes(certificate, fields_to_reveal: ['email'])
+      expect(result).to be_a(BSV::Overlay::OverlayBroadcastResult)
+    end
+
+    it 'calls prove_certificate with the anyone verifier key' do
+      client.publicly_reveal_attributes(certificate, fields_to_reveal: ['email'])
+      expect(wallet).to have_received(:prove_certificate).with(
+        { certificate: certificate, fields_to_reveal: ['email'],
+          verifier: BSV::Script::PushDropTemplate::GENERATOR_PUBKEY_HEX },
+        originator: nil
+      )
+    end
+
+    it 'broadcasts to the tm_identity topic' do
+      client.publicly_reveal_attributes(certificate, fields_to_reveal: ['email'])
+      expect(broadcaster).to have_received(:broadcast)
+    end
+
+    context 'when certificate has no fields' do
+      let(:certificate) { { fields: {}, type: 'x', serial_number: 'y', subject: IDENTITY_CLIENT_SPEC_PUBKEY } }
+
+      it 'raises ArgumentError' do
+        expect do
+          client.publicly_reveal_attributes(certificate, fields_to_reveal: ['email'])
+        end.to raise_error(ArgumentError, /no fields to reveal/)
+      end
+    end
+
+    context 'when fields_to_reveal is empty' do
+      it 'raises ArgumentError' do
+        expect do
+          client.publicly_reveal_attributes(certificate, fields_to_reveal: [])
+        end.to raise_error(ArgumentError, /at least one field/)
+      end
+    end
+
+    context 'when certificate verification fails' do
+      let(:verifier) { ->(_cert) { raise 'Invalid signature' } }
+
+      it 'raises with a descriptive message' do
+        expect do
+          client.publicly_reveal_attributes(certificate, fields_to_reveal: ['email'])
+        end.to raise_error(RuntimeError, /verification failed/)
+      end
+    end
+
+    context 'when using the default verifier' do
+      subject(:client) do
+        described_class.new(wallet: wallet, broadcaster: broadcaster)
+      end
+
+      it 'raises NotImplementedError' do
+        expect do
+          client.publicly_reveal_attributes(certificate, fields_to_reveal: ['email'])
+        end.to raise_error(NotImplementedError, /BSV::Auth::Certificate/)
+      end
+    end
+
+    context 'when create_action returns no tx' do
+      before do
+        allow(wallet).to receive(:create_action).and_return({ txid: nil, tx: nil })
+      end
+
+      it 'raises a RuntimeError' do
+        expect do
+          client.publicly_reveal_attributes(certificate, fields_to_reveal: ['email'])
+        end.to raise_error(RuntimeError, /failed to create action/)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Part 2 — revoke_certificate_revelation
+  # ---------------------------------------------------------------------------
+
+  describe '#revoke_certificate_revelation' do
+    subject(:client) do
+      described_class.new(wallet: wallet, broadcaster: broadcaster, resolver: resolver,
+                          certificate_verifier: ->(c) { c })
+    end
+
+    let(:serial_number) { 'AAABBBCCC==' }
+    let(:resolver) { instance_double(BSV::Overlay::LookupResolver) }
+    let(:broadcaster) { instance_double(BSV::Overlay::TopicBroadcaster) }
+
+    # Minimal BEEF-like stub: just needs to respond to .transactions.last.transaction
+    let(:inner_tx) { instance_double(BSV::Transaction::Transaction, txid_hex: 'deadbeef01') }
+    let(:beef_tx) { instance_double(BSV::Transaction::Beef::BeefTx, transaction: inner_tx) }
+    let(:beef_obj) { instance_double(BSV::Transaction::Beef, transactions: [beef_tx]) }
+    let(:beef_bytes) { 'fake_beef' }
+
+    let(:output) { { 'beef' => beef_bytes, 'outputIndex' => 0 } }
+    let(:answer) { BSV::Overlay::LookupAnswer.new(type: 'output-list', outputs: [output]) }
+
+    let(:partial_tx) { instance_double(BSV::Transaction::Transaction) }
+    let(:signed_tx) { instance_double(BSV::Transaction::Transaction) }
+    let(:mock_script) { instance_double(BSV::Script::Script, to_hex: '00' * 107) }
+    let(:mock_unlocker) { instance_double(BSV::Script::PushDropTemplate::Unlocker, sign: mock_script) }
+    let(:mock_template) { instance_double(BSV::Script::PushDropTemplate, unlock: mock_unlocker) }
+    let(:broadcast_result) do
+      BSV::Overlay::OverlayBroadcastResult.new(status: 'success', txid: 'deadbeef01', message: 'ok')
+    end
+
+    before do
+      allow(resolver).to receive(:query).and_return(answer)
+      allow(BSV::Transaction::Beef).to receive(:from_binary).and_return(beef_obj)
+      allow(BSV::Script::PushDropTemplate).to receive(:new).and_return(mock_template)
+
+      allow(wallet).to receive(:create_action) do |args, **_opts|
+        if args[:inputs]
+          { signable_transaction: { tx: beef_bytes, reference: 'REF123' } }
+        else
+          { tx: beef_bytes, txid: 'deadbeef01' }
+        end
+      end
+
+      allow(BSV::Transaction::Transaction).to receive(:from_beef).with(beef_bytes).and_return(partial_tx)
+      allow(wallet).to receive(:sign_action).and_return({ tx: 'signed_beef', txid: 'deadbeef01' })
+      allow(BSV::Transaction::Transaction).to receive(:from_beef).with('signed_beef').and_return(signed_tx)
+      allow(broadcaster).to receive(:broadcast).and_return(broadcast_result)
+    end
+
+    it 'queries the resolver for the serial number' do
+      client.revoke_certificate_revelation(serial_number)
+      expect(resolver).to have_received(:query) do |question|
+        expect(question.service).to eq('ls_identity')
+        expect(question.query[:serial_number]).to eq(serial_number)
+      end
+    end
+
+    it 'broadcasts the spending transaction' do
+      client.revoke_certificate_revelation(serial_number)
+      expect(broadcaster).to have_received(:broadcast)
+    end
+
+    context 'when no outputs are found' do
+      let(:answer) { BSV::Overlay::LookupAnswer.new(type: 'output-list', outputs: []) }
+
+      it 'raises a RuntimeError' do
+        expect do
+          client.revoke_certificate_revelation(serial_number)
+        end.to raise_error(RuntimeError, /no outputs found/)
+      end
+    end
+
+    context 'when the lookup returns a non-output-list type' do
+      let(:answer) { BSV::Overlay::LookupAnswer.new(type: 'freeform', outputs: []) }
+
+      it 'raises a RuntimeError' do
+        expect do
+          client.revoke_certificate_revelation(serial_number)
+        end.to raise_error(RuntimeError, /could not find revelation output/)
+      end
+    end
+  end
+end

--- a/spec/bsv/identity/constants_spec.rb
+++ b/spec/bsv/identity/constants_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+RSpec.describe BSV::Identity::Constants do
+  subject(:constants) { described_class }
+
+  describe 'TOPIC' do
+    it 'identifies the identity overlay topic' do
+      expect(constants::TOPIC).to eq('tm_identity')
+    end
+  end
+
+  describe 'SERVICE' do
+    it 'identifies the identity lookup service' do
+      expect(constants::SERVICE).to eq('ls_identity')
+    end
+  end
+
+  describe 'KNOWN_IDENTITY_TYPES' do
+    subject(:types) { constants::KNOWN_IDENTITY_TYPES }
+
+    it 'contains all 9 recognised certificate types' do
+      expect(types.size).to eq(9)
+    end
+
+    it 'is frozen' do
+      expect(types).to be_frozen
+    end
+
+    it 'includes x_cert with correct Base64 type ID' do
+      expect(types[:x_cert]).to eq('vdDWvftf1H+5+ZprUw123kjHlywH+v20aPQTuXgMpNc=')
+    end
+
+    it 'includes discord_cert with correct Base64 type ID' do
+      expect(types[:discord_cert]).to eq('2TgqRC35B1zehGmB21xveZNc7i5iqHc0uxMb+1NMPW4=')
+    end
+
+    it 'includes phone_cert with correct Base64 type ID' do
+      expect(types[:phone_cert]).to eq('mffUklUzxbHr65xLohn0hRL0Tq2GjW1GYF/OPfzqJ6A=')
+    end
+
+    it 'includes email_cert with correct Base64 type ID' do
+      expect(types[:email_cert]).to eq('exOl3KM0dIJ04EW5pZgbZmPag6MdJXd3/a1enmUU/BA=')
+    end
+
+    it 'includes identi_cert with correct Base64 type ID' do
+      expect(types[:identi_cert]).to eq('z40BOInXkI8m7f/wBrv4MJ09bZfzZbTj2fJqCtONqCY=')
+    end
+
+    it 'includes registrant with correct Base64 type ID' do
+      expect(types[:registrant]).to eq('YoPsbfR6YQczjzPdHCoGC7nJsOdPQR50+SYqcWpJ0y0=')
+    end
+
+    it 'includes cool_cert with correct Base64 type ID' do
+      expect(types[:cool_cert]).to eq('AGfk/WrT1eBDXpz3mcw386Zww2HmqcIn3uY6x4Af1eo=')
+    end
+
+    it 'includes anyone with correct Base64 type ID' do
+      expect(types[:anyone]).to eq('mfkOMfLDQmrr3SBxBQ5WeE+6Hy3VJRFq6w4A5Ljtlis=')
+    end
+
+    it 'includes self with correct Base64 type ID' do
+      expect(types[:self]).to eq('Hkge6X5JRxt1cWXtHLCrSTg6dCVTxjQJJ48iOYd7n3g=')
+    end
+
+    it 'values decode to 32 bytes each' do
+      require 'base64'
+      types.each_value do |b64|
+        expect(Base64.decode64(b64).bytesize).to eq(32)
+      end
+    end
+  end
+
+  describe 'DEFAULT_IDENTITY' do
+    subject(:default_id) { constants::DEFAULT_IDENTITY }
+
+    it 'is a DisplayableIdentity' do
+      expect(default_id).to be_a(BSV::Identity::DisplayableIdentity)
+    end
+
+    it 'is frozen' do
+      expect(default_id).to be_frozen
+    end
+
+    it 'has fallback name' do
+      expect(default_id.name).to eq('Unknown Identity')
+    end
+
+    it 'has a default avatar URL' do
+      expect(default_id.avatar_url).to eq('XUUB8bbn9fEthk15Ge3zTQXypUShfC94vFjp65v7u5CQ8qkpxzst')
+    end
+
+    it 'has empty abbreviated_key' do
+      expect(default_id.abbreviated_key).to eq('')
+    end
+
+    it 'has empty identity_key' do
+      expect(default_id.identity_key).to eq('')
+    end
+
+    it 'has a default badge icon URL' do
+      expect(default_id.badge_icon_url).to eq('XUUV39HVPkpmMzYNTx7rpKzJvXfeiVyQWg2vfSpjBAuhunTCA9uG')
+    end
+
+    it 'has a default badge label indicating unverified status' do
+      expect(default_id.badge_label).to eq('Not verified by anyone you trust.')
+    end
+
+    it 'has a default badge click URL pointing to documentation' do
+      expect(default_id.badge_click_url).to eq('https://projectbabbage.com/docs/unknown-identity')
+    end
+  end
+
+  describe 'BSV::Identity::ClientOptions::DEFAULT' do
+    subject(:default_opts) { BSV::Identity::ClientOptions::DEFAULT }
+
+    it 'is a ClientOptions instance' do
+      expect(default_opts).to be_a(BSV::Identity::ClientOptions)
+    end
+
+    it 'is frozen' do
+      expect(default_opts).to be_frozen
+    end
+
+    it 'uses identity protocol with security level 1' do
+      expect(default_opts.protocol_id).to eq([1, 'identity'])
+    end
+
+    it 'uses key ID 1' do
+      expect(default_opts.key_id).to eq('1')
+    end
+
+    it 'uses token amount of 1 satoshi' do
+      expect(default_opts.token_amount).to eq(1)
+    end
+
+    it 'uses output index 0' do
+      expect(default_opts.output_index).to eq(0)
+    end
+  end
+
+  describe 'autoload' do
+    it 'is accessible via BSV::Identity::Constants' do
+      expect(described_class).to be_a(Module)
+    end
+
+    it 'loads DisplayableIdentity via BSV::Identity' do
+      expect(BSV::Identity::DisplayableIdentity).to be_a(Class)
+    end
+
+    it 'loads ClientOptions via BSV::Identity' do
+      expect(BSV::Identity::ClientOptions).to be_a(Class)
+    end
+  end
+end

--- a/spec/bsv/identity/identity_parser_spec.rb
+++ b/spec/bsv/identity/identity_parser_spec.rb
@@ -1,0 +1,439 @@
+# frozen_string_literal: true
+
+RSpec.describe 'BSV::Identity::IdentityParser' do
+  subject(:parser) { BSV::Identity::IdentityParser }
+
+  let(:default_identity) { BSV::Identity::Constants::DEFAULT_IDENTITY }
+  let(:types)            { BSV::Identity::Constants::KNOWN_IDENTITY_TYPES }
+  let(:certifier) do
+    BSV::Identity::CertifierInfo.new(name: 'TrustCo', icon_url: 'https://example.com/icon.png')
+  end
+
+  # Builds an IdentityCertificate for a well-known type key.
+  def cert_for(type_key, fields, certifier_info: nil)
+    BSV::Identity::IdentityCertificate.new(
+      certificate: { type: BSV::Identity::Constants::KNOWN_IDENTITY_TYPES[type_key],
+                     subject: 'abcdefghij1234567890' },
+      decrypted_fields: fields,
+      certifier_info: certifier_info
+    )
+  end
+
+  # Builds an IdentityCertificate for an arbitrary type Base64 string.
+  def cert_with_type(type_b64, fields, certifier_info: nil, subject: 'abcdefghij1234567890')
+    BSV::Identity::IdentityCertificate.new(
+      certificate: { type: type_b64, subject: subject },
+      decrypted_fields: fields,
+      certifier_info: certifier_info
+    )
+  end
+
+  # ---------------------------------------------------------------------------
+  # Known identity types
+  # ---------------------------------------------------------------------------
+
+  describe 'xCert' do
+    subject(:result) do
+      parser.parse(cert_for(:x_cert, { 'userName' => '@alice', 'profilePhoto' => 'xphoto' },
+                            certifier_info: certifier))
+    end
+
+    it 'extracts name from userName' do
+      expect(result.name).to eq('@alice')
+    end
+
+    it 'extracts avatar from profilePhoto' do
+      expect(result.avatar_url).to eq('xphoto')
+    end
+
+    it 'includes certifier name in badge label' do
+      expect(result.badge_label).to eq('X account certified by TrustCo')
+    end
+
+    it 'uses certifier icon_url as badge icon' do
+      expect(result.badge_icon_url).to eq('https://example.com/icon.png')
+    end
+
+    it 'sets badge click URL to socialcert.net' do
+      expect(result.badge_click_url).to eq('https://socialcert.net')
+    end
+  end
+
+  describe 'discordCert' do
+    subject(:result) do
+      parser.parse(cert_for(:discord_cert, { 'userName' => 'bob#1234', 'profilePhoto' => 'dphoto' },
+                            certifier_info: certifier))
+    end
+
+    it 'extracts name from userName' do
+      expect(result.name).to eq('bob#1234')
+    end
+
+    it 'extracts avatar from profilePhoto' do
+      expect(result.avatar_url).to eq('dphoto')
+    end
+
+    it 'includes certifier name in badge label' do
+      expect(result.badge_label).to eq('Discord account certified by TrustCo')
+    end
+
+    it 'sets badge click URL to socialcert.net' do
+      expect(result.badge_click_url).to eq('https://socialcert.net')
+    end
+  end
+
+  describe 'emailCert' do
+    subject(:result) do
+      parser.parse(cert_for(:email_cert, { 'email' => 'alice@example.com' }, certifier_info: certifier))
+    end
+
+    it 'extracts name from email field' do
+      expect(result.name).to eq('alice@example.com')
+    end
+
+    it 'uses the fixed email avatar opaque string' do
+      expect(result.avatar_url).to eq(BSV::Identity::IdentityParser::EMAIL_AVATAR)
+    end
+
+    it 'includes certifier name in badge label' do
+      expect(result.badge_label).to eq('Email certified by TrustCo')
+    end
+
+    it 'sets badge click URL to socialcert.net' do
+      expect(result.badge_click_url).to eq('https://socialcert.net')
+    end
+  end
+
+  describe 'phoneCert' do
+    subject(:result) do
+      parser.parse(cert_for(:phone_cert, { 'phoneNumber' => '+447700900123' }, certifier_info: certifier))
+    end
+
+    it 'extracts name from phoneNumber field' do
+      expect(result.name).to eq('+447700900123')
+    end
+
+    it 'uses the fixed phone avatar opaque string' do
+      expect(result.avatar_url).to eq(BSV::Identity::IdentityParser::PHONE_AVATAR)
+    end
+
+    it 'includes certifier name in badge label' do
+      expect(result.badge_label).to eq('Phone certified by TrustCo')
+    end
+
+    it 'sets badge click URL to socialcert.net' do
+      expect(result.badge_click_url).to eq('https://socialcert.net')
+    end
+  end
+
+  describe 'identiCert' do
+    subject(:result) do
+      parser.parse(cert_for(:identi_cert,
+                            { 'firstName' => 'Jane', 'lastName' => 'Smith', 'profilePhoto' => 'iphoto' },
+                            certifier_info: certifier))
+    end
+
+    it 'combines firstName and lastName for name' do
+      expect(result.name).to eq('Jane Smith')
+    end
+
+    it 'extracts avatar from profilePhoto' do
+      expect(result.avatar_url).to eq('iphoto')
+    end
+
+    it 'includes certifier name in badge label' do
+      expect(result.badge_label).to eq('Government ID certified by TrustCo')
+    end
+
+    it 'sets badge click URL to identicert.me' do
+      expect(result.badge_click_url).to eq('https://identicert.me')
+    end
+  end
+
+  describe 'registrant' do
+    subject(:result) do
+      parser.parse(cert_for(:registrant, { 'name' => 'Acme Corp', 'icon' => 'acme_icon' },
+                            certifier_info: certifier))
+    end
+
+    it 'extracts name from name field' do
+      expect(result.name).to eq('Acme Corp')
+    end
+
+    it 'extracts avatar from icon field' do
+      expect(result.avatar_url).to eq('acme_icon')
+    end
+
+    it 'includes certifier name in badge label' do
+      expect(result.badge_label).to eq('Entity certified by TrustCo')
+    end
+
+    it 'sets badge click URL to projectbabbage.com/docs/registrant' do
+      expect(result.badge_click_url).to eq('https://projectbabbage.com/docs/registrant')
+    end
+  end
+
+  describe 'coolCert' do
+    it 'returns Cool Person! when cool field is the string true' do
+      result = parser.parse(cert_for(:cool_cert, { 'cool' => 'true' }))
+      expect(result.name).to eq('Cool Person!')
+    end
+
+    it 'returns Not cool! when cool field is anything other than true' do
+      result = parser.parse(cert_for(:cool_cert, { 'cool' => 'false' }))
+      expect(result.name).to eq('Not cool!')
+    end
+
+    it 'returns Not cool! when cool field is absent' do
+      result = parser.parse(cert_for(:cool_cert, {}))
+      expect(result.name).to eq('Not cool!')
+    end
+
+    it 'sets no badge label' do
+      result = parser.parse(cert_for(:cool_cert, { 'cool' => 'true' }))
+      expect(result.badge_label).to be_nil
+    end
+  end
+
+  describe 'anyone' do
+    subject(:result) { parser.parse(cert_for(:anyone, {})) }
+
+    it 'returns the name Anyone' do
+      expect(result.name).to eq('Anyone')
+    end
+
+    it 'uses the anyone avatar opaque string' do
+      expect(result.avatar_url).to eq(BSV::Identity::IdentityParser::ANYONE_AVATAR)
+    end
+
+    it 'sets the badge label' do
+      expect(result.badge_label).to eq('Represents the ability for anyone to access this information.')
+    end
+
+    it 'uses the shared badge icon' do
+      expect(result.badge_icon_url).to eq(BSV::Identity::IdentityParser::BADGE_ICON)
+    end
+
+    it 'sets badge click URL' do
+      expect(result.badge_click_url).to eq('https://projectbabbage.com/docs/anyone-identity')
+    end
+  end
+
+  describe 'self' do
+    subject(:result) { parser.parse(cert_for(:self, {})) }
+
+    it 'returns the name You' do
+      expect(result.name).to eq('You')
+    end
+
+    it 'uses the self avatar opaque string' do
+      expect(result.avatar_url).to eq(BSV::Identity::IdentityParser::SELF_AVATAR)
+    end
+
+    it 'sets the badge label' do
+      expect(result.badge_label).to eq('Represents your ability to access this information.')
+    end
+
+    it 'uses the shared badge icon' do
+      expect(result.badge_icon_url).to eq(BSV::Identity::IdentityParser::BADGE_ICON)
+    end
+
+    it 'sets badge click URL' do
+      expect(result.badge_click_url).to eq('https://projectbabbage.com/docs/self-identity')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Unknown type — generic fallback: name resolution chain
+  # ---------------------------------------------------------------------------
+
+  describe 'generic fallback — name resolution' do
+    let(:unknown_type) { 'dW5rbm93blR5cGU=' }
+
+    it 'uses name field when present' do
+      result = parser.parse(cert_with_type(unknown_type, { 'name' => 'Direct Name' }))
+      expect(result.name).to eq('Direct Name')
+    end
+
+    it 'falls back to userName when name is absent' do
+      result = parser.parse(cert_with_type(unknown_type, { 'userName' => 'username_fallback' }))
+      expect(result.name).to eq('username_fallback')
+    end
+
+    it 'falls back to firstName + lastName when userName is absent' do
+      result = parser.parse(cert_with_type(unknown_type, { 'firstName' => 'John', 'lastName' => 'Doe' }))
+      expect(result.name).to eq('John Doe')
+    end
+
+    it 'uses only firstName when lastName is absent' do
+      result = parser.parse(cert_with_type(unknown_type, { 'firstName' => 'JustFirst' }))
+      expect(result.name).to eq('JustFirst')
+    end
+
+    it 'uses only lastName when firstName is absent' do
+      result = parser.parse(cert_with_type(unknown_type, { 'lastName' => 'JustLast' }))
+      expect(result.name).to eq('JustLast')
+    end
+
+    it 'falls back to email when no name fields are present' do
+      result = parser.parse(cert_with_type(unknown_type, { 'email' => 'test@example.com' }))
+      expect(result.name).to eq('test@example.com')
+    end
+
+    it 'falls back to default identity name when no recognisable fields are present' do
+      result = parser.parse(cert_with_type(unknown_type, {}))
+      expect(result.name).to eq(default_identity.name)
+    end
+
+    it 'prefers name over userName' do
+      result = parser.parse(cert_with_type(unknown_type, { 'name' => 'Full Name', 'userName' => 'handle' }))
+      expect(result.name).to eq('Full Name')
+    end
+
+    it 'prefers userName over firstName+lastName' do
+      result = parser.parse(cert_with_type(unknown_type,
+                                           { 'userName' => 'handle', 'firstName' => 'John', 'lastName' => 'Doe' }))
+      expect(result.name).to eq('handle')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Unknown type — generic fallback: avatar resolution chain
+  # ---------------------------------------------------------------------------
+
+  describe 'generic fallback — avatar resolution' do
+    let(:unknown_type) { 'dW5rbm93blR5cGU=' }
+
+    it 'uses profilePhoto as avatar when present' do
+      result = parser.parse(cert_with_type(unknown_type, { 'profilePhoto' => 'pp_url' }))
+      expect(result.avatar_url).to eq('pp_url')
+    end
+
+    it 'falls back to avatar field' do
+      result = parser.parse(cert_with_type(unknown_type, { 'avatar' => 'av_url' }))
+      expect(result.avatar_url).to eq('av_url')
+    end
+
+    it 'falls back to icon field' do
+      result = parser.parse(cert_with_type(unknown_type, { 'icon' => 'ic_url' }))
+      expect(result.avatar_url).to eq('ic_url')
+    end
+
+    it 'falls back to photo field' do
+      result = parser.parse(cert_with_type(unknown_type, { 'photo' => 'ph_url' }))
+      expect(result.avatar_url).to eq('ph_url')
+    end
+
+    it 'uses default avatar when no photo fields are present' do
+      result = parser.parse(cert_with_type(unknown_type, {}))
+      expect(result.avatar_url).to eq(default_identity.avatar_url)
+    end
+
+    it 'prefers profilePhoto over avatar' do
+      result = parser.parse(cert_with_type(unknown_type, { 'profilePhoto' => 'pp', 'avatar' => 'av' }))
+      expect(result.avatar_url).to eq('pp')
+    end
+
+    it 'prefers avatar over icon' do
+      result = parser.parse(cert_with_type(unknown_type, { 'avatar' => 'av', 'icon' => 'ic' }))
+      expect(result.avatar_url).to eq('av')
+    end
+
+    it 'prefers icon over photo' do
+      result = parser.parse(cert_with_type(unknown_type, { 'icon' => 'ic', 'photo' => 'ph' }))
+      expect(result.avatar_url).to eq('ic')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Badge from certifier_info
+  # ---------------------------------------------------------------------------
+
+  describe 'badge generation' do
+    let(:unknown_type) { 'dW5rbm93blR5cGU=' }
+
+    it 'sets badge_label from certifier name for unknown type' do
+      result = parser.parse(cert_with_type(unknown_type, {}, certifier_info: certifier))
+      expect(result.badge_label).to eq("#{unknown_type} certified by TrustCo")
+    end
+
+    it 'sets badge_icon_url from certifier icon_url' do
+      result = parser.parse(cert_with_type(unknown_type, {}, certifier_info: certifier))
+      expect(result.badge_icon_url).to eq('https://example.com/icon.png')
+    end
+
+    it 'falls back to default badge_label when certifier_info is nil' do
+      result = parser.parse(cert_with_type(unknown_type, {}))
+      expect(result.badge_label).to eq(default_identity.badge_label)
+    end
+
+    it 'falls back to default badge_icon_url when certifier_info is nil' do
+      result = parser.parse(cert_with_type(unknown_type, {}))
+      expect(result.badge_icon_url).to eq(default_identity.badge_icon_url)
+    end
+
+    it 'falls back to default badge_label when certifier name is empty string' do
+      info   = BSV::Identity::CertifierInfo.new(name: '')
+      result = parser.parse(cert_with_type(unknown_type, {}, certifier_info: info))
+      expect(result.badge_label).to eq(default_identity.badge_label)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Abbreviated key
+  # ---------------------------------------------------------------------------
+
+  describe 'abbreviated_key' do
+    it 'abbreviates subjects of 10 or more characters' do
+      cert = cert_with_type(types[:anyone], {}, subject: 'abcdefghij1234567890')
+      expect(parser.parse(cert).abbreviated_key).to eq('abcdefghij...')
+    end
+
+    it 'does not truncate subjects shorter than 10 characters' do
+      cert = cert_with_type(types[:anyone], {}, subject: 'abc')
+      expect(parser.parse(cert).abbreviated_key).to eq('abc')
+    end
+
+    it 'returns empty string when subject is empty' do
+      cert = cert_with_type(types[:anyone], {}, subject: '')
+      expect(parser.parse(cert).abbreviated_key).to eq('')
+    end
+
+    it 'returns empty string when subject is nil' do
+      cert = cert_with_type(types[:anyone], {}, subject: nil)
+      expect(parser.parse(cert).abbreviated_key).to eq('')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Empty string fields treated as absent
+  # ---------------------------------------------------------------------------
+
+  describe 'empty string fields treated as absent' do
+    let(:unknown_type) { 'dW5rbm93blR5cGU=' }
+
+    it 'skips empty name field and tries userName' do
+      cert = cert_with_type(unknown_type, { 'name' => '', 'userName' => 'user_handle' })
+      expect(parser.parse(cert).name).to eq('user_handle')
+    end
+
+    it 'skips empty userName and tries firstName+lastName' do
+      cert = cert_with_type(unknown_type, { 'userName' => '', 'firstName' => 'Jo', 'lastName' => 'Bloggs' })
+      expect(parser.parse(cert).name).to eq('Jo Bloggs')
+    end
+
+    it 'skips empty profilePhoto and falls back to avatar' do
+      cert = cert_with_type(unknown_type, { 'profilePhoto' => '', 'avatar' => 'av_url' })
+      expect(parser.parse(cert).avatar_url).to eq('av_url')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # identity_key is set from certificate subject
+  # ---------------------------------------------------------------------------
+
+  it 'sets identity_key to the certificate subject' do
+    cert = cert_with_type(types[:anyone], {}, subject: 'mysubjectkey')
+    expect(parser.parse(cert).identity_key).to eq('mysubjectkey')
+  end
+end

--- a/spec/bsv/identity/types_spec.rb
+++ b/spec/bsv/identity/types_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'BSV::Identity types' do
+  describe BSV::Identity::DisplayableIdentity do
+    subject(:identity) do
+      described_class.new(
+        name: 'Alice',
+        avatar_url: 'https://example.com/avatar.png',
+        abbreviated_key: 'abc...xyz',
+        identity_key: 'abcdef1234567890'
+      )
+    end
+
+    it 'exposes name' do
+      expect(identity.name).to eq('Alice')
+    end
+
+    it 'exposes avatar_url' do
+      expect(identity.avatar_url).to eq('https://example.com/avatar.png')
+    end
+
+    it 'exposes abbreviated_key' do
+      expect(identity.abbreviated_key).to eq('abc...xyz')
+    end
+
+    it 'exposes identity_key' do
+      expect(identity.identity_key).to eq('abcdef1234567890')
+    end
+
+    it 'defaults badge_icon_url to nil' do
+      expect(identity.badge_icon_url).to be_nil
+    end
+
+    it 'defaults badge_label to nil' do
+      expect(identity.badge_label).to be_nil
+    end
+
+    it 'defaults badge_click_url to nil' do
+      expect(identity.badge_click_url).to be_nil
+    end
+
+    it 'accepts optional badge fields' do
+      instance = described_class.new(
+        name: 'Bob',
+        avatar_url: 'https://example.com/bob.png',
+        abbreviated_key: 'bbb...bbb',
+        identity_key: 'bbbbb',
+        badge_icon_url: 'https://example.com/badge.png',
+        badge_label: 'Verified',
+        badge_click_url: 'https://example.com/verify'
+      )
+      expect(instance.badge_icon_url).to eq('https://example.com/badge.png')
+      expect(instance.badge_label).to eq('Verified')
+      expect(instance.badge_click_url).to eq('https://example.com/verify')
+    end
+  end
+
+  describe BSV::Identity::CertifierInfo do
+    it 'exposes name' do
+      instance = described_class.new(name: 'Trust Authority')
+      expect(instance.name).to eq('Trust Authority')
+    end
+
+    it 'defaults icon_url to nil' do
+      instance = described_class.new(name: 'Trust Authority')
+      expect(instance.icon_url).to be_nil
+    end
+
+    it 'accepts icon_url when provided' do
+      instance = described_class.new(name: 'Trust Authority', icon_url: 'https://example.com/icon.png')
+      expect(instance.icon_url).to eq('https://example.com/icon.png')
+    end
+  end
+
+  describe BSV::Identity::IdentityCertificate do
+    subject(:cert) { described_class.new(certificate: cert_data, decrypted_fields: field_data) }
+
+    let(:cert_data)   { { type: 'xCert', subject: 'abc123', fields: {} } }
+    let(:field_data)  { { 'handle' => '@alice' } }
+
+    it 'exposes certificate' do
+      expect(cert.certificate).to eq(cert_data)
+    end
+
+    it 'exposes decrypted_fields' do
+      expect(cert.decrypted_fields).to eq(field_data)
+    end
+
+    it 'defaults certifier_info to nil' do
+      expect(cert.certifier_info).to be_nil
+    end
+
+    it 'accepts certifier_info when provided' do
+      info     = BSV::Identity::CertifierInfo.new(name: 'Trust Authority')
+      instance = described_class.new(
+        certificate: cert_data,
+        decrypted_fields: field_data,
+        certifier_info: info
+      )
+      expect(instance.certifier_info).to be_a(BSV::Identity::CertifierInfo)
+      expect(instance.certifier_info.name).to eq('Trust Authority')
+    end
+  end
+
+  describe BSV::Identity::ClientOptions do
+    subject(:opts) do
+      described_class.new(
+        protocol_id: [1, 'identity'],
+        key_id: '1',
+        token_amount: 1,
+        output_index: 0
+      )
+    end
+
+    it 'exposes protocol_id' do
+      expect(opts.protocol_id).to eq([1, 'identity'])
+    end
+
+    it 'exposes key_id' do
+      expect(opts.key_id).to eq('1')
+    end
+
+    it 'exposes token_amount' do
+      expect(opts.token_amount).to eq(1)
+    end
+
+    it 'exposes output_index' do
+      expect(opts.output_index).to eq(0)
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/bsv/script/push_drop_template_spec.rb
+++ b/spec/bsv/script/push_drop_template_spec.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+require 'bsv-sdk'
+require 'bsv-wallet'
+
+RSpec.describe 'BSV::Script::PushDropTemplate' do
+  let(:private_key) { BSV::Primitives::PrivateKey.new(OpenSSL::BN.new(42)) }
+  let(:wallet)      { BSV::Wallet::ProtoWallet.new(private_key) }
+  let(:template)    { BSV::Script::PushDropTemplate.new(wallet: wallet) }
+
+  let(:protocol_id)  { [1, 'push drop test'] }
+  let(:key_id)       { '1' }
+  let(:counterparty) { 'self' }
+  let(:fields)       { ['hello'.b, 'world'.b] }
+
+  describe '#lock' do
+    it 'returns a PushDrop script' do
+      script = template.lock(
+        fields: fields,
+        protocol_id: protocol_id,
+        key_id: key_id,
+        counterparty: counterparty
+      )
+      expect(script).to be_a(BSV::Script::Script)
+      expect(script.pushdrop?).to be true
+    end
+
+    it 'appends a signature field when include_signature is true (default)' do
+      script = template.lock(
+        fields: fields,
+        protocol_id: protocol_id,
+        key_id: key_id,
+        counterparty: counterparty,
+        include_signature: true
+      )
+      extracted = script.pushdrop_fields
+      # Original 2 fields + 1 signature field
+      expect(extracted.length).to eq(3)
+    end
+
+    it 'does not append a signature field when include_signature is false' do
+      script = template.lock(
+        fields: fields,
+        protocol_id: protocol_id,
+        key_id: key_id,
+        counterparty: counterparty,
+        include_signature: false
+      )
+      extracted = script.pushdrop_fields
+      expect(extracted.length).to eq(2)
+    end
+
+    it 'preserves the original field data in order' do
+      script = template.lock(
+        fields: fields,
+        protocol_id: protocol_id,
+        key_id: key_id,
+        counterparty: counterparty,
+        include_signature: false
+      )
+      extracted = script.pushdrop_fields
+      expect(extracted[0]).to eq('hello'.b)
+      expect(extracted[1]).to eq('world'.b)
+    end
+
+    it 'raises ArgumentError when fields is empty' do
+      expect do
+        template.lock(
+          fields: [],
+          protocol_id: protocol_id,
+          key_id: key_id,
+          counterparty: counterparty
+        )
+      end.to raise_error(ArgumentError, /fields must not be empty/)
+    end
+
+    context 'when counterparty is "anyone"' do
+      it 'uses the generator point as the locking public key' do
+        script = template.lock(
+          fields: fields,
+          protocol_id: protocol_id,
+          key_id: key_id,
+          counterparty: 'anyone',
+          include_signature: false
+        )
+
+        # The underlying lock script is P2PKH; extract the pubkey hash from it
+        lock_part = script.pushdrop_lock_script
+        expect(lock_part.p2pkh?).to be true
+
+        # The hash160 of the generator point G should be the embedded pubkey hash
+        generator_bytes = [BSV::Script::PushDropTemplate::GENERATOR_PUBKEY_HEX].pack('H*')
+        expected_hash = BSV::Primitives::Digest.hash160(generator_bytes)
+
+        # Extract pubkey hash from P2PKH script: bytes 3..22 (after OP_DUP OP_HASH160 0x14)
+        lock_bytes = lock_part.bytes
+        embedded_hash = lock_bytes[3, 20]
+        expect(embedded_hash).to eq(expected_hash)
+      end
+
+      it 'GENERATOR_PUBKEY_HEX matches PrivateKey(1).public_key' do
+        gen_key = BSV::Primitives::PrivateKey.new(OpenSSL::BN.new(1))
+        expect(BSV::Script::PushDropTemplate::GENERATOR_PUBKEY_HEX)
+          .to eq(gen_key.public_key.to_hex)
+      end
+    end
+
+    context 'when originator is set' do
+      let(:template_with_originator) do
+        BSV::Script::PushDropTemplate.new(wallet: wallet, originator: 'example.com')
+      end
+
+      it 'passes originator through to wallet calls' do
+        # Verify that originator does not break normal operation
+        script = template_with_originator.lock(
+          fields: fields,
+          protocol_id: protocol_id,
+          key_id: key_id,
+          counterparty: counterparty
+        )
+        expect(script.pushdrop?).to be true
+      end
+    end
+  end
+
+  describe '#unlock' do
+    it 'returns an Unlocker object' do
+      unlocker = template.unlock(
+        protocol_id: protocol_id,
+        key_id: key_id,
+        counterparty: counterparty
+      )
+      expect(unlocker).to be_a(BSV::Script::PushDropTemplate::Unlocker)
+    end
+
+    it 'returns an estimated length of 107' do
+      unlocker = template.unlock(
+        protocol_id: protocol_id,
+        key_id: key_id,
+        counterparty: counterparty
+      )
+      expect(unlocker.estimated_length(nil, nil)).to eq(107)
+    end
+
+    describe '#sign' do
+      it 'produces a valid unlocking script' do
+        lock_script = template.lock(
+          fields: fields,
+          protocol_id: protocol_id,
+          key_id: key_id,
+          counterparty: counterparty,
+          include_signature: false
+        )
+
+        spending_tx = build_spending_tx(lock_script, satoshis: 10_000)
+
+        unlocker = template.unlock(
+          protocol_id: protocol_id,
+          key_id: key_id,
+          counterparty: counterparty
+        )
+        unlock_script = unlocker.sign(spending_tx, 0)
+
+        expect(unlock_script).to be_a(BSV::Script::Script)
+        expect(unlock_script.bytes).not_to be_empty
+      end
+    end
+  end
+
+  describe 'round-trip: lock then unlock passes interpreter verification' do
+    it 'verifies a PushDrop transaction with P2PKH underlying lock' do
+      lock_script = template.lock(
+        fields: fields,
+        protocol_id: protocol_id,
+        key_id: key_id,
+        counterparty: counterparty,
+        include_signature: true
+      )
+
+      satoshis = 10_000
+      spending_tx = build_spending_tx(lock_script, satoshis: satoshis)
+
+      unlocker = template.unlock(
+        protocol_id: protocol_id,
+        key_id: key_id,
+        counterparty: counterparty
+      )
+      spending_tx.inputs[0].unlocking_script = unlocker.sign(spending_tx, 0)
+
+      result = BSV::Script::Interpreter.verify(
+        tx: spending_tx,
+        input_index: 0,
+        unlock_script: spending_tx.inputs[0].unlocking_script,
+        lock_script: lock_script,
+        satoshis: satoshis
+      )
+      expect(result).to be true
+    end
+
+    it 'also verifies without the field signature' do
+      lock_script = template.lock(
+        fields: fields,
+        protocol_id: protocol_id,
+        key_id: key_id,
+        counterparty: counterparty,
+        include_signature: false
+      )
+
+      satoshis = 5_000
+      spending_tx = build_spending_tx(lock_script, satoshis: satoshis)
+
+      unlocker = template.unlock(
+        protocol_id: protocol_id,
+        key_id: key_id,
+        counterparty: counterparty
+      )
+      spending_tx.inputs[0].unlocking_script = unlocker.sign(spending_tx, 0)
+
+      result = BSV::Script::Interpreter.verify(
+        tx: spending_tx,
+        input_index: 0,
+        unlock_script: spending_tx.inputs[0].unlocking_script,
+        lock_script: lock_script,
+        satoshis: satoshis
+      )
+      expect(result).to be true
+    end
+  end
+
+  private
+
+  # Build a transaction spending a PushDrop output with the given locking script.
+  #
+  # Sets +source_locking_script+ and +source_satoshis+ on the input so the
+  # sighash computation has everything it needs.
+  def build_spending_tx(lock_script, satoshis:)
+    tx = BSV::Transaction::Transaction.new
+    input = BSV::Transaction::TransactionInput.new(
+      prev_tx_id: "\x00" * 32,
+      prev_tx_out_index: 0
+    )
+    input.source_locking_script = lock_script
+    input.source_satoshis = satoshis
+    tx.add_input(input)
+    # Add a dummy output so the transaction is structurally valid
+    dummy_lock = BSV::Script::Script.p2pkh_lock(("\x00" * 20).b)
+    tx.add_output(BSV::Transaction::TransactionOutput.new(
+                    satoshis: satoshis - 1_000,
+                    locking_script: dummy_lock
+                  ))
+    tx
+  end
+end


### PR DESCRIPTION
## Summary

- **BSV::Identity::Client** — identity resolution and attribute publication via overlay
  - `resolve_by_identity_key` / `resolve_by_attributes` — discover identities via wallet, parse through IdentityParser
  - `publicly_reveal_attributes` — prove certificate to "anyone" (PrivateKey(1)), create PushDrop token, broadcast to `tm_identity`
  - `revoke_certificate_revelation` — look up via `ls_identity`, spend the revelation output
- **BSV::Identity::IdentityParser** — converts identity certificates to DisplayableIdentity, handling all 9 known types plus generic fallback with field-name heuristics
- **BSV::Identity::Types** — DisplayableIdentity, IdentityCertificate, CertifierInfo, ClientOptions with cross-SDK constant alignment
- **BSV::Script::PushDropTemplate** — reusable wallet-aware PushDrop template with key derivation, field signing, and P2PKH lock/unlock (used by Identity Client, reusable for ContactsManager and other features)

All dependencies injectable (broadcaster, resolver, certificate verifier, wallet). Certificate verifier defaults to raising NotImplementedError — `BSV::Auth::Certificate` is a separate HLR.

## Test plan

- [x] 158 new specs pass (identity + PushDropTemplate)
- [x] Full suite: 2707 examples, 0 failures, 5 pending
- [x] RuboCop: 0 offences
- [x] Cross-SDK alignment verified against TS and Go reference implementations

Closes #238, closes #247, closes #248, closes #249, closes #250, closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)