### PR TITLE
test(wallet): assert BEEF validity in template signing spec

### DIFF
--- a/spec/bsv/wallet_interface/wallet_client_template_signing_spec.rb
+++ b/spec/bsv/wallet_interface/wallet_client_template_signing_spec.rb
@@ -117,12 +117,10 @@ RSpec.describe 'WalletClient P2PKH template signing' do
       expect(txids).to include(source_txid)
     end
 
-    it 'wire_source_from_storage sets source_transaction on the input' do
-      # Verify by checking the BEEF contains the ancestor rather than inspecting internals
+    it 'produces a valid BEEF (all inputs reference known transactions)' do
       beef_binary = result[:tx].pack('C*')
       beef = BSV::Transaction::Beef.from_binary(beef_binary)
-      subject_tx = beef.transactions.last.transaction
-      expect(subject_tx.inputs.first.source_transaction).not_to be_nil
+      expect(beef.valid?).to be true
     end
   end
 end


### PR DESCRIPTION
## Summary

- Replaces the weaker `source_transaction.not_to be_nil` check with `beef.valid?`
- `valid?` verifies all inputs reference known transactions in the BEEF envelope — the actual validation ARC performs
- This would have caught #275 before it reached production

## Test plan

- [ ] 8 wallet template signing specs passing
- [ ] 541 total wallet specs passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)