### PR TITLE
fix(wallet): include source transactions in BEEF output

### DIFF
--- a/lib/bsv/wallet_interface/wallet_client.rb
+++ b/lib/bsv/wallet_interface/wallet_client.rb
@@ -520,6 +520,10 @@ module BSV
 
         input.source_satoshis = stored[:satoshis]
         input.source_locking_script = BSV::Script::Script.from_hex(stored[:locking_script])
+
+        return unless stored[:source_tx_hex]
+
+        input.source_transaction = BSV::Transaction::Transaction.from_hex(stored[:source_tx_hex])
       end
 
       def build_outputs(tx, outputs)
@@ -601,6 +605,8 @@ module BSV
       def store_tracked_outputs(txid, tx, output_specs)
         return unless output_specs
 
+        tx_hex = tx.to_hex
+
         output_specs.each do |spec|
           next unless spec[:basket]
 
@@ -617,7 +623,8 @@ module BSV
                                   basket: spec[:basket],
                                   tags: spec[:tags] || [],
                                   custom_instructions: spec[:custom_instructions],
-                                  spendable: true
+                                  spendable: true,
+                                  source_tx_hex: tx_hex
                                 })
         end
       end
@@ -660,6 +667,7 @@ module BSV
 
       def process_internalize_outputs(tx, output_specs)
         txid = tx.txid_hex
+        tx_hex = tx.to_hex
 
         output_specs.each do |spec|
           output_index = spec[:output_index]
@@ -668,16 +676,16 @@ module BSV
 
           case spec[:protocol]
           when 'wallet payment'
-            internalize_payment(txid, output_index, tx_output, spec[:payment_remittance])
+            internalize_payment(txid, output_index, tx_output, spec[:payment_remittance], tx_hex)
           when 'basket insertion'
-            internalize_basket(txid, output_index, tx_output, spec[:insertion_remittance])
+            internalize_basket(txid, output_index, tx_output, spec[:insertion_remittance], tx_hex)
           else
             raise InvalidParameterError.new('protocol', '"wallet payment" or "basket insertion"')
           end
         end
       end
 
-      def internalize_payment(txid, output_index, tx_output, remittance)
+      def internalize_payment(txid, output_index, tx_output, remittance, tx_hex = nil)
         unless remittance
           raise InvalidParameterError.new('payment_remittance',
                                           'present for wallet payment protocol')
@@ -705,11 +713,12 @@ module BSV
                                 spendable: true,
                                 sender_identity_key: sender_key,
                                 derivation_prefix: prefix,
-                                derivation_suffix: suffix
+                                derivation_suffix: suffix,
+                                source_tx_hex: tx_hex
                               })
       end
 
-      def internalize_basket(txid, output_index, tx_output, remittance)
+      def internalize_basket(txid, output_index, tx_output, remittance, tx_hex = nil)
         unless remittance
           raise InvalidParameterError.new('insertion_remittance',
                                           'present for basket insertion protocol')
@@ -724,7 +733,8 @@ module BSV
                                 basket: remittance[:basket],
                                 tags: remittance[:tags] || [],
                                 custom_instructions: remittance[:custom_instructions],
-                                spendable: true
+                                spendable: true,
+                                source_tx_hex: tx_hex
                               })
       end
 

--- a/spec/bsv/wallet_interface/wallet_client_template_signing_spec.rb
+++ b/spec/bsv/wallet_interface/wallet_client_template_signing_spec.rb
@@ -29,8 +29,17 @@ RSpec.describe 'WalletClient P2PKH template signing' do
   let(:locking_script) { BSV::Script::Script.p2pkh_lock(pub_key.hash160) }
   let(:locking_script_hex) { locking_script.to_hex }
 
-  # A tracked source output stored directly in the MemoryStore
-  let(:source_txid) { 'a' * 64 }
+  # A real source transaction (needed to produce valid hex for BEEF ancestry)
+  let(:source_tx) do
+    tx = BSV::Transaction::Transaction.new
+    tx.add_output(BSV::Transaction::TransactionOutput.new(
+                    satoshis: source_satoshis,
+                    locking_script: locking_script
+                  ))
+    tx
+  end
+  let(:source_tx_hex) { source_tx.to_hex }
+  let(:source_txid) { source_tx.txid_hex }
   let(:source_outpoint) { "#{source_txid}.0" }
   let(:source_satoshis) { 5000 }
 
@@ -41,7 +50,8 @@ RSpec.describe 'WalletClient P2PKH template signing' do
                            locking_script: locking_script_hex,
                            basket: 'test-basket',
                            tags: [],
-                           spendable: true
+                           spendable: true,
+                           source_tx_hex: source_tx_hex
                          })
   end
 
@@ -81,11 +91,38 @@ RSpec.describe 'WalletClient P2PKH template signing' do
       beef = BSV::Transaction::Beef.from_binary(beef_binary)
       tx = beef.transactions.last.transaction
 
-      # Wire source data for verification (not present in BEEF for a 1-hop tx)
-      tx.inputs.first.source_satoshis = source_satoshis
-      tx.inputs.first.source_locking_script = locking_script
+      # Source transaction is now included in the BEEF; wire it for verification
+      input = tx.inputs.first
+      input.source_satoshis = source_satoshis
+      input.source_locking_script = locking_script
 
       expect(tx.verify_input(0)).to be true
+    end
+  end
+
+  # --- Gap 4: BEEF contains parent transactions via source_tx_hex ---
+
+  describe 'Gap 4: to_beef includes ancestor transactions from source_transaction' do
+    it 'produces a BEEF with more than one transaction entry' do
+      beef_binary = result[:tx].pack('C*')
+      beef = BSV::Transaction::Beef.from_binary(beef_binary)
+      tx_entries = beef.transactions.select(&:transaction)
+      expect(tx_entries.length).to be > 1
+    end
+
+    it 'includes the source transaction as a BEEF ancestor' do
+      beef_binary = result[:tx].pack('C*')
+      beef = BSV::Transaction::Beef.from_binary(beef_binary)
+      txids = beef.transactions.select(&:transaction).map { |bt| bt.transaction.txid_hex }
+      expect(txids).to include(source_txid)
+    end
+
+    it 'wire_source_from_storage sets source_transaction on the input' do
+      # Verify by checking the BEEF contains the ancestor rather than inspecting internals
+      beef_binary = result[:tx].pack('C*')
+      beef = BSV::Transaction::Beef.from_binary(beef_binary)
+      subject_tx = beef.transactions.last.transaction
+      expect(subject_tx.inputs.first.source_transaction).not_to be_nil
     end
   end
 end


### PR DESCRIPTION
## Summary

- Store `source_tx_hex` at all three output write sites (`store_tracked_outputs`, `internalize_payment`, `internalize_basket`)
- Reconstruct `source_transaction` in `wire_source_from_storage` so `to_beef` can walk the ancestry chain
- Without this, BEEF contained only the subject transaction and ARC rejected it as malformed (463)

## Test plan

- [ ] 3 new specs verify BEEF contains ancestor transactions
- [ ] 541 total wallet specs passing
- [ ] Full suite passing
- [ ] Rubocop clean

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)