### PR TITLE
feat(wallet): broadcast/rollback semantics for create_action (F8.13)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,6 +61,7 @@ Naming/PredicateMethod:
     - is_authenticated
     - delete_output
     - delete_certificate
+    - delete_action
 
 # is_authenticated uses the BRC-100 wire-protocol naming convention (is_ prefix).
 Naming/PredicatePrefix:

--- a/gem/bsv-sdk/lib/bsv/network/arc.rb
+++ b/gem/bsv-sdk/lib/bsv/network/arc.rb
@@ -195,7 +195,8 @@ module BSV
           raise BroadcastError.new(
             body['detail'] || body['title'] || body['txStatus'],
             status_code: code,
-            txid: body['txid']
+            txid: body['txid'],
+            arc_status: body['txStatus'].to_s.upcase
           )
         end
 
@@ -277,7 +278,8 @@ module BSV
           BroadcastError.new(
             body['detail'] || body['title'] || body['txStatus'],
             status_code: 200,
-            txid: body['txid']
+            txid: body['txid'],
+            arc_status: body['txStatus'].to_s.upcase
           )
         elsif !body['txid']
           BroadcastError.new(

--- a/gem/bsv-sdk/lib/bsv/network/broadcast_error.rb
+++ b/gem/bsv-sdk/lib/bsv/network/broadcast_error.rb
@@ -3,11 +3,12 @@
 module BSV
   module Network
     class BroadcastError < StandardError
-      attr_reader :status_code, :txid
+      attr_reader :status_code, :txid, :arc_status
 
-      def initialize(message, status_code: nil, txid: nil)
+      def initialize(message, status_code: nil, txid: nil, arc_status: nil)
         @status_code = status_code
         @txid = txid
+        @arc_status = arc_status
         super(message)
       end
     end

--- a/gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/postgres_store.rb
+++ b/gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/postgres_store.rb
@@ -102,6 +102,23 @@ module BSV
         filter_actions(@db[:wallet_actions], query).count
       end
 
+      def update_action_status(txid, new_status)
+        ds = @db[:wallet_actions].where(txid: txid)
+        raise WalletError, "Action not found: #{txid}" if ds.empty?
+
+        ds.update(
+          data: Sequel.lit(
+            "data || jsonb_build_object('status', ?)",
+            new_status
+          )
+        )
+        symbolise_keys(ds.first[:data])
+      end
+
+      def delete_action(txid)
+        @db[:wallet_actions].where(txid: txid).delete.positive?
+      end
+
       # --- Outputs ---
 
       def store_output(output_data)

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/file_store.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/file_store.rb
@@ -48,6 +48,18 @@ module BSV
         result
       end
 
+      def update_action_status(txid, new_status)
+        result = super
+        save_actions
+        result
+      end
+
+      def delete_action(txid)
+        result = super
+        save_actions if result
+        result
+      end
+
       def store_output(output_data)
         result = super
         save_outputs

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/memory_store.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/memory_store.rb
@@ -30,6 +30,22 @@ module BSV
         action_data
       end
 
+      def update_action_status(txid, new_status)
+        action = @actions.find { |a| a[:txid] == txid }
+        raise WalletError, "Action not found: #{txid}" unless action
+
+        action[:status] = new_status
+        action
+      end
+
+      def delete_action(txid)
+        idx = @actions.index { |a| a[:txid] == txid }
+        return false unless idx
+
+        @actions.delete_at(idx)
+        true
+      end
+
       def find_actions(query)
         apply_pagination(filter_actions(query), query)
       end

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/storage_adapter.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/storage_adapter.rb
@@ -67,6 +67,26 @@ module BSV
         raise NotImplementedError, "#{self.class}#find_transaction not implemented"
       end
 
+      # Updates the status field of a stored action identified by txid.
+      #
+      # @param _txid [String] the transaction identifier of the action to update
+      # @param _new_status [String] the new status value (e.g. 'failed', 'completed')
+      # @return [Hash] the updated action hash
+      # @raise [BSV::Wallet::WalletError] if no action with the given txid is found
+      # @raise [NotImplementedError]
+      def update_action_status(_txid, _new_status)
+        raise NotImplementedError, "#{self.class}#update_action_status not implemented"
+      end
+
+      # Removes a stored action by txid.
+      #
+      # @param _txid [String] the transaction identifier of the action to remove
+      # @return [Boolean] true if the action was deleted, false if not found
+      # @raise [NotImplementedError]
+      def delete_action(_txid)
+        raise NotImplementedError, "#{self.class}#delete_action not implemented"
+      end
+
       # Transitions the state of an existing output.
       #
       # When +new_state+ is +:pending+, pass a +pending_reference:+ string to

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
@@ -70,6 +70,7 @@ module BSV
         @http_client = http_client
         @broadcaster = broadcaster
         @pending = {}
+        @pending_by_txid = {}
         @injected_fee_estimator    = fee_estimator
         @injected_coin_selector    = coin_selector
         @injected_change_generator = change_generator
@@ -103,11 +104,29 @@ module BSV
       def create_action(args, _originator: nil)
         validate_create_action!(args)
 
+        send_with_txids = Array(args.dig(:options, :send_with))
+
         outputs = args[:outputs] || []
         inputs  = args[:inputs]
 
+        # When send_with is provided but no new transaction body is specified,
+        # broadcast only the batched no_send transactions.
+        if !send_with_txids.empty? && outputs.empty? && (inputs.nil? || inputs.empty?)
+          raise WalletError, 'A broadcaster is required to use send_with' unless broadcast_enabled?
+
+          return { send_with_results: broadcast_send_with(send_with_txids) }
+        end
+
         if (inputs.nil? || inputs.empty?) && !outputs.empty? && (args[:auto_fund] || spendable_pool_eligible?)
-          return auto_fund_and_create(args, outputs)
+          result = auto_fund_and_create(args, outputs)
+          # If send_with was also specified, batch-broadcast those alongside the
+          # current transaction's implicit broadcast.
+          unless send_with_txids.empty?
+            raise WalletError, 'A broadcaster is required to use send_with' unless broadcast_enabled?
+
+            result[:send_with_results] = broadcast_send_with(send_with_txids)
+          end
+          return result
         end
 
         beef = parse_input_beef(args[:input_beef])
@@ -163,6 +182,7 @@ module BSV
 
         pending_entry = @pending.delete(reference)
         txid = pending_entry[:tx]&.txid_hex
+        @pending_by_txid.delete(txid) if txid
         rollback_pending_action(
           pending_entry[:locked_outpoints],
           pending_entry[:change_outpoints],
@@ -689,13 +709,15 @@ module BSV
             store_action(tx, args, status: 'nosend')
             store_tracked_outputs(txid, tx, caller_outputs)
 
-            # Register in @pending so abort_action can release inputs and
-            # remove change outputs.
+            # Register in @pending so abort_action (or send_with) can release
+            # inputs and remove change outputs. Secondary index by txid allows
+            # send_with callers to look up pending entries by txid.
             @pending[fund_ref] = {
               tx: tx, args: args,
               locked_outpoints: selected_outpoints,
               change_outpoints: change_outpoints
             }
+            @pending_by_txid[txid] = fund_ref
 
             beef_binary = tx.to_beef
             { txid: txid, tx: beef_binary.unpack('C*'), reference: fund_ref, no_send_change: change_outpoints }
@@ -951,7 +973,10 @@ module BSV
         Validators.validate_description!(args[:description])
         inputs_present = args[:inputs] && !args[:inputs].empty?
         outputs_present = args[:outputs] && !args[:outputs].empty?
-        raise InvalidParameterError.new('inputs/outputs', 'at least one input or output') unless inputs_present || outputs_present
+        send_with_present = args.dig(:options, :send_with) && !Array(args.dig(:options, :send_with)).empty?
+        unless inputs_present || outputs_present || send_with_present
+          raise InvalidParameterError.new('inputs/outputs', 'at least one input or output')
+        end
 
         validate_action_inputs!(args[:inputs]) if args[:inputs]
         validate_action_outputs!(args[:outputs]) if args[:outputs]
@@ -1216,6 +1241,71 @@ module BSV
       rescue StandardError => e
         rollback_pending_action(input_outpoints, change_outpoints, txid, fund_ref, action_status: 'failed')
         { txid: txid, tx: beef_binary.unpack('C*'), broadcast_error: e.message, broadcast_status: broadcast_status_for(e) }
+      end
+
+      # Batch-broadcasts a list of previously no_send transactions.
+      #
+      # Each txid must correspond to a pending no_send entry registered in
+      # +@pending_by_txid+. Transactions are broadcast individually so that one
+      # failure does not block the others. On per-tx success the inputs are
+      # promoted to +:spent+ and change outputs to +:spendable+. On failure the
+      # pending state is rolled back via +rollback_pending_action+.
+      #
+      # @param txids [Array<String>] txids of no_send transactions to broadcast
+      # @return [Array<Hash>] per-tx results matching TS SDK +SendWithResult[]+ shape:
+      #   +{ txid: String, status: 'unproven' | 'failed' }+
+      def broadcast_send_with(txids)
+        txids.map { |txid| broadcast_single_no_send(txid) }
+      end
+
+      # Broadcasts one no_send transaction and promotes or rolls back its state.
+      #
+      # @param txid [String] hex txid of the no_send transaction
+      # @return [Hash] +{ txid:, status: }+ result entry
+      def broadcast_single_no_send(txid)
+        fund_ref = @pending_by_txid[txid]
+        return { txid: txid, status: 'failed', error: 'Transaction not found in pending no_send store' } unless fund_ref
+
+        pending_entry = @pending[fund_ref]
+        unless pending_entry
+          @pending_by_txid.delete(txid)
+          return { txid: txid, status: 'failed', error: 'Pending entry expired or already processed' }
+        end
+
+        tx_hex = @storage.find_transaction(txid)
+        return { txid: txid, status: 'failed', error: 'Transaction hex not found in storage' } unless tx_hex
+
+        tx = BSV::Transaction::Transaction.from_hex(tx_hex)
+        promote_no_send(tx, txid, fund_ref, pending_entry)
+      rescue StandardError => e
+        # Catch unexpected errors outside the broadcast rescue block.
+        { txid: txid, status: 'failed', error: e.message }
+      end
+
+      # Attempts to broadcast and promote a single no_send transaction.
+      def promote_no_send(tx, txid, fund_ref, pending_entry)
+        @broadcaster.broadcast(tx)
+
+        # Broadcast succeeded — promote state and remove from pending indices.
+        pending_entry[:locked_outpoints].each { |op| @storage.update_output_state(op, :spent) }
+        pending_entry[:change_outpoints].each { |op| @storage.update_output_state(op, :spendable) }
+        @storage.update_action_status(txid, 'completed')
+        @pending.delete(fund_ref)
+        @pending_by_txid.delete(txid)
+
+        { txid: txid, status: 'unproven' }
+      rescue StandardError => e
+        rollback_pending_action(
+          pending_entry[:locked_outpoints],
+          pending_entry[:change_outpoints],
+          txid,
+          fund_ref,
+          action_status: 'failed'
+        )
+        @pending.delete(fund_ref)
+        @pending_by_txid.delete(txid)
+
+        { txid: txid, status: 'failed', error: e.message }
       end
 
       # Maps a broadcast exception to a {ReviewActionResultStatus} string.

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
@@ -1227,8 +1227,9 @@ module BSV
 
         arc_status = error.arc_status.to_s.upcase
         return 'doubleSpend' if arc_status == 'DOUBLE_SPEND_ATTEMPTED'
-        return 'invalidTx'   if %w[REJECTED INVALID MALFORMED MINED_IN_STALE_BLOCK].include?(arc_status) ||
-                                  arc_status.include?('ORPHAN')
+
+        invalid_statuses = %w[REJECTED INVALID MALFORMED MINED_IN_STALE_BLOCK]
+        return 'invalidTx' if invalid_statuses.include?(arc_status) || arc_status.include?('ORPHAN')
 
         'serviceError'
       end

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
@@ -154,11 +154,13 @@ module BSV
         raise WalletError, 'Transaction not found for the given reference' unless @pending.key?(reference)
 
         pending_entry = @pending.delete(reference)
-        # Release locked input UTXOs back to :spendable.
-        release_pending_utxos(pending_entry[:locked_outpoints], reference) if pending_entry[:locked_outpoints]
-        # Remove change outputs created by the aborted transaction —
-        # they reference an unbroadcast tx and must not remain in storage.
-        Array(pending_entry[:change_outpoints]).each { |op| @storage.delete_output(op) }
+        txid = pending_entry[:tx]&.txid_hex
+        rollback_pending_action(
+          pending_entry[:locked_outpoints],
+          pending_entry[:change_outpoints],
+          txid,
+          reference
+        )
         { aborted: true }
       end
 
@@ -690,15 +692,39 @@ module BSV
             beef_binary = tx.to_beef
             { txid: txid, tx: beef_binary.unpack('C*'), reference: fund_ref, no_send_change: change_outpoints }
           else
-            store_action(tx, args, status: 'completed')
+            # Store everything in pending state first — inputs are already locked
+            # as :pending by lock_utxos above, so we match that discipline here.
+            store_action(tx, args, status: 'pending')
             store_change_outputs(txid, tx, change_outputs, tx_hex)
+
+            # Record change outpoints and mark them :pending so a concurrent
+            # create_action cannot double-spend them before broadcast completes.
+            change_outpoints = []
+            change_outputs.each do |spec|
+              idx = tx.outputs.index { |o| o.instance_variable_get(:@_spec).equal?(spec) }
+              next unless idx
+
+              op = "#{txid}.#{idx}"
+              change_outpoints << op
+              @storage.update_output_state(op, :pending, pending_reference: fund_ref)
+            end
+
             store_tracked_outputs(txid, tx, caller_outputs)
 
-            # Promote from :pending to :spent now that all storage writes are done.
-            selected_outpoints.each { |op| @storage.update_output_state(op, :spent) }
-
             beef_binary = tx.to_beef
-            { txid: txid, tx: beef_binary.unpack('C*') }
+
+            if broadcast_enabled?
+              broadcast_and_promote(
+                tx, txid, selected_outpoints, change_outpoints, fund_ref, beef_binary
+              )
+            else
+              # No broadcaster configured — promote immediately and return BEEF
+              # for the caller to broadcast (backwards-compatible behaviour).
+              selected_outpoints.each { |op| @storage.update_output_state(op, :spent) }
+              change_outpoints.each { |op| @storage.update_output_state(op, :spendable) }
+              @storage.update_action_status(txid, 'completed')
+              { txid: txid, tx: beef_binary.unpack('C*') }
+            end
           end
         rescue StandardError
           # Release the pending lock so the UTXOs are available for retry.
@@ -1130,6 +1156,47 @@ module BSV
 
           @storage.update_output_state(op, :spendable)
         end
+      end
+
+      # Rolls back a pending auto-funded action.
+      #
+      # Releases locked input UTXOs back to +:spendable+, deletes phantom change
+      # outputs, and optionally updates the action status. Used by both
+      # broadcast failure and +abort_action+ so UTXO state is always consistent.
+      #
+      # @param input_outpoints [Array<String>] outpoints locked as inputs
+      # @param change_outpoints [Array<String>] change outputs to delete
+      # @param txid [String, nil] txid of the action to update (may be nil)
+      # @param ref [String] fund reference used when locking inputs
+      # @param action_status [String, nil] new action status; nil skips the update
+      def rollback_pending_action(input_outpoints, change_outpoints, txid, ref, action_status: nil)
+        release_pending_utxos(input_outpoints, ref)
+        Array(change_outpoints).each { |op| @storage.delete_output(op) }
+        @storage.update_action_status(txid, action_status) if txid && action_status
+      end
+
+      # Broadcasts the transaction and promotes storage state on success.
+      # On failure, rolls back all pending state changes.
+      #
+      # @param tx [Transaction] signed transaction to broadcast
+      # @param txid [String] hex transaction id
+      # @param input_outpoints [Array<String>] outpoints locked as inputs
+      # @param change_outpoints [Array<String>] change output outpoints
+      # @param fund_ref [String] fund reference used when locking
+      # @param beef_binary [String] raw BEEF bytes
+      # @return [Hash] result hash with :txid, :tx, and :broadcast_result or :broadcast_error
+      def broadcast_and_promote(tx, txid, input_outpoints, change_outpoints, fund_ref, beef_binary)
+        broadcast_result = @broadcaster.broadcast(tx)
+
+        # Broadcast succeeded — promote all pending state to final.
+        input_outpoints.each { |op| @storage.update_output_state(op, :spent) }
+        change_outpoints.each { |op| @storage.update_output_state(op, :spendable) }
+        @storage.update_action_status(txid, 'completed')
+
+        { txid: txid, tx: beef_binary.unpack('C*'), broadcast_result: broadcast_result }
+      rescue StandardError => e
+        rollback_pending_action(input_outpoints, change_outpoints, txid, fund_ref, action_status: 'failed')
+        { txid: txid, tx: beef_binary.unpack('C*'), broadcast_error: e.message }
       end
 
       def finalize_action(tx, args)

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
@@ -136,7 +136,15 @@ module BSV
         tx = pending[:tx]
         apply_spends(tx, args[:spends])
         @pending.delete(reference)
-        finalize_action(tx, pending[:args])
+
+        # Merge sign_action's own options over the original create_action args so
+        # callers can supply accept_delayed_broadcast at sign time.
+        merged_args = if args[:options]
+                        pending[:args].merge(options: (pending[:args][:options] || {}).merge(args[:options]))
+                      else
+                        pending[:args]
+                      end
+        finalize_action(tx, merged_args)
       end
 
       # Aborts a pending signable transaction.
@@ -722,7 +730,16 @@ module BSV
               # for the caller to broadcast (backwards-compatible behaviour).
               selected_outpoints.each { |op| @storage.update_output_state(op, :spent) }
               change_outpoints.each { |op| @storage.update_output_state(op, :spendable) }
-              @storage.update_action_status(txid, 'completed')
+
+              final_status = if args.dig(:options, :accept_delayed_broadcast)
+                               warn '[bsv-wallet] accept_delayed_broadcast: true is not yet implemented; ' \
+                                    'falling through to synchronous processing. ' \
+                                    'Background broadcasting is a planned future feature.'
+                               'unproven'
+                             else
+                               'completed'
+                             end
+              @storage.update_action_status(txid, final_status)
               { txid: txid, tx: beef_binary.unpack('C*') }
             end
           end
@@ -1184,7 +1201,7 @@ module BSV
       # @param change_outpoints [Array<String>] change output outpoints
       # @param fund_ref [String] fund reference used when locking
       # @param beef_binary [String] raw BEEF bytes
-      # @return [Hash] result hash with :txid, :tx, and :broadcast_result or :broadcast_error
+      # @return [Hash] result hash with :txid, :tx, :broadcast_result or :broadcast_error, and :broadcast_status
       def broadcast_and_promote(tx, txid, input_outpoints, change_outpoints, fund_ref, beef_binary)
         broadcast_result = @broadcaster.broadcast(tx)
 
@@ -1193,16 +1210,43 @@ module BSV
         change_outpoints.each { |op| @storage.update_output_state(op, :spendable) }
         @storage.update_action_status(txid, 'completed')
 
-        { txid: txid, tx: beef_binary.unpack('C*'), broadcast_result: broadcast_result }
+        result = { txid: txid, tx: beef_binary.unpack('C*'), broadcast_result: broadcast_result, broadcast_status: 'success' }
+        result[:competing_txs] = broadcast_result.competing_txs if broadcast_result.competing_txs
+        result
       rescue StandardError => e
         rollback_pending_action(input_outpoints, change_outpoints, txid, fund_ref, action_status: 'failed')
-        { txid: txid, tx: beef_binary.unpack('C*'), broadcast_error: e.message }
+        { txid: txid, tx: beef_binary.unpack('C*'), broadcast_error: e.message, broadcast_status: broadcast_status_for(e) }
+      end
+
+      # Maps a broadcast exception to a {ReviewActionResultStatus} string.
+      #
+      # @param error [StandardError] the exception raised during broadcast
+      # @return [String] one of 'doubleSpend', 'invalidTx', 'serviceError'
+      def broadcast_status_for(error)
+        return 'serviceError' unless error.is_a?(BSV::Network::BroadcastError)
+
+        arc_status = error.arc_status.to_s.upcase
+        return 'doubleSpend' if arc_status == 'DOUBLE_SPEND_ATTEMPTED'
+        return 'invalidTx'   if %w[REJECTED INVALID MALFORMED MINED_IN_STALE_BLOCK].include?(arc_status) ||
+                                  arc_status.include?('ORPHAN')
+
+        'serviceError'
       end
 
       def finalize_action(tx, args)
         tx.sign_all if tx.inputs.any?(&:unlocking_script_template)
         txid = tx.txid_hex
-        status = args.dig(:options, :no_send) ? 'nosend' : 'completed'
+
+        status = if args.dig(:options, :no_send)
+                   'nosend'
+                 elsif args.dig(:options, :accept_delayed_broadcast)
+                   warn '[bsv-wallet] accept_delayed_broadcast: true is not yet implemented; ' \
+                        'falling through to synchronous processing. ' \
+                        'Background broadcasting is a planned future feature.'
+                   'unproven'
+                 else
+                   'completed'
+                 end
 
         @storage.store_transaction(txid, tx.to_hex)
         store_action(tx, args, status: status)

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
@@ -1272,10 +1272,17 @@ module BSV
           return { txid: txid, status: 'failed', error: 'Pending entry expired or already processed' }
         end
 
-        tx_hex = @storage.find_transaction(txid)
-        return { txid: txid, status: 'failed', error: 'Transaction hex not found in storage' } unless tx_hex
+        # Use the original signed transaction from the pending entry — it has
+        # source_satoshis and source_locking_script wired on each input, which
+        # the broadcaster needs for Extended Format (EF/BRC-30) submission.
+        # Reconstructing from stored hex would lose that metadata.
+        tx = pending_entry[:tx]
+        unless tx
+          tx_hex = @storage.find_transaction(txid)
+          return { txid: txid, status: 'failed', error: 'Transaction not found' } unless tx_hex
 
-        tx = BSV::Transaction::Transaction.from_hex(tx_hex)
+          tx = BSV::Transaction::Transaction.from_hex(tx_hex)
+        end
         promote_no_send(tx, txid, fund_ref, pending_entry)
       rescue StandardError => e
         # Catch unexpected errors outside the broadcast rescue block.
@@ -1283,13 +1290,15 @@ module BSV
       end
 
       # Attempts to broadcast and promote a single no_send transaction.
+      # Action status is set to 'unproven' (matching TS SDK SendWithResult)
+      # because the transaction has been submitted but not yet confirmed.
       def promote_no_send(tx, txid, fund_ref, pending_entry)
         @broadcaster.broadcast(tx)
 
         # Broadcast succeeded — promote state and remove from pending indices.
         pending_entry[:locked_outpoints].each { |op| @storage.update_output_state(op, :spent) }
         pending_entry[:change_outpoints].each { |op| @storage.update_output_state(op, :spendable) }
-        @storage.update_action_status(txid, 'completed')
+        @storage.update_action_status(txid, 'unproven')
         @pending.delete(fund_ref)
         @pending_by_txid.delete(txid)
 
@@ -1328,15 +1337,13 @@ module BSV
         tx.sign_all if tx.inputs.any?(&:unlocking_script_template)
         txid = tx.txid_hex
 
-        status = if args.dig(:options, :no_send)
+        no_send = args.dig(:options, :no_send)
+        delayed = args.dig(:options, :accept_delayed_broadcast)
+
+        status = if no_send
                    'nosend'
-                 elsif args.dig(:options, :accept_delayed_broadcast)
-                   warn '[bsv-wallet] accept_delayed_broadcast: true is not yet implemented; ' \
-                        'falling through to synchronous processing. ' \
-                        'Background broadcasting is a planned future feature.'
-                   'unproven'
                  else
-                   'completed'
+                   'pending'
                  end
 
         @storage.store_transaction(txid, tx.to_hex)
@@ -1345,7 +1352,35 @@ module BSV
 
         beef_binary = tx.to_beef
         result = { txid: txid, tx: beef_binary.unpack('C*') }
-        result[:no_send_change] = [] if args.dig(:options, :no_send)
+
+        if no_send
+          result[:no_send_change] = []
+        elsif broadcast_enabled?
+          # Broadcast and promote or rollback — same discipline as auto_fund path.
+          broadcast_result = nil
+          begin
+            broadcast_result = @broadcaster.broadcast(tx)
+            @storage.update_action_status(txid, 'completed')
+            result[:broadcast_result] = broadcast_result
+            result[:broadcast_status] = 'success'
+          rescue StandardError => e
+            @storage.update_action_status(txid, 'failed')
+            result[:broadcast_error] = e.message
+            result[:broadcast_status] = broadcast_status_for(e)
+          end
+        else
+          # No broadcaster — promote immediately (backwards compatible).
+          final_status = if delayed
+                           warn '[bsv-wallet] accept_delayed_broadcast: true is not yet implemented; ' \
+                                'falling through to synchronous processing. ' \
+                                'Background broadcasting is a planned future feature.'
+                           'unproven'
+                         else
+                           'completed'
+                         end
+          @storage.update_action_status(txid, final_status)
+        end
+
         result
       end
 

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
@@ -39,6 +39,9 @@ module BSV
       # @return [ProofStore] the merkle proof persistence store
       attr_reader :proof_store
 
+      # @return [#broadcast, nil] the optional broadcaster (responds to #broadcast(tx))
+      attr_reader :broadcaster
+
       # @param key [BSV::Primitives::PrivateKey, String, KeyDeriver] signing key
       # @param storage [StorageAdapter] persistence adapter (default: FileStore).
       #   Use +storage: MemoryStore.new+ for tests.
@@ -46,6 +49,7 @@ module BSV
       # @param chain_provider [ChainProvider] blockchain data provider (default: NullChainProvider)
       # @param proof_store [ProofStore, nil] merkle proof store (default: LocalProofStore backed by storage)
       # @param http_client [#request, nil] injectable HTTP client for certificate issuance
+      # @param broadcaster [#broadcast, nil] optional broadcaster; any object responding to #broadcast(tx)
       def initialize(
         key,
         storage: FileStore.new,
@@ -55,7 +59,8 @@ module BSV
         http_client: nil,
         fee_estimator: nil,
         coin_selector: nil,
-        change_generator: nil
+        change_generator: nil,
+        broadcaster: nil
       )
         super(key)
         @storage = storage
@@ -63,10 +68,16 @@ module BSV
         @chain_provider = chain_provider
         @proof_store = proof_store || LocalProofStore.new(storage)
         @http_client = http_client
+        @broadcaster = broadcaster
         @pending = {}
         @injected_fee_estimator    = fee_estimator
         @injected_coin_selector    = coin_selector
         @injected_change_generator = change_generator
+      end
+
+      # Returns true when a broadcaster has been configured.
+      def broadcast_enabled?
+        !@broadcaster.nil?
       end
 
       # --- Transaction Operations ---

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_auto_fund_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_auto_fund_spec.rb
@@ -485,18 +485,14 @@ RSpec.describe 'WalletClient auto-fund mode' do
         expect(result).not_to have_key(:competing_txs)
       end
 
-      context 'when ARC returns competing_txs' do
-        let(:broadcast_response) do
-          BSV::Network::BroadcastResponse.new(
-            txid: 'abc', tx_status: 'SEEN_ON_NETWORK',
-            competing_txs: %w[deadbeef cafebabe]
-          )
-        end
-
-        it 'propagates competing_txs into the result' do
-          result = wallet.create_action(action_opts)
-          expect(result[:competing_txs]).to eq(%w[deadbeef cafebabe])
-        end
+      it 'propagates competing_txs when ARC returns them' do
+        response_with_competing = BSV::Network::BroadcastResponse.new(
+          txid: 'abc', tx_status: 'SEEN_ON_NETWORK',
+          competing_txs: %w[deadbeef cafebabe]
+        )
+        allow(broadcaster).to receive(:broadcast).and_return(response_with_competing)
+        result = wallet.create_action(action_opts)
+        expect(result[:competing_txs]).to eq(%w[deadbeef cafebabe])
       end
 
       it 'promotes input UTXOs to :spent' do

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_auto_fund_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_auto_fund_spec.rb
@@ -475,6 +475,30 @@ RSpec.describe 'WalletClient auto-fund mode' do
         expect(result[:broadcast_result]).to eq(broadcast_response)
       end
 
+      it 'includes broadcast_status: success' do
+        result = wallet.create_action(action_opts)
+        expect(result[:broadcast_status]).to eq('success')
+      end
+
+      it 'does not include :competing_txs when none returned' do
+        result = wallet.create_action(action_opts)
+        expect(result).not_to have_key(:competing_txs)
+      end
+
+      context 'when ARC returns competing_txs' do
+        let(:broadcast_response) do
+          BSV::Network::BroadcastResponse.new(
+            txid: 'abc', tx_status: 'SEEN_ON_NETWORK',
+            competing_txs: %w[deadbeef cafebabe]
+          )
+        end
+
+        it 'propagates competing_txs into the result' do
+          result = wallet.create_action(action_opts)
+          expect(result[:competing_txs]).to eq(%w[deadbeef cafebabe])
+        end
+      end
+
       it 'promotes input UTXOs to :spent' do
         wallet.create_action(action_opts)
         spendable = storage.find_spendable_outputs(basket: 'default')
@@ -564,6 +588,57 @@ RSpec.describe 'WalletClient auto-fund mode' do
         all_actions = storage.find_actions({ limit: 100, offset: 0 })
         action = all_actions.find { |a| a[:txid] == result[:txid] }
         expect(action[:status]).to eq('failed')
+      end
+    end
+
+    # -------------------------------------------------------------------------
+    # ReviewActionResultStatus mapping
+    # -------------------------------------------------------------------------
+    describe 'broadcast_status mapping' do
+      it "returns 'doubleSpend' for DOUBLE_SPEND_ATTEMPTED" do
+        allow(broadcaster).to receive(:broadcast).and_raise(
+          BSV::Network::BroadcastError.new('double spend', arc_status: 'DOUBLE_SPEND_ATTEMPTED')
+        )
+        result = wallet.create_action(action_opts)
+        expect(result[:broadcast_status]).to eq('doubleSpend')
+      end
+
+      it "returns 'invalidTx' for REJECTED" do
+        allow(broadcaster).to receive(:broadcast).and_raise(
+          BSV::Network::BroadcastError.new('rejected', arc_status: 'REJECTED')
+        )
+        result = wallet.create_action(action_opts)
+        expect(result[:broadcast_status]).to eq('invalidTx')
+      end
+
+      it "returns 'invalidTx' for INVALID" do
+        allow(broadcaster).to receive(:broadcast).and_raise(
+          BSV::Network::BroadcastError.new('invalid tx', arc_status: 'INVALID')
+        )
+        result = wallet.create_action(action_opts)
+        expect(result[:broadcast_status]).to eq('invalidTx')
+      end
+
+      it "returns 'invalidTx' for MALFORMED" do
+        allow(broadcaster).to receive(:broadcast).and_raise(
+          BSV::Network::BroadcastError.new('malformed', arc_status: 'MALFORMED')
+        )
+        result = wallet.create_action(action_opts)
+        expect(result[:broadcast_status]).to eq('invalidTx')
+      end
+
+      it "returns 'serviceError' for HTTP-level BroadcastError (no arc_status)" do
+        allow(broadcaster).to receive(:broadcast).and_raise(
+          BSV::Network::BroadcastError.new('HTTP 503', status_code: 503)
+        )
+        result = wallet.create_action(action_opts)
+        expect(result[:broadcast_status]).to eq('serviceError')
+      end
+
+      it "returns 'serviceError' for network-level errors (non-BroadcastError)" do
+        allow(broadcaster).to receive(:broadcast).and_raise(RuntimeError, 'connection refused')
+        result = wallet.create_action(action_opts)
+        expect(result[:broadcast_status]).to eq('serviceError')
       end
     end
 
@@ -664,6 +739,68 @@ RSpec.describe 'WalletClient auto-fund mode' do
                                     })
       expect(result).not_to have_key(:broadcast_result)
       expect(result).not_to have_key(:broadcast_error)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # accept_delayed_broadcast option (stub)
+  # -------------------------------------------------------------------------
+  describe 'accept_delayed_broadcast option' do
+    before { seed_utxo(satoshis: 10_000) }
+
+    let(:base_args) do
+      {
+        description: 'delayed broadcast test',
+        auto_fund: true,
+        outputs: [{
+          locking_script: recipient_lock_hex,
+          satoshis: 1_000,
+          output_description: 'payment'
+        }]
+      }
+    end
+
+    it 'accepts accept_delayed_broadcast: false without error (synchronous default)' do
+      args = base_args.merge(options: { accept_delayed_broadcast: false })
+      result = wallet.create_action(args)
+      expect(result[:txid]).to match(/\A[0-9a-f]{64}\z/)
+    end
+
+    it 'stores the action as completed when accept_delayed_broadcast is false' do
+      result = wallet.create_action(base_args.merge(options: { accept_delayed_broadcast: false }))
+      all_actions = storage.find_actions({ limit: 100, offset: 0 })
+      action = all_actions.find { |a| a[:txid] == result[:txid] }
+      expect(action[:status]).to eq('completed')
+    end
+
+    it 'accepts accept_delayed_broadcast: true without error (stub)' do
+      args = base_args.merge(options: { accept_delayed_broadcast: true })
+      expect { wallet.create_action(args) }.not_to raise_error
+    end
+
+    it 'stores the action as unproven when accept_delayed_broadcast: true' do
+      result = wallet.create_action(base_args.merge(options: { accept_delayed_broadcast: true }))
+      all_actions = storage.find_actions({ limit: 100, offset: 0 })
+      action = all_actions.find { |a| a[:txid] == result[:txid] }
+      expect(action[:status]).to eq('unproven')
+    end
+
+    it 'logs a warning when accept_delayed_broadcast: true' do
+      args = base_args.merge(options: { accept_delayed_broadcast: true })
+      expect { wallet.create_action(args) }.to output(/accept_delayed_broadcast.*not yet implemented/i).to_stderr
+    end
+
+    it 'still returns txid and tx bytes when accept_delayed_broadcast: true' do
+      result = wallet.create_action(base_args.merge(options: { accept_delayed_broadcast: true }))
+      expect(result[:txid]).to match(/\A[0-9a-f]{64}\z/)
+      expect(result[:tx]).to be_a(Array)
+    end
+
+    it 'defaults to synchronous behaviour (completed) when option is absent' do
+      result = wallet.create_action(base_args)
+      all_actions = storage.find_actions({ limit: 100, offset: 0 })
+      action = all_actions.find { |a| a[:txid] == result[:txid] }
+      expect(action[:status]).to eq('completed')
     end
   end
 end

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_auto_fund_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_auto_fund_spec.rb
@@ -799,4 +799,163 @@ RSpec.describe 'WalletClient auto-fund mode' do
       expect(action[:status]).to eq('completed')
     end
   end
+
+  # -------------------------------------------------------------------------
+  # send_with option — batched broadcast of no_send transactions
+  # -------------------------------------------------------------------------
+  describe 'send_with option' do
+    let(:broadcast_response) { BSV::Network::BroadcastResponse.new(txid: 'abc', tx_status: 'SEEN_ON_NETWORK') }
+    let(:broadcaster) { double('broadcaster') } # rubocop:disable RSpec/VerifiedDoubles
+    let(:wallet) { BSV::Wallet::WalletClient.new(private_key, storage: storage, broadcaster: broadcaster) }
+
+    let(:no_send_args) do
+      {
+        description: 'no_send tx to batch',
+        auto_fund: true,
+        outputs: [{
+          locking_script: recipient_lock_hex,
+          satoshis: 1_000,
+          output_description: 'payment'
+        }],
+        options: { no_send: true }
+      }
+    end
+
+    before { seed_utxo(satoshis: 10_000) }
+
+    it 'raises WalletError when no broadcaster is configured' do
+      no_broadcaster_wallet = BSV::Wallet::WalletClient.new(private_key, storage: storage)
+
+      expect do
+        no_broadcaster_wallet.create_action({
+                                              description: 'send_with call',
+                                              options: { send_with: ['a' * 64] }
+                                            })
+      end.to raise_error(BSV::Wallet::WalletError, /broadcaster/)
+    end
+
+    context 'with broadcaster configured' do
+      before { allow(broadcaster).to receive(:broadcast).and_return(broadcast_response) }
+
+      it 'broadcasts previously no_send transactions and returns send_with_results' do
+        no_send_result = wallet.create_action(no_send_args)
+        txid = no_send_result[:txid]
+
+        result = wallet.create_action({
+                                        description: 'send_with call',
+                                        options: { send_with: [txid] }
+                                      })
+
+        expect(result[:send_with_results]).to be_a(Array)
+        expect(result[:send_with_results].length).to eq(1)
+        expect(result[:send_with_results].first[:txid]).to eq(txid)
+        expect(result[:send_with_results].first[:status]).to eq('unproven')
+      end
+
+      it 'promotes input UTXOs to :spent on success' do
+        no_send_result = wallet.create_action(no_send_args)
+        txid = no_send_result[:txid]
+
+        wallet.create_action({
+                               description: 'send_with call',
+                               options: { send_with: [txid] }
+                             })
+
+        all_outputs = storage.find_outputs({ include_spent: true, limit: 100 })
+        spent = all_outputs.select { |o| o[:state] == :spent }
+        expect(spent).not_to be_empty
+      end
+
+      it 'promotes change outputs to :spendable on success' do
+        no_send_result = wallet.create_action(no_send_args)
+        txid = no_send_result[:txid]
+
+        wallet.create_action({
+                               description: 'send_with call',
+                               options: { send_with: [txid] }
+                             })
+
+        spendable = storage.find_spendable_outputs(basket: 'default')
+        # change output(s) from the no_send tx should now be spendable
+        expect(spendable).not_to be_empty
+      end
+
+      it 'marks the action as completed on success' do
+        no_send_result = wallet.create_action(no_send_args)
+        txid = no_send_result[:txid]
+
+        wallet.create_action({
+                               description: 'send_with call',
+                               options: { send_with: [txid] }
+                             })
+
+        all_actions = storage.find_actions({ limit: 100, offset: 0 })
+        action = all_actions.find { |a| a[:txid] == txid }
+        expect(action[:status]).to eq('completed')
+      end
+
+      it 'returns failed status for unknown txid' do
+        result = wallet.create_action({
+                                        description: 'send_with unknown',
+                                        options: { send_with: ['a' * 64] }
+                                      })
+
+        entry = result[:send_with_results].first
+        expect(entry[:status]).to eq('failed')
+        expect(entry[:error]).to be_a(String)
+      end
+
+      it 'handles mixed success/failure — each tx processed independently' do
+        seed_utxo(satoshis: 10_000)
+        no_send1 = wallet.create_action(no_send_args)
+        txid1 = no_send1[:txid]
+        fake_txid = 'b' * 64
+
+        result = wallet.create_action({
+                                        description: 'mixed send_with',
+                                        options: { send_with: [txid1, fake_txid] }
+                                      })
+
+        results = result[:send_with_results]
+        expect(results.find { |r| r[:txid] == txid1 }[:status]).to eq('unproven')
+        expect(results.find { |r| r[:txid] == fake_txid }[:status]).to eq('failed')
+      end
+    end
+
+    context 'when broadcast fails' do
+      before do
+        allow(broadcaster).to receive(:broadcast).and_raise(
+          BSV::Network::BroadcastError.new('rejected', arc_status: 'REJECTED')
+        )
+      end
+
+      it 'returns failed status for the tx' do
+        no_send_result = wallet.create_action(no_send_args)
+        txid = no_send_result[:txid]
+
+        result = wallet.create_action({
+                                        description: 'send_with fail',
+                                        options: { send_with: [txid] }
+                                      })
+
+        entry = result[:send_with_results].first
+        expect(entry[:status]).to eq('failed')
+        expect(entry[:txid]).to eq(txid)
+      end
+
+      it 'rolls back inputs to :spendable on broadcast failure' do
+        no_send_result = wallet.create_action(no_send_args)
+        txid = no_send_result[:txid]
+
+        wallet.create_action({
+                               description: 'send_with fail rollback',
+                               options: { send_with: [txid] }
+                             })
+
+        spendable = storage.find_spendable_outputs(basket: 'default')
+        # Original 10 000-sat UTXO should be released back to spendable
+        expect(spendable.any? { |o| o[:satoshis] == 10_000 }).to be true
+      end
+    end
+  end
 end

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_auto_fund_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_auto_fund_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe 'WalletClient auto-fund mode' do
       tx = BSV::Transaction::Transaction.from_hex(tx_hex)
       tx.inputs.each do |inp|
         expect(inp.unlocking_script).not_to be_nil
-        expect(inp.unlocking_script.to_binary.bytesize).to be > 0
+        expect(inp.unlocking_script.to_binary.bytesize).to be_positive
       end
     end
   end
@@ -433,6 +433,237 @@ RSpec.describe 'WalletClient auto-fund mode' do
       # target of 6), the change generator should produce multiple change outputs.
       change_outputs = storage.find_spendable_outputs(basket: 'default').select { |o| o[:derivation_prefix] }
       expect(change_outputs.size).to be > 1
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Broadcaster integration: broadcast-before-promote semantics
+  # -------------------------------------------------------------------------
+  describe 'with broadcaster configured' do
+    let(:broadcaster) { double('broadcaster') } # rubocop:disable RSpec/VerifiedDoubles
+    let(:wallet) { BSV::Wallet::WalletClient.new(private_key, storage: storage, broadcaster: broadcaster) }
+
+    let(:action_opts) do
+      {
+        description: 'broadcaster integration test',
+        auto_fund: true,
+        outputs: [{
+          locking_script: recipient_lock_hex,
+          satoshis: 1_000,
+          output_description: 'payment'
+        }]
+      }
+    end
+
+    before { seed_utxo(satoshis: 10_000) }
+
+    describe 'successful broadcast' do
+      let(:broadcast_response) do
+        BSV::Network::BroadcastResponse.new(txid: 'abc', tx_status: 'SEEN_ON_NETWORK')
+      end
+
+      before { allow(broadcaster).to receive(:broadcast).and_return(broadcast_response) }
+
+      it 'returns :txid and :tx in the result' do
+        result = wallet.create_action(action_opts)
+        expect(result[:txid]).to match(/\A[0-9a-f]{64}\z/)
+        expect(result[:tx]).to be_a(Array)
+      end
+
+      it 'includes :broadcast_result in the response' do
+        result = wallet.create_action(action_opts)
+        expect(result[:broadcast_result]).to eq(broadcast_response)
+      end
+
+      it 'promotes input UTXOs to :spent' do
+        wallet.create_action(action_opts)
+        spendable = storage.find_spendable_outputs(basket: 'default')
+        expect(spendable.none? { |o| o[:satoshis] == 10_000 }).to be true
+      end
+
+      it 'promotes change outputs to :spendable' do
+        wallet.create_action(action_opts)
+        change = storage.find_spendable_outputs(basket: 'default').select { |o| o[:derivation_prefix] }
+        expect(change).not_to be_empty
+      end
+
+      it 'marks the action as completed' do
+        wallet.create_action(action_opts)
+        actions = storage.find_actions({ limit: 10, offset: 0 })
+        expect(actions.first[:status]).to eq('completed')
+      end
+    end
+
+    describe 'failed broadcast (BroadcastError)' do
+      before do
+        allow(broadcaster).to receive(:broadcast).and_raise(
+          BSV::Network::BroadcastError.new('double spend attempted')
+        )
+      end
+
+      it 'does not raise — returns a result hash with :broadcast_error' do
+        result = wallet.create_action(action_opts)
+        expect(result[:broadcast_error]).to eq('double spend attempted')
+      end
+
+      it 'still returns :txid and :tx' do
+        result = wallet.create_action(action_opts)
+        expect(result[:txid]).to match(/\A[0-9a-f]{64}\z/)
+        expect(result[:tx]).to be_a(Array)
+      end
+
+      it 'releases input UTXOs back to :spendable' do
+        wallet.create_action(action_opts)
+        spendable = storage.find_spendable_outputs(basket: 'default')
+        expect(spendable.any? { |o| o[:satoshis] == 10_000 }).to be true
+      end
+
+      it 'deletes phantom change outputs' do
+        # Only the original seeded UTXO should remain; rollback must not leave
+        # extra outputs in storage.
+        wallet.create_action(action_opts)
+        spendable = storage.find_spendable_outputs(basket: 'default')
+        expect(spendable.size).to eq(1)
+        expect(spendable.first[:satoshis]).to eq(10_000)
+      end
+
+      it 'marks the action as failed' do
+        result = wallet.create_action(action_opts)
+        all_actions = storage.find_actions({ limit: 100, offset: 0 })
+        action = all_actions.find { |a| a[:txid] == result[:txid] }
+        expect(action[:status]).to eq('failed')
+      end
+    end
+
+    describe 'failed broadcast (network error / StandardError)' do
+      before do
+        allow(broadcaster).to receive(:broadcast).and_raise(RuntimeError, 'connection timeout')
+      end
+
+      it 'returns :broadcast_error without raising' do
+        result = wallet.create_action(action_opts)
+        expect(result[:broadcast_error]).to eq('connection timeout')
+      end
+
+      it 'releases input UTXOs back to :spendable' do
+        wallet.create_action(action_opts)
+        spendable = storage.find_spendable_outputs(basket: 'default')
+        expect(spendable.any? { |o| o[:satoshis] == 10_000 }).to be true
+      end
+
+      it 'deletes phantom change outputs' do
+        # Only the original seeded UTXO should remain after rollback.
+        wallet.create_action(action_opts)
+        spendable = storage.find_spendable_outputs(basket: 'default')
+        expect(spendable.size).to eq(1)
+        expect(spendable.first[:satoshis]).to eq(10_000)
+      end
+
+      it 'marks the action as failed' do
+        result = wallet.create_action(action_opts)
+        all_actions = storage.find_actions({ limit: 100, offset: 0 })
+        action = all_actions.find { |a| a[:txid] == result[:txid] }
+        expect(action[:status]).to eq('failed')
+      end
+    end
+
+    describe 'rollback does not affect other outputs or actions' do
+      before { seed_utxo(satoshis: 50_000) }
+
+      it 'leaves unrelated UTXOs intact after rollback' do
+        # First action succeeds (we have two seeded UTXOs: 10_000 and 50_000).
+        good_broadcaster = double('good_broadcaster') # rubocop:disable RSpec/VerifiedDoubles
+        good_response = BSV::Network::BroadcastResponse.new(txid: 'ok', tx_status: 'SEEN_ON_NETWORK')
+        allow(good_broadcaster).to receive(:broadcast).and_return(good_response)
+
+        good_wallet = BSV::Wallet::WalletClient.new(private_key, storage: storage, broadcaster: good_broadcaster)
+        good_wallet.create_action({
+                                    description: 'first succeeds',
+                                    auto_fund: true,
+                                    outputs: [{
+                                      locking_script: recipient_lock_hex,
+                                      satoshis: 1_000,
+                                      output_description: 'good payment'
+                                    }]
+                                  })
+
+        # Remaining spendable UTXOs after the first action.
+        before_count = storage.find_spendable_outputs(basket: 'default').size
+
+        # Second action fails broadcast.
+        allow(broadcaster).to receive(:broadcast).and_raise(
+          BSV::Network::BroadcastError.new('rejected')
+        )
+        wallet.create_action(action_opts)
+
+        # The spendable pool should not shrink permanently.
+        after_count = storage.find_spendable_outputs(basket: 'default').size
+        expect(after_count).to eq(before_count)
+      end
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Without broadcaster: backwards-compatible (no-broadcaster) behaviour
+  # -------------------------------------------------------------------------
+  describe 'without broadcaster (backwards-compatible)' do
+    before { seed_utxo(satoshis: 10_000) }
+
+    it 'promotes inputs to :spent immediately' do
+      wallet.create_action({
+                             description: 'no broadcaster test',
+                             auto_fund: true,
+                             outputs: [{
+                               locking_script: recipient_lock_hex,
+                               satoshis: 1_000,
+                               output_description: 'payment'
+                             }]
+                           })
+      spendable = storage.find_spendable_outputs(basket: 'default')
+      expect(spendable.none? { |o| o[:satoshis] == 10_000 }).to be true
+    end
+
+    it 'promotes change to :spendable immediately' do
+      wallet.create_action({
+                             description: 'no broadcaster change test',
+                             auto_fund: true,
+                             outputs: [{
+                               locking_script: recipient_lock_hex,
+                               satoshis: 1_000,
+                               output_description: 'payment'
+                             }]
+                           })
+      change = storage.find_spendable_outputs(basket: 'default').select { |o| o[:derivation_prefix] }
+      expect(change).not_to be_empty
+    end
+
+    it 'stores the action as completed' do
+      result = wallet.create_action({
+                                      description: 'no broadcaster action status test',
+                                      auto_fund: true,
+                                      outputs: [{
+                                        locking_script: recipient_lock_hex,
+                                        satoshis: 1_000,
+                                        output_description: 'payment'
+                                      }]
+                                    })
+      all_actions = storage.find_actions({ limit: 100, offset: 0 })
+      action = all_actions.find { |a| a[:txid] == result[:txid] }
+      expect(action[:status]).to eq('completed')
+    end
+
+    it 'does not include :broadcast_result or :broadcast_error in the result' do
+      result = wallet.create_action({
+                                      description: 'no broadcaster result shape test',
+                                      auto_fund: true,
+                                      outputs: [{
+                                        locking_script: recipient_lock_hex,
+                                        satoshis: 1_000,
+                                        output_description: 'payment'
+                                      }]
+                                    })
+      expect(result).not_to have_key(:broadcast_result)
+      expect(result).not_to have_key(:broadcast_error)
     end
   end
 end

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_auto_fund_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_auto_fund_spec.rb
@@ -891,7 +891,7 @@ RSpec.describe 'WalletClient auto-fund mode' do
 
         all_actions = storage.find_actions({ limit: 100, offset: 0 })
         action = all_actions.find { |a| a[:txid] == txid }
-        expect(action[:status]).to eq('completed')
+        expect(action[:status].to_s).to eq('unproven')
       end
 
       it 'returns failed status for unknown txid' do

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_spec.rb
@@ -61,6 +61,26 @@ RSpec.describe BSV::Wallet::WalletClient do
         wallet.abort_action({ reference: 'nonexistent' })
       end.to raise_error(BSV::Wallet::WalletError)
     end
+
+    it 'defaults broadcaster to nil' do
+      expect(wallet.broadcaster).to be_nil
+    end
+
+    it 'accepts a broadcaster: keyword argument' do
+      broadcaster = double('broadcaster', broadcast: nil) # rubocop:disable RSpec/VerifiedDoubles
+      w = described_class.new(private_key, storage: BSV::Wallet::MemoryStore.new, broadcaster: broadcaster)
+      expect(w.broadcaster).to equal(broadcaster)
+    end
+
+    it 'returns false from broadcast_enabled? when broadcaster is nil' do
+      expect(wallet.broadcast_enabled?).to be(false)
+    end
+
+    it 'returns true from broadcast_enabled? when broadcaster is set' do
+      broadcaster = double('broadcaster', broadcast: nil) # rubocop:disable RSpec/VerifiedDoubles
+      w = described_class.new(private_key, storage: BSV::Wallet::MemoryStore.new, broadcaster: broadcaster)
+      expect(w.broadcast_enabled?).to be(true)
+    end
   end
 
   # -------------------------------------------------------------------------

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_spec.rb
@@ -458,6 +458,141 @@ RSpec.describe BSV::Wallet::WalletClient do
   end
 
   # -------------------------------------------------------------------------
+  # accept_delayed_broadcast option — finalize_action path
+  # -------------------------------------------------------------------------
+  describe 'accept_delayed_broadcast option (finalize_action path)' do
+    let(:source_tx_and_beef) { build_source_beef }
+    let(:source_tx) { source_tx_and_beef[0] }
+    let(:input_beef_bytes) { source_tx_and_beef[1] }
+    let(:source_txid) { source_tx.txid_hex }
+
+    let(:base_args) do
+      {
+        description: 'accept delayed broadcast test',
+        input_beef: input_beef_bytes,
+        inputs: [{
+          outpoint: "#{source_txid}.0",
+          unlocking_script: 'aabb',
+          input_description: 'input for delayed broadcast test'
+        }],
+        outputs: [{
+          locking_script: locking_script_hex,
+          satoshis: 4000,
+          output_description: 'payment output'
+        }]
+      }
+    end
+
+    it 'accepts accept_delayed_broadcast: false without error' do
+      result = wallet.create_action(base_args.merge(options: { accept_delayed_broadcast: false }))
+      expect(result[:txid]).to match(/\A[0-9a-f]{64}\z/)
+    end
+
+    it 'stores the action as completed when accept_delayed_broadcast is false' do
+      result = wallet.create_action(base_args.merge(options: { accept_delayed_broadcast: false }))
+      all_actions = wallet.storage.find_actions({ limit: 100, offset: 0 })
+      action = all_actions.find { |a| a[:txid] == result[:txid] }
+      expect(action[:status]).to eq('completed')
+    end
+
+    it 'accepts accept_delayed_broadcast: true without raising' do
+      expect do
+        wallet.create_action(base_args.merge(options: { accept_delayed_broadcast: true }))
+      end.not_to raise_error
+    end
+
+    it 'stores the action as unproven when accept_delayed_broadcast: true' do
+      result = wallet.create_action(base_args.merge(options: { accept_delayed_broadcast: true }))
+      all_actions = wallet.storage.find_actions({ limit: 100, offset: 0 })
+      action = all_actions.find { |a| a[:txid] == result[:txid] }
+      expect(action[:status]).to eq('unproven')
+    end
+
+    it 'logs a warning when accept_delayed_broadcast: true' do
+      expect do
+        wallet.create_action(base_args.merge(options: { accept_delayed_broadcast: true }))
+      end.to output(/accept_delayed_broadcast.*not yet implemented/i).to_stderr
+    end
+
+    it 'defaults to completed status when option is absent' do
+      result = wallet.create_action(base_args)
+      all_actions = wallet.storage.find_actions({ limit: 100, offset: 0 })
+      action = all_actions.find { |a| a[:txid] == result[:txid] }
+      expect(action[:status]).to eq('completed')
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # accept_delayed_broadcast option — sign_action path
+  # -------------------------------------------------------------------------
+  describe 'accept_delayed_broadcast option (sign_action path)' do
+    let(:source_tx_and_beef) { build_source_beef }
+    let(:source_tx) { source_tx_and_beef[0] }
+    let(:input_beef_bytes) { source_tx_and_beef[1] }
+    let(:source_txid) { source_tx.txid_hex }
+    let(:dummy_unlock_hex) { 'aabb' }
+
+    let(:signable_result) do
+      wallet.create_action({
+                             description: 'sign action delayed broadcast test',
+                             input_beef: input_beef_bytes,
+                             inputs: [{
+                               outpoint: "#{source_txid}.0",
+                               unlocking_script_length: 107,
+                               input_description: 'spend for sign action test'
+                             }],
+                             outputs: [{
+                               locking_script: locking_script_hex,
+                               satoshis: 4000,
+                               output_description: 'payment output'
+                             }]
+                           })
+    end
+
+    let(:reference) { signable_result[:signable_transaction][:reference] }
+
+    it 'accepts accept_delayed_broadcast: false in sign_action without error' do
+      result = wallet.sign_action({
+                                    reference: reference,
+                                    spends: { 0 => { unlocking_script: dummy_unlock_hex } },
+                                    options: { accept_delayed_broadcast: false }
+                                  })
+      expect(result[:txid]).to match(/\A[0-9a-f]{64}\z/)
+    end
+
+    it 'accepts accept_delayed_broadcast: true in sign_action without raising' do
+      expect do
+        wallet.sign_action({
+                             reference: reference,
+                             spends: { 0 => { unlocking_script: dummy_unlock_hex } },
+                             options: { accept_delayed_broadcast: true }
+                           })
+      end.not_to raise_error
+    end
+
+    it 'stores the action as unproven when sign_action passes accept_delayed_broadcast: true' do
+      result = wallet.sign_action({
+                                    reference: reference,
+                                    spends: { 0 => { unlocking_script: dummy_unlock_hex } },
+                                    options: { accept_delayed_broadcast: true }
+                                  })
+      all_actions = wallet.storage.find_actions({ limit: 100, offset: 0 })
+      action = all_actions.find { |a| a[:txid] == result[:txid] }
+      expect(action[:status]).to eq('unproven')
+    end
+
+    it 'logs a warning when sign_action passes accept_delayed_broadcast: true' do
+      expect do
+        wallet.sign_action({
+                             reference: reference,
+                             spends: { 0 => { unlocking_script: dummy_unlock_hex } },
+                             options: { accept_delayed_broadcast: true }
+                           })
+      end.to output(/accept_delayed_broadcast.*not yet implemented/i).to_stderr
+    end
+  end
+
+  # -------------------------------------------------------------------------
   # #abort_action
   # -------------------------------------------------------------------------
   describe '#abort_action' do

--- a/gem/bsv-wallet/spec/support/shared_examples_for_storage_adapter.rb
+++ b/gem/bsv-wallet/spec/support/shared_examples_for_storage_adapter.rb
@@ -66,6 +66,53 @@ RSpec.shared_examples 'a storage adapter' do
         expect(results.length).to eq(2)
       end
     end
+
+    describe '#update_action_status' do
+      before do
+        store.store_action(labels: ['payment'], txid: 'abc', status: 'completed')
+      end
+
+      it 'updates the status of the matching action' do
+        store.update_action_status('abc', 'failed')
+        results = store.find_actions({})
+        expect(results.first[:status].to_s).to eq('failed')
+      end
+
+      it 'returns the updated action hash' do
+        result = store.update_action_status('abc', 'failed')
+        expect(result).to be_a(Hash)
+        expect(result[:txid]).to eq('abc')
+      end
+
+      it 'raises WalletError when no action with the given txid exists' do
+        expect do
+          store.update_action_status('nonexistent', 'failed')
+        end.to raise_error(BSV::Wallet::WalletError, /nonexistent/)
+      end
+    end
+
+    describe '#delete_action' do
+      before do
+        store.store_action(labels: ['payment'], txid: 'abc')
+      end
+
+      it 'removes the action and returns true' do
+        expect(store.delete_action('abc')).to be true
+        expect(store.find_actions({})).to be_empty
+      end
+
+      it 'returns false when no action with the given txid exists' do
+        expect(store.delete_action('nonexistent')).to be false
+      end
+
+      it 'does not affect other actions' do
+        store.store_action(labels: ['transfer'], txid: 'def')
+        store.delete_action('abc')
+        results = store.find_actions({})
+        expect(results.length).to eq(1)
+        expect(results.first[:txid]).to eq('def')
+      end
+    end
   end
 
   describe 'outputs' do


### PR DESCRIPTION
## Summary

Fixes the broadcast/rollback semantics in `create_action` to prevent phantom UTXOs when broadcasts fail (F8.13 cross-SDK compliance).

- Add optional `broadcaster:` parameter to WalletClient (duck-typed, any object with `#broadcast`) (#369)
- Add `delete_action` and `update_action_status` to StorageAdapter — implemented in MemoryStore, FileStore; PostgresStore flagged for downstream update (#370)
- Non-`no_send` path now stores state as `:pending` first, broadcasts via configured broadcaster, promotes on success, rolls back on failure — no more phantom UTXOs (#371)
- Broadcast results mapped to TS SDK's `ReviewActionResultStatus` (`success` / `doubleSpend` / `invalidTx` / `serviceError`) and returned in the result hash, not raised (#372)
- `send_with` batches previously `no_send` transactions for broadcast, with per-tx rollback on failure (#373)
- `accept_delayed_broadcast` option accepted (stub — defaults to `false`, background processing deferred to follow-up) (#374)
- Backwards compatible: no broadcaster configured preserves current behaviour

## Acceptance Criteria Verification

- [x] Default `create_action` (no `noSend`) broadcasts before promoting state
- [x] Failed broadcast rolls back: inputs return to `:spendable`, phantom change deleted
- [x] Successful broadcast promotes state as before
- [x] `acceptDelayedBroadcast` option accepted (defaults to `false`)
- [x] `noSend: true` path unchanged
- [x] `sendWith` batching works with previously `noSend` transactions
- [x] Broadcast errors returned in result hash (not raised), matching TS SDK `ReviewActionResultStatus`
- [x] No phantom UTXOs after any failure mode (ARC rejection, network timeout, invalid tx)
- [x] Existing auto_fund specs pass
- [x] New specs cover: broadcast failure rollback, double-spend detection, network error handling

## Test Results

- **bsv-sdk:** 3,035 examples, 0 failures, 8 pending
- **bsv-wallet:** 1,008 examples, 0 failures (up from 938 — 70 new specs)
- **bsv-wallet-postgres:** 131 examples, 0 failures, 131 pending
- **RuboCop:** 7 offences (all pre-existing, not introduced by this branch)

## Test Plan

- [x] `bundle exec rake` — full suite passes (4,200 examples, 0 failures)
- [x] RuboCop clean (no new offences)
- [x] All 10 acceptance criteria verified against implementation and specs
- [x] Backwards compatibility confirmed: no broadcaster = current behaviour preserved

Closes #368

Generated with [Claude Code](https://claude.com/claude-code)
