### PR TITLE
fix(wallet): store all BEEF transactions, not just proven ones

### DIFF
--- a/lib/bsv/wallet_interface/wallet_client.rb
+++ b/lib/bsv/wallet_interface/wallet_client.rb
@@ -685,11 +685,11 @@ module BSV
 
       def store_proofs_from_beef(beef)
         beef.transactions.each do |beef_tx|
-          next unless beef_tx.transaction&.merkle_path
+          next unless beef_tx.transaction
 
           txid_hex = beef_tx.transaction.txid_hex
-          @proof_store.store_proof(txid_hex, beef_tx.transaction.merkle_path)
           @storage.store_transaction(txid_hex, beef_tx.transaction.to_hex)
+          @proof_store.store_proof(txid_hex, beef_tx.transaction.merkle_path) if beef_tx.transaction.merkle_path
         end
       end
 


### PR DESCRIPTION
## Summary

- `store_proofs_from_beef` was skipping transactions without merkle proofs, losing unproven ancestors from incoming BEEF
- Now stores all transactions; proofs stored separately for those that have them
- Fixes ancestry chain reconstruction when spending through unconfirmed intermediates

## Context

Live x402-doom flow: proven grandparent → unconfirmed INSERT COIN tx → spending tx. The intermediate INSERT COIN tx was in the incoming BEEF but was skipped because it had no proof. `wire_source_tx_ancestors` then couldn't find it.

## Test plan

- [ ] 551 wallet specs passing
- [ ] Full suite passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)