### PR TITLE
fix(wallet): store subject transaction hex during internalize_action

### DIFF
--- a/lib/bsv/wallet_interface/wallet_client.rb
+++ b/lib/bsv/wallet_interface/wallet_client.rb
@@ -183,6 +183,7 @@ module BSV
         tx = extract_subject_transaction(beef)
 
         store_proofs_from_beef(beef)
+        @storage.store_transaction(tx.txid_hex, tx.to_hex)
         process_internalize_outputs(tx, args[:outputs])
         store_action(tx, args, status: 'completed')
         { accepted: true }


### PR DESCRIPTION
## Summary

- One-line fix: `@storage.store_transaction(tx.txid_hex, tx.to_hex)` after extracting the subject tx from BEEF
- Without this, `wire_source_from_storage` can't find the source tx when spending internalized outputs, breaking the BEEF ancestry chain

## Test plan

- [ ] 551 wallet specs passing
- [ ] Full suite passing

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)