### PR TITLE
fix(beef): serialise BUMPs from @bumps, not tx.merkle_path walk

### DIFF
--- a/lib/bsv/transaction/beef.rb
+++ b/lib/bsv/transaction/beef.rb
@@ -54,7 +54,10 @@ module BSV
         # @param transaction [Transaction, nil] the transaction
         # @param known_txid [String, nil] 32-byte txid for TXID-only entries
         # @param bump_index [Integer, nil] index into the bumps array
+        # @raise [ArgumentError] if format is FORMAT_RAW_TX_AND_BUMP without a bump_index
         def initialize(format:, transaction: nil, known_txid: nil, bump_index: nil)
+          raise ArgumentError, 'FORMAT_RAW_TX_AND_BUMP requires a bump_index' if format == FORMAT_RAW_TX_AND_BUMP && bump_index.nil?
+
           @format = format
           @transaction = transaction
           @known_txid = known_txid
@@ -324,7 +327,12 @@ module BSV
         return existing if existing
 
         entry = if bump_index
-                  tx.merkle_path = @bumps[bump_index] if bump_index < @bumps.length
+                  unless bump_index.is_a?(Integer) && bump_index >= 0 && bump_index < @bumps.length
+                    raise ArgumentError,
+                          "bump_index #{bump_index.inspect} out of range (have #{@bumps.length} bumps)"
+                  end
+
+                  tx.merkle_path = @bumps[bump_index]
                   BeefTx.new(format: FORMAT_RAW_TX_AND_BUMP, transaction: tx, bump_index: bump_index)
                 else
                   BeefTx.new(format: FORMAT_RAW_TX, transaction: tx)

--- a/spec/bsv/transaction/beef_spec.rb
+++ b/spec/bsv/transaction/beef_spec.rb
@@ -582,6 +582,77 @@ RSpec.describe BSV::Transaction::Beef do
     end
   end
 
+  describe '#merge_raw_tx' do
+    let(:raw_tx_hex) do
+      '010000000193a35408b6068499e0d5abd799d3e827d9bfe70c9b75ebe209c91d25072326510000000000ffffffff' \
+        '02404b4c00000000001976a91404ff367be719efa79d76e4416ffb072cd53b208888acde94a905000000001976a914' \
+        '04d03f746652cfcb6cb55119ab473a045137d26588ac00000000'
+    end
+
+    it 'stores a raw transaction without a BUMP' do
+      beef = described_class.new
+      entry = beef.merge_raw_tx([raw_tx_hex].pack('H*'))
+      expect(entry.format).to eq(described_class::FORMAT_RAW_TX)
+    end
+
+    it 'stores a raw transaction with a valid BUMP index' do
+      source = described_class.from_hex(brc62_hex)
+      beef = described_class.new
+      beef.merge_bump(source.bumps.first)
+
+      entry = beef.merge_raw_tx([raw_tx_hex].pack('H*'), bump_index: 0)
+      expect(entry.format).to eq(described_class::FORMAT_RAW_TX_AND_BUMP)
+      expect(entry.bump_index).to eq(0)
+    end
+
+    it 'raises when bump_index is beyond @bumps' do
+      beef = described_class.new
+      expect do
+        beef.merge_raw_tx([raw_tx_hex].pack('H*'), bump_index: 99)
+      end.to raise_error(ArgumentError, /out of range/)
+    end
+
+    it 'raises when bump_index is negative' do
+      source = described_class.from_hex(brc62_hex)
+      beef = described_class.new
+      beef.merge_bump(source.bumps.first)
+
+      expect do
+        beef.merge_raw_tx([raw_tx_hex].pack('H*'), bump_index: -1)
+      end.to raise_error(ArgumentError, /out of range/)
+    end
+  end
+
+  describe 'BeefTx initialisation invariants' do
+    it 'raises when FORMAT_RAW_TX_AND_BUMP is constructed without a bump_index' do
+      tx = BSV::Transaction::Transaction.new
+      expect do
+        described_class::BeefTx.new(
+          format: described_class::FORMAT_RAW_TX_AND_BUMP,
+          transaction: tx
+        )
+      end.to raise_error(ArgumentError, /FORMAT_RAW_TX_AND_BUMP requires a bump_index/)
+    end
+
+    it 'accepts FORMAT_RAW_TX_AND_BUMP with a bump_index' do
+      tx = BSV::Transaction::Transaction.new
+      expect do
+        described_class::BeefTx.new(
+          format: described_class::FORMAT_RAW_TX_AND_BUMP,
+          transaction: tx,
+          bump_index: 0
+        )
+      end.not_to raise_error
+    end
+
+    it 'accepts FORMAT_RAW_TX without a bump_index' do
+      tx = BSV::Transaction::Transaction.new
+      expect do
+        described_class::BeefTx.new(format: described_class::FORMAT_RAW_TX, transaction: tx)
+      end.not_to raise_error
+    end
+  end
+
   describe '#merge_transaction' do
     it 'adds a transaction and its ancestors' do
       source = described_class.from_hex(beef_set_hex)


### PR DESCRIPTION
## Summary

Fixes #288.

`Beef#to_binary` previously used `build_bump_map` to walk each transaction's `merkle_path` attribute via object identity. When two same-block ancestors were merged via `merge_bump`, the second path was combined into the existing `@bumps` entry — but the absorbed transaction's `merkle_path` still pointed at its un-merged instance. `build_bump_map` then wrote both as separate BUMPs, defeating the in-memory dedupe and producing bloated BEEF bundles with duplicate BUMPs at the same block height. ARC rejects these with parser-misalignment errors.

The fix drives serialisation from `@bumps` directly and uses `beef_tx.bump_index` (already set on every `FORMAT_RAW_TX_AND_BUMP` entry across all six construction paths) as the on-wire reference. `build_bump_map` is deleted. This matches the pattern used in the TS and Go reference SDKs.

## Why not the fix proposed in the issue?

The original issue identified two bugs and proposed targeted fixes for both. Investigation found:

- **Bug 1 (`compute_root(nil)` picks wrong leaf)**: not actually a bug. Empirically verified that walking up from a level-0 sibling produces the same merkle root as walking from the txid itself, because direct merkle-pair siblings share all ancestors upward. The issue's own trace contained the contradiction — *"every single same-block call producing `match=true`"* proves `merge_bump`'s root comparison was already working.

- **Bug 2 (`to_binary` ignores `@bumps`)**: real. The issue's proposed fix in `Transaction#to_beef` works but is a band-aid — it re-points `tx.merkle_path` to `beef.bumps[bump_idx]` so identity comparison finds the merged object. It doesn't fix `Beef#merge_transaction`, which has the identical bug pattern, nor direct `Beef` construction.

The cleaner fix addresses the root cause: there shouldn't be two sources of truth for "which BUMPs does this BEEF contain". `@bumps` is canonical; `bump_index` already points into it. Use them directly.

## Changes

- `lib/bsv/transaction/beef.rb`: `to_binary` writes `@bumps` directly; `write_v1_tx`/`write_v2_tx` use `beef_tx.bump_index`; `build_bump_map` deleted. Net −23 lines.
- `spec/bsv/transaction/beef_spec.rb`: 6 regression tests under `"same-block BUMP dedup in to_binary (issue #288)"` covering merkle-root equivalence, in-memory `merge_bump` dedupe, V1 and V2 serialisation round-trips, `Beef#merge_transaction`, and `Transaction#to_beef`.

## Test plan

- [x] Full suite passes (`bundle exec rake`): 3021 examples, 0 failures
- [x] RuboCop clean on modified files
- [x] New regression tests fail against the old code (verified by stashing the fix) — 4 of 6 report `expected: 1, got: 2` BUMPs, confirming they exercise the bug
- [x] Existing BRC-62 V1 and BRC-96 V2 round-trip tests still pass
- [ ] Manual ARC broadcast of a same-block sweep (not automated — original reporter's environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)