### PR TITLE
feat(wallet-postgres): implement auto-fund storage methods

### DIFF
--- a/gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/migrations/004_add_pending_metadata.rb
+++ b/gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/migrations/004_add_pending_metadata.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Add pending lock metadata columns and satoshis to wallet_outputs.
+#
+# Introduces dedicated columns to support the auto-fund UTXO management
+# methods (+find_spendable_outputs+, +lock_utxos+, +update_output_state+,
+# +release_stale_pending!+) without requiring expensive JSONB extraction
+# on every query.
+#
+# === Columns added
+#
+# * +satoshis+          — bigint, nullable. Mirrors the value stored inside
+#                         the JSONB +data+ blob so that +find_spendable_outputs+
+#                         can +ORDER BY satoshis+ without casting. New writes
+#                         populate this column; existing rows leave it NULL
+#                         and queries fall back to +COALESCE(satoshis, (data->>'satoshis')::bigint, 0)+.
+#
+# * +pending_since+     — timestamp (UTC), nullable. Set to +NOW()+ when a
+#                         UTXO is locked via +lock_utxos+. Used by
+#                         +release_stale_pending!+ to identify stale locks.
+#
+# * +pending_reference+ — text, nullable. Caller-supplied label passed to
+#                         +lock_utxos+. Carried through for observability.
+#
+# * +no_send+           — boolean, default +false+. When +true+ the lock is
+#                         exempt from automatic stale recovery by
+#                         +release_stale_pending!+.
+#
+# === Index added
+#
+# A partial index on +(state, basket)+ filtered to rows where
+# +state IS NULL OR state = 'spendable'+ accelerates the hot path of
+# +find_spendable_outputs+: the vast majority of rows in a live wallet
+# are spendable, not pending or spent.
+#
+# === Backward compatibility
+#
+# All new columns are nullable (or carry a safe default). No existing rows
+# are modified. The application layer handles NULL values via +COALESCE+ or
+# explicit IS NULL checks.
+Sequel.migration do
+  up do
+    alter_table(:wallet_outputs) do
+      add_column :satoshis,          :bigint, null: true
+      add_column :pending_since,     :timestamptz, null: true
+      add_column :pending_reference, String,   null: true
+      add_column :no_send,           :boolean, null: false, default: false
+    end
+
+    # Partial index on spendable rows only — keeps the index small and
+    # fast for the typical coin-selection scan.
+    run <<~SQL
+      CREATE INDEX wallet_outputs_spendable_basket_idx
+        ON wallet_outputs (state, basket)
+        WHERE (state IS NULL OR state = 'spendable');
+    SQL
+  end
+
+  down do
+    run 'DROP INDEX IF EXISTS wallet_outputs_spendable_basket_idx;'
+
+    alter_table(:wallet_outputs) do
+      drop_column :no_send
+      drop_column :pending_reference
+      drop_column :pending_since
+      drop_column :satoshis
+    end
+  end
+end

--- a/gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/postgres_store.rb
+++ b/gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/postgres_store.rb
@@ -135,6 +135,80 @@ module BSV
         @db[:wallet_outputs].where(outpoint: outpoint).delete.positive?
       end
 
+      # Returns outputs whose effective state is +:spendable+.
+      #
+      # Legacy rows with +state = NULL+ are treated as spendable when the
+      # +spendable+ boolean is true (or absent), matching MemoryStore's
+      # effective_state logic.
+      #
+      # @param basket [String, nil] restrict to this basket when provided
+      # @param min_satoshis [Integer, nil] exclude outputs below this value
+      # @param sort_order [Symbol] +:asc+ or +:desc+ (default +:desc+, largest first)
+      # @return [Array<Hash>]
+      def find_spendable_outputs(basket: nil, min_satoshis: nil, sort_order: :desc)
+        ds = @db[:wallet_outputs]
+             .where(Sequel.lit('(state = ? OR (state IS NULL AND spendable = TRUE))', 'spendable'))
+        ds = ds.where(basket: basket) if basket
+        if min_satoshis
+          ds = ds.where(
+            Sequel.lit('COALESCE(satoshis, (data->>?)::bigint, 0) >= ?', 'satoshis', min_satoshis)
+          )
+        end
+        satoshis_expr = Sequel.lit('COALESCE(satoshis, (data->>?)::bigint, 0)', 'satoshis')
+        ds = ds.order(sort_order == :asc ? Sequel.asc(satoshis_expr) : Sequel.desc(satoshis_expr))
+        ds.all.map { |r| symbolise_keys(r[:data]) }
+      end
+
+      # Transitions the state of an existing output.
+      #
+      # When +new_state+ is +:pending+, sets +pending_since+, +pending_reference+,
+      # and +no_send+, and merges those values into the JSONB +data+ blob.
+      #
+      # When transitioning away from +:pending+, clears the pending metadata
+      # columns and removes the corresponding keys from the JSONB blob.
+      #
+      # @param outpoint [String] the outpoint identifier
+      # @param new_state [Symbol] +:spendable+, +:pending+, or +:spent+
+      # @param pending_reference [String, nil] caller-supplied label for a pending lock
+      # @param no_send [Boolean, nil] true if the lock belongs to a no_send transaction
+      # @raise [BSV::Wallet::WalletError] if the outpoint is not found
+      # @return [Hash] the updated output hash
+      def update_output_state(outpoint, new_state, pending_reference: nil, no_send: nil)
+        state_str = new_state.to_s
+
+        if new_state == :pending
+          updates = {
+            state: state_str,
+            pending_since: Sequel.lit('NOW()'),
+            pending_reference: pending_reference,
+            no_send: no_send ? true : false,
+            data: Sequel.lit(
+              "data || jsonb_build_object('state', ?, 'pending_since', NOW()::text, 'pending_reference', ?, 'no_send', ?)",
+              state_str, pending_reference, no_send ? true : false
+            )
+          }
+        else
+          updates = {
+            state: state_str,
+            pending_since: nil,
+            pending_reference: nil,
+            no_send: false
+          }
+          # Remove pending keys from JSONB blob, update state
+          updates[:data] = Sequel.lit(
+            "(data - 'pending_since' - 'pending_reference' - 'no_send') || jsonb_build_object('state', ?)",
+            state_str
+          )
+        end
+
+        ds = @db[:wallet_outputs].where(outpoint: outpoint)
+        rows_updated = ds.update(updates)
+        raise WalletError, "Output not found: #{outpoint}" if rows_updated.zero?
+
+        row = ds.first
+        symbolise_keys(row[:data])
+      end
+
       # --- Certificates ---
 
       def store_certificate(cert_data)

--- a/gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/postgres_store.rb
+++ b/gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/postgres_store.rb
@@ -176,9 +176,14 @@ module BSV
       def update_output_state(outpoint, new_state, pending_reference: nil, no_send: nil)
         state_str = new_state.to_s
 
+        # Keep legacy spendable boolean in sync so filter_outputs and other
+        # queries that haven't migrated to the state column still work.
+        spendable_bool = new_state == :spendable
+
         if new_state == :pending
           updates = {
             state: state_str,
+            spendable: spendable_bool,
             pending_since: Sequel.lit('NOW()'),
             pending_reference: pending_reference,
             no_send: no_send ? true : false,
@@ -190,6 +195,7 @@ module BSV
         else
           updates = {
             state: state_str,
+            spendable: spendable_bool,
             pending_since: nil,
             pending_reference: nil,
             no_send: false
@@ -232,6 +238,7 @@ module BSV
                .returning(:outpoint)
                .update(
                  state: 'pending',
+                 spendable: false,
                  pending_since: Sequel.lit('NOW()'),
                  pending_reference: reference,
                  no_send: no_send ? true : false,
@@ -264,6 +271,7 @@ module BSV
                .returning(:outpoint)
                .update(
                  state: 'spendable',
+                 spendable: true,
                  pending_since: nil,
                  pending_reference: nil,
                  no_send: false,
@@ -386,7 +394,7 @@ module BSV
         ds = ds.where(outpoint: query[:outpoint]) if query[:outpoint]
         ds = ds.where(basket: query[:basket]) if query[:basket]
         ds = apply_array_filter(ds, :tags, query[:tags], query[:tag_query_mode])
-        ds = ds.where(spendable: true) unless query[:include_spent]
+        ds = ds.where(Sequel.lit('(state = ? OR (state IS NULL AND spendable = TRUE))', 'spendable')) unless query[:include_spent]
         ds
       end
 

--- a/gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/postgres_store.rb
+++ b/gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/postgres_store.rb
@@ -209,6 +209,72 @@ module BSV
         symbolise_keys(row[:data])
       end
 
+      # Atomically marks a set of outpoints as +:pending+.
+      #
+      # Uses +UPDATE ... WHERE state = 'spendable' ... RETURNING outpoint+ so that
+      # the check-and-set is atomic at the database level. A concurrent caller that
+      # wins the race will have already changed the state to 'pending', so the
+      # second caller's WHERE clause will not match and will return nothing. No
+      # explicit row-level locking is needed — the UPDATE itself takes the lock.
+      #
+      # Legacy rows with +state = NULL AND spendable = TRUE+ are also eligible.
+      #
+      # @param outpoints [Array<String>] outpoint identifiers to lock
+      # @param reference [String] caller-supplied pending reference
+      # @param no_send [Boolean] true if this is a no_send lock
+      # @return [Array<String>] outpoints that were actually locked
+      def lock_utxos(outpoints, reference:, no_send: false)
+        return [] if outpoints.empty?
+
+        rows = @db[:wallet_outputs]
+               .where(outpoint: outpoints)
+               .where(Sequel.lit('(state = ? OR (state IS NULL AND spendable = TRUE))', 'spendable'))
+               .returning(:outpoint)
+               .update(
+                 state: 'pending',
+                 pending_since: Sequel.lit('NOW()'),
+                 pending_reference: reference,
+                 no_send: no_send ? true : false,
+                 data: Sequel.lit(
+                   "data || jsonb_build_object('state', 'pending', 'pending_since', NOW()::text, " \
+                   "'pending_reference', ?, 'no_send', ?)",
+                   reference, no_send ? true : false
+                 )
+               )
+
+        rows.map { |r| r[:outpoint] }
+      end
+
+      # Releases stale pending locks back to +:spendable+.
+      #
+      # Any output in +:pending+ state whose +pending_since+ is older than
+      # +timeout+ seconds is reset to +spendable+ and its pending metadata is
+      # cleared. Outputs with +no_send = true+ are exempt and remain pending.
+      # Outputs with +pending_since = NULL+ are also skipped — they are treated
+      # as freshly locked (NULL means "just acquired but no timestamp yet").
+      #
+      # @param timeout [Integer] age in seconds before a lock is considered stale (default 300)
+      # @return [Integer] number of outputs released
+      def release_stale_pending!(timeout: 300)
+        rows = @db[:wallet_outputs]
+               .where(state: 'pending')
+               .where(Sequel.lit('no_send IS NOT TRUE'))
+               .where(Sequel.lit('pending_since IS NOT NULL'))
+               .where(Sequel.lit('pending_since < (NOW() - INTERVAL ?)', "#{timeout} seconds"))
+               .returning(:outpoint)
+               .update(
+                 state: 'spendable',
+                 pending_since: nil,
+                 pending_reference: nil,
+                 no_send: false,
+                 data: Sequel.lit(
+                   "(data - 'pending_since' - 'pending_reference' - 'no_send') || jsonb_build_object('state', 'spendable')"
+                 )
+               )
+
+        rows.length
+      end
+
       # --- Certificates ---
 
       def store_certificate(cert_data)

--- a/gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/postgres_store.rb
+++ b/gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/postgres_store.rb
@@ -109,7 +109,14 @@ module BSV
         @db[:wallet_outputs]
           .insert_conflict(
             target: :outpoint,
-            update: { basket: row[:basket], tags: row[:tags], spendable: row[:spendable], data: row[:data] }
+            update: {
+              basket: row[:basket],
+              tags: row[:tags],
+              spendable: row[:spendable],
+              state: row[:state],
+              satoshis: row[:satoshis],
+              data: row[:data]
+            }
           )
           .insert(row)
         output_data
@@ -207,11 +214,14 @@ module BSV
 
       def output_row(data)
         spendable = data[:spendable] != false # nil treated as spendable, like MemoryStore
+        state = data[:state]&.to_s
         {
           outpoint: data[:outpoint],
           basket: data[:basket],
           tags: Sequel.pg_array(Array(data[:tags]), :text),
           spendable: spendable,
+          state: state,
+          satoshis: data[:satoshis],
           data: Sequel.pg_jsonb(data.to_h)
         }
       end

--- a/spec/bsv/wallet_postgres/postgres_store_spec.rb
+++ b/spec/bsv/wallet_postgres/postgres_store_spec.rb
@@ -124,6 +124,118 @@ RSpec.describe BSV::Wallet::PostgresStore, :postgres do
       end
     end
 
+    describe '#find_spendable_outputs' do
+      before do
+        store.store_output(basket: 'default', outpoint: 'aa.0', spendable: true, satoshis: 500)
+        store.store_output(basket: 'default', outpoint: 'bb.0', spendable: true, satoshis: 1000)
+        store.store_output(basket: 'default', outpoint: 'cc.0', spendable: true, satoshis: 200)
+        store.store_output(basket: 'other',   outpoint: 'dd.0', spendable: true, satoshis: 800)
+        store.store_output(basket: 'default', outpoint: 'ee.0', spendable: false, satoshis: 300)
+      end
+
+      it 'returns only spendable outputs' do
+        results = store.find_spendable_outputs
+        outpoints = results.map { |o| o[:outpoint] }
+        expect(outpoints).not_to include('ee.0')
+      end
+
+      it 'includes legacy rows with state NULL and spendable true' do
+        # All rows stored via store_output have state populated; simulate legacy row
+        db[:wallet_outputs]
+          .where(outpoint: 'aa.0')
+          .update(state: nil, spendable: true)
+
+        results = store.find_spendable_outputs(basket: 'default')
+        expect(results.map { |o| o[:outpoint] }).to include('aa.0')
+      end
+
+      it 'filters by basket when provided' do
+        results = store.find_spendable_outputs(basket: 'default')
+        outpoints = results.map { |o| o[:outpoint] }
+        expect(outpoints).not_to include('dd.0')
+        expect(outpoints).to include('aa.0', 'bb.0', 'cc.0')
+      end
+
+      it 'orders largest-first by default (desc)' do
+        results = store.find_spendable_outputs(basket: 'default')
+        satoshis = results.map { |o| o[:satoshis] }
+        expect(satoshis).to eq(satoshis.sort.reverse)
+      end
+
+      it 'orders smallest-first when sort_order is :asc' do
+        results = store.find_spendable_outputs(basket: 'default', sort_order: :asc)
+        satoshis = results.map { |o| o[:satoshis] }
+        expect(satoshis).to eq(satoshis.sort)
+      end
+
+      it 'filters by min_satoshis' do
+        results = store.find_spendable_outputs(basket: 'default', min_satoshis: 500)
+        outpoints = results.map { |o| o[:outpoint] }
+        expect(outpoints).to contain_exactly('aa.0', 'bb.0')
+      end
+
+      it 'returns an empty array when no spendable outputs exist in basket' do
+        expect(store.find_spendable_outputs(basket: 'empty')).to be_empty
+      end
+    end
+
+    describe '#update_output_state' do
+      before do
+        store.store_output(basket: 'default', outpoint: 'tx.0', spendable: true, satoshis: 1000)
+      end
+
+      it 'transitions to :spent and clears pending metadata' do
+        store.update_output_state('tx.0', :spent)
+        row = store.find_outputs(outpoint: 'tx.0', include_spent: true).first
+        expect(row[:state]).to eq('spent')
+      end
+
+      it 'sets pending metadata when transitioning to :pending' do
+        store.update_output_state('tx.0', :pending, pending_reference: 'ref-001', no_send: false)
+        row = db[:wallet_outputs].where(outpoint: 'tx.0').first
+        expect(row[:state]).to eq('pending')
+        expect(row[:pending_since]).not_to be_nil
+        expect(row[:pending_reference]).to eq('ref-001')
+        expect(row[:no_send]).to be false
+      end
+
+      it 'sets no_send true when passed' do
+        store.update_output_state('tx.0', :pending, pending_reference: 'ref-002', no_send: true)
+        row = db[:wallet_outputs].where(outpoint: 'tx.0').first
+        expect(row[:no_send]).to be true
+      end
+
+      it 'clears pending metadata when transitioning away from :pending' do
+        store.update_output_state('tx.0', :pending, pending_reference: 'ref-001', no_send: true)
+        store.update_output_state('tx.0', :spendable)
+        row = db[:wallet_outputs].where(outpoint: 'tx.0').first
+        expect(row[:state]).to eq('spendable')
+        expect(row[:pending_since]).to be_nil
+        expect(row[:pending_reference]).to be_nil
+        expect(row[:no_send]).to be false
+      end
+
+      it 'removes pending keys from the JSONB data blob when clearing' do
+        store.update_output_state('tx.0', :pending, pending_reference: 'ref-001', no_send: true)
+        result = store.update_output_state('tx.0', :spendable)
+        expect(result).not_to have_key(:pending_since)
+        expect(result).not_to have_key(:pending_reference)
+        expect(result).not_to have_key(:no_send)
+      end
+
+      it 'raises WalletError when the outpoint does not exist' do
+        expect do
+          store.update_output_state('nonexistent.0', :spent)
+        end.to raise_error(BSV::Wallet::WalletError, /nonexistent\.0/)
+      end
+
+      it 'returns the updated output hash' do
+        result = store.update_output_state('tx.0', :spent)
+        expect(result).to be_a(Hash)
+        expect(result[:outpoint]).to eq('tx.0')
+      end
+    end
+
     describe '.migrate!' do
       it 'creates all five wallet tables' do
         described_class.migrate!(db)

--- a/spec/bsv/wallet_postgres/postgres_store_spec.rb
+++ b/spec/bsv/wallet_postgres/postgres_store_spec.rb
@@ -236,6 +236,153 @@ RSpec.describe BSV::Wallet::PostgresStore, :postgres do
       end
     end
 
+    describe '#lock_utxos' do
+      before do
+        store.store_output(basket: 'default', outpoint: 'tx1.0', spendable: true, satoshis: 500)
+        store.store_output(basket: 'default', outpoint: 'tx2.0', spendable: true, satoshis: 1000)
+        store.store_output(basket: 'default', outpoint: 'tx3.0', spendable: false, satoshis: 200)
+      end
+
+      it 'locks spendable outputs and returns the locked outpoints' do
+        locked = store.lock_utxos(%w[tx1.0 tx2.0], reference: 'ref-abc', no_send: false)
+        expect(locked).to contain_exactly('tx1.0', 'tx2.0')
+      end
+
+      it 'returns empty array without hitting the database when given empty list' do
+        expect(store.lock_utxos([], reference: 'ref')).to eq([])
+      end
+
+      it 'skips outputs not in spendable state' do
+        locked = store.lock_utxos(%w[tx1.0 tx3.0], reference: 'ref', no_send: false)
+        expect(locked).to contain_exactly('tx1.0')
+      end
+
+      it 'returns empty array when all requested outpoints are already pending' do
+        store.update_output_state('tx1.0', :pending, pending_reference: 'first', no_send: false)
+        locked = store.lock_utxos(['tx1.0'], reference: 'second', no_send: false)
+        expect(locked).to be_empty
+      end
+
+      it 'sets state, pending_since, pending_reference, and no_send on the row' do
+        store.lock_utxos(['tx1.0'], reference: 'ref-001', no_send: true)
+        row = db[:wallet_outputs].where(outpoint: 'tx1.0').first
+        expect(row[:state]).to eq('pending')
+        expect(row[:pending_since]).not_to be_nil
+        expect(row[:pending_reference]).to eq('ref-001')
+        expect(row[:no_send]).to be true
+      end
+
+      it 'merges pending metadata into the JSONB data blob' do
+        store.lock_utxos(['tx1.0'], reference: 'ref-001', no_send: false)
+        result = store.find_outputs(outpoint: 'tx1.0', include_spent: true).first
+        expect(result[:state]).to eq('pending')
+        expect(result[:pending_reference]).to eq('ref-001')
+      end
+
+      it 'is safe under concurrent access — only one caller locks the outpoint' do
+        results = []
+        mutex = Mutex.new
+        threads = Array.new(5) do
+          Thread.new do
+            locked = store.lock_utxos(['tx1.0'], reference: 'race', no_send: false)
+            mutex.synchronize { results.concat(locked) }
+          end
+        end
+        threads.each(&:join)
+
+        # Exactly one thread should have locked it
+        expect(results.count('tx1.0')).to eq(1)
+      end
+
+      it 'locks legacy rows with state NULL and spendable true' do
+        db[:wallet_outputs].where(outpoint: 'tx1.0').update(state: nil, spendable: true)
+        locked = store.lock_utxos(['tx1.0'], reference: 'ref', no_send: false)
+        expect(locked).to include('tx1.0')
+      end
+    end
+
+    describe '#release_stale_pending!' do
+      before do
+        store.store_output(basket: 'default', outpoint: 'tx1.0', spendable: true, satoshis: 500)
+        store.store_output(basket: 'default', outpoint: 'tx2.0', spendable: true, satoshis: 500)
+        store.store_output(basket: 'default', outpoint: 'tx3.0', spendable: true, satoshis: 500)
+        store.store_output(basket: 'default', outpoint: 'tx4.0', spendable: true, satoshis: 500)
+      end
+
+      it 'returns 0 when no pending outputs exist' do
+        expect(store.release_stale_pending!(timeout: 300)).to eq(0)
+      end
+
+      it 'releases stale pending outputs and returns count' do
+        store.lock_utxos(%w[tx1.0 tx2.0], reference: 'ref', no_send: false)
+        # Back-date pending_since to simulate stale locks
+        db[:wallet_outputs]
+          .where(outpoint: %w[tx1.0 tx2.0])
+          .update(pending_since: Sequel.lit("NOW() - INTERVAL '600 seconds'"))
+
+        released = store.release_stale_pending!(timeout: 300)
+        expect(released).to eq(2)
+      end
+
+      it 'resets state to spendable and clears pending metadata on released rows' do
+        store.lock_utxos(['tx1.0'], reference: 'ref', no_send: false)
+        db[:wallet_outputs]
+          .where(outpoint: 'tx1.0')
+          .update(pending_since: Sequel.lit("NOW() - INTERVAL '600 seconds'"))
+
+        store.release_stale_pending!(timeout: 300)
+
+        row = db[:wallet_outputs].where(outpoint: 'tx1.0').first
+        expect(row[:state]).to eq('spendable')
+        expect(row[:pending_since]).to be_nil
+        expect(row[:pending_reference]).to be_nil
+        expect(row[:no_send]).to be false
+      end
+
+      it 'removes pending keys from the JSONB data blob on release' do
+        store.lock_utxos(['tx1.0'], reference: 'ref', no_send: false)
+        db[:wallet_outputs]
+          .where(outpoint: 'tx1.0')
+          .update(pending_since: Sequel.lit("NOW() - INTERVAL '600 seconds'"))
+
+        store.release_stale_pending!(timeout: 300)
+
+        result = store.find_outputs(outpoint: 'tx1.0').first
+        expect(result).not_to have_key(:pending_since)
+        expect(result).not_to have_key(:pending_reference)
+        expect(result[:state]).to eq('spendable')
+      end
+
+      it 'does not release no_send pending outputs' do
+        store.lock_utxos(['tx3.0'], reference: 'ref', no_send: true)
+        db[:wallet_outputs]
+          .where(outpoint: 'tx3.0')
+          .update(pending_since: Sequel.lit("NOW() - INTERVAL '600 seconds'"))
+
+        released = store.release_stale_pending!(timeout: 300)
+        expect(released).to eq(0)
+
+        row = db[:wallet_outputs].where(outpoint: 'tx3.0').first
+        expect(row[:state]).to eq('pending')
+      end
+
+      it 'does not release pending outputs locked within the timeout window' do
+        store.lock_utxos(['tx4.0'], reference: 'ref', no_send: false)
+        # pending_since is just NOW() — well within 300s timeout
+
+        released = store.release_stale_pending!(timeout: 300)
+        expect(released).to eq(0)
+      end
+
+      it 'does not release outputs with pending_since = NULL' do
+        store.lock_utxos(['tx1.0'], reference: 'ref', no_send: false)
+        db[:wallet_outputs].where(outpoint: 'tx1.0').update(pending_since: nil)
+
+        released = store.release_stale_pending!(timeout: 0)
+        expect(released).to eq(0)
+      end
+    end
+
     describe '.migrate!' do
       it 'creates all five wallet tables' do
         described_class.migrate!(db)

--- a/spec/support/shared_examples_for_storage_adapter.rb
+++ b/spec/support/shared_examples_for_storage_adapter.rb
@@ -395,6 +395,211 @@ RSpec.shared_examples 'a storage adapter' do
     end
   end
 
+  # ---------------------------------------------------------------------------
+  # Auto-fund interface contract
+  # These four methods form the UTXO state-management contract.  All adapter
+  # implementations must pass this suite unchanged.  State values may be
+  # returned as Symbols or Strings depending on serialisation (MemoryStore
+  # uses Symbols; FileStore and PostgresStore use Strings after a round-trip).
+  # Examples use `.to_s` to normalise before comparing.
+  # ---------------------------------------------------------------------------
+
+  describe 'auto-fund interface' do
+    describe '#find_spendable_outputs' do
+      before do
+        store.store_output(basket: 'default', outpoint: 'aa.0', spendable: true, satoshis: 500,
+                           state: :spendable)
+        store.store_output(basket: 'default', outpoint: 'bb.0', spendable: true, satoshis: 1000,
+                           state: :spendable)
+        store.store_output(basket: 'default', outpoint: 'cc.0', spendable: true, satoshis: 200,
+                           state: :spendable)
+        store.store_output(basket: 'other',   outpoint: 'dd.0', spendable: true, satoshis: 800,
+                           state: :spendable)
+        store.store_output(basket: 'default', outpoint: 'ee.0', spendable: false, satoshis: 300,
+                           state: :spent)
+      end
+
+      it 'returns outputs sorted largest-first by default' do
+        results = store.find_spendable_outputs(basket: 'default')
+        expect(results.map { |o| o[:satoshis] }).to eq([1000, 500, 200])
+      end
+
+      it 'returns outputs sorted smallest-first when sort_order is :asc' do
+        results = store.find_spendable_outputs(basket: 'default', sort_order: :asc)
+        expect(results.map { |o| o[:satoshis] }).to eq([200, 500, 1000])
+      end
+
+      it 'filters by basket' do
+        results = store.find_spendable_outputs(basket: 'default')
+        expect(results.map { |o| o[:outpoint] }).not_to include('dd.0')
+      end
+
+      it 'returns outputs from all baskets when no basket filter is given' do
+        results = store.find_spendable_outputs
+        expect(results.map { |o| o[:outpoint] }).to include('aa.0', 'dd.0')
+      end
+
+      it 'filters by min_satoshis' do
+        results = store.find_spendable_outputs(basket: 'default', min_satoshis: 500)
+        expect(results.map { |o| o[:outpoint] }).to contain_exactly('aa.0', 'bb.0')
+      end
+
+      it 'excludes non-spendable outputs' do
+        results = store.find_spendable_outputs(basket: 'default')
+        expect(results.map { |o| o[:outpoint] }).not_to include('ee.0')
+      end
+
+      it 'returns an empty array when the basket is empty' do
+        expect(store.find_spendable_outputs(basket: 'nonexistent')).to be_empty
+      end
+
+      it 'treats a legacy output with spendable: true and no state as spendable' do
+        store.store_output(basket: 'legacy', outpoint: 'leg.0', satoshis: 999, spendable: true)
+        results = store.find_spendable_outputs(basket: 'legacy')
+        expect(results.map { |o| o[:outpoint] }).to include('leg.0')
+      end
+    end
+
+    describe '#update_output_state' do
+      before do
+        store.store_output(basket: 'default', outpoint: 'tx.0', spendable: true, satoshis: 1000,
+                           state: :spendable)
+      end
+
+      it 'transitions to :pending and records pending metadata' do
+        store.update_output_state('tx.0', :pending, pending_reference: 'ref-001', no_send: false)
+        results = store.find_outputs(outpoint: 'tx.0', include_spent: true, limit: 1, offset: 0)
+        row = results.first
+        expect(row[:state].to_s).to eq('pending')
+        expect(row[:pending_reference]).to eq('ref-001')
+        expect(row[:pending_since]).not_to be_nil
+      end
+
+      it 'transitions to :spent' do
+        store.update_output_state('tx.0', :spent)
+        results = store.find_outputs(outpoint: 'tx.0', include_spent: true, limit: 1, offset: 0)
+        expect(results.first[:state].to_s).to eq('spent')
+      end
+
+      it 'transitions back to :spendable and clears pending metadata' do
+        store.update_output_state('tx.0', :pending, pending_reference: 'ref-x', no_send: false)
+        store.update_output_state('tx.0', :spendable)
+        results = store.find_outputs(outpoint: 'tx.0', include_spent: true, limit: 1, offset: 0)
+        row = results.first
+        expect(row[:state].to_s).to eq('spendable')
+        expect(row[:pending_since]).to be_nil
+        expect(row[:pending_reference]).to be_nil
+      end
+
+      it 'returns the updated output hash' do
+        result = store.update_output_state('tx.0', :spent)
+        expect(result).to be_a(Hash)
+        expect(result[:outpoint]).to eq('tx.0')
+      end
+
+      it 'raises WalletError when the outpoint does not exist' do
+        expect do
+          store.update_output_state('nonexistent.0', :spent)
+        end.to raise_error(BSV::Wallet::WalletError, /nonexistent\.0/)
+      end
+
+      it 'sets no_send: true when passed' do
+        store.update_output_state('tx.0', :pending, pending_reference: 'ref-ns', no_send: true)
+        result = store.update_output_state('tx.0', :spendable)
+        # After clearing, no_send must be absent or falsy
+        expect(result[:no_send]).to be_falsy
+      end
+    end
+
+    describe '#lock_utxos' do
+      before do
+        store.store_output(basket: 'default', outpoint: 'tx1.0', spendable: true, satoshis: 500,
+                           state: :spendable)
+        store.store_output(basket: 'default', outpoint: 'tx2.0', spendable: true, satoshis: 1000,
+                           state: :spendable)
+        store.store_output(basket: 'default', outpoint: 'tx3.0', spendable: false, satoshis: 200,
+                           state: :spent)
+      end
+
+      it 'locks spendable outputs and returns the locked outpoints' do
+        locked = store.lock_utxos(%w[tx1.0 tx2.0], reference: 'ref-abc', no_send: false)
+        expect(locked).to contain_exactly('tx1.0', 'tx2.0')
+      end
+
+      it 'returns an empty array when given an empty list' do
+        expect(store.lock_utxos([], reference: 'ref')).to eq([])
+      end
+
+      it 'skips outputs that are not in spendable state' do
+        locked = store.lock_utxos(%w[tx1.0 tx3.0], reference: 'ref', no_send: false)
+        expect(locked).to contain_exactly('tx1.0')
+      end
+
+      it 'skips outputs already locked (pending)' do
+        store.update_output_state('tx1.0', :pending, pending_reference: 'first', no_send: false)
+        locked = store.lock_utxos(['tx1.0'], reference: 'second', no_send: false)
+        expect(locked).to be_empty
+      end
+
+      it 'marks locked outputs as pending so they disappear from find_spendable_outputs' do
+        store.lock_utxos(['tx1.0'], reference: 'ref-001', no_send: false)
+        results = store.find_spendable_outputs(basket: 'default')
+        expect(results.map { |o| o[:outpoint] }).not_to include('tx1.0')
+      end
+
+      it 'sets no_send flag on the locked output when passed' do
+        store.lock_utxos(['tx1.0'], reference: 'ref-ns', no_send: true)
+        results = store.find_outputs(outpoint: 'tx1.0', include_spent: true, limit: 1, offset: 0)
+        expect(results.first[:no_send]).to be true
+      end
+    end
+
+    describe '#release_stale_pending!' do
+      before do
+        store.store_output(basket: 'default', outpoint: 'tx1.0', spendable: true, satoshis: 500,
+                           state: :spendable)
+        store.store_output(basket: 'default', outpoint: 'tx2.0', spendable: true, satoshis: 500,
+                           state: :spendable)
+        store.store_output(basket: 'default', outpoint: 'tx3.0', spendable: true, satoshis: 500,
+                           state: :spendable)
+      end
+
+      it 'returns 0 when no pending outputs exist' do
+        expect(store.release_stale_pending!(timeout: 300)).to eq(0)
+      end
+
+      it 'returns 0 when pending outputs are within the timeout window' do
+        store.lock_utxos(['tx1.0'], reference: 'fresh', no_send: false)
+        expect(store.release_stale_pending!(timeout: 300)).to eq(0)
+      end
+
+      it 'releases a pending output that is past the timeout and returns count' do
+        # timeout: 0 makes any lock immediately stale (cutoff = now, locked_at < now is true)
+        store.lock_utxos(['tx1.0'], reference: 'stale', no_send: false)
+        released = store.release_stale_pending!(timeout: 0)
+        expect(released).to eq(1)
+      end
+
+      it 'restores state to spendable after releasing a stale lock' do
+        store.lock_utxos(['tx2.0'], reference: 'stale', no_send: false)
+        store.release_stale_pending!(timeout: 0)
+
+        results = store.find_spendable_outputs(basket: 'default')
+        expect(results.map { |o| o[:outpoint] }).to include('tx2.0')
+      end
+
+      it 'does not release no_send pending outputs even when stale' do
+        # timeout: 0 means cutoff = now; any pending lock is already "stale"
+        # but no_send: true must exempt it from automatic release
+        store.lock_utxos(['tx3.0'], reference: 'ns', no_send: true)
+        expect(store.release_stale_pending!(timeout: 0)).to eq(0)
+
+        results = store.find_spendable_outputs(basket: 'default')
+        expect(results.map { |o| o[:outpoint] }).not_to include('tx3.0')
+      end
+    end
+  end
+
   describe 'settings' do
     describe '#store_setting and #find_setting' do
       it 'persists a setting and retrieves it by key' do


### PR DESCRIPTION
## Summary

- Migration 004: add pending_since, pending_reference, no_send, satoshis columns to wallet_outputs
- Implement find_spendable_outputs with backward-compatible COALESCE for legacy rows
- Implement update_output_state with JSONB data synchronisation
- Implement lock_utxos with atomic UPDATE ... WHERE state = 'spendable' RETURNING pattern
- Implement release_stale_pending! with no_send exemption
- Shared conformance examples added to spec/support/ — all three adapters pass

## Test plan

- [x] All tests pass (4115 examples, 0 failures)
- [x] Linter clean (0 new offences)
- [x] Acceptance criteria verified
- [x] Shared examples confirm MemoryStore/FileStore/PostgresStore conformance

Closes #351

Generated with [Claude Code](https://claude.com/claude-code)
