### PR TITLE
fix(wallet): store spending transaction during finalize_action

### DIFF
--- a/lib/bsv/wallet_interface/wallet_client.rb
+++ b/lib/bsv/wallet_interface/wallet_client.rb
@@ -598,6 +598,7 @@ module BSV
         txid = tx.txid_hex
         status = args.dig(:options, :no_send) ? 'nosend' : 'completed'
 
+        @storage.store_transaction(txid, tx.to_hex)
         store_action(tx, args, status: status)
         store_tracked_outputs(txid, tx, args[:outputs])
 


### PR DESCRIPTION
## Summary

- Store the spending transaction in the transaction cache during `finalize_action`
- Without this, unconfirmed change outputs can't be respent — the BEEF ancestry chain breaks at the first refund
- Same pattern as #281 (store subject tx during internalize_action)

## Context

x402-doom: first two pickups work, third fails with 463. The change output from the second refund is three levels deep with no proven ancestor reachable — because the intermediate refund tx was never stored.

## Test plan

- [ ] 551 wallet specs passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)