### PR TITLE
fix: auto-fund coin selection and change use default basket

### DIFF
--- a/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
@@ -610,7 +610,7 @@ module BSV
       def auto_fund_and_create(args, caller_outputs)
         release_stale_if_due
         target = caller_outputs.sum { |o| o[:satoshis] || 0 }
-        all_spendable = @storage.find_spendable_outputs
+        all_spendable = @storage.find_spendable_outputs(basket: 'default')
         available = all_spendable.select do |o|
           (o[:derivation_prefix] && o[:derivation_suffix] && o[:sender_identity_key]) ||
             o[:derivation_type] == :identity
@@ -756,7 +756,7 @@ module BSV
         params = @storage.find_setting('change_params')
         return {} unless params
 
-        pool_size = @storage.find_spendable_outputs.size
+        pool_size = @storage.find_spendable_outputs(basket: 'default').size
         { pool_size: pool_size, change_params: params }
       end
 
@@ -862,7 +862,7 @@ module BSV
                                   outpoint: "#{txid}.#{actual_idx}",
                                   satoshis: spec[:satoshis],
                                   locking_script: locking_script_hex,
-                                  basket: nil,
+                                  basket: 'default',
                                   tags: [],
                                   derivation_prefix: spec[:derivation_prefix],
                                   derivation_suffix: spec[:derivation_suffix],

--- a/spec/bsv/wallet_interface/auto_funding_spec.rb
+++ b/spec/bsv/wallet_interface/auto_funding_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe 'WalletClient auto-funding pipeline' do
                                   outpoint: outpoint,
                                   satoshis: satoshis,
                                   locking_script: locking_script.to_hex,
+                                  basket: 'default',
                                   state: :spendable,
                                   spendable: true,
                                   derivation_prefix: prefix,
@@ -122,11 +123,11 @@ RSpec.describe 'WalletClient auto-funding pipeline' do
       expect(change[:sender_identity_key]).to be_a(String)
     end
 
-    it 'change output is not assigned to a basket' do
+    it 'change output is stored in the default basket' do
       result
-      spendable = storage.find_spendable_outputs
+      spendable = storage.find_spendable_outputs(basket: 'default')
       change = spendable.find { |o| o[:derivation_prefix] }
-      expect(change[:basket]).to be_nil
+      expect(change[:basket]).to eq('default')
     end
 
     it 'stores the action as completed' do

--- a/spec/bsv/wallet_interface/wallet_client_auto_fund_spec.rb
+++ b/spec/bsv/wallet_interface/wallet_client_auto_fund_spec.rb
@@ -102,14 +102,14 @@ RSpec.describe 'WalletClient auto-fund mode' do
       expect(storage.find_transaction(txid)).to be_a(String)
     end
 
-    it 'stores a change output as :spendable with no basket assignment' do
+    it 'stores a change output as :spendable in the default basket' do
       result
-      # Change outputs are not assigned to a basket — they are free-floating
-      # spendable outputs identifiable only by their BRC-29 derivation metadata.
-      change = storage.find_spendable_outputs.select { |o| o[:derivation_prefix] }
+      # Change outputs are stored in the default basket so they are selectable
+      # by subsequent auto-fund calls.
+      change = storage.find_spendable_outputs(basket: 'default').select { |o| o[:derivation_prefix] }
       expect(change).not_to be_empty
       expect(change.first[:satoshis]).to be_positive
-      expect(change.first[:basket]).to be_nil
+      expect(change.first[:basket]).to eq('default')
     end
 
     it 'stores change with derivation metadata' do
@@ -227,8 +227,8 @@ RSpec.describe 'WalletClient auto-fund mode' do
                              }]
                            })
 
-      # Change outputs have no basket assignment; query all spendable outputs.
-      spendable = storage.find_spendable_outputs
+      # Change outputs are stored in the default basket.
+      spendable = storage.find_spendable_outputs(basket: 'default')
       # The original 10 000-sat UTXO must not appear; change output should.
       sats_values = spendable.map { |o| o[:satoshis] }
       expect(sats_values).not_to include(10_000)
@@ -309,9 +309,9 @@ RSpec.describe 'WalletClient auto-fund mode' do
                                      })
       expect(result1[:txid]).to match(/\A[0-9a-f]{64}\z/)
 
-      # At this point the original UTXO is spent; change is a free-floating
-      # spendable output (no basket assignment) with BRC-29 derivation metadata.
-      change = storage.find_spendable_outputs.select { |o| o[:derivation_prefix] }
+      # At this point the original UTXO is spent; change is a spendable output
+      # in the default basket with BRC-29 derivation metadata.
+      change = storage.find_spendable_outputs(basket: 'default').select { |o| o[:derivation_prefix] }
       expect(change).not_to be_empty
 
       # Second action: auto-funded from the change.
@@ -346,6 +346,93 @@ RSpec.describe 'WalletClient auto-fund mode' do
                                }]
                              })
       end.to raise_error(BSV::Wallet::InsufficientFundsError)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Basket isolation: auto-fund must never touch custom baskets
+  # -------------------------------------------------------------------------
+  describe 'basket isolation' do
+    let(:action_opts) do
+      {
+        description: description,
+        auto_fund: true,
+        outputs: [{
+          locking_script: recipient_lock_hex,
+          satoshis: 1_000,
+          output_description: 'payment'
+        }]
+      }
+    end
+
+    it 'does not consume outputs from custom baskets' do
+      tokens_utxo = seed_utxo(satoshis: 10_000, basket: 'tokens')
+      seed_utxo(satoshis: 10_000, basket: 'default')
+
+      wallet.create_action(action_opts)
+
+      # The 'tokens' UTXO must remain untouched.
+      tokens_remaining = storage.find_spendable_outputs(basket: 'tokens')
+      expect(tokens_remaining.any? { |o| o[:outpoint] == tokens_utxo[:outpoint] }).to be true
+    end
+
+    it 'raises InsufficientFundsError when only a custom basket has funds' do
+      seed_utxo(satoshis: 10_000, basket: 'tokens')
+
+      expect do
+        wallet.create_action(action_opts)
+      end.to raise_error(BSV::Wallet::InsufficientFundsError)
+
+      # The 'tokens' UTXO must remain untouched.
+      expect(storage.find_spendable_outputs(basket: 'tokens').size).to eq(1)
+    end
+
+    it 'stores change output in the default basket' do
+      seed_utxo(satoshis: 10_000, basket: 'default')
+
+      wallet.create_action(action_opts)
+
+      change = storage.find_spendable_outputs(basket: 'default').select { |o| o[:derivation_prefix] }
+      expect(change).not_to be_empty
+      expect(change.first[:basket]).to eq('default')
+      expect(change.first[:satoshis]).to be_positive
+    end
+
+    it 'change is usable by subsequent auto-fund' do
+      seed_utxo(satoshis: 50_000, basket: 'default')
+
+      # First action consumes the seeded UTXO and produces change in 'default'.
+      result1 = wallet.create_action(action_opts)
+      expect(result1[:txid]).to match(/\A[0-9a-f]{64}\z/)
+
+      # Second action must be able to spend the change output.
+      result2 = wallet.create_action({
+                                       description: 'second action',
+                                       auto_fund: true,
+                                       outputs: [{
+                                         locking_script: recipient_lock_hex,
+                                         satoshis: 500,
+                                         output_description: 'second payment'
+                                       }]
+                                     })
+      expect(result2[:txid]).to match(/\A[0-9a-f]{64}\z/)
+      expect(result2[:txid]).not_to eq(result1[:txid])
+    end
+
+    it 'pool size counts only default basket outputs' do
+      # Seed 3 outputs in 'default' and 2 in 'tokens'.
+      3.times { seed_utxo(satoshis: 5_000, basket: 'default') }
+      2.times { seed_utxo(satoshis: 5_000, basket: 'tokens') }
+
+      # Set change params with a pool target larger than the default basket count.
+      wallet.set_wallet_change_params(count: 6, satoshis: 1_000)
+
+      wallet.create_action(action_opts)
+
+      # Because pool_size reflects only the 3 default-basket UTXOs (below the
+      # target of 6), the change generator should produce multiple change outputs.
+      change_outputs = storage.find_spendable_outputs(basket: 'default').select { |o| o[:derivation_prefix] }
+      expect(change_outputs.size).to be > 1
     end
   end
 end


### PR DESCRIPTION
## Summary

- Auto-fund coin selection now draws only from the `'default'` basket, matching the TS SDK / wallet-toolbox reference design
- Change outputs are stored in `'default'` instead of `nil`, keeping them in the funding pool for subsequent transactions
- Pool size check in `load_pool_opts` counts only default-basket outputs, preventing custom baskets from inflating the count and suppressing change generation

Three production lines changed in `wallet_client.rb`, five new basket isolation specs.

## Test plan

- [x] All 3822 specs pass (0 failures)
- [x] Linter clean (0 offences)
- [x] Existing auto-fund assertion flipped from `be_nil` to `eq('default')`
- [x] New specs: custom basket outputs excluded from coin selection
- [x] New specs: InsufficientFundsError when only custom basket has funds
- [x] New specs: change lands in default basket
- [x] New specs: chain spending works (change reusable by next auto-fund)
- [x] New specs: pool size counts only default basket

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)