### PR TITLE
feat(registry): implement Registry client

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,6 +82,8 @@ Metrics/AbcSize:
     - 'lib/bsv/overlay/**/*'
     - 'lib/bsv/identity.rb'
     - 'lib/bsv/identity/**/*'
+    - 'lib/bsv/registry.rb'
+    - 'lib/bsv/registry/**/*'
     - 'spec/**/*'
 
 Metrics/MethodLength:
@@ -101,6 +103,8 @@ Metrics/MethodLength:
     - 'lib/bsv/overlay/**/*'
     - 'lib/bsv/identity.rb'
     - 'lib/bsv/identity/**/*'
+    - 'lib/bsv/registry.rb'
+    - 'lib/bsv/registry/**/*'
     - 'spec/**/*'
 
 Metrics/CyclomaticComplexity:
@@ -120,6 +124,8 @@ Metrics/CyclomaticComplexity:
     - 'lib/bsv/overlay/**/*'
     - 'lib/bsv/identity.rb'
     - 'lib/bsv/identity/**/*'
+    - 'lib/bsv/registry.rb'
+    - 'lib/bsv/registry/**/*'
     - 'spec/**/*'
 
 Metrics/PerceivedComplexity:
@@ -139,6 +145,8 @@ Metrics/PerceivedComplexity:
     - 'lib/bsv/overlay/**/*'
     - 'lib/bsv/identity.rb'
     - 'lib/bsv/identity/**/*'
+    - 'lib/bsv/registry.rb'
+    - 'lib/bsv/registry/**/*'
     - 'spec/**/*'
 
 Metrics/ModuleLength:
@@ -149,6 +157,7 @@ Metrics/ModuleLength:
     - 'lib/bsv/script/interpreter/operations/**/*'
     - 'lib/bsv/wallet_interface/wire/**/*'
     - 'lib/bsv/identity/**/*'
+    - 'lib/bsv/registry/**/*'
     - 'spec/**/*'
 
 Metrics/ClassLength:
@@ -162,6 +171,7 @@ Metrics/ClassLength:
     - 'lib/bsv/auth/**/*'
     - 'lib/bsv/overlay/**/*'
     - 'lib/bsv/identity/**/*'
+    - 'lib/bsv/registry/**/*'
 
 Metrics/ParameterLists:
   Exclude:
@@ -170,6 +180,7 @@ Metrics/ParameterLists:
     - 'lib/bsv/transaction/**/*'
     - 'lib/bsv/overlay/**/*'
     - 'lib/bsv/identity/**/*'
+    - 'lib/bsv/registry/**/*'
 
 # The interpreter condition stack uses :true/:false symbols intentionally
 # (matching the Go SDK pattern) to distinguish from boolean values.
@@ -206,6 +217,7 @@ RSpec/MultipleExpectations:
     - 'spec/bsv/auth/**/*'
     - 'spec/bsv/overlay/**/*'
     - 'spec/bsv/identity/**/*'
+    - 'spec/bsv/registry/**/*'
     - 'spec/bsv/wallet_interface/**/*'
     - 'spec/integration/**/*'
     - 'spec/conformance/**/*'
@@ -218,6 +230,7 @@ RSpec/MultipleMemoizedHelpers:
     - 'spec/bsv/auth/**/*'
     - 'spec/bsv/overlay/**/*'
     - 'spec/bsv/identity/**/*'
+    - 'spec/bsv/registry/**/*'
     - 'spec/conformance/**/*'
     - 'spec/bsv/wallet_interface/**/*'
 
@@ -233,6 +246,7 @@ RSpec/ExampleLength:
     - 'spec/bsv/auth/**/*'
     - 'spec/bsv/overlay/**/*'
     - 'spec/bsv/identity/**/*'
+    - 'spec/bsv/registry/**/*'
     - 'spec/bsv/wallet_interface/**/*'
     - 'spec/integration/**/*'
     - 'spec/conformance/**/*'
@@ -256,6 +270,7 @@ RSpec/SpecFilePathFormat:
     - 'spec/bsv/transaction/live_policy_spec.rb'
     - 'spec/conformance/**/*'
     - 'spec/bsv/wallet_interface/**/*'
+    - 'spec/bsv/registry/**/*'
 
 # Vector and conformance specs use string describes for cross-cutting test suites.
 RSpec/DescribeClass:
@@ -266,6 +281,7 @@ RSpec/DescribeClass:
     - 'spec/integration/**/*'
     - 'spec/conformance/**/*'
     - 'spec/bsv/wallet_interface/**/*'
+    - 'spec/bsv/registry/**/*'
 
 # Vector specs define constants at spec scope for shared test infrastructure.
 Lint/ConstantDefinitionInBlock:

--- a/lib/bsv-sdk.rb
+++ b/lib/bsv-sdk.rb
@@ -11,4 +11,5 @@ module BSV
   autoload :Auth,        'bsv/auth'
   autoload :Overlay,     'bsv/overlay'
   autoload :Identity,    'bsv/identity'
+  autoload :Registry,    'bsv/registry'
 end

--- a/lib/bsv/registry.rb
+++ b/lib/bsv/registry.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module BSV
+  # Registry module for managing on-chain definitions for protocols, baskets,
+  # and certificate types via PushDrop-based UTXOs on the BSV overlay network.
+  #
+  # Registry operators use this module to establish and manage canonical
+  # references for basket IDs, protocol specifications, and certificate schemas.
+  module Registry
+    autoload :DefinitionType, 'bsv/registry/types'
+    autoload :CertificateFieldDescriptor, 'bsv/registry/types'
+    autoload :BasketDefinitionData, 'bsv/registry/types'
+    autoload :ProtocolDefinitionData, 'bsv/registry/types'
+    autoload :CertificateDefinitionData, 'bsv/registry/types'
+    autoload :RegisteredDefinition, 'bsv/registry/types'
+    autoload :Constants,           'bsv/registry/constants'
+    autoload :Client,              'bsv/registry/client'
+  end
+end

--- a/lib/bsv/registry/client.rb
+++ b/lib/bsv/registry/client.rb
@@ -1,0 +1,569 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module BSV
+  module Registry
+    # Client for managing on-chain registry definitions for protocols, baskets,
+    # and certificate types on the BSV overlay network.
+    #
+    # Registry operators use this client to establish canonical references for
+    # basket IDs, protocol specifications, and certificate schemas via
+    # PushDrop-based UTXOs.
+    #
+    # All overlay dependencies (broadcaster, resolver) are injectable for testing.
+    #
+    # @example Register a new basket definition
+    #   client = BSV::Registry::Client.new(wallet: my_wallet)
+    #   data   = BSV::Registry::BasketDefinitionData.new(
+    #     basket_id:         'my-basket',
+    #     name:              'My Basket',
+    #     icon_url:          'https://example.com/icon.png',
+    #     description:       'Stores my tokens',
+    #     documentation_url: 'https://example.com/docs'
+    #   )
+    #   result = client.register_definition(BSV::Registry::DefinitionType::BASKET, data)
+    #
+    # @example Resolve basket definitions
+    #   records = client.resolve(BSV::Registry::DefinitionType::BASKET, { basket_id: 'my-basket' })
+    class Client
+      # @param wallet [#get_public_key, #get_network, #create_action, #sign_action,
+      #   #list_outputs] BRC-100 wallet interface
+      # @param originator [String, nil] optional FQDN of the originating application
+      # @param broadcaster [BSV::Overlay::TopicBroadcaster, nil] injectable broadcaster;
+      #   built from the wallet's network preset when nil
+      # @param resolver [BSV::Overlay::LookupResolver, nil] injectable lookup resolver;
+      #   built from the wallet's network preset when nil
+      def initialize(wallet:, originator: nil, broadcaster: nil, resolver: nil)
+        @wallet     = wallet
+        @originator = originator
+        @broadcaster = broadcaster
+        @resolver    = resolver
+      end
+
+      # Publishes a new on-chain definition for baskets, protocols, or certificates.
+      #
+      # The definition data is encoded in a PushDrop-based UTXO and broadcast
+      # to the appropriate overlay topic for the given definition type.
+      #
+      # @param definition_type [String] one of {DefinitionType} constants
+      # @param data [BasketDefinitionData, ProtocolDefinitionData, CertificateDefinitionData]
+      #   structured definition data
+      # @return [BSV::Overlay::OverlayBroadcastResult]
+      # @raise [RuntimeError] if the transaction cannot be created or broadcast
+      def register_definition(definition_type, data)
+        registry_operator = identity_key
+        fields = build_pushdrop_fields(definition_type, data, registry_operator)
+
+        protocol_id = protocol_for(definition_type)
+        template = BSV::Script::PushDropTemplate.new(wallet: @wallet, originator: @originator)
+        locking_script = template.lock(
+          fields: fields,
+          protocol_id: protocol_id,
+          key_id: Constants::KEY_ID,
+          counterparty: 'anyone'
+        )
+
+        basket_name = basket_name_for(definition_type)
+        create_result = @wallet.create_action(
+          {
+            description: "Register a new #{definition_type} definition",
+            outputs: [
+              {
+                satoshis: Constants::TOKEN_AMOUNT,
+                locking_script: locking_script.to_hex,
+                output_description: "New #{definition_type} registration token",
+                basket: basket_name
+              }
+            ],
+            options: { randomize_outputs: false }
+          },
+          originator: @originator
+        )
+
+        raise "Register failed: could not create #{definition_type} registration transaction" if create_result[:tx].nil?
+
+        tx = BSV::Transaction::Transaction.from_beef(create_result[:tx])
+        broadcaster_for(definition_type).broadcast(tx)
+      end
+
+      # Resolves registry definitions of a given type using the overlay lookup service.
+      #
+      # @param definition_type [String] one of {DefinitionType} constants
+      # @param query [Hash] filter criteria; keys depend on definition type:
+      #   - basket: basket_id, name, registry_operators
+      #   - protocol: name, protocol_id, registry_operators
+      #   - certificate: type, name, registry_operators
+      # @return [Array<RegisteredDefinition>] matching registered definitions
+      def resolve(definition_type, query)
+        service = service_for(definition_type)
+        question = BSV::Overlay::LookupQuestion.new(
+          service: service,
+          query: query
+        )
+        answer = resolver_for.query(question)
+
+        return [] unless answer.type == 'output-list'
+
+        answer.outputs.filter_map do |output|
+          parse_output_to_registered_definition(definition_type, output)
+        rescue StandardError
+          nil
+        end
+      end
+
+      # Lists the registry operator's own published definitions for the given type.
+      #
+      # Queries the wallet for spendable outputs in the appropriate basket,
+      # then parses the PushDrop scripts back into structured definition data.
+      #
+      # @param definition_type [String] one of {DefinitionType} constants
+      # @return [Array<RegisteredDefinition>] the operator's own registered definitions
+      def list_own_registry_entries(definition_type)
+        basket_name = basket_name_for(definition_type)
+        list_result = @wallet.list_outputs(
+          { basket: basket_name, include: 'entire transactions' },
+          originator: @originator
+        )
+
+        outputs  = list_result[:outputs] || list_result['outputs'] || []
+        beef_raw = list_result[:beef] || list_result['beef'] || list_result[:BEEF] || list_result['BEEF']
+
+        return [] if beef_raw.nil? || outputs.empty?
+
+        beef = BSV::Transaction::Beef.from_binary(beef_raw)
+
+        outputs.filter_map do |output|
+          next unless spendable?(output)
+
+          begin
+            parse_own_output_to_registered_definition(definition_type, output, beef, beef_raw)
+          rescue StandardError
+            nil
+          end
+        end
+      end
+
+      # Revokes an existing registry definition by spending its UTXO.
+      #
+      # Verifies that the definition belongs to the current wallet before spending.
+      #
+      # @param registered_definition [RegisteredDefinition] the definition to revoke
+      # @return [BSV::Overlay::OverlayBroadcastResult]
+      # @raise [RuntimeError] if the definition does not belong to this wallet or
+      #   the transaction cannot be created
+      def revoke_definition(registered_definition)
+        verify_ownership(registered_definition)
+
+        definition_type = registered_definition.definition_type
+        outpoint = "#{registered_definition.txid}.#{registered_definition.output_index}"
+
+        create_result = @wallet.create_action(
+          {
+            description: "Revoke #{definition_type} definition: #{item_identifier(registered_definition)}",
+            input_beef: registered_definition.beef,
+            inputs: [
+              {
+                outpoint: outpoint,
+                unlocking_script_length: BSV::Script::PushDropTemplate::Unlocker::ESTIMATED_LENGTH,
+                input_description: "Revoking #{definition_type} token"
+              }
+            ],
+            options: { randomize_outputs: false, no_send: true }
+          },
+          originator: @originator
+        )
+
+        raise 'Revoke failed: could not create signable transaction' if create_result[:signable_transaction].nil?
+
+        sign_and_broadcast(definition_type, registered_definition, create_result)
+      end
+
+      # Updates an existing registry definition by revoking it and registering new data.
+      #
+      # The update is performed as two sequential operations: revoke then register.
+      # This is not atomic — if registration fails after revocation, the definition
+      # will have been removed without replacement.
+      #
+      # @param registered_definition [RegisteredDefinition] the existing definition to replace
+      # @param new_data [BasketDefinitionData, ProtocolDefinitionData, CertificateDefinitionData]
+      #   new definition data (must be same type as the existing definition)
+      # @return [BSV::Overlay::OverlayBroadcastResult] result of the registration broadcast
+      # @raise [ArgumentError] if the definition types do not match
+      # @raise [RuntimeError] if revocation or registration fails
+      def update_definition(registered_definition, new_data)
+        unless registered_definition.definition_type == new_data.definition_type
+          raise ArgumentError,
+                "Cannot change definition type from #{registered_definition.definition_type} to #{new_data.definition_type}"
+        end
+
+        revoke_definition(registered_definition)
+        register_definition(registered_definition.definition_type, new_data)
+      end
+
+      private
+
+      # Returns the cached identity public key, fetching it on first call.
+      #
+      # @return [String] compressed public key hex
+      def identity_key
+        return @identity_key if defined?(@identity_key)
+
+        result = @wallet.get_public_key({ identity_key: true }, originator: @originator)
+        @identity_key = result[:public_key] || result['public_key'] || result['publicKey'] || result[:publicKey]
+      end
+
+      # Returns the overlay topic name for a given definition type.
+      #
+      # @param definition_type [String]
+      # @return [String]
+      def topic_for(definition_type)
+        case definition_type
+        when DefinitionType::BASKET      then Constants::TOPIC_BASKET
+        when DefinitionType::PROTOCOL    then Constants::TOPIC_PROTOCOL
+        when DefinitionType::CERTIFICATE then Constants::TOPIC_CERTIFICATE
+        else raise ArgumentError, "Unknown definition type: #{definition_type}"
+        end
+      end
+
+      # Returns the lookup service name for a given definition type.
+      #
+      # @param definition_type [String]
+      # @return [String]
+      def service_for(definition_type)
+        case definition_type
+        when DefinitionType::BASKET      then Constants::SERVICE_BASKET
+        when DefinitionType::PROTOCOL    then Constants::SERVICE_PROTOCOL
+        when DefinitionType::CERTIFICATE then Constants::SERVICE_CERTIFICATE
+        else raise ArgumentError, "Unknown definition type: #{definition_type}"
+        end
+      end
+
+      # Returns the BRC-43 protocol ID for a given definition type.
+      #
+      # @param definition_type [String]
+      # @return [Array]
+      def protocol_for(definition_type)
+        case definition_type
+        when DefinitionType::BASKET      then Constants::PROTOCOL_BASKET
+        when DefinitionType::PROTOCOL    then Constants::PROTOCOL_PROTOCOL
+        when DefinitionType::CERTIFICATE then Constants::PROTOCOL_CERTIFICATE
+        else raise ArgumentError, "Unknown definition type: #{definition_type}"
+        end
+      end
+
+      # Returns the wallet basket name for a given definition type.
+      #
+      # @param definition_type [String]
+      # @return [String]
+      def basket_name_for(definition_type)
+        case definition_type
+        when DefinitionType::BASKET      then Constants::BASKET_NAME_BASKET
+        when DefinitionType::PROTOCOL    then Constants::BASKET_NAME_PROTOCOL
+        when DefinitionType::CERTIFICATE then Constants::BASKET_NAME_CERTIFICATE
+        else raise ArgumentError, "Unknown definition type: #{definition_type}"
+        end
+      end
+
+      # Builds an ordered array of binary fields for a PushDrop script.
+      #
+      # Field ordering per reference SDK:
+      # - basket:      basket_id, name, icon_url, description, documentation_url, registry_operator
+      # - protocol:    protocol_id (JSON), name, icon_url, description, documentation_url, registry_operator
+      # - certificate: type, name, icon_url, description, documentation_url, fields (JSON), registry_operator
+      #
+      # @param definition_type [String]
+      # @param data [BasketDefinitionData, ProtocolDefinitionData, CertificateDefinitionData]
+      # @param registry_operator [String] public key hex
+      # @return [Array<String>] binary field strings
+      def build_pushdrop_fields(definition_type, data, registry_operator)
+        string_fields = case definition_type
+                        when DefinitionType::BASKET
+                          [
+                            data.basket_id,
+                            data.name,
+                            data.icon_url,
+                            data.description,
+                            data.documentation_url
+                          ]
+                        when DefinitionType::PROTOCOL
+                          [
+                            JSON.generate(data.protocol_id),
+                            data.name,
+                            data.icon_url,
+                            data.description,
+                            data.documentation_url
+                          ]
+                        when DefinitionType::CERTIFICATE
+                          fields_hash = data.fields.transform_values do |v|
+                            v.respond_to?(:to_h) ? v.to_h : v
+                          end
+                          [
+                            data.type,
+                            data.name,
+                            data.icon_url,
+                            data.description,
+                            data.documentation_url,
+                            JSON.generate(fields_hash)
+                          ]
+                        else
+                          raise ArgumentError, "Unknown definition type: #{definition_type}"
+                        end
+
+        string_fields << registry_operator
+        string_fields.map(&:b)
+      end
+
+      # Parses a PushDrop locking script into a definition data object.
+      #
+      # {Script#pushdrop_fields} returns ALL pushed fields before the DROP opcodes,
+      # which includes the ECDSA signature appended by {PushDropTemplate#lock} when
+      # +include_signature: true+ (the default). The signature is always the last
+      # field, so we drop it before interpreting the data fields.
+      #
+      # Expected total field counts (data + operator + signature):
+      # - basket:      5 + 1 + 1 = 7
+      # - protocol:    5 + 1 + 1 = 7
+      # - certificate: 6 + 1 + 1 = 8
+      #
+      # @param definition_type [String]
+      # @param script [BSV::Script::Script]
+      # @return [BasketDefinitionData, ProtocolDefinitionData, CertificateDefinitionData]
+      # @raise [RuntimeError] if the script is not a valid registry PushDrop
+      def parse_locking_script(definition_type, script)
+        all_fields = script.pushdrop_fields
+        raise 'Not a valid registry PushDrop script' if all_fields.nil? || all_fields.empty?
+
+        # Drop the trailing signature field; the remaining fields are data + operator.
+        fields = all_fields[0..-2].map { |f| f.force_encoding('UTF-8') }
+
+        case definition_type
+        when DefinitionType::BASKET
+          raise "Unexpected field count for basket (got #{fields.length}, expected 6)" unless fields.length == 6
+
+          BasketDefinitionData.new(
+            basket_id: fields[0],
+            name: fields[1],
+            icon_url: fields[2],
+            description: fields[3],
+            documentation_url: fields[4],
+            registry_operator: fields[5]
+          )
+
+        when DefinitionType::PROTOCOL
+          raise "Unexpected field count for protocol (got #{fields.length}, expected 6)" unless fields.length == 6
+
+          protocol_id = JSON.parse(fields[0])
+          ProtocolDefinitionData.new(
+            protocol_id: protocol_id,
+            name: fields[1],
+            icon_url: fields[2],
+            description: fields[3],
+            documentation_url: fields[4],
+            registry_operator: fields[5]
+          )
+
+        when DefinitionType::CERTIFICATE
+          raise "Unexpected field count for certificate (got #{fields.length}, expected 7)" unless fields.length == 7
+
+          raw_cert_fields = begin
+            JSON.parse(fields[5])
+          rescue JSON::ParserError
+            {}
+          end
+          cer_fields = raw_cert_fields.transform_values do |v|
+            next v unless v.is_a?(Hash)
+
+            CertificateFieldDescriptor.new(
+              friendly_name: v['friendlyName'] || '',
+              description: v['description'] || '',
+              type: v['type'] || 'text',
+              field_icon: v['fieldIcon'] || ''
+            )
+          end
+
+          CertificateDefinitionData.new(
+            type: fields[0],
+            name: fields[1],
+            icon_url: fields[2],
+            description: fields[3],
+            documentation_url: fields[4],
+            fields: cer_fields,
+            registry_operator: fields[6]
+          )
+
+        else
+          raise ArgumentError, "Unknown definition type: #{definition_type}"
+        end
+      end
+
+      # Parses a single overlay output into a RegisteredDefinition, or returns nil.
+      #
+      # @param definition_type [String]
+      # @param output [Hash] overlay output with :beef and :outputIndex keys
+      # @return [RegisteredDefinition, nil]
+      def parse_output_to_registered_definition(definition_type, output)
+        beef_raw   = output['beef'] || output[:beef]
+        output_idx = (output['outputIndex'] || output[:output_index]).to_i
+
+        beef = BSV::Transaction::Beef.from_binary(beef_raw)
+        tx   = beef.transactions.last&.transaction
+        return nil unless tx
+
+        locking_script = tx.outputs[output_idx]&.locking_script
+        return nil unless locking_script
+
+        definition_data = parse_locking_script(definition_type, locking_script)
+
+        RegisteredDefinition.new(
+          definition_data: definition_data,
+          txid: tx.txid_hex,
+          output_index: output_idx,
+          locking_script: locking_script.to_hex,
+          beef: beef_raw,
+          satoshis: tx.outputs[output_idx].satoshis
+        )
+      end
+
+      # Parses a wallet list_outputs entry into a RegisteredDefinition.
+      #
+      # @param definition_type [String]
+      # @param output [Hash] wallet output with :outpoint, :satoshis keys
+      # @param beef [BSV::Transaction::Beef] parsed BEEF
+      # @param beef_raw [String] raw BEEF bytes
+      # @return [RegisteredDefinition, nil]
+      def parse_own_output_to_registered_definition(definition_type, output, beef, beef_raw)
+        outpoint_str = output[:outpoint] || output['outpoint']
+        return nil unless outpoint_str
+
+        txid, output_idx_str = outpoint_str.split('.')
+        output_idx = output_idx_str.to_i
+
+        tx = beef.transactions.last&.transaction
+        return nil unless tx
+
+        locking_script = tx.outputs[output_idx]&.locking_script
+        return nil unless locking_script
+
+        definition_data = parse_locking_script(definition_type, locking_script)
+        satoshis = output[:satoshis] || output['satoshis'] || Constants::TOKEN_AMOUNT
+
+        RegisteredDefinition.new(
+          definition_data: definition_data,
+          txid: txid,
+          output_index: output_idx,
+          locking_script: locking_script.to_hex,
+          beef: beef_raw,
+          satoshis: satoshis
+        )
+      end
+
+      # Signs and broadcasts a signable transaction for a revocation or update.
+      #
+      # @param definition_type [String]
+      # @param registered_definition [RegisteredDefinition]
+      # @param create_result [Hash] result from wallet.create_action containing :signable_transaction
+      # @return [BSV::Overlay::OverlayBroadcastResult]
+      def sign_and_broadcast(definition_type, _registered_definition, create_result)
+        signable   = create_result[:signable_transaction]
+        partial_tx = BSV::Transaction::Transaction.from_beef(signable[:tx])
+
+        template = BSV::Script::PushDropTemplate.new(wallet: @wallet, originator: @originator)
+        unlocker = template.unlock(
+          protocol_id: protocol_for(definition_type),
+          key_id: Constants::KEY_ID,
+          counterparty: 'anyone'
+        )
+
+        spending_input_idx = 0
+        unlocking_script = unlocker.sign(partial_tx, spending_input_idx)
+
+        sign_result = @wallet.sign_action(
+          {
+            reference: signable[:reference],
+            spends: { spending_input_idx => { unlocking_script: unlocking_script.to_hex } },
+            options: { no_send: true }
+          },
+          originator: @originator
+        )
+
+        raise 'Revoke failed: could not sign transaction' if sign_result[:tx].nil?
+
+        signed_tx = BSV::Transaction::Transaction.from_beef(sign_result[:tx])
+        broadcaster_for(definition_type).broadcast(signed_tx)
+      end
+
+      # Verifies that the registered definition belongs to the current wallet.
+      #
+      # @param registered_definition [RegisteredDefinition]
+      # @raise [RuntimeError] if the definition does not belong to this wallet
+      def verify_ownership(registered_definition)
+        operator = registered_definition.definition_data.registry_operator
+        current  = identity_key
+        return if operator == current
+
+        raise 'Registry token does not belong to the current wallet ' \
+              "(operator: #{operator}, current: #{current})"
+      end
+
+      # Returns a human-readable identifier for a registered definition.
+      #
+      # @param registered_definition [RegisteredDefinition]
+      # @return [String]
+      def item_identifier(registered_definition)
+        data = registered_definition.definition_data
+        case data.definition_type
+        when DefinitionType::BASKET      then data.basket_id
+        when DefinitionType::PROTOCOL    then data.name
+        when DefinitionType::CERTIFICATE then data.name.empty? ? data.type : data.name
+        else 'unknown'
+        end
+      end
+
+      # Returns whether an output from wallet.list_outputs is spendable.
+      #
+      # @param output [Hash]
+      # @return [Boolean]
+      def spendable?(output)
+        # Use key? rather than || to avoid false || nil collapsing to nil.
+        val = output.key?(:spendable) ? output[:spendable] : output['spendable']
+        val.nil? || val
+      end
+
+      # Returns the broadcaster to use, building one from the wallet's network
+      # when no injectable broadcaster was provided.
+      #
+      # @param definition_type [String]
+      # @return [BSV::Overlay::TopicBroadcaster]
+      def broadcaster_for(definition_type)
+        return @broadcaster if @broadcaster
+
+        network = wallet_network
+        BSV::Overlay::TopicBroadcaster.new(
+          [topic_for(definition_type)],
+          network_preset: network
+        )
+      end
+
+      # Returns the lookup resolver, building one from the wallet's network
+      # when no injectable resolver was provided.
+      #
+      # @return [BSV::Overlay::LookupResolver]
+      def resolver_for
+        return @resolver if @resolver
+
+        network = wallet_network
+        BSV::Overlay::LookupResolver.new(network_preset: network)
+      end
+
+      # Queries the wallet for the current network and converts the string to a symbol.
+      #
+      # @return [Symbol] :mainnet or :testnet
+      def wallet_network
+        result  = @wallet.get_network({}, originator: @originator)
+        net_str = result[:network] || result['network'] || 'mainnet'
+        net_str.to_sym
+      end
+    end
+  end
+end

--- a/lib/bsv/registry/client.rb
+++ b/lib/bsv/registry/client.rb
@@ -83,7 +83,7 @@ module BSV
 
         raise "Register failed: could not create #{definition_type} registration transaction" if create_result[:tx].nil?
 
-        tx = BSV::Transaction::Transaction.from_beef(create_result[:tx])
+        tx = BSV::Transaction::Transaction.from_beef(normalise_beef(create_result[:tx]))
         broadcaster_for(definition_type).broadcast(tx)
       end
 
@@ -129,9 +129,10 @@ module BSV
         outputs  = list_result[:outputs] || list_result['outputs'] || []
         beef_raw = list_result[:beef] || list_result['beef'] || list_result[:BEEF] || list_result['BEEF']
 
-        return [] if beef_raw.nil? || outputs.empty?
+        normalised_beef = normalise_beef(beef_raw)
+        return [] if normalised_beef.nil? || outputs.empty?
 
-        beef = BSV::Transaction::Beef.from_binary(beef_raw)
+        beef = BSV::Transaction::Beef.from_binary(normalised_beef)
 
         outputs.filter_map do |output|
           next unless spendable?(output)
@@ -403,9 +404,9 @@ module BSV
       # @param output [Hash] overlay output with :beef and :outputIndex keys
       # @return [RegisteredDefinition, nil]
       def parse_output_to_registered_definition(definition_type, output)
-        beef_raw   = output['beef'] || output[:beef]
+        beef_raw   = normalise_beef(output['beef'] || output[:beef])
         output_idx = (output['outputIndex'] || output[:output_index]).to_i
-        return nil if output_idx.negative?
+        return nil if output_idx.negative? || beef_raw.nil?
 
         beef = BSV::Transaction::Beef.from_binary(beef_raw)
         tx   = beef.transactions.last&.transaction
@@ -466,7 +467,7 @@ module BSV
       # @return [BSV::Overlay::OverlayBroadcastResult]
       def sign_and_broadcast(definition_type, create_result)
         signable   = create_result[:signable_transaction]
-        partial_tx = BSV::Transaction::Transaction.from_beef(signable[:tx])
+        partial_tx = BSV::Transaction::Transaction.from_beef(normalise_beef(signable[:tx]))
 
         template = BSV::Script::PushDropTemplate.new(wallet: @wallet, originator: @originator)
         unlocker = template.unlock(
@@ -489,7 +490,7 @@ module BSV
 
         raise 'Revoke failed: could not sign transaction' if sign_result[:tx].nil?
 
-        signed_tx = BSV::Transaction::Transaction.from_beef(sign_result[:tx])
+        signed_tx = BSV::Transaction::Transaction.from_beef(normalise_beef(sign_result[:tx]))
         broadcaster_for(definition_type).broadcast(signed_tx)
       end
 
@@ -563,6 +564,18 @@ module BSV
         result  = @wallet.get_network({}, originator: @originator)
         net_str = result[:network] || result['network'] || 'mainnet'
         net_str.to_sym
+      end
+
+      # Normalises BEEF data that may arrive as an Array<Integer> (wire format)
+      # into a binary String suitable for Beef.from_binary.
+      #
+      # @param data [String, Array<Integer>, nil] raw BEEF data
+      # @return [String, nil] binary string, or nil if data is nil
+      def normalise_beef(data)
+        case data
+        when Array  then data.pack('C*')
+        when String then data
+        end
       end
     end
   end

--- a/lib/bsv/registry/client.rb
+++ b/lib/bsv/registry/client.rb
@@ -176,7 +176,7 @@ module BSV
 
         raise 'Revoke failed: could not create signable transaction' if create_result[:signable_transaction].nil?
 
-        sign_and_broadcast(definition_type, registered_definition, create_result)
+        sign_and_broadcast(definition_type, create_result)
       end
 
       # Updates an existing registry definition by revoking it and registering new data.
@@ -405,6 +405,7 @@ module BSV
       def parse_output_to_registered_definition(definition_type, output)
         beef_raw   = output['beef'] || output[:beef]
         output_idx = (output['outputIndex'] || output[:output_index]).to_i
+        return nil if output_idx.negative?
 
         beef = BSV::Transaction::Beef.from_binary(beef_raw)
         tx   = beef.transactions.last&.transaction
@@ -461,10 +462,9 @@ module BSV
       # Signs and broadcasts a signable transaction for a revocation or update.
       #
       # @param definition_type [String]
-      # @param registered_definition [RegisteredDefinition]
       # @param create_result [Hash] result from wallet.create_action containing :signable_transaction
       # @return [BSV::Overlay::OverlayBroadcastResult]
-      def sign_and_broadcast(definition_type, _registered_definition, create_result)
+      def sign_and_broadcast(definition_type, create_result)
         signable   = create_result[:signable_transaction]
         partial_tx = BSV::Transaction::Transaction.from_beef(signable[:tx])
 

--- a/lib/bsv/registry/constants.rb
+++ b/lib/bsv/registry/constants.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module BSV
+  module Registry
+    # Protocol constants and well-known values for the BSV Registry system.
+    #
+    # Topic and service names match the TS SDK and Go SDK exactly.
+    # Each definition type has its own topic/service/protocol/basket triplet
+    # so overlay nodes can route and index them independently.
+    module Constants
+      # Overlay topic names — one per definition type.
+      TOPIC_BASKET      = 'tm_basketmap'
+      TOPIC_PROTOCOL    = 'tm_protomap'
+      TOPIC_CERTIFICATE = 'tm_certmap'
+
+      # Lookup service names — one per definition type.
+      SERVICE_BASKET      = 'ls_basketmap'
+      SERVICE_PROTOCOL    = 'ls_protomap'
+      SERVICE_CERTIFICATE = 'ls_certmap'
+
+      # BRC-43 wallet protocol IDs — one per definition type.
+      # Security level 1 = every app and counterparty (matching TS/Go SDKs).
+      PROTOCOL_BASKET      = [1, 'basketmap'].freeze
+      PROTOCOL_PROTOCOL    = [1, 'protomap'].freeze
+      PROTOCOL_CERTIFICATE = [1, 'certmap'].freeze
+
+      # Basket names used when listing wallet outputs — one per definition type.
+      BASKET_NAME_BASKET      = 'basketmap'
+      BASKET_NAME_PROTOCOL    = 'protomap'
+      BASKET_NAME_CERTIFICATE = 'certmap'
+
+      # Key ID used for all PushDrop registry tokens (matches TS/Go SDKs).
+      KEY_ID = '1'
+
+      # Satoshi value of each registry UTXO token.
+      TOKEN_AMOUNT = 1
+    end
+  end
+end

--- a/lib/bsv/registry/types.rb
+++ b/lib/bsv/registry/types.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+module BSV
+  module Registry
+    # Enum-like module for the three supported registry definition types.
+    module DefinitionType
+      BASKET      = 'basket'
+      PROTOCOL    = 'protocol'
+      CERTIFICATE = 'certificate'
+
+      ALL = [BASKET, PROTOCOL, CERTIFICATE].freeze
+    end
+
+    # Describes the structure and metadata for a single certificate field.
+    #
+    # Used within {CertificateDefinitionData} to document the shape of
+    # each field in a certificate schema.
+    class CertificateFieldDescriptor
+      # @return [String] human-readable field name
+      attr_reader :friendly_name
+
+      # @return [String] description of the field's purpose
+      attr_reader :description
+
+      # @return [String] field type: 'text', 'imageURL', or 'other'
+      attr_reader :type
+
+      # @return [String] icon identifier for the field
+      attr_reader :field_icon
+
+      # @param friendly_name [String]
+      # @param description [String]
+      # @param type [String] 'text', 'imageURL', or 'other'
+      # @param field_icon [String]
+      def initialize(friendly_name:, description:, type:, field_icon:)
+        @friendly_name = friendly_name
+        @description   = description
+        @type          = type
+        @field_icon    = field_icon
+      end
+
+      # Serialise to a plain Hash for JSON encoding.
+      #
+      # @return [Hash]
+      def to_h
+        {
+          'friendlyName' => @friendly_name,
+          'description' => @description,
+          'type' => @type,
+          'fieldIcon' => @field_icon
+        }
+      end
+    end
+
+    # Registry data for a basket definition.
+    class BasketDefinitionData
+      # @return [String] always DefinitionType::BASKET
+      attr_reader :definition_type
+
+      # @return [String] unique basket identifier
+      attr_reader :basket_id
+
+      # @return [String] human-readable name
+      attr_reader :name
+
+      # @return [String] URL or opaque string for the basket icon
+      attr_reader :icon_url
+
+      # @return [String] description of the basket's purpose
+      attr_reader :description
+
+      # @return [String] URL to the basket documentation
+      attr_reader :documentation_url
+
+      # @return [String, nil] public key hex of the registry operator
+      attr_reader :registry_operator
+
+      # @param basket_id [String]
+      # @param name [String]
+      # @param icon_url [String]
+      # @param description [String]
+      # @param documentation_url [String]
+      # @param registry_operator [String, nil]
+      def initialize(basket_id:, name:, icon_url:, description:, documentation_url:,
+                     registry_operator: nil)
+        @definition_type   = DefinitionType::BASKET
+        @basket_id         = basket_id
+        @name              = name
+        @icon_url          = icon_url
+        @description       = description
+        @documentation_url = documentation_url
+        @registry_operator = registry_operator
+      end
+    end
+
+    # Registry data for a protocol definition.
+    class ProtocolDefinitionData
+      # @return [String] always DefinitionType::PROTOCOL
+      attr_reader :definition_type
+
+      # @return [Array] two-element BRC-43 protocol ID, e.g. [1, 'protomap']
+      attr_reader :protocol_id
+
+      # @return [String] human-readable name
+      attr_reader :name
+
+      # @return [String] URL or opaque string for the protocol icon
+      attr_reader :icon_url
+
+      # @return [String] description of the protocol's purpose
+      attr_reader :description
+
+      # @return [String] URL to the protocol documentation
+      attr_reader :documentation_url
+
+      # @return [String, nil] public key hex of the registry operator
+      attr_reader :registry_operator
+
+      # @param protocol_id [Array] two-element [security_level, protocol_name]
+      # @param name [String]
+      # @param icon_url [String]
+      # @param description [String]
+      # @param documentation_url [String]
+      # @param registry_operator [String, nil]
+      def initialize(protocol_id:, name:, icon_url:, description:, documentation_url:,
+                     registry_operator: nil)
+        @definition_type   = DefinitionType::PROTOCOL
+        @protocol_id       = protocol_id
+        @name              = name
+        @icon_url          = icon_url
+        @description       = description
+        @documentation_url = documentation_url
+        @registry_operator = registry_operator
+      end
+    end
+
+    # Registry data for a certificate type definition.
+    class CertificateDefinitionData
+      # @return [String] always DefinitionType::CERTIFICATE
+      attr_reader :definition_type
+
+      # @return [String] Base64-encoded certificate type identifier
+      attr_reader :type
+
+      # @return [String] human-readable name
+      attr_reader :name
+
+      # @return [String] URL or opaque string for the certificate type icon
+      attr_reader :icon_url
+
+      # @return [String] description of the certificate type's purpose
+      attr_reader :description
+
+      # @return [String] URL to the certificate type documentation
+      attr_reader :documentation_url
+
+      # @return [Hash<String, CertificateFieldDescriptor>] field schema descriptors
+      attr_reader :fields
+
+      # @return [String, nil] public key hex of the registry operator
+      attr_reader :registry_operator
+
+      # @param type [String]
+      # @param name [String]
+      # @param icon_url [String]
+      # @param description [String]
+      # @param documentation_url [String]
+      # @param fields [Hash<String, CertificateFieldDescriptor>]
+      # @param registry_operator [String, nil]
+      def initialize(type:, name:, icon_url:, description:, documentation_url:,
+                     fields: {}, registry_operator: nil)
+        @definition_type   = DefinitionType::CERTIFICATE
+        @type              = type
+        @name              = name
+        @icon_url          = icon_url
+        @description       = description
+        @documentation_url = documentation_url
+        @fields            = fields
+        @registry_operator = registry_operator
+      end
+    end
+
+    # A parsed registry entry combining definition data with on-chain token data.
+    #
+    # Returned by {Client#resolve}, {Client#list_own_registry_entries}, and
+    # similar methods that reconstruct registry records from locking scripts.
+    class RegisteredDefinition
+      # @return [String] the definition type (see {DefinitionType})
+      attr_reader :definition_type
+
+      # @return [String] transaction ID of the containing UTXO
+      attr_reader :txid
+
+      # @return [Integer] output index within the transaction
+      attr_reader :output_index
+
+      # @return [String] hex-encoded locking script of the UTXO
+      attr_reader :locking_script
+
+      # @return [String] raw BEEF bytes for the containing transaction
+      attr_reader :beef
+
+      # @return [Integer] satoshi value of the UTXO
+      attr_reader :satoshis
+
+      # @return [BasketDefinitionData, ProtocolDefinitionData, CertificateDefinitionData]
+      #   the parsed definition data
+      attr_reader :definition_data
+
+      # @param definition_data [BasketDefinitionData, ProtocolDefinitionData, CertificateDefinitionData]
+      # @param txid [String]
+      # @param output_index [Integer]
+      # @param locking_script [String]
+      # @param beef [String]
+      # @param satoshis [Integer]
+      def initialize(definition_data:, txid:, output_index:, locking_script:, beef:, satoshis: 1)
+        @definition_data = definition_data
+        @definition_type = definition_data.definition_type
+        @txid            = txid
+        @output_index    = output_index
+        @locking_script  = locking_script
+        @beef            = beef
+        @satoshis        = satoshis
+      end
+    end
+  end
+end

--- a/spec/bsv/registry/client_spec.rb
+++ b/spec/bsv/registry/client_spec.rb
@@ -1,0 +1,672 @@
+# frozen_string_literal: true
+
+# Constants defined at spec-file scope to avoid Lint/ConstantDefinitionInBlock.
+REGISTRY_SPEC_IDENTITY_KEY   = "02#{'ab' * 32}"
+REGISTRY_SPEC_TXID           = 'cd' * 32
+REGISTRY_SPEC_LOCKING_HEX    = "76a914#{'ff' * 20}88ac"
+REGISTRY_SPEC_BEEF_BYTES     = 'fake_beef_bytes'
+
+RSpec.describe 'BSV::Registry::Client' do
+  subject(:client) do
+    described_class.new(wallet: wallet, broadcaster: broadcaster, resolver: resolver)
+  end
+
+  let(:described_class) { BSV::Registry::Client }
+  let(:broadcast_result) do
+    BSV::Overlay::OverlayBroadcastResult.new(status: 'success', txid: REGISTRY_SPEC_TXID, message: 'ok')
+  end
+  let(:mock_script) { instance_double(BSV::Script::Script, to_hex: REGISTRY_SPEC_LOCKING_HEX) }
+  let(:mock_template) { instance_double(BSV::Script::PushDropTemplate, lock: mock_script) }
+  let(:basket_data) do
+    BSV::Registry::BasketDefinitionData.new(
+      basket_id: 'my-basket-001',
+      name: 'My Basket',
+      icon_url: 'https://example.com/icon.png',
+      description: 'Stores my tokens',
+      documentation_url: 'https://example.com/docs'
+    )
+  end
+  let(:protocol_data) do
+    BSV::Registry::ProtocolDefinitionData.new(
+      protocol_id: [1, 'test-protocol'],
+      name: 'Test Protocol',
+      icon_url: 'https://example.com/proto.png',
+      description: 'A test protocol',
+      documentation_url: 'https://example.com/proto-docs'
+    )
+  end
+  let(:cert_data) do
+    BSV::Registry::CertificateDefinitionData.new(
+      type: 'cert-type-base64==',
+      name: 'Email Certificate',
+      icon_url: 'https://example.com/cert.png',
+      description: 'Certifies email ownership',
+      documentation_url: 'https://example.com/cert-docs',
+      fields: {}
+    )
+  end
+
+  # Plain double — wallet is duck-typed, Interface is not loaded at boot.
+  let(:wallet)      { double('wallet') } # rubocop:disable RSpec/VerifiedDoubles
+  let(:broadcaster) { instance_double(BSV::Overlay::TopicBroadcaster) }
+  let(:resolver)    { instance_double(BSV::Overlay::LookupResolver) }
+
+  before do
+    allow(wallet).to receive(:get_public_key)
+      .with({ identity_key: true }, originator: nil)
+      .and_return({ public_key: REGISTRY_SPEC_IDENTITY_KEY })
+  end
+
+  # ---------------------------------------------------------------------------
+  # #register_definition
+  # ---------------------------------------------------------------------------
+
+  describe '#register_definition' do
+    before do
+      allow(BSV::Script::PushDropTemplate).to receive(:new).and_return(mock_template)
+      allow(wallet).to receive(:create_action).and_return({ tx: REGISTRY_SPEC_BEEF_BYTES })
+      allow(BSV::Transaction::Transaction).to receive(:from_beef)
+        .and_return(instance_double(BSV::Transaction::Transaction, txid_hex: REGISTRY_SPEC_TXID))
+      allow(broadcaster).to receive(:broadcast).and_return(broadcast_result)
+    end
+
+    context 'with a basket definition' do
+      it 'returns an OverlayBroadcastResult' do
+        result = client.register_definition(BSV::Registry::DefinitionType::BASKET, basket_data)
+        expect(result).to be_a(BSV::Overlay::OverlayBroadcastResult)
+      end
+
+      it 'creates a PushDropTemplate with the wallet' do
+        client.register_definition(BSV::Registry::DefinitionType::BASKET, basket_data)
+        expect(BSV::Script::PushDropTemplate).to have_received(:new).with(wallet: wallet, originator: nil)
+      end
+
+      it 'locks with the basket protocol ID and anyone counterparty' do
+        client.register_definition(BSV::Registry::DefinitionType::BASKET, basket_data)
+        expect(mock_template).to have_received(:lock).with(
+          fields: anything,
+          protocol_id: BSV::Registry::Constants::PROTOCOL_BASKET,
+          key_id: '1',
+          counterparty: 'anyone'
+        )
+      end
+
+      it 'calls create_action with the basket basket name' do
+        client.register_definition(BSV::Registry::DefinitionType::BASKET, basket_data)
+        expect(wallet).to have_received(:create_action) do |args, **_kw|
+          expect(args[:outputs].first[:basket]).to eq('basketmap')
+        end
+      end
+
+      it 'broadcasts to the basket topic' do
+        client.register_definition(BSV::Registry::DefinitionType::BASKET, basket_data)
+        expect(broadcaster).to have_received(:broadcast)
+      end
+    end
+
+    context 'with a protocol definition' do
+      it 'locks with the protocol protocol ID' do
+        client.register_definition(BSV::Registry::DefinitionType::PROTOCOL, protocol_data)
+        expect(mock_template).to have_received(:lock).with(
+          fields: anything,
+          protocol_id: BSV::Registry::Constants::PROTOCOL_PROTOCOL,
+          key_id: '1',
+          counterparty: 'anyone'
+        )
+      end
+
+      it 'calls create_action with the protomap basket name' do
+        client.register_definition(BSV::Registry::DefinitionType::PROTOCOL, protocol_data)
+        expect(wallet).to have_received(:create_action) do |args, **_kw|
+          expect(args[:outputs].first[:basket]).to eq('protomap')
+        end
+      end
+    end
+
+    context 'with a certificate definition' do
+      it 'locks with the certmap protocol ID' do
+        client.register_definition(BSV::Registry::DefinitionType::CERTIFICATE, cert_data)
+        expect(mock_template).to have_received(:lock).with(
+          fields: anything,
+          protocol_id: BSV::Registry::Constants::PROTOCOL_CERTIFICATE,
+          key_id: '1',
+          counterparty: 'anyone'
+        )
+      end
+    end
+
+    context 'when create_action returns no tx' do
+      before do
+        allow(wallet).to receive(:create_action).and_return({ tx: nil })
+      end
+
+      it 'raises a RuntimeError' do
+        expect do
+          client.register_definition(BSV::Registry::DefinitionType::BASKET, basket_data)
+        end.to raise_error(RuntimeError, /could not create.*registration transaction/)
+      end
+    end
+
+    context 'with an originator' do
+      subject(:client_with_originator) do
+        described_class.new(wallet: wallet, broadcaster: broadcaster, originator: 'myapp.example.com')
+      end
+
+      before do
+        allow(wallet).to receive(:get_public_key)
+          .with({ identity_key: true }, originator: 'myapp.example.com')
+          .and_return({ public_key: REGISTRY_SPEC_IDENTITY_KEY })
+      end
+
+      it 'passes the originator to create_action' do
+        client_with_originator.register_definition(BSV::Registry::DefinitionType::BASKET, basket_data)
+        expect(wallet).to have_received(:create_action) do |_args, originator:|
+          expect(originator).to eq('myapp.example.com')
+        end
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Field ordering in buildPushDropFields
+  # ---------------------------------------------------------------------------
+
+  describe 'PushDrop field ordering' do
+    before do
+      allow(BSV::Script::PushDropTemplate).to receive(:new).and_return(mock_template)
+      allow(wallet).to receive(:create_action).and_return({ tx: REGISTRY_SPEC_BEEF_BYTES })
+      allow(BSV::Transaction::Transaction).to receive(:from_beef)
+        .and_return(instance_double(BSV::Transaction::Transaction, txid_hex: REGISTRY_SPEC_TXID))
+      allow(broadcaster).to receive(:broadcast).and_return(broadcast_result)
+    end
+
+    it 'encodes basket fields in correct order (basketID, name, iconURL, desc, docURL, operator)' do
+      captured_fields = nil
+      allow(mock_template).to receive(:lock) do |args|
+        captured_fields = args[:fields]
+        mock_script
+      end
+
+      client.register_definition(BSV::Registry::DefinitionType::BASKET, basket_data)
+
+      expect(captured_fields[0]).to eq('my-basket-001'.b)
+      expect(captured_fields[1]).to eq('My Basket'.b)
+      expect(captured_fields[2]).to eq('https://example.com/icon.png'.b)
+      expect(captured_fields[3]).to eq('Stores my tokens'.b)
+      expect(captured_fields[4]).to eq('https://example.com/docs'.b)
+      expect(captured_fields[5]).to eq(REGISTRY_SPEC_IDENTITY_KEY.b)
+    end
+
+    it 'encodes protocol fields with JSON-serialised protocolID first' do
+      captured_fields = nil
+      allow(mock_template).to receive(:lock) do |args|
+        captured_fields = args[:fields]
+        mock_script
+      end
+
+      client.register_definition(BSV::Registry::DefinitionType::PROTOCOL, protocol_data)
+
+      expect(captured_fields[0]).to eq(JSON.generate([1, 'test-protocol']).b)
+      expect(captured_fields[1]).to eq('Test Protocol'.b)
+    end
+
+    it 'encodes certificate fields with JSON-serialised fields map second-to-last' do
+      cert_with_fields = BSV::Registry::CertificateDefinitionData.new(
+        type: 'cert-base64==',
+        name: 'My Cert',
+        icon_url: '',
+        description: '',
+        documentation_url: '',
+        fields: {
+          'email' => BSV::Registry::CertificateFieldDescriptor.new(
+            friendly_name: 'Email',
+            description: 'Your email',
+            type: 'text',
+            field_icon: ''
+          )
+        }
+      )
+
+      captured_fields = nil
+      allow(mock_template).to receive(:lock) do |args|
+        captured_fields = args[:fields]
+        mock_script
+      end
+
+      client.register_definition(BSV::Registry::DefinitionType::CERTIFICATE, cert_with_fields)
+
+      parsed_fields = JSON.parse(captured_fields[5])
+      expect(parsed_fields).to have_key('email')
+      expect(parsed_fields['email']['friendlyName']).to eq('Email')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #resolve
+  # ---------------------------------------------------------------------------
+
+  describe '#resolve' do
+    let(:mock_output_tx) do
+      tx_output = instance_double(
+        BSV::Transaction::TransactionOutput,
+        locking_script: mock_locking_script,
+        satoshis: 1
+      )
+      instance_double(BSV::Transaction::Transaction,
+                      txid_hex: REGISTRY_SPEC_TXID,
+                      outputs: [tx_output])
+    end
+
+    # Build a locking script mock that returns the right field count for basket (7 = 5 + op + sig)
+    let(:mock_locking_script) do
+      fields = [
+        'my-basket-001'.b,
+        'My Basket'.b,
+        'https://example.com/icon.png'.b,
+        'Stores my tokens'.b,
+        'https://example.com/docs'.b,
+        REGISTRY_SPEC_IDENTITY_KEY.b,
+        'fake_signature'.b # signature field — will be dropped
+      ]
+      script = instance_double(BSV::Script::Script)
+      allow(script).to receive_messages(pushdrop_fields: fields, to_hex: REGISTRY_SPEC_LOCKING_HEX)
+      script
+    end
+
+    let(:beef_obj) do
+      beef_tx = instance_double(BSV::Transaction::Beef::BeefTx, transaction: mock_output_tx)
+      instance_double(BSV::Transaction::Beef, transactions: [beef_tx])
+    end
+
+    let(:overlay_output) { { 'beef' => REGISTRY_SPEC_BEEF_BYTES, 'outputIndex' => 0 } }
+    let(:answer) { BSV::Overlay::LookupAnswer.new(type: 'output-list', outputs: [overlay_output]) }
+
+    before do
+      allow(resolver).to receive(:query).and_return(answer)
+      allow(BSV::Transaction::Beef).to receive(:from_binary).and_return(beef_obj)
+    end
+
+    it 'returns an array of RegisteredDefinition' do
+      results = client.resolve(BSV::Registry::DefinitionType::BASKET, { basket_id: 'my-basket-001' })
+      expect(results).to all(be_a(BSV::Registry::RegisteredDefinition))
+    end
+
+    it 'queries the resolver with the basket service name' do
+      client.resolve(BSV::Registry::DefinitionType::BASKET, { basket_id: 'my-basket-001' })
+      expect(resolver).to have_received(:query) do |question|
+        expect(question.service).to eq('ls_basketmap')
+      end
+    end
+
+    it 'parses the basket_id from the locking script' do
+      results = client.resolve(BSV::Registry::DefinitionType::BASKET, { basket_id: 'my-basket-001' })
+      expect(results.first.definition_data.basket_id).to eq('my-basket-001')
+    end
+
+    it 'parses the registry_operator from the locking script' do
+      results = client.resolve(BSV::Registry::DefinitionType::BASKET, { basket_id: 'my-basket-001' })
+      expect(results.first.definition_data.registry_operator).to eq(REGISTRY_SPEC_IDENTITY_KEY)
+    end
+
+    context 'when the lookup returns a non-output-list type' do
+      let(:answer) { BSV::Overlay::LookupAnswer.new(type: 'freeform', outputs: []) }
+
+      it 'returns an empty array' do
+        expect(client.resolve(BSV::Registry::DefinitionType::BASKET, {})).to eq([])
+      end
+    end
+
+    context 'with a protocol definition' do
+      let(:mock_locking_script) do
+        fields = [
+          JSON.generate([1, 'test-protocol']).b,
+          'Test Protocol'.b,
+          'https://example.com/proto.png'.b,
+          'A test protocol'.b,
+          'https://example.com/proto-docs'.b,
+          REGISTRY_SPEC_IDENTITY_KEY.b,
+          'fake_signature'.b
+        ]
+        script = instance_double(BSV::Script::Script)
+        allow(script).to receive_messages(pushdrop_fields: fields, to_hex: REGISTRY_SPEC_LOCKING_HEX)
+        script
+      end
+
+      it 'parses the protocol_id from the locking script' do
+        results = client.resolve(BSV::Registry::DefinitionType::PROTOCOL, { name: 'Test Protocol' })
+        expect(results.first.definition_data.protocol_id).to eq([1, 'test-protocol'])
+      end
+    end
+
+    context 'with a certificate definition' do
+      let(:mock_locking_script) do
+        fields_json = JSON.generate({
+                                      'email' => {
+                                        'friendlyName' => 'Email',
+                                        'description' => 'Your email',
+                                        'type' => 'text',
+                                        'fieldIcon' => ''
+                                      }
+                                    })
+        fields = [
+          'cert-type-base64=='.b,
+          'Email Certificate'.b,
+          'https://example.com/cert.png'.b,
+          'Certifies email ownership'.b,
+          'https://example.com/cert-docs'.b,
+          fields_json.b,
+          REGISTRY_SPEC_IDENTITY_KEY.b,
+          'fake_signature'.b
+        ]
+        script = instance_double(BSV::Script::Script)
+        allow(script).to receive_messages(pushdrop_fields: fields, to_hex: REGISTRY_SPEC_LOCKING_HEX)
+        script
+      end
+
+      it 'parses the certificate type from the locking script' do
+        results = client.resolve(BSV::Registry::DefinitionType::CERTIFICATE, { type: 'cert-type-base64==' })
+        expect(results.first.definition_data.type).to eq('cert-type-base64==')
+      end
+
+      it 'parses the certificate fields hash' do
+        results = client.resolve(BSV::Registry::DefinitionType::CERTIFICATE, {})
+        field_data = results.first.definition_data.fields['email']
+        expect(field_data).to be_a(BSV::Registry::CertificateFieldDescriptor)
+        expect(field_data.friendly_name).to eq('Email')
+      end
+    end
+
+    context 'when an output fails to parse' do
+      let(:bad_output) { { 'beef' => 'bad_beef', 'outputIndex' => 0 } }
+      let(:answer) do
+        BSV::Overlay::LookupAnswer.new(type: 'output-list', outputs: [bad_output, overlay_output])
+      end
+
+      before do
+        allow(BSV::Transaction::Beef).to receive(:from_binary).with('bad_beef').and_raise(StandardError, 'bad BEEF')
+        allow(BSV::Transaction::Beef).to receive(:from_binary).with(REGISTRY_SPEC_BEEF_BYTES).and_return(beef_obj)
+      end
+
+      it 'skips the invalid output and returns valid results' do
+        results = client.resolve(BSV::Registry::DefinitionType::BASKET, {})
+        expect(results.length).to eq(1)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #list_own_registry_entries
+  # ---------------------------------------------------------------------------
+
+  describe '#list_own_registry_entries' do
+    let(:mock_locking_script) do
+      fields = [
+        'my-basket-001'.b,
+        'My Basket'.b,
+        'https://example.com/icon.png'.b,
+        'Stores my tokens'.b,
+        'https://example.com/docs'.b,
+        REGISTRY_SPEC_IDENTITY_KEY.b,
+        'fake_signature'.b
+      ]
+      script = instance_double(BSV::Script::Script)
+      allow(script).to receive_messages(pushdrop_fields: fields, to_hex: REGISTRY_SPEC_LOCKING_HEX)
+      script
+    end
+
+    let(:mock_tx_output) do
+      instance_double(BSV::Transaction::TransactionOutput,
+                      locking_script: mock_locking_script,
+                      satoshis: 1)
+    end
+
+    let(:mock_tx) do
+      instance_double(BSV::Transaction::Transaction,
+                      txid_hex: REGISTRY_SPEC_TXID,
+                      outputs: [mock_tx_output])
+    end
+
+    let(:mock_beef_tx) { instance_double(BSV::Transaction::Beef::BeefTx, transaction: mock_tx) }
+    let(:mock_beef)    { instance_double(BSV::Transaction::Beef, transactions: [mock_beef_tx]) }
+
+    let(:wallet_output) do
+      { outpoint: "#{REGISTRY_SPEC_TXID}.0", satoshis: 1, spendable: true }
+    end
+
+    before do
+      allow(wallet).to receive(:list_outputs)
+        .with({ basket: 'basketmap', include: 'entire transactions' }, originator: nil)
+        .and_return({ outputs: [wallet_output], beef: REGISTRY_SPEC_BEEF_BYTES })
+      allow(BSV::Transaction::Beef).to receive(:from_binary).and_return(mock_beef)
+    end
+
+    it 'returns an array of RegisteredDefinition' do
+      results = client.list_own_registry_entries(BSV::Registry::DefinitionType::BASKET)
+      expect(results).to all(be_a(BSV::Registry::RegisteredDefinition))
+    end
+
+    it 'queries wallet for the correct basket' do
+      client.list_own_registry_entries(BSV::Registry::DefinitionType::BASKET)
+      expect(wallet).to have_received(:list_outputs) do |args, **_kw|
+        expect(args[:basket]).to eq('basketmap')
+      end
+    end
+
+    it 'parses the basket_id from the output' do
+      results = client.list_own_registry_entries(BSV::Registry::DefinitionType::BASKET)
+      expect(results.first.definition_data.basket_id).to eq('my-basket-001')
+    end
+
+    it 'sets the txid from the outpoint' do
+      results = client.list_own_registry_entries(BSV::Registry::DefinitionType::BASKET)
+      expect(results.first.txid).to eq(REGISTRY_SPEC_TXID)
+    end
+
+    it 'sets the output_index from the outpoint' do
+      results = client.list_own_registry_entries(BSV::Registry::DefinitionType::BASKET)
+      expect(results.first.output_index).to eq(0)
+    end
+
+    context 'when there are no outputs' do
+      before do
+        allow(wallet).to receive(:list_outputs)
+          .and_return({ outputs: [], beef: REGISTRY_SPEC_BEEF_BYTES })
+      end
+
+      it 'returns an empty array' do
+        expect(client.list_own_registry_entries(BSV::Registry::DefinitionType::BASKET)).to eq([])
+      end
+    end
+
+    context 'when beef is nil' do
+      before do
+        allow(wallet).to receive(:list_outputs)
+          .and_return({ outputs: [wallet_output], beef: nil })
+      end
+
+      it 'returns an empty array' do
+        expect(client.list_own_registry_entries(BSV::Registry::DefinitionType::BASKET)).to eq([])
+      end
+    end
+
+    context 'when output is not spendable' do
+      let(:unspendable_output) do
+        { outpoint: "#{REGISTRY_SPEC_TXID}.0", satoshis: 1, spendable: false }
+      end
+
+      before do
+        allow(wallet).to receive(:list_outputs)
+          .and_return({ outputs: [unspendable_output], beef: REGISTRY_SPEC_BEEF_BYTES })
+      end
+
+      it 'skips non-spendable outputs' do
+        expect(client.list_own_registry_entries(BSV::Registry::DefinitionType::BASKET)).to eq([])
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #revoke_definition
+  # ---------------------------------------------------------------------------
+
+  describe '#revoke_definition' do
+    let(:definition_data) do
+      BSV::Registry::BasketDefinitionData.new(
+        basket_id: 'my-basket-001',
+        name: 'My Basket',
+        icon_url: '',
+        description: '',
+        documentation_url: '',
+        registry_operator: REGISTRY_SPEC_IDENTITY_KEY
+      )
+    end
+
+    let(:registered) do
+      BSV::Registry::RegisteredDefinition.new(
+        definition_data: definition_data,
+        txid: REGISTRY_SPEC_TXID,
+        output_index: 0,
+        locking_script: REGISTRY_SPEC_LOCKING_HEX,
+        beef: REGISTRY_SPEC_BEEF_BYTES
+      )
+    end
+
+    let(:partial_tx) { instance_double(BSV::Transaction::Transaction) }
+    let(:signed_tx)  { instance_double(BSV::Transaction::Transaction) }
+    let(:mock_unlock_script) { instance_double(BSV::Script::Script, to_hex: '00' * 107) }
+    let(:mock_unlocker) { instance_double(BSV::Script::PushDropTemplate::Unlocker, sign: mock_unlock_script) }
+    let(:mock_template_revoke) { instance_double(BSV::Script::PushDropTemplate, unlock: mock_unlocker) }
+
+    before do
+      allow(BSV::Script::PushDropTemplate).to receive(:new).and_return(mock_template_revoke)
+      allow(BSV::Transaction::Transaction).to receive(:from_beef).with(REGISTRY_SPEC_BEEF_BYTES).and_return(partial_tx)
+      allow(wallet).to receive_messages(create_action: { signable_transaction: { tx: REGISTRY_SPEC_BEEF_BYTES, reference: 'REF456' } }, sign_action: { tx: 'signed_beef' })
+      allow(BSV::Transaction::Transaction).to receive(:from_beef).with('signed_beef').and_return(signed_tx)
+      allow(broadcaster).to receive(:broadcast).and_return(broadcast_result)
+    end
+
+    it 'broadcasts the spending transaction' do
+      client.revoke_definition(registered)
+      expect(broadcaster).to have_received(:broadcast)
+    end
+
+    it 'creates a spending input for the correct outpoint' do
+      client.revoke_definition(registered)
+      expect(wallet).to have_received(:create_action) do |args, **_kw|
+        expect(args[:inputs].first[:outpoint]).to eq("#{REGISTRY_SPEC_TXID}.0")
+      end
+    end
+
+    it 'signs with the basket protocol ID' do
+      client.revoke_definition(registered)
+      expect(mock_template_revoke).to have_received(:unlock).with(
+        protocol_id: BSV::Registry::Constants::PROTOCOL_BASKET,
+        key_id: '1',
+        counterparty: 'anyone'
+      )
+    end
+
+    context 'when the definition does not belong to this wallet' do
+      let(:definition_data) do
+        BSV::Registry::BasketDefinitionData.new(
+          basket_id: 'other-basket',
+          name: 'Other',
+          icon_url: '',
+          description: '',
+          documentation_url: '',
+          registry_operator: "02#{'11' * 32}"
+        )
+      end
+
+      it 'raises a RuntimeError about ownership' do
+        expect do
+          client.revoke_definition(registered)
+        end.to raise_error(RuntimeError, /does not belong to the current wallet/)
+      end
+    end
+
+    context 'when create_action returns no signable_transaction' do
+      before do
+        allow(wallet).to receive(:create_action).and_return({ signable_transaction: nil })
+      end
+
+      it 'raises a RuntimeError' do
+        expect do
+          client.revoke_definition(registered)
+        end.to raise_error(RuntimeError, /could not create signable transaction/)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #update_definition
+  # ---------------------------------------------------------------------------
+
+  describe '#update_definition' do
+    let(:definition_data) do
+      BSV::Registry::BasketDefinitionData.new(
+        basket_id: 'old-basket',
+        name: 'Old Basket',
+        icon_url: '',
+        description: '',
+        documentation_url: '',
+        registry_operator: REGISTRY_SPEC_IDENTITY_KEY
+      )
+    end
+
+    let(:registered) do
+      BSV::Registry::RegisteredDefinition.new(
+        definition_data: definition_data,
+        txid: REGISTRY_SPEC_TXID,
+        output_index: 0,
+        locking_script: REGISTRY_SPEC_LOCKING_HEX,
+        beef: REGISTRY_SPEC_BEEF_BYTES
+      )
+    end
+
+    let(:new_data) do
+      BSV::Registry::BasketDefinitionData.new(
+        basket_id: 'new-basket',
+        name: 'New Basket',
+        icon_url: '',
+        description: '',
+        documentation_url: ''
+      )
+    end
+
+    let(:partial_tx) { instance_double(BSV::Transaction::Transaction) }
+    let(:signed_tx)  { instance_double(BSV::Transaction::Transaction) }
+    let(:mock_unlock_script) { instance_double(BSV::Script::Script, to_hex: '00' * 107) }
+    let(:mock_unlocker) { instance_double(BSV::Script::PushDropTemplate::Unlocker, sign: mock_unlock_script) }
+    let(:mock_template_update) { instance_double(BSV::Script::PushDropTemplate, lock: mock_script, unlock: mock_unlocker) }
+
+    before do
+      allow(BSV::Script::PushDropTemplate).to receive(:new).and_return(mock_template_update)
+
+      allow(wallet).to receive(:create_action) do |args, **_opts|
+        if args.key?(:inputs)
+          { signable_transaction: { tx: REGISTRY_SPEC_BEEF_BYTES, reference: 'REF789' } }
+        else
+          { tx: REGISTRY_SPEC_BEEF_BYTES }
+        end
+      end
+
+      allow(BSV::Transaction::Transaction).to receive(:from_beef).with(REGISTRY_SPEC_BEEF_BYTES).and_return(partial_tx)
+      allow(wallet).to receive(:sign_action).and_return({ tx: 'signed_beef' })
+      allow(BSV::Transaction::Transaction).to receive(:from_beef).with('signed_beef').and_return(signed_tx)
+      allow(broadcaster).to receive(:broadcast).and_return(broadcast_result)
+    end
+
+    it 'broadcasts the new registration after revoking' do
+      client.update_definition(registered, new_data)
+      # broadcast called twice — once for revoke, once for register
+      expect(broadcaster).to have_received(:broadcast).twice
+    end
+
+    it 'raises ArgumentError when definition types do not match' do
+      expect do
+        client.update_definition(registered, cert_data)
+      end.to raise_error(ArgumentError, /Cannot change definition type/)
+    end
+  end
+end

--- a/spec/bsv/registry/constants_spec.rb
+++ b/spec/bsv/registry/constants_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe 'BSV::Registry::Constants' do
+  describe 'topic names' do
+    it 'defines TOPIC_BASKET' do
+      expect(BSV::Registry::Constants::TOPIC_BASKET).to eq('tm_basketmap')
+    end
+
+    it 'defines TOPIC_PROTOCOL' do
+      expect(BSV::Registry::Constants::TOPIC_PROTOCOL).to eq('tm_protomap')
+    end
+
+    it 'defines TOPIC_CERTIFICATE' do
+      expect(BSV::Registry::Constants::TOPIC_CERTIFICATE).to eq('tm_certmap')
+    end
+  end
+
+  describe 'service names' do
+    it 'defines SERVICE_BASKET' do
+      expect(BSV::Registry::Constants::SERVICE_BASKET).to eq('ls_basketmap')
+    end
+
+    it 'defines SERVICE_PROTOCOL' do
+      expect(BSV::Registry::Constants::SERVICE_PROTOCOL).to eq('ls_protomap')
+    end
+
+    it 'defines SERVICE_CERTIFICATE' do
+      expect(BSV::Registry::Constants::SERVICE_CERTIFICATE).to eq('ls_certmap')
+    end
+  end
+
+  describe 'protocol IDs' do
+    it 'defines PROTOCOL_BASKET as [1, basketmap]' do
+      expect(BSV::Registry::Constants::PROTOCOL_BASKET).to eq([1, 'basketmap'])
+    end
+
+    it 'defines PROTOCOL_PROTOCOL as [1, protomap]' do
+      expect(BSV::Registry::Constants::PROTOCOL_PROTOCOL).to eq([1, 'protomap'])
+    end
+
+    it 'defines PROTOCOL_CERTIFICATE as [1, certmap]' do
+      expect(BSV::Registry::Constants::PROTOCOL_CERTIFICATE).to eq([1, 'certmap'])
+    end
+  end
+
+  describe 'basket names' do
+    it 'defines BASKET_NAME_BASKET as basketmap' do
+      expect(BSV::Registry::Constants::BASKET_NAME_BASKET).to eq('basketmap')
+    end
+
+    it 'defines BASKET_NAME_PROTOCOL as protomap' do
+      expect(BSV::Registry::Constants::BASKET_NAME_PROTOCOL).to eq('protomap')
+    end
+
+    it 'defines BASKET_NAME_CERTIFICATE as certmap' do
+      expect(BSV::Registry::Constants::BASKET_NAME_CERTIFICATE).to eq('certmap')
+    end
+  end
+
+  describe 'token constants' do
+    it 'defines KEY_ID as "1"' do
+      expect(BSV::Registry::Constants::KEY_ID).to eq('1')
+    end
+
+    it 'defines TOKEN_AMOUNT as 1' do
+      expect(BSV::Registry::Constants::TOKEN_AMOUNT).to eq(1)
+    end
+  end
+end

--- a/spec/bsv/registry/types_spec.rb
+++ b/spec/bsv/registry/types_spec.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+RSpec.describe 'BSV::Registry types' do
+  describe 'BSV::Registry::DefinitionType' do
+    it 'defines BASKET constant' do
+      expect(BSV::Registry::DefinitionType::BASKET).to eq('basket')
+    end
+
+    it 'defines PROTOCOL constant' do
+      expect(BSV::Registry::DefinitionType::PROTOCOL).to eq('protocol')
+    end
+
+    it 'defines CERTIFICATE constant' do
+      expect(BSV::Registry::DefinitionType::CERTIFICATE).to eq('certificate')
+    end
+
+    it 'exposes ALL containing all three types' do
+      expect(BSV::Registry::DefinitionType::ALL).to contain_exactly('basket', 'protocol', 'certificate')
+    end
+  end
+
+  describe 'BSV::Registry::CertificateFieldDescriptor' do
+    let(:descriptor) do
+      BSV::Registry::CertificateFieldDescriptor.new(
+        friendly_name: 'Email Address',
+        description: 'The user\'s email',
+        type: 'text',
+        field_icon: 'https://example.com/email.png'
+      )
+    end
+
+    it 'stores friendly_name' do
+      expect(descriptor.friendly_name).to eq('Email Address')
+    end
+
+    it 'stores description' do
+      expect(descriptor.description).to eq('The user\'s email')
+    end
+
+    it 'stores type' do
+      expect(descriptor.type).to eq('text')
+    end
+
+    it 'stores field_icon' do
+      expect(descriptor.field_icon).to eq('https://example.com/email.png')
+    end
+
+    it 'serialises to a Hash with camelCase keys' do
+      h = descriptor.to_h
+      expect(h['friendlyName']).to eq('Email Address')
+      expect(h['description']).to eq('The user\'s email')
+      expect(h['type']).to eq('text')
+      expect(h['fieldIcon']).to eq('https://example.com/email.png')
+    end
+  end
+
+  describe 'BSV::Registry::BasketDefinitionData' do
+    let(:data) do
+      BSV::Registry::BasketDefinitionData.new(
+        basket_id: 'my-basket-001',
+        name: 'My Basket',
+        icon_url: 'https://example.com/icon.png',
+        description: 'Stores my tokens',
+        documentation_url: 'https://example.com/docs'
+      )
+    end
+
+    it 'reports definition_type as basket' do
+      expect(data.definition_type).to eq(BSV::Registry::DefinitionType::BASKET)
+    end
+
+    it 'stores basket_id' do
+      expect(data.basket_id).to eq('my-basket-001')
+    end
+
+    it 'stores name' do
+      expect(data.name).to eq('My Basket')
+    end
+
+    it 'stores icon_url' do
+      expect(data.icon_url).to eq('https://example.com/icon.png')
+    end
+
+    it 'stores description' do
+      expect(data.description).to eq('Stores my tokens')
+    end
+
+    it 'stores documentation_url' do
+      expect(data.documentation_url).to eq('https://example.com/docs')
+    end
+
+    it 'defaults registry_operator to nil' do
+      expect(data.registry_operator).to be_nil
+    end
+
+    it 'accepts an explicit registry_operator' do
+      data_with_op = BSV::Registry::BasketDefinitionData.new(
+        basket_id: 'x',
+        name: 'X',
+        icon_url: '',
+        description: '',
+        documentation_url: '',
+        registry_operator: '02abcd'
+      )
+      expect(data_with_op.registry_operator).to eq('02abcd')
+    end
+  end
+
+  describe 'BSV::Registry::ProtocolDefinitionData' do
+    let(:data) do
+      BSV::Registry::ProtocolDefinitionData.new(
+        protocol_id: [1, 'my-protocol'],
+        name: 'My Protocol',
+        icon_url: 'https://example.com/proto.png',
+        description: 'A test protocol',
+        documentation_url: 'https://example.com/proto-docs'
+      )
+    end
+
+    it 'reports definition_type as protocol' do
+      expect(data.definition_type).to eq(BSV::Registry::DefinitionType::PROTOCOL)
+    end
+
+    it 'stores protocol_id' do
+      expect(data.protocol_id).to eq([1, 'my-protocol'])
+    end
+
+    it 'stores name, icon_url, description, documentation_url' do
+      expect(data.name).to eq('My Protocol')
+      expect(data.icon_url).to eq('https://example.com/proto.png')
+      expect(data.description).to eq('A test protocol')
+      expect(data.documentation_url).to eq('https://example.com/proto-docs')
+    end
+
+    it 'defaults registry_operator to nil' do
+      expect(data.registry_operator).to be_nil
+    end
+  end
+
+  describe 'BSV::Registry::CertificateDefinitionData' do
+    let(:fields) do
+      {
+        'email' => BSV::Registry::CertificateFieldDescriptor.new(
+          friendly_name: 'Email',
+          description: 'Email address',
+          type: 'text',
+          field_icon: ''
+        )
+      }
+    end
+
+    let(:data) do
+      BSV::Registry::CertificateDefinitionData.new(
+        type: 'cert-type-base64==',
+        name: 'Email Certificate',
+        icon_url: 'https://example.com/cert.png',
+        description: 'Certifies email ownership',
+        documentation_url: 'https://example.com/cert-docs',
+        fields: fields
+      )
+    end
+
+    it 'reports definition_type as certificate' do
+      expect(data.definition_type).to eq(BSV::Registry::DefinitionType::CERTIFICATE)
+    end
+
+    it 'stores type' do
+      expect(data.type).to eq('cert-type-base64==')
+    end
+
+    it 'stores fields' do
+      expect(data.fields).to have_key('email')
+    end
+
+    it 'defaults fields to an empty hash' do
+      d = BSV::Registry::CertificateDefinitionData.new(
+        type: 't', name: 'n', icon_url: '', description: '', documentation_url: ''
+      )
+      expect(d.fields).to eq({})
+    end
+  end
+
+  describe 'BSV::Registry::RegisteredDefinition' do
+    let(:definition_data) do
+      BSV::Registry::BasketDefinitionData.new(
+        basket_id: 'test-basket',
+        name: 'Test',
+        icon_url: '',
+        description: '',
+        documentation_url: ''
+      )
+    end
+
+    let(:registered) do
+      BSV::Registry::RegisteredDefinition.new(
+        definition_data: definition_data,
+        txid: 'ab' * 32,
+        output_index: 0,
+        locking_script: 'deadbeef',
+        beef: 'rawbeef'
+      )
+    end
+
+    it 'exposes definition_type from the embedded data' do
+      expect(registered.definition_type).to eq(BSV::Registry::DefinitionType::BASKET)
+    end
+
+    it 'stores txid' do
+      expect(registered.txid).to eq('ab' * 32)
+    end
+
+    it 'stores output_index' do
+      expect(registered.output_index).to eq(0)
+    end
+
+    it 'stores locking_script' do
+      expect(registered.locking_script).to eq('deadbeef')
+    end
+
+    it 'stores beef' do
+      expect(registered.beef).to eq('rawbeef')
+    end
+
+    it 'defaults satoshis to 1' do
+      expect(registered.satoshis).to eq(1)
+    end
+
+    it 'stores explicit satoshis' do
+      r = BSV::Registry::RegisteredDefinition.new(
+        definition_data: definition_data,
+        txid: 'ab' * 32,
+        output_index: 0,
+        locking_script: '',
+        beef: '',
+        satoshis: 42
+      )
+      expect(r.satoshis).to eq(42)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **BSV::Registry::Client** — on-chain definition management for protocols, baskets, and certificate types via PushDrop tokens over the overlay network
  - `register_definition` — build PushDrop fields, lock via PushDropTemplate, create tx, broadcast to per-type topics (tm_basketmap, tm_protomap, tm_certmap)
  - `resolve` — query per-type lookup services, parse BEEF responses, decode PushDrop fields into RegisteredDefinition structs
  - `list_own_registry_entries` — query wallet outputs in registry basket, parse PushDrop scripts
  - `revoke_definition` — look up existing definition, create spending tx, broadcast
  - `update_definition` — revoke then re-register with updated data
- **Types**: DefinitionType (protocol/basket/certificate_type), BasketDefinitionData, ProtocolDefinitionData, CertificateDefinitionData, RegisteredDefinition
- **Constants**: per-type topics, services, protocol IDs, basket names — matching TS and Go SDK values

All dependencies injectable (broadcaster, resolver, wallet). Follows the Identity client pattern exactly.

## Test plan

- [x] 83 new registry specs pass
- [x] Full suite: 2790 examples, 0 failures, 5 pending
- [x] RuboCop: 0 offences
- [x] Cross-SDK alignment verified against TS and Go reference implementations

Closes #239, closes #254, closes #255, closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)