### PR TITLE
feat: Arcade integration — Chaintracks, default broadcaster, batch broadcast

### DIFF
--- a/gem/bsv-sdk/lib/bsv/network/arc.rb
+++ b/gem/bsv-sdk/lib/bsv/network/arc.rb
@@ -15,6 +15,16 @@ module BSV
     # The HTTP client is injectable for testability. It must respond to
     # #request(uri, request) and return an object with #code and #body.
     class ARC
+      # Returns an ARC instance pointed at the GorillaPool public ARC endpoint.
+      #
+      # @param testnet [Boolean] when true, uses the GorillaPool testnet endpoint
+      # @param opts [Hash] forwarded to {#initialize} (e.g. +api_key:+, +callback_url:+)
+      # @return [ARC]
+      def self.default(testnet: false, **opts)
+        url = testnet ? 'https://testnet.arc.gorillapool.io' : 'https://arc.gorillapool.io'
+        new(url, **opts)
+      end
+
       # ARC response statuses that indicate the transaction was NOT accepted.
       # Matches the TypeScript SDK's ARC broadcaster failure set (issue #305,
       # finding F5.13). Prior to this fix, Ruby only recognised REJECTED and

--- a/gem/bsv-sdk/lib/bsv/network/arc.rb
+++ b/gem/bsv-sdk/lib/bsv/network/arc.rb
@@ -278,6 +278,11 @@ module BSV
             status_code: 200,
             txid: body['txid']
           )
+        elsif !body['txid']
+          BroadcastError.new(
+            'ARC returned a malformed 2xx response',
+            status_code: 200
+          )
         else
           build_response(body)
         end

--- a/gem/bsv-sdk/lib/bsv/network/arc.rb
+++ b/gem/bsv-sdk/lib/bsv/network/arc.rb
@@ -86,15 +86,9 @@ module BSV
       #   rejected/orphan +txStatus+
       def broadcast(tx, wait_for: nil, skip_fee_validation: nil, skip_script_validation: nil)
         uri = URI("#{@url}/v1/tx")
-        request = Net::HTTP::Post.new(uri)
-        request['Content-Type'] = 'application/json'
-        request['XDeployment-ID'] = @deployment_id
-        request['X-WaitFor'] = wait_for if wait_for
-        request['X-CallbackUrl'] = @callback_url if @callback_url
-        request['X-CallbackToken'] = @callback_token if @callback_token
-        request['X-SkipFeeValidation'] = 'true' if skip_fee_validation
-        request['X-SkipScriptValidation'] = 'true' if skip_script_validation
-        apply_auth_header(request)
+        request = build_post_request(uri, wait_for: wait_for,
+                                          skip_fee_validation: skip_fee_validation,
+                                          skip_script_validation: skip_script_validation)
         request.body = JSON.generate(rawTx: raw_tx_hex(tx))
 
         response = execute(uri, request)
@@ -126,15 +120,9 @@ module BSV
         return [] if txs.empty?
 
         uri = URI("#{@url}/v1/txs")
-        request = Net::HTTP::Post.new(uri)
-        request['Content-Type'] = 'application/json'
-        request['XDeployment-ID'] = @deployment_id
-        request['X-WaitFor'] = wait_for if wait_for
-        request['X-CallbackUrl'] = @callback_url if @callback_url
-        request['X-CallbackToken'] = @callback_token if @callback_token
-        request['X-SkipFeeValidation'] = 'true' if skip_fee_validation
-        request['X-SkipScriptValidation'] = 'true' if skip_script_validation
-        apply_auth_header(request)
+        request = build_post_request(uri, wait_for: wait_for,
+                                          skip_fee_validation: skip_fee_validation,
+                                          skip_script_validation: skip_script_validation)
         request.body = JSON.generate(txs.map { |tx| { rawTx: raw_tx_hex(tx) } })
 
         response = execute(uri, request)
@@ -162,6 +150,19 @@ module BSV
         tx.to_ef_hex
       rescue ArgumentError
         tx.to_hex
+      end
+
+      def build_post_request(uri, wait_for: nil, skip_fee_validation: nil, skip_script_validation: nil)
+        request = Net::HTTP::Post.new(uri)
+        request['Content-Type'] = 'application/json'
+        request['XDeployment-ID'] = @deployment_id
+        request['X-WaitFor'] = wait_for if wait_for
+        request['X-CallbackUrl'] = @callback_url if @callback_url
+        request['X-CallbackToken'] = @callback_token if @callback_token
+        request['X-SkipFeeValidation'] = 'true' if skip_fee_validation
+        request['X-SkipScriptValidation'] = 'true' if skip_script_validation
+        apply_auth_header(request)
+        request
       end
 
       def apply_auth_header(request)
@@ -252,23 +253,23 @@ module BSV
 
       def handle_batch_response(response)
         code = response.code.to_i
+        body = parse_json(response.body)
+
         unless (200..299).cover?(code)
-          body = parse_json(response.body)
           raise BroadcastError.new(
             body['detail'] || body['title'] || "HTTP #{code}",
             status_code: code
           )
         end
 
-        results = JSON.parse(response.body)
-        unless results.is_a?(Array)
+        unless body.is_a?(Array)
           raise BroadcastError.new(
             'ARC returned a malformed batch response',
             status_code: code
           )
         end
 
-        results.map { |body| build_response_or_error(body) }
+        body.map { |item| build_response_or_error(item) }
       end
 
       def build_response_or_error(body)

--- a/gem/bsv-sdk/lib/bsv/network/arc.rb
+++ b/gem/bsv-sdk/lib/bsv/network/arc.rb
@@ -73,10 +73,18 @@ module BSV
       #   'SEEN_ON_NETWORK', or 'MINED'. When set, ARC holds the
       #   connection open until the transaction reaches the requested
       #   state (or times out). Defaults to nil (no wait).
+      # @param skip_fee_validation [Boolean, nil] when truthy, sends the
+      #   +X-SkipFeeValidation: true+ header, asking ARC to bypass its
+      #   minimum-fee check. Useful for zero-fee data transactions or
+      #   during local testing. Defaults to nil (fee validation applies).
+      # @param skip_script_validation [Boolean, nil] when truthy, sends the
+      #   +X-SkipScriptValidation: true+ header, asking ARC to bypass
+      #   script correctness checks. Defaults to nil (script validation
+      #   applies).
       # @return [BroadcastResponse]
       # @raise [BroadcastError] when ARC returns a non-2xx HTTP status or a
       #   rejected/orphan +txStatus+
-      def broadcast(tx, wait_for: nil)
+      def broadcast(tx, wait_for: nil, skip_fee_validation: nil, skip_script_validation: nil)
         uri = URI("#{@url}/v1/tx")
         request = Net::HTTP::Post.new(uri)
         request['Content-Type'] = 'application/json'
@@ -84,6 +92,8 @@ module BSV
         request['X-WaitFor'] = wait_for if wait_for
         request['X-CallbackUrl'] = @callback_url if @callback_url
         request['X-CallbackToken'] = @callback_token if @callback_token
+        request['X-SkipFeeValidation'] = 'true' if skip_fee_validation
+        request['X-SkipScriptValidation'] = 'true' if skip_script_validation
         apply_auth_header(request)
         request.body = JSON.generate(rawTx: raw_tx_hex(tx))
 

--- a/gem/bsv-sdk/lib/bsv/network/arc.rb
+++ b/gem/bsv-sdk/lib/bsv/network/arc.rb
@@ -101,6 +101,46 @@ module BSV
         handle_broadcast_response(response)
       end
 
+      # Submit multiple transactions to ARC in a single batch request.
+      #
+      # Each transaction is encoded as Extended Format (BRC-30) hex where
+      # possible, falling back to plain raw-tx hex per transaction independently.
+      #
+      # Returns a mixed array of {BroadcastResponse} and {BroadcastError} objects
+      # — one element per submitted transaction in the same order. Per-transaction
+      # rejections are returned as {BroadcastError} values rather than raised, so
+      # callers can inspect the full result set even when some transactions fail.
+      # Only HTTP-level errors (non-2xx) raise a {BroadcastError} for the whole
+      # batch.
+      #
+      # @param txs [Array<Transaction>] transactions to broadcast
+      # @param wait_for [String, nil] ARC wait condition (see {#broadcast})
+      # @param skip_fee_validation [Boolean, nil] when truthy, sends
+      #   +X-SkipFeeValidation: true+ for the batch request
+      # @param skip_script_validation [Boolean, nil] when truthy, sends
+      #   +X-SkipScriptValidation: true+ for the batch request
+      # @return [Array<BroadcastResponse, BroadcastError>]
+      # @raise [BroadcastError] when ARC returns a non-2xx HTTP status or a
+      #   malformed (non-array) response body
+      def broadcast_many(txs, wait_for: nil, skip_fee_validation: nil, skip_script_validation: nil)
+        return [] if txs.empty?
+
+        uri = URI("#{@url}/v1/txs")
+        request = Net::HTTP::Post.new(uri)
+        request['Content-Type'] = 'application/json'
+        request['XDeployment-ID'] = @deployment_id
+        request['X-WaitFor'] = wait_for if wait_for
+        request['X-CallbackUrl'] = @callback_url if @callback_url
+        request['X-CallbackToken'] = @callback_token if @callback_token
+        request['X-SkipFeeValidation'] = 'true' if skip_fee_validation
+        request['X-SkipScriptValidation'] = 'true' if skip_script_validation
+        apply_auth_header(request)
+        request.body = JSON.generate(txs.map { |tx| { rawTx: raw_tx_hex(tx) } })
+
+        response = execute(uri, request)
+        handle_batch_response(response)
+      end
+
       # Query the status of a previously submitted transaction.
       # Returns BroadcastResponse on success, raises BroadcastError on failure.
       def status(txid)
@@ -208,6 +248,39 @@ module BSV
           timestamp: body['timestamp'],
           competing_txs: body['competingTxs']
         )
+      end
+
+      def handle_batch_response(response)
+        code = response.code.to_i
+        unless (200..299).cover?(code)
+          body = parse_json(response.body)
+          raise BroadcastError.new(
+            body['detail'] || body['title'] || "HTTP #{code}",
+            status_code: code
+          )
+        end
+
+        results = JSON.parse(response.body)
+        unless results.is_a?(Array)
+          raise BroadcastError.new(
+            'ARC returned a malformed batch response',
+            status_code: code
+          )
+        end
+
+        results.map { |body| build_response_or_error(body) }
+      end
+
+      def build_response_or_error(body)
+        if rejected_status?(body)
+          BroadcastError.new(
+            body['detail'] || body['title'] || body['txStatus'],
+            status_code: 200,
+            txid: body['txid']
+          )
+        else
+          build_response(body)
+        end
       end
     end
   end

--- a/gem/bsv-sdk/lib/bsv/transaction/chain_trackers.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/chain_trackers.rb
@@ -5,6 +5,17 @@ module BSV
     # Namespace for chain tracker implementations.
     module ChainTrackers
       autoload :WhatsOnChain, 'bsv/transaction/chain_trackers/whats_on_chain'
+      autoload :Chaintracks,  'bsv/transaction/chain_trackers/chaintracks'
+
+      # Return a default chain tracker backed by the Arcade/GorillaPool Chaintracks API.
+      #
+      # @param testnet [Boolean] use the testnet endpoint when true
+      # @param api_key [String, nil] optional Bearer API key
+      # @return [Chaintracks]
+      def self.default(testnet: false, api_key: nil)
+        url = testnet ? Chaintracks::TESTNET_URL : Chaintracks::MAINNET_URL
+        Chaintracks.new(url: url, api_key: api_key)
+      end
     end
   end
 end

--- a/gem/bsv-sdk/lib/bsv/transaction/chain_trackers/chaintracks.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/chain_trackers/chaintracks.rb
@@ -43,7 +43,10 @@ module BSV
           return false if response.nil?
 
           data = JSON.parse(response.body)
-          data['merkleRoot'].downcase == root.downcase
+          merkle_root = data['merkleRoot']
+          return false unless merkle_root
+
+          merkle_root.downcase == root.downcase
         end
 
         # Return the current blockchain height.

--- a/gem/bsv-sdk/lib/bsv/transaction/chain_trackers/chaintracks.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/chain_trackers/chaintracks.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+require 'uri'
+
+module BSV
+  module Transaction
+    module ChainTrackers
+      # Chain tracker that verifies merkle roots using the Chaintracks API (Arcade/GorillaPool).
+      #
+      # Queries the Chaintracks v2 block header endpoint to retrieve the merkle root for a
+      # given block height and compares it with the provided root.
+      #
+      # @example
+      #   tracker = BSV::Transaction::ChainTrackers::Chaintracks.new
+      #   tracker.valid_root_for_height?('abcd...', 800_000)
+      #
+      # @example With API key
+      #   tracker = BSV::Transaction::ChainTrackers::Chaintracks.new(api_key: 'my-key')
+      #   tracker.current_height
+      class Chaintracks < ChainTracker
+        MAINNET_URL = 'https://arcade.gorillapool.io'
+        TESTNET_URL = 'https://testnet.arcade.gorillapool.io'
+
+        # @param url [String] base URL for the Chaintracks API
+        # @param api_key [String, nil] optional Bearer API key
+        # @param http_client [#request, nil] injectable HTTP client for testing
+        def initialize(url: MAINNET_URL, api_key: nil, http_client: nil)
+          super()
+          @url = url
+          @api_key = api_key
+          @http_client = http_client
+        end
+
+        # Verify that a merkle root is valid for the given block height.
+        #
+        # @param root [String] merkle root as a hex string
+        # @param height [Integer] block height
+        # @return [Boolean]
+        def valid_root_for_height?(root, height)
+          response = get("/chaintracks/v2/header/height/#{height}")
+          return false if response.nil?
+
+          data = JSON.parse(response.body)
+          data['merkleRoot'].downcase == root.downcase
+        end
+
+        # Return the current blockchain height.
+        #
+        # @return [Integer]
+        def current_height
+          response = get('/chaintracks/v2/tip', not_found_returns_nil: false)
+          data = JSON.parse(response.body)
+          data['height']
+        end
+
+        private
+
+        # @param path [String] API path
+        # @param not_found_returns_nil [Boolean] if true, return nil on 404 instead of raising
+        # @return [Net::HTTPResponse, nil]
+        def get(path, not_found_returns_nil: true)
+          uri = URI("#{@url}#{path}")
+          request = Net::HTTP::Get.new(uri)
+          request['Authorization'] = "Bearer #{@api_key}" if @api_key
+
+          response = execute(uri, request)
+          code = response.code.to_i
+
+          return nil if not_found_returns_nil && code == 404
+          return response if (200..299).cover?(code)
+
+          raise BSV::Network::ChainProviderError.new(
+            response.body || "HTTP #{code}",
+            status_code: code
+          )
+        end
+
+        def execute(uri, request)
+          if @http_client
+            @http_client.request(uri, request)
+          else
+            Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+              http.request(request)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/bsv/network/arc_spec.rb
+++ b/spec/bsv/network/arc_spec.rb
@@ -601,13 +601,11 @@ RSpec.describe BSV::Network::ARC do
 
   describe '.default' do
     it 'returns an ARC instance pointed at the mainnet GorillaPool endpoint' do
-      arc = described_class.default
+      http = mock_http.new(200, success_body)
+      arc = described_class.default(http_client: http)
 
       expect(arc).to be_a(described_class)
-      # Verify the URL by posting a broadcast and inspecting the request URI
-      http = mock_http.new(200, success_body)
-      mainnet_arc = described_class.default(http_client: http)
-      mainnet_arc.broadcast(tx)
+      arc.broadcast(tx)
       expect(http.last_uri.host).to eq('arc.gorillapool.io')
     end
 

--- a/spec/bsv/network/arc_spec.rb
+++ b/spec/bsv/network/arc_spec.rb
@@ -441,6 +441,153 @@ RSpec.describe BSV::Network::ARC do
     end
   end
 
+  describe '#broadcast_many' do
+    # Second transaction double for multi-tx batch tests
+    let(:tx2) do
+      instance_double(
+        BSV::Transaction::Transaction,
+        to_ef_hex: '020000000000ef0000',
+        to_hex: '02000000'
+      )
+    end
+
+    # Reusable single-item batch response body (parses success_body JSON string)
+    def single_batch(extra_txid: nil)
+      item1 = JSON.parse(success_body)
+      return [item1].to_json unless extra_txid
+
+      item2 = item1.merge('txid' => extra_txid)
+      [item1, item2].to_json
+    end
+
+    it 'POSTs to /v1/txs with a JSON array body' do
+      http = mock_http.new(200, single_batch(extra_txid: 'def456'))
+      arc = described_class.new('https://arc.example.com', http_client: http)
+
+      arc.broadcast_many([tx, tx2])
+
+      expect(http.last_uri.to_s).to eq('https://arc.example.com/v1/txs')
+      expect(http.last_request).to be_a(Net::HTTP::Post)
+      body = JSON.parse(http.last_request.body)
+      expected = [{ 'rawTx' => '010000000000ef0000' }, { 'rawTx' => '020000000000ef0000' }]
+      expect(body).to eq(expected)
+    end
+
+    it 'returns an array of BroadcastResponse on all-success' do
+      http = mock_http.new(200, single_batch(extra_txid: 'def456'))
+      arc = described_class.new('https://arc.example.com', http_client: http)
+
+      results = arc.broadcast_many([tx, tx2])
+
+      expect(results.length).to eq(2)
+      expect(results[0]).to be_a(BSV::Network::BroadcastResponse)
+      expect(results[0].txid).to eq('abc123')
+      expect(results[1]).to be_a(BSV::Network::BroadcastResponse)
+      expect(results[1].txid).to eq('def456')
+    end
+
+    it 'returns a mixed array when some txs are rejected' do
+      rejected = {
+        'txid' => 'def456',
+        'txStatus' => 'REJECTED',
+        'title' => 'Transaction rejected',
+        'detail' => 'inputs already spent'
+      }
+      batch = [JSON.parse(success_body), rejected].to_json
+      http = mock_http.new(200, batch)
+      arc = described_class.new('https://arc.example.com', http_client: http)
+
+      results = arc.broadcast_many([tx, tx2])
+
+      expect(results[0]).to be_a(BSV::Network::BroadcastResponse)
+      expect(results[0].txid).to eq('abc123')
+      expect(results[1]).to be_a(BSV::Network::BroadcastError)
+      expect(results[1].message).to eq('inputs already spent')
+      expect(results[1].txid).to eq('def456')
+      expect(results[1].status_code).to eq(200)
+    end
+
+    it 'raises BroadcastError on HTTP 500' do
+      body = { 'title' => 'Internal error', 'detail' => 'server fault' }.to_json
+      http = mock_http.new(500, body)
+      arc = described_class.new('https://arc.example.com', http_client: http)
+
+      expect { arc.broadcast_many([tx]) }.to raise_error(BSV::Network::BroadcastError) do |error|
+        expect(error.message).to eq('server fault')
+        expect(error.status_code).to eq(500)
+      end
+    end
+
+    it 'raises BroadcastError when ARC returns a non-array response body' do
+      body = { 'txid' => 'abc123', 'txStatus' => 'SEEN_ON_NETWORK' }.to_json
+      http = mock_http.new(200, body)
+      arc = described_class.new('https://arc.example.com', http_client: http)
+
+      expect { arc.broadcast_many([tx]) }
+        .to raise_error(BSV::Network::BroadcastError, /malformed batch response/)
+    end
+
+    it 'uses EF hex for each tx when available' do
+      http = mock_http.new(200, single_batch)
+      arc = described_class.new('https://arc.example.com', http_client: http)
+
+      arc.broadcast_many([tx])
+
+      body = JSON.parse(http.last_request.body)
+      expect(body[0]['rawTx']).to eq('010000000000ef0000')
+    end
+
+    it 'falls back to plain hex per tx when EF is unavailable' do
+      http = mock_http.new(200, single_batch(extra_txid: 'def456'))
+      arc = described_class.new('https://arc.example.com', http_client: http)
+
+      arc.broadcast_many([tx_no_source, tx2])
+
+      body = JSON.parse(http.last_request.body)
+      expect(body[0]['rawTx']).to eq('01000000')
+      expect(body[1]['rawTx']).to eq('020000000000ef0000')
+    end
+
+    it 'passes X-SkipFeeValidation and X-SkipScriptValidation headers when set' do
+      http = mock_http.new(200, single_batch)
+      arc = described_class.new('https://arc.example.com', http_client: http)
+
+      arc.broadcast_many([tx], skip_fee_validation: true, skip_script_validation: true)
+
+      expect(http.last_request['X-SkipFeeValidation']).to eq('true')
+      expect(http.last_request['X-SkipScriptValidation']).to eq('true')
+    end
+
+    it 'omits skip-validation headers when not set' do
+      http = mock_http.new(200, single_batch)
+      arc = described_class.new('https://arc.example.com', http_client: http)
+
+      arc.broadcast_many([tx])
+
+      expect(http.last_request['X-SkipFeeValidation']).to be_nil
+      expect(http.last_request['X-SkipScriptValidation']).to be_nil
+    end
+
+    it 'passes X-WaitFor header when wait_for is set' do
+      http = mock_http.new(200, single_batch)
+      arc = described_class.new('https://arc.example.com', http_client: http)
+
+      arc.broadcast_many([tx], wait_for: 'SEEN_ON_NETWORK')
+
+      expect(http.last_request['X-WaitFor']).to eq('SEEN_ON_NETWORK')
+    end
+
+    it 'returns an empty array without making an HTTP request when given empty input' do
+      http = mock_http.new(200, '[]')
+      arc = described_class.new('https://arc.example.com', http_client: http)
+
+      results = arc.broadcast_many([])
+
+      expect(results).to eq([])
+      expect(http.last_request).to be_nil
+    end
+  end
+
   describe '.default' do
     it 'returns an ARC instance pointed at the mainnet GorillaPool endpoint' do
       arc = described_class.default

--- a/spec/bsv/network/arc_spec.rb
+++ b/spec/bsv/network/arc_spec.rb
@@ -322,6 +322,56 @@ RSpec.describe BSV::Network::ARC do
         expect(error.status_code).to eq(500)
       end
     end
+
+    describe 'skip-validation headers (#340)' do
+      it 'sends X-SkipFeeValidation header when skip_fee_validation: true' do
+        http = mock_http.new(200, success_body)
+        arc = described_class.new('https://arc.example.com', http_client: http)
+
+        arc.broadcast(tx, skip_fee_validation: true)
+
+        expect(http.last_request['X-SkipFeeValidation']).to eq('true')
+      end
+
+      it 'sends X-SkipScriptValidation header when skip_script_validation: true' do
+        http = mock_http.new(200, success_body)
+        arc = described_class.new('https://arc.example.com', http_client: http)
+
+        arc.broadcast(tx, skip_script_validation: true)
+
+        expect(http.last_request['X-SkipScriptValidation']).to eq('true')
+      end
+
+      it 'omits X-SkipFeeValidation and X-SkipScriptValidation when not set' do
+        http = mock_http.new(200, success_body)
+        arc = described_class.new('https://arc.example.com', http_client: http)
+
+        arc.broadcast(tx)
+
+        expect(http.last_request['X-SkipFeeValidation']).to be_nil
+        expect(http.last_request['X-SkipScriptValidation']).to be_nil
+      end
+
+      it 'omits X-SkipFeeValidation and X-SkipScriptValidation when set to false' do
+        http = mock_http.new(200, success_body)
+        arc = described_class.new('https://arc.example.com', http_client: http)
+
+        arc.broadcast(tx, skip_fee_validation: false, skip_script_validation: false)
+
+        expect(http.last_request['X-SkipFeeValidation']).to be_nil
+        expect(http.last_request['X-SkipScriptValidation']).to be_nil
+      end
+
+      it 'can set both skip headers simultaneously' do
+        http = mock_http.new(200, success_body)
+        arc = described_class.new('https://arc.example.com', http_client: http)
+
+        arc.broadcast(tx, skip_fee_validation: true, skip_script_validation: true)
+
+        expect(http.last_request['X-SkipFeeValidation']).to eq('true')
+        expect(http.last_request['X-SkipScriptValidation']).to eq('true')
+      end
+    end
   end
 
   describe '#status' do

--- a/spec/bsv/network/arc_spec.rb
+++ b/spec/bsv/network/arc_spec.rb
@@ -390,4 +390,38 @@ RSpec.describe BSV::Network::ARC do
       expect(http.last_uri.to_s).to eq('https://arc.example.com/v1/tx')
     end
   end
+
+  describe '.default' do
+    it 'returns an ARC instance pointed at the mainnet GorillaPool endpoint' do
+      arc = described_class.default
+
+      expect(arc).to be_a(described_class)
+      # Verify the URL by posting a broadcast and inspecting the request URI
+      http = mock_http.new(200, success_body)
+      mainnet_arc = described_class.default(http_client: http)
+      mainnet_arc.broadcast(tx)
+      expect(http.last_uri.host).to eq('arc.gorillapool.io')
+    end
+
+    it 'returns an ARC instance pointed at the testnet GorillaPool endpoint' do
+      http = mock_http.new(200, success_body)
+      arc = described_class.default(testnet: true, http_client: http)
+      arc.broadcast(tx)
+      expect(http.last_uri.host).to eq('testnet.arc.gorillapool.io')
+    end
+
+    it 'passes api_key through to the underlying instance' do
+      http = mock_http.new(200, success_body)
+      arc = described_class.default(api_key: 'x', http_client: http)
+      arc.broadcast(tx)
+      expect(http.last_request['Authorization']).to eq('Bearer x')
+    end
+
+    it 'passes callback_url through to the underlying instance' do
+      http = mock_http.new(200, success_body)
+      arc = described_class.default(callback_url: 'https://example.com/cb', http_client: http)
+      arc.broadcast(tx)
+      expect(http.last_request['X-CallbackUrl']).to eq('https://example.com/cb')
+    end
+  end
 end

--- a/spec/bsv/network/arc_spec.rb
+++ b/spec/bsv/network/arc_spec.rb
@@ -527,6 +527,17 @@ RSpec.describe BSV::Network::ARC do
         .to raise_error(BSV::Network::BroadcastError, /malformed batch response/)
     end
 
+    it 'returns BroadcastError for batch items missing txid' do
+      body = [{ 'txStatus' => 'SEEN_ON_NETWORK', 'title' => 'ok' }].to_json
+      http = mock_http.new(200, body)
+      arc = described_class.new('https://arc.example.com', http_client: http)
+
+      results = arc.broadcast_many([tx])
+
+      expect(results[0]).to be_a(BSV::Network::BroadcastError)
+      expect(results[0].message).to match(/malformed/)
+    end
+
     it 'uses EF hex for each tx when available' do
       http = mock_http.new(200, single_batch)
       arc = described_class.new('https://arc.example.com', http_client: http)

--- a/spec/bsv/transaction/chain_trackers/chaintracks_spec.rb
+++ b/spec/bsv/transaction/chain_trackers/chaintracks_spec.rb
@@ -40,6 +40,13 @@ RSpec.describe BSV::Transaction::ChainTrackers::Chaintracks do
       expect(tracker.valid_root_for_height?('0000' * 16, 0)).to be false
     end
 
+    it 'returns false when response is missing merkleRoot field' do
+      body = { 'height' => 0, 'hash' => 'abc' }.to_json
+      allow(http_client).to receive(:request).and_return(mock_response(200, body))
+
+      expect(tracker.valid_root_for_height?(merkle_root, 0)).to be false
+    end
+
     it 'returns false on 404 (block not found)' do
       allow(http_client).to receive(:request).and_return(mock_response(404, 'Not Found'))
 

--- a/spec/bsv/transaction/chain_trackers/chaintracks_spec.rb
+++ b/spec/bsv/transaction/chain_trackers/chaintracks_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/MultipleDescribes
+
+RSpec.describe BSV::Transaction::ChainTrackers::Chaintracks do
+  let(:http_client) { instance_double(Net::HTTP) }
+  let(:tracker) { described_class.new(http_client: http_client) }
+
+  let(:merkle_root) { '4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b' }
+
+  let(:header_json) do
+    {
+      'hash' => '000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f',
+      'height' => 0,
+      'merkleRoot' => merkle_root,
+      'time' => 1_231_006_505
+    }.to_json
+  end
+
+  def mock_response(code, body)
+    instance_double(Net::HTTPResponse, code: code.to_s, body: body)
+  end
+
+  describe '#valid_root_for_height?' do
+    it 'returns true when merkleRoot matches' do
+      allow(http_client).to receive(:request).and_return(mock_response(200, header_json))
+
+      expect(tracker.valid_root_for_height?(merkle_root, 0)).to be true
+    end
+
+    it 'returns true with case-insensitive comparison' do
+      allow(http_client).to receive(:request).and_return(mock_response(200, header_json))
+
+      expect(tracker.valid_root_for_height?(merkle_root.upcase, 0)).to be true
+    end
+
+    it 'returns false when root does not match' do
+      allow(http_client).to receive(:request).and_return(mock_response(200, header_json))
+
+      expect(tracker.valid_root_for_height?('0000' * 16, 0)).to be false
+    end
+
+    it 'returns false on 404 (block not found)' do
+      allow(http_client).to receive(:request).and_return(mock_response(404, 'Not Found'))
+
+      expect(tracker.valid_root_for_height?(merkle_root, 999_999_999)).to be false
+    end
+
+    it 'raises ChainProviderError on server error' do
+      allow(http_client).to receive(:request).and_return(mock_response(500, 'Internal Server Error'))
+
+      expect { tracker.valid_root_for_height?(merkle_root, 0) }
+        .to raise_error(BSV::Network::ChainProviderError) { |e| expect(e.status_code).to eq(500) }
+    end
+
+    it 'sends GET to correct URL path' do
+      allow(http_client).to receive(:request).and_return(mock_response(200, header_json))
+
+      tracker.valid_root_for_height?(merkle_root, 100)
+
+      expect(http_client).to have_received(:request) do |uri, _req|
+        expect(uri.to_s).to eq('https://arcade.gorillapool.io/chaintracks/v2/header/height/100')
+      end
+    end
+
+    it 'sends Bearer auth header when api_key provided' do
+      keyed_tracker = described_class.new(api_key: 'my-key', http_client: http_client)
+      allow(http_client).to receive(:request).and_return(mock_response(200, header_json))
+
+      keyed_tracker.valid_root_for_height?(merkle_root, 0)
+
+      expect(http_client).to have_received(:request) do |_uri, req|
+        expect(req['Authorization']).to eq('Bearer my-key')
+      end
+    end
+
+    it 'does not send Authorization header when api_key is nil' do
+      allow(http_client).to receive(:request).and_return(mock_response(200, header_json))
+
+      tracker.valid_root_for_height?(merkle_root, 0)
+
+      expect(http_client).to have_received(:request) do |_uri, req|
+        expect(req['Authorization']).to be_nil
+      end
+    end
+  end
+
+  describe '#current_height' do
+    let(:tip_json) { { 'height' => 800_123, 'hash' => 'abc' }.to_json }
+
+    it 'returns the current block height' do
+      allow(http_client).to receive(:request).and_return(mock_response(200, tip_json))
+
+      expect(tracker.current_height).to eq(800_123)
+    end
+
+    it 'raises ChainProviderError on failure' do
+      allow(http_client).to receive(:request).and_return(mock_response(503, 'Unavailable'))
+
+      expect { tracker.current_height }
+        .to raise_error(BSV::Network::ChainProviderError) { |e| expect(e.status_code).to eq(503) }
+    end
+
+    it 'sends GET to correct URL path' do
+      allow(http_client).to receive(:request).and_return(mock_response(200, tip_json))
+
+      tracker.current_height
+
+      expect(http_client).to have_received(:request) do |uri, _req|
+        expect(uri.to_s).to eq('https://arcade.gorillapool.io/chaintracks/v2/tip')
+      end
+    end
+  end
+
+  describe 'URL configuration' do
+    it 'defaults to mainnet URL' do
+      expect(described_class.new.instance_variable_get(:@url)).to eq(described_class::MAINNET_URL)
+    end
+
+    it 'accepts a custom URL' do
+      testnet_tracker = described_class.new(url: described_class::TESTNET_URL, http_client: http_client)
+      allow(http_client).to receive(:request).and_return(mock_response(200, { 'height' => 1 }.to_json))
+
+      testnet_tracker.current_height
+
+      expect(http_client).to have_received(:request) do |uri, _req|
+        expect(uri.host).to eq('testnet.arcade.gorillapool.io')
+      end
+    end
+  end
+end
+
+RSpec.describe BSV::Transaction::ChainTrackers do
+  describe '.default' do
+    it 'returns a Chaintracks instance' do
+      expect(described_class.default).to be_a(BSV::Transaction::ChainTrackers::Chaintracks)
+    end
+
+    it 'uses the mainnet URL by default' do
+      tracker = described_class.default
+      expect(tracker.instance_variable_get(:@url)).to eq(BSV::Transaction::ChainTrackers::Chaintracks::MAINNET_URL)
+    end
+
+    it 'uses the testnet URL when testnet: true' do
+      tracker = described_class.default(testnet: true)
+      expect(tracker.instance_variable_get(:@url)).to eq(BSV::Transaction::ChainTrackers::Chaintracks::TESTNET_URL)
+    end
+
+    it 'passes api_key through to the tracker' do
+      tracker = described_class.default(api_key: 'my-key')
+      expect(tracker.instance_variable_get(:@api_key)).to eq('my-key')
+    end
+  end
+end
+
+# rubocop:enable RSpec/MultipleDescribes


### PR DESCRIPTION
## Summary
- **Chaintracks chain tracker** — new `BSV::Transaction::ChainTrackers::Chaintracks` class querying Arcade's Chaintracks v2 API for SPV verification (`/chaintracks/v2/header/height/{height}` and `/chaintracks/v2/tip`)
- **`ChainTrackers.default(testnet:)`** — factory returning Chaintracks instance pointed at Arcade mainnet/testnet
- **`ARC.default(testnet:)`** — factory returning ARC broadcaster pointed at GorillaPool, matching TS/Go/Py SDK pattern
- **`ARC#broadcast_many(txs)`** — batch broadcast via POST `/v1/txs`, returns mixed array of `BroadcastResponse`/`BroadcastError` (per-tx failure detection, not raise-on-first)
- **Skip-validation headers** — `skip_fee_validation:` and `skip_script_validation:` kwargs on `#broadcast` and `#broadcast_many`

## Test plan
- [x] All tests pass (3788 examples, 0 failures)
- [x] Linter clean (304 files, 0 offences)
- [x] Acceptance criteria verified against HLR #329

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)