### PR TITLE
feat: SDK cross-SDK alignment polish (F1.1, F1.2, F1.7, F3.18, F4.6, F4.10/F4.11, F5.11, F6.7, F6.16)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,11 @@ AllCops:
 Style/Documentation:
   Enabled: false
 
+# `be > 0` is idiomatic RSpec for numeric comparisons; `be.positive?` is broken syntax.
+Style/NumericPredicate:
+  Exclude:
+    - 'gem/*/spec/**/*'
+
 Metrics/BlockLength:
   Exclude:
     - 'gem/bsv-wallet/lib/bsv/wallet_interface/wire/**/*'

--- a/gem/bsv-sdk/lib/bsv-sdk.rb
+++ b/gem/bsv-sdk/lib/bsv-sdk.rb
@@ -13,4 +13,5 @@ module BSV
   autoload :Identity,    'bsv/identity'
   autoload :Registry,    'bsv/registry'
   autoload :MCP,         'bsv/mcp'
+  autoload :Messages,    'bsv/messages'
 end

--- a/gem/bsv-sdk/lib/bsv/messages.rb
+++ b/gem/bsv-sdk/lib/bsv/messages.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module BSV
+  # Namespace providing TS SDK naming parity for messaging primitives.
+  #
+  # Re-exports {BSV::Primitives::SignedMessage} and {BSV::Primitives::EncryptedMessage}
+  # under the +BSV::Messages+ namespace, matching the structure of the TypeScript SDK
+  # (ts-sdk/src/messages/index.ts).
+  #
+  # The canonical implementations remain in +BSV::Primitives+; this module is a
+  # lightweight re-export only.
+  module Messages
+    SignedMessage = BSV::Primitives::SignedMessage
+    EncryptedMessage = BSV::Primitives::EncryptedMessage
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/primitives/base58.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/base58.rb
@@ -61,9 +61,9 @@ module BSV
       #
       # @param string [String] Base58-encoded string
       # @return [String] decoded binary data
-      # @raise [ArgumentError] if the string contains invalid Base58 characters
+      # @raise [ArgumentError] if the string is empty or contains invalid Base58 characters
       def decode(string)
-        return ''.b if string.empty?
+        raise ArgumentError, 'cannot decode empty string' if string.empty?
 
         # Count leading '1' characters (representing zero bytes)
         leading_ones = 0

--- a/gem/bsv-sdk/lib/bsv/primitives/base58.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/base58.rb
@@ -89,19 +89,30 @@ module BSV
 
       # Encode binary data with a 4-byte double-SHA-256 checksum appended.
       #
+      # When +prefix+ is given, it is prepended to the payload before checksumming.
+      # The checksum covers the full +prefix + payload+ concatenation.
+      #
       # @param payload [String] binary data to encode
+      # @param prefix [String, nil] optional version prefix to prepend (binary string)
       # @return [String] Base58Check-encoded string
-      def check_encode(payload)
-        checksum = Digest.sha256d(payload)[0, 4]
-        encode(payload + checksum)
+      def check_encode(payload, prefix: nil)
+        full = (prefix || ''.b) + payload
+        checksum = Digest.sha256d(full)[0, 4]
+        encode(full + checksum)
       end
 
       # Decode a Base58Check string and verify its checksum.
       #
+      # When +prefix_length+ is greater than zero, the decoded payload is split
+      # into a prefix and data portion. The returned value is then a Hash with
+      # +:prefix+ and +:data+ keys. When +prefix_length+ is zero (default), the
+      # raw payload is returned unchanged for backwards compatibility.
+      #
       # @param string [String] Base58Check-encoded string
-      # @return [String] decoded payload (without checksum)
+      # @param prefix_length [Integer] number of leading bytes to treat as a prefix (default: 0)
+      # @return [String, Hash] decoded payload, or +{ prefix:, data: }+ when prefix_length > 0
       # @raise [ChecksumError] if the checksum does not match or input is too short
-      def check_decode(string)
+      def check_decode(string, prefix_length: 0)
         data = decode(string)
         raise ChecksumError, 'input too short for checksum' if data.length < 4
 
@@ -110,7 +121,9 @@ module BSV
         expected = Digest.sha256d(payload)[0, 4]
         raise ChecksumError, 'checksum mismatch' unless checksum == expected
 
-        payload
+        return payload if prefix_length.zero?
+
+        { prefix: payload[0, prefix_length], data: payload[prefix_length..] }
       end
     end
   end

--- a/gem/bsv-sdk/lib/bsv/primitives/base58.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/base58.rb
@@ -123,6 +123,8 @@ module BSV
 
         return payload if prefix_length.zero?
 
+        raise ArgumentError, 'prefix_length exceeds payload' if prefix_length > payload.length
+
         { prefix: payload[0, prefix_length], data: payload[prefix_length..] }
       end
     end

--- a/gem/bsv-sdk/lib/bsv/primitives/digest.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/digest.rb
@@ -38,6 +38,9 @@ module BSV
         sha256(sha256(data))
       end
 
+      alias hash256 sha256d
+      module_function :hash256
+
       # Compute SHA-512 digest.
       #
       # @param data [String] binary data to hash

--- a/gem/bsv-sdk/lib/bsv/primitives/ecies.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/ecies.rb
@@ -33,8 +33,9 @@ module BSV
       # @param message [String] the plaintext message
       # @param public_key [PublicKey] the recipient's public key
       # @param private_key [PrivateKey, nil] optional ephemeral key (random if omitted)
-      # @return [String] encrypted payload: BIE1 magic + ephemeral pubkey + ciphertext + HMAC
-      def encrypt(message, public_key, private_key: nil)
+      # @param no_key [Boolean] when +true+, omit the ephemeral public key from the payload
+      # @return [String] encrypted payload: BIE1 magic + [ephemeral pubkey] + ciphertext + HMAC
+      def encrypt(message, public_key, private_key: nil, no_key: false)
         message = message.b if message.encoding != Encoding::ASCII_8BIT
 
         ephemeral = private_key || PrivateKey.generate
@@ -48,7 +49,11 @@ module BSV
         cipher.iv = iv
         ciphertext = message.empty? ? cipher.final : cipher.update(message) + cipher.final
 
-        payload = MAGIC + ephemeral_pub.compressed + ciphertext
+        payload = if no_key
+                    MAGIC + ciphertext
+                  else
+                    MAGIC + ephemeral_pub.compressed + ciphertext
+                  end
         mac = Digest.hmac_sha256(key_m, payload)
 
         payload + mac
@@ -58,29 +63,59 @@ module BSV
       #
       # Verifies the HMAC before attempting decryption (encrypt-then-MAC).
       #
+      # The ephemeral public key may be embedded in the payload (compressed or
+      # uncompressed), or absent entirely (when the payload was encrypted with
+      # +no_key: true+). When absent, +sender_public_key+ must be provided.
+      #
+      # If a key is found in the payload and +sender_public_key+ is also given,
+      # the payload key takes precedence (matching TS SDK behaviour).
+      #
       # @param data [String] the encrypted payload (BIE1 format)
       # @param private_key [PrivateKey] the recipient's private key
+      # @param sender_public_key [PublicKey, nil] sender's public key (required when no key in payload)
       # @return [String] the decrypted plaintext
-      # @raise [ArgumentError] if the data is too short or has invalid magic bytes
+      # @raise [ArgumentError] if the data is too short, has invalid magic, or has no key and none provided
       # @raise [DecryptionError] if HMAC verification or AES decryption fails
-      def decrypt(data, private_key)
+      def decrypt(data, private_key, sender_public_key: nil)
         data = data.b if data.encoding != Encoding::ASCII_8BIT
 
-        raise ArgumentError, 'data too short' if data.bytesize < 85
+        # Minimum: magic(4) + ciphertext(16) + HMAC(32) = 52 (no-key case)
+        raise ArgumentError, 'data too short' if data.bytesize < 52
 
         magic = data[0, 4]
         raise ArgumentError, 'invalid magic: expected BIE1' unless magic == MAGIC
 
-        ephemeral_pub_bytes = data[4, 33]
-        mac = data[-32, 32]
-        ciphertext = data[37...-32]
+        # Determine ephemeral key presence and format by inspecting byte at offset 4.
+        # Guard: only attempt to read a key if sufficient bytes remain beyond HMAC.
+        tag_length = 32
+        offset = 4
+        ephemeral_pub = nil
 
-        ephemeral_pub = PublicKey.from_bytes(ephemeral_pub_bytes)
+        remaining_after_offset = data.bytesize - offset - tag_length
+        if remaining_after_offset >= 33
+          first_byte = data.getbyte(offset)
+          if [0x02, 0x03].include?(first_byte)
+            # Compressed key: 33 bytes
+            ephemeral_pub = PublicKey.from_bytes(data[offset, 33])
+            offset += 33
+          elsif first_byte == 0x04 && remaining_after_offset >= 65
+            # Uncompressed key: 65 bytes
+            ephemeral_pub = PublicKey.from_bytes(data[offset, 65])
+            offset += 65
+          end
+        end
+
+        # If no key found in payload, fall back to provided sender_public_key
+        ephemeral_pub ||= sender_public_key
+        raise ArgumentError, 'sender_public_key required when no key in payload' if ephemeral_pub.nil?
+
+        mac = data[-tag_length, tag_length]
+        ciphertext = data[offset...-tag_length]
 
         iv, key_e, key_m = derive_keys(private_key, ephemeral_pub)
 
         # Verify HMAC before decryption (encrypt-then-MAC)
-        payload = data[0...-32]
+        payload = data[0...-tag_length]
         expected_mac = Digest.hmac_sha256(key_m, payload)
 
         raise DecryptionError, 'HMAC verification failed' unless secure_compare(mac, expected_mac)

--- a/gem/bsv-sdk/lib/bsv/primitives/ecies.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/ecies.rb
@@ -86,6 +86,11 @@ module BSV
         raise ArgumentError, 'invalid magic: expected BIE1' unless magic == MAGIC
 
         # Determine ephemeral key presence and format by inspecting byte at offset 4.
+        # Ambiguity note: a no-key payload whose ciphertext starts with 0x02/0x03/0x04
+        # could be misinterpreted as containing an embedded key. The HMAC check below
+        # will catch this (wrong shared secret → HMAC mismatch), but the resulting
+        # error message will be misleading. This is a TS SDK design inheritance —
+        # the wire format has no explicit key-presence flag.
         # Guard: only attempt to read a key if sufficient bytes remain beyond HMAC.
         tag_length = 32
         offset = 4

--- a/gem/bsv-sdk/lib/bsv/script/script.rb
+++ b/gem/bsv-sdk/lib/bsv/script/script.rb
@@ -144,11 +144,19 @@ module BSV
 
       # Construct a Pay-to-Public-Key-Hash (P2PKH) locking script.
       #
-      # @param pubkey_hash [String] 20-byte public key hash
+      # Accepts either a raw 20-byte binary hash or a Base58Check address string.
+      # When given an address string, the version prefix is validated: +0x00+
+      # (mainnet) and +0x6f+ (testnet) are accepted; +0x05+ (P2SH) is rejected
+      # with a clear error message.
+      #
+      # @param pubkey_hash_or_address [String] 20-byte binary pubkey hash, or a
+      #   Base58Check address string
       # @return [Script]
-      # @raise [ArgumentError] if pubkey_hash is not 20 bytes
-      def self.p2pkh_lock(pubkey_hash)
-        raise ArgumentError, 'pubkey_hash must be 20 bytes' unless pubkey_hash.bytesize == 20
+      # @raise [ArgumentError] if the argument is not a valid 20-byte hash, if the
+      #   address has an unrecognised prefix, or if a P2SH address is supplied
+      # @raise [BSV::Primitives::Base58::ChecksumError] if the address checksum is invalid
+      def self.p2pkh_lock(pubkey_hash_or_address)
+        pubkey_hash = resolve_pubkey_hash(pubkey_hash_or_address)
 
         buf = [
           Opcodes::OP_DUP,
@@ -158,6 +166,35 @@ module BSV
         buf << [Opcodes::OP_EQUALVERIFY, Opcodes::OP_CHECKSIG].pack('CC')
         new(buf)
       end
+
+      # @api private
+      # Resolve a pubkey_hash argument that may be a raw binary hash or a
+      # Base58Check address string.
+      def self.resolve_pubkey_hash(arg)
+        # A 20-byte ASCII-8BIT string is treated as a raw binary hash.
+        return arg if arg.encoding == Encoding::ASCII_8BIT && arg.bytesize == 20
+
+        # Otherwise treat as a Base58Check address string.
+        decoded = BSV::Primitives::Base58.check_decode(arg, prefix_length: 1)
+        prefix = decoded[:prefix]
+        data   = decoded[:data]
+
+        p2sh_prefix = "\x05".b
+        mainnet_prefix = "\x00".b
+        testnet_prefix = "\x6f".b
+
+        if prefix == p2sh_prefix
+          raise ArgumentError,
+                'P2SH addresses are not supported on BSV; ' \
+                'use p2pkh_lock with a P2PKH address or 20-byte hash'
+        end
+
+        raise ArgumentError, "unrecognised address prefix: 0x#{prefix.unpack1('H*')}" \
+          unless prefix == mainnet_prefix || prefix == testnet_prefix
+
+        data
+      end
+      private_class_method :resolve_pubkey_hash
 
       # Construct a P2PKH unlocking script.
       #

--- a/gem/bsv-sdk/lib/bsv/script/script.rb
+++ b/gem/bsv-sdk/lib/bsv/script/script.rb
@@ -181,7 +181,7 @@ module BSV
 
         p2sh_prefix = "\x05".b
         mainnet_prefix = "\x00".b
-        testnet_prefix = "\x6f".b
+        testnet_prefix = "\x6f".b # accepted for testnet interop; no mainnet-only restriction
 
         if prefix == p2sh_prefix
           raise ArgumentError,

--- a/gem/bsv-sdk/lib/bsv/script/script.rb
+++ b/gem/bsv-sdk/lib/bsv/script/script.rb
@@ -192,6 +192,8 @@ module BSV
         raise ArgumentError, "unrecognised address prefix: 0x#{prefix.unpack1('H*')}" \
           unless prefix == mainnet_prefix || prefix == testnet_prefix
 
+        raise ArgumentError, 'decoded hash must be 20 bytes' unless data.bytesize == 20
+
         data
       end
       private_class_method :resolve_pubkey_hash

--- a/gem/bsv-sdk/lib/bsv/transaction/merkle_path.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/merkle_path.rb
@@ -303,10 +303,29 @@ module BSV
       # Computes the merkle root from the path and txid, then checks it
       # against the blockchain via the provided chain tracker.
       #
+      # For coinbase transactions (offset 0 in the merkle tree), an additional
+      # maturity check is performed: the coinbase must have at least 100
+      # confirmations before it is considered spendable/valid.
+      #
+      # NOTE: The TS SDK has an inverted coinbase maturity check at MerklePath.ts:378
+      # (`this.blockHeight + 100 < height`), which rejects mature coinbase transactions
+      # and accepts immature ones — the opposite of the intended behaviour. The correct
+      # logic is: reject when `current_height - block_height < 100` (immature).
+      #
       # @param txid_hex [String] hex-encoded transaction ID (display order)
       # @param chain_tracker [ChainTracker] chain tracker to verify the root against
       # @return [Boolean] true if the computed root matches the block at this height
       def verify(txid_hex, chain_tracker)
+        txid_bytes = [txid_hex].pack('H*').reverse
+        txid_leaf = @path[0].find { |l| l.hash == txid_bytes }
+
+        # Offset 0 in a block's merkle tree is always the coinbase transaction —
+        # a Bitcoin protocol invariant. Apply the 100-block maturity check.
+        if txid_leaf&.offset&.zero?
+          current = chain_tracker.current_height
+          return false if current - @block_height < 100
+        end
+
         root_hex = compute_root_hex(txid_hex)
         chain_tracker.valid_root_for_height?(root_hex, @block_height)
       end

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -801,7 +801,7 @@ module BSV
         when FeeModel
           model_or_fee.compute_fee(self)
         when Numeric
-          model_or_fee.ceil
+          model_or_fee.ceil # round up — fractional satoshis from callers are not valid; rounding up prevents underpayment
         else
           raise ArgumentError, "expected FeeModel, Numeric, or nil; got #{model_or_fee.class}"
         end

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction_input.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction_input.rb
@@ -15,7 +15,7 @@ module BSV
       attr_reader :prev_tx_out_index
 
       # @return [Integer] sequence number (default: 0xFFFFFFFF)
-      attr_reader :sequence
+      attr_accessor :sequence
 
       # @return [Script::Script, nil] the unlocking script (set after signing)
       attr_accessor :unlocking_script

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction_output.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction_output.rb
@@ -12,7 +12,7 @@ module BSV
       attr_accessor :satoshis
 
       # @return [Script::Script] the locking script (spending conditions)
-      attr_reader :locking_script
+      attr_accessor :locking_script
 
       # @return [Boolean] whether this output receives change
       attr_accessor :change

--- a/gem/bsv-sdk/spec/bsv/messages_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/messages_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'BSV::Messages namespace' do
+  let(:sender) { BSV::Primitives::PrivateKey.new(OpenSSL::BN.new(15)) }
+  let(:recipient) { BSV::Primitives::PrivateKey.new(OpenSSL::BN.new(21)) }
+  let(:message) { 'hello world' }
+
+  describe 'BSV::Messages::SignedMessage' do
+    it 'is the same constant as BSV::Primitives::SignedMessage' do
+      expect(BSV::Messages::SignedMessage).to equal(BSV::Primitives::SignedMessage)
+    end
+
+    it 'can sign and verify a message' do
+      sig = BSV::Messages::SignedMessage.sign(message, sender, recipient.public_key)
+      expect(BSV::Messages::SignedMessage.verify(message, sig, recipient)).to be true
+    end
+  end
+
+  describe 'BSV::Messages::EncryptedMessage' do
+    it 'is the same constant as BSV::Primitives::EncryptedMessage' do
+      expect(BSV::Messages::EncryptedMessage).to equal(BSV::Primitives::EncryptedMessage)
+    end
+
+    it 'can encrypt and decrypt a message' do
+      ct = BSV::Messages::EncryptedMessage.encrypt(message, sender, recipient.public_key)
+      expect(BSV::Messages::EncryptedMessage.decrypt(ct, recipient)).to eq(message)
+    end
+  end
+
+  describe 'BSV::Primitives namespace unaffected' do
+    it 'BSV::Primitives::SignedMessage still works directly' do
+      sig = BSV::Primitives::SignedMessage.sign(message, sender, recipient.public_key)
+      expect(BSV::Primitives::SignedMessage.verify(message, sig, recipient)).to be true
+    end
+
+    it 'BSV::Primitives::EncryptedMessage still works directly' do
+      ct = BSV::Primitives::EncryptedMessage.encrypt(message, sender, recipient.public_key)
+      expect(BSV::Primitives::EncryptedMessage.decrypt(ct, recipient)).to eq(message)
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/gem/bsv-sdk/spec/bsv/primitives/base58_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/primitives/base58_spec.rb
@@ -21,8 +21,16 @@ RSpec.describe BSV::Primitives::Base58 do
       expect(described_class.encode('')).to eq('')
     end
 
-    it 'decodes empty string to empty bytes' do
-      expect(described_class.decode('')).to eq(''.b)
+    it 'raises ArgumentError when decoding empty string' do
+      expect { described_class.decode('') }.to raise_error(ArgumentError, 'cannot decode empty string')
+    end
+
+    it 'raises ArgumentError via check_decode when given empty string' do
+      expect { described_class.check_decode('') }.to raise_error(ArgumentError, 'cannot decode empty string')
+    end
+
+    it 'decodes "1" to a single zero byte (leading-zero round-trip)' do
+      expect(described_class.decode('1')).to eq("\x00".b)
     end
 
     it 'raises on invalid characters' do

--- a/gem/bsv-sdk/spec/bsv/primitives/base58_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/primitives/base58_spec.rb
@@ -79,5 +79,52 @@ RSpec.describe BSV::Primitives::Base58 do
       expect { described_class.check_decode(short) }
         .to raise_error(BSV::Primitives::Base58::ChecksumError, /too short/)
     end
+
+    context 'prefix: parameter on check_encode' do
+      it 'check_encode with prefix: produces same result as pre-concatenating prefix' do
+        data = 'data'.b
+        prefix = "\x00".b
+        with_keyword = described_class.check_encode(data, prefix: prefix)
+        pre_concat = described_class.check_encode(prefix + data)
+        expect(with_keyword).to eq(pre_concat)
+      end
+
+      it 'check_encode with prefix: nil behaves identically to omitting the keyword' do
+        data = 'data'.b
+        without_keyword = described_class.check_encode(data)
+        with_nil = described_class.check_encode(data, prefix: nil)
+        expect(with_nil).to eq(without_keyword)
+      end
+
+      it 'check_encode with empty-string prefix behaves identically to no prefix' do
+        data = 'data'.b
+        expect(described_class.check_encode(data, prefix: ''.b)).to eq(described_class.check_encode(data))
+      end
+    end
+
+    context 'prefix_length: parameter on check_decode' do
+      it 'returns hash with :prefix and :data when prefix_length: 1' do
+        prefix = "\x00".b
+        data = 'hello'.b
+        encoded = described_class.check_encode(data, prefix: prefix)
+        result = described_class.check_decode(encoded, prefix_length: 1)
+        expect(result).to eq({ prefix: prefix, data: data })
+      end
+
+      it 'returns raw payload (no hash) when prefix_length: 0 (backwards compatible)' do
+        payload = ['00751e76e8199196d454941c45d1b3a323f1433bd6'].pack('H*')
+        encoded = described_class.check_encode(payload)
+        expect(described_class.check_decode(encoded)).to eq(payload)
+      end
+
+      it 'round-trips with a 4-byte (extended key style) prefix' do
+        prefix = "\x04\x88\xb2\x1e".b
+        data = ('x' * 74).b
+        encoded = described_class.check_encode(data, prefix: prefix)
+        result = described_class.check_decode(encoded, prefix_length: 4)
+        expect(result[:prefix]).to eq(prefix)
+        expect(result[:data]).to eq(data)
+      end
+    end
   end
 end

--- a/gem/bsv-sdk/spec/bsv/primitives/digest_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/primitives/digest_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe BSV::Primitives::Digest do
     end
   end
 
+  describe '.hash256' do
+    it 'returns the same result as sha256d' do
+      data = 'abc'
+      expect(described_class.hash256(data)).to eq(described_class.sha256d(data))
+    end
+
+    it 'is callable as a module function' do
+      result = described_class.hash256('test')
+      expect(result).to eq(described_class.sha256d('test'))
+    end
+  end
+
   describe '.sha512' do
     it 'hashes "abc" correctly' do
       result = described_class.sha512('abc')

--- a/gem/bsv-sdk/spec/bsv/primitives/ecies_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/primitives/ecies_spec.rb
@@ -113,9 +113,64 @@ RSpec.describe BSV::Primitives::ECIES do
     end
   end
 
+  describe 'no_key option' do
+    context 'encrypt with no_key: true, decrypt with sender_public_key' do
+      it 'round-trips successfully' do
+        ciphertext = described_class.encrypt(plaintext, bob_privkey.public_key, private_key: alice_privkey, no_key: true)
+        result = described_class.decrypt(ciphertext, bob_privkey, sender_public_key: alice_privkey.public_key)
+        expect(result).to eq(plaintext.b)
+      end
+
+      it 'produces a shorter payload than the standard format' do
+        with_key    = described_class.encrypt(plaintext, bob_privkey.public_key, private_key: alice_privkey)
+        without_key = described_class.encrypt(plaintext, bob_privkey.public_key, private_key: alice_privkey, no_key: true)
+        expect(without_key.bytesize).to eq(with_key.bytesize - 33)
+      end
+    end
+
+    context 'encrypt with no_key: true, decrypt without sender_public_key' do
+      it 'raises ArgumentError' do
+        ciphertext = described_class.encrypt(plaintext, bob_privkey.public_key, private_key: alice_privkey, no_key: true)
+        expect { described_class.decrypt(ciphertext, bob_privkey) }
+          .to raise_error(ArgumentError, /sender_public_key required/)
+      end
+    end
+  end
+
+  describe 'uncompressed ephemeral key' do
+    it 'decrypts a payload with an uncompressed (0x04) ephemeral key' do
+      # Construct a payload with an uncompressed ephemeral key manually:
+      # encrypt normally, then rebuild the payload replacing the compressed key
+      # with its uncompressed equivalent.
+      ephemeral = BSV::Primitives::PrivateKey.from_hex(
+        '77e06abc52bf065cb5164c5deca839d0276911991a2730be4d8d0a0307de7ceb'
+      )
+      recipient = bob_privkey
+
+      iv, key_e, key_m = described_class.send(:derive_keys, ephemeral, recipient.public_key)
+
+      cipher = OpenSSL::Cipher.new('aes-128-cbc')
+      cipher.encrypt
+      cipher.key = key_e
+      cipher.iv = iv
+      ciphertext = cipher.update(plaintext.b) + cipher.final
+
+      uncompressed_pub = ephemeral.public_key.uncompressed
+      expect(uncompressed_pub.bytesize).to eq(65)
+      expect(uncompressed_pub.getbyte(0)).to eq(0x04)
+
+      payload = BSV::Primitives::ECIES::MAGIC + uncompressed_pub + ciphertext
+      mac = BSV::Primitives::Digest.hmac_sha256(key_m, payload)
+      data = payload + mac
+
+      result = described_class.decrypt(data, recipient)
+      expect(result).to eq(plaintext.b)
+    end
+  end
+
   describe 'error handling' do
-    it 'raises ArgumentError for data shorter than 85 bytes' do
-      expect { described_class.decrypt("\x00" * 84, bob_privkey) }.to raise_error(ArgumentError, /too short/)
+    it 'raises ArgumentError for data shorter than 52 bytes' do
+      expect { described_class.decrypt("\x00" * 51, bob_privkey) }.to raise_error(ArgumentError, /too short/)
     end
 
     it 'raises ArgumentError for wrong magic bytes' do

--- a/gem/bsv-sdk/spec/bsv/script/script_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/script/script_spec.rb
@@ -110,15 +110,54 @@ RSpec.describe BSV::Script::Script do
   end
 
   describe '.p2pkh_lock' do
-    it 'creates a standard P2PKH locking script' do
+    # Mainnet address for the generator point pubkey hash (1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH)
+    let(:p2pkh_mainnet_address) { '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH' }
+    # Testnet address for the same hash
+    let(:p2pkh_testnet_address) { 'mrCDrCybB6J1vRfbwM5hemdJz73FwDBC8r' }
+    # A P2SH address (same hash, prefix 0x05) — should be rejected
+    let(:p2sh_address) { '3CNHUhP3uyB9EUtRLsmvFUmvGdjGdkTxJw' }
+
+    it 'creates a standard P2PKH locking script from a raw binary hash' do
       script = described_class.p2pkh_lock(p2pkh_hash)
       expect(script.to_hex).to eq(p2pkh_hex)
       expect(script.to_asm).to eq(p2pkh_asm)
     end
 
-    it 'raises on invalid hash length' do
+    it 'raises when given an ASCII-8BIT string shorter than 20 bytes' do
+      # A 19-byte binary blob is not a valid 20-byte hash, and contains null
+      # bytes that are not valid Base58 characters, so ArgumentError is raised
+      # from whichever path is taken.
       expect { described_class.p2pkh_lock("\x00".b * 19) }
-        .to raise_error(ArgumentError, /20 bytes/)
+        .to raise_error(ArgumentError)
+    end
+
+    it 'accepts a mainnet Base58Check address string and produces the same script as the raw hash' do
+      script_from_address = described_class.p2pkh_lock(p2pkh_mainnet_address)
+      script_from_hash    = described_class.p2pkh_lock(p2pkh_hash)
+      expect(script_from_address.to_hex).to eq(script_from_hash.to_hex)
+    end
+
+    it 'accepts a testnet Base58Check address string' do
+      script_from_address = described_class.p2pkh_lock(p2pkh_testnet_address)
+      script_from_hash    = described_class.p2pkh_lock(p2pkh_hash)
+      expect(script_from_address.to_hex).to eq(script_from_hash.to_hex)
+    end
+
+    it 'raises ArgumentError for a P2SH address' do
+      expect { described_class.p2pkh_lock(p2sh_address) }
+        .to raise_error(ArgumentError, /P2SH/)
+    end
+
+    it 'raises ArgumentError for an invalid Base58 character' do
+      expect { described_class.p2pkh_lock('1InvalidBase58O0Il') }
+        .to raise_error(ArgumentError)
+    end
+
+    it 'raises ChecksumError for a valid Base58 string with wrong checksum' do
+      # Flip the last character of the valid address to corrupt the checksum
+      bad_address = p2pkh_mainnet_address[0..-2] + (p2pkh_mainnet_address[-1] == 'H' ? 'J' : 'H')
+      expect { described_class.p2pkh_lock(bad_address) }
+        .to raise_error(BSV::Primitives::Base58::ChecksumError)
     end
   end
 

--- a/gem/bsv-sdk/spec/bsv/transaction/merkle_path_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/merkle_path_spec.rb
@@ -352,6 +352,83 @@ RSpec.describe BSV::Transaction::MerklePath do
     end
   end
 
+  # F5.11 — coinbase 100-block maturity check
+  describe '#verify coinbase maturity (F5.11)' do
+    # Build a minimal 2-leaf path at a known block height so we can control
+    # the txid offset precisely.
+    let(:pe) { BSV::Transaction::MerklePath::PathElement }
+    let(:block_height) { 1_000 }
+    let(:coinbase_hash) { BSV::Primitives::Digest.sha256('coinbase_tx') }
+    let(:normal_hash)   { BSV::Primitives::Digest.sha256('normal_tx') }
+    let(:expected_root) { described_class.merkle_tree_parent(coinbase_hash, normal_hash) }
+    let(:root_hex)      { expected_root.reverse.unpack1('H*') }
+    let(:coinbase_txid_hex) { coinbase_hash.reverse.unpack1('H*') }
+    let(:normal_txid_hex)   { normal_hash.reverse.unpack1('H*') }
+
+    # Coinbase tx is at offset 0; normal tx is at offset 1
+    let(:coinbase_mp) do
+      described_class.new(
+        block_height: block_height,
+        path: [
+          [pe.new(offset: 0, hash: coinbase_hash, txid: true),
+           pe.new(offset: 1, hash: normal_hash)]
+        ]
+      )
+    end
+
+    let(:normal_mp) do
+      described_class.new(
+        block_height: block_height,
+        path: [
+          [pe.new(offset: 0, hash: coinbase_hash),
+           pe.new(offset: 1, hash: normal_hash, txid: true)]
+        ]
+      )
+    end
+
+    def tracker_returning(current_h, root_result)
+      t = instance_double(BSV::Transaction::ChainTracker)
+      allow(t).to receive_messages(current_height: current_h, valid_root_for_height?: root_result)
+      t
+    end
+
+    it 'skips the maturity check for a non-coinbase tx (offset > 0)' do
+      tracker = instance_double(BSV::Transaction::ChainTracker)
+      allow(tracker).to receive(:valid_root_for_height?).and_return(true)
+
+      result = normal_mp.verify(normal_txid_hex, tracker)
+
+      expect(result).to be true
+      # current_height must NOT be called for non-coinbase txs
+      expect(tracker).not_to have_received(:current_height) if tracker.respond_to?(:current_height)
+    end
+
+    it 'returns false for coinbase tx with only 50 confirmations (immature)' do
+      tracker = tracker_returning(block_height + 50, true)
+      expect(coinbase_mp.verify(coinbase_txid_hex, tracker)).to be false
+    end
+
+    it 'returns false for coinbase tx with 99 confirmations (still immature)' do
+      tracker = tracker_returning(block_height + 99, true)
+      expect(coinbase_mp.verify(coinbase_txid_hex, tracker)).to be false
+    end
+
+    it 'proceeds to root check for coinbase tx with exactly 100 confirmations (mature)' do
+      tracker = tracker_returning(block_height + 100, true)
+      expect(coinbase_mp.verify(coinbase_txid_hex, tracker)).to be true
+    end
+
+    it 'returns false for mature coinbase when root check fails' do
+      tracker = tracker_returning(block_height + 100, false)
+      expect(coinbase_mp.verify(coinbase_txid_hex, tracker)).to be false
+    end
+
+    it 'returns false at 0 confirmations (current height == block height)' do
+      tracker = tracker_returning(block_height, true)
+      expect(coinbase_mp.verify(coinbase_txid_hex, tracker)).to be false
+    end
+  end
+
   # Issue #280 — TSC proof conversion
   describe '.from_tsc' do
     # Real WhatsOnChain TSC proof for tx 294cd1eb… in block 612251.

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_input_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_input_spec.rb
@@ -75,6 +75,35 @@ RSpec.describe BSV::Transaction::TransactionInput do
     end
   end
 
+  describe '#sequence=' do
+    it 'allows the sequence to be mutated after construction' do
+      input = described_class.new(prev_tx_id: txid_internal, prev_tx_out_index: 0)
+      expect(input.sequence).to eq(0xFFFFFFFF)
+
+      input.sequence = 0x00000001
+      expect(input.sequence).to eq(0x00000001)
+    end
+
+    it 'reflects the new sequence in to_binary' do
+      input = described_class.new(prev_tx_id: txid_internal, prev_tx_out_index: 0)
+      input.sequence = 0x00000001
+
+      binary = input.to_binary
+      expect(binary.byteslice(37, 4).unpack1('V')).to eq(0x00000001)
+    end
+
+    it 'serialises correctly when mutated from 0xFFFFFFFF to 0' do
+      input = described_class.new(prev_tx_id: txid_internal, prev_tx_out_index: 0, sequence: 0xFFFFFFFF)
+      input.sequence = 0
+
+      binary = input.to_binary
+      expect(binary.byteslice(37, 4).unpack1('V')).to eq(0)
+
+      parsed, = described_class.from_binary(binary)
+      expect(parsed.sequence).to eq(0)
+    end
+  end
+
   describe '#outpoint_binary' do
     it 'returns 36-byte outpoint (txid + vout)' do
       input = described_class.new(prev_tx_id: txid_internal, prev_tx_out_index: 2)

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_output_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_output_spec.rb
@@ -42,6 +42,26 @@ RSpec.describe BSV::Transaction::TransactionOutput do
     end
   end
 
+  describe '#locking_script=' do
+    it 'allows the locking script to be mutated after construction' do
+      output = described_class.new(satoshis: 1000, locking_script: locking_script)
+      new_script = BSV::Script::Script.op_return('data'.b)
+
+      output.locking_script = new_script
+      expect(output.locking_script.to_hex).to eq(new_script.to_hex)
+    end
+
+    it 'reflects the new locking script in to_binary' do
+      output = described_class.new(satoshis: 1000, locking_script: locking_script)
+      new_script = BSV::Script::Script.op_return('data'.b)
+      output.locking_script = new_script
+
+      binary = output.to_binary
+      parsed, = described_class.from_binary(binary)
+      expect(parsed.locking_script.to_hex).to eq(new_script.to_hex)
+    end
+  end
+
   describe 'round-trip' do
     it 'serialises and deserialises an OP_RETURN output' do
       script = BSV::Script::Script.op_return('hello world'.b)

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
@@ -654,6 +654,52 @@ RSpec.describe BSV::Transaction::Transaction do
     end
   end
 
+  describe '#fee with numeric argument' do
+    # Builds a minimal transaction with one input and one change output so that
+    # distribute_change runs, and we can observe the resulting change satoshis.
+    def tx_with_input_sats(input_sats)
+      tx = described_class.new
+      input = BSV::Transaction::TransactionInput.new(
+        prev_tx_id: "\x00".b * 32,
+        prev_tx_out_index: 0
+      )
+      input.source_satoshis = input_sats
+      tx.add_input(input)
+      pubkey_hash = "\x00".b * 20
+      output = BSV::Transaction::TransactionOutput.new(
+        satoshis: 0,
+        locking_script: BSV::Script::Script.p2pkh_lock(pubkey_hash)
+      )
+      output.change = true
+      tx.add_output(output)
+      tx
+    end
+
+    it 'passes an integer fee through unchanged' do
+      tx = tx_with_input_sats(1_000)
+      tx.fee(100)
+      expect(tx.outputs.first.satoshis).to eq(900)
+    end
+
+    it 'rounds a fractional fee of 100.5 up to 101' do
+      tx = tx_with_input_sats(1_000)
+      tx.fee(100.5)
+      expect(tx.outputs.first.satoshis).to eq(899)
+    end
+
+    it 'rounds a fractional fee of 100.1 up to 101' do
+      tx = tx_with_input_sats(1_000)
+      tx.fee(100.1)
+      expect(tx.outputs.first.satoshis).to eq(899)
+    end
+
+    it 'keeps 100.0 as 100 — ceil is a no-op for whole floats' do
+      tx = tx_with_input_sats(1_000)
+      tx.fee(100.0)
+      expect(tx.outputs.first.satoshis).to eq(900)
+    end
+  end
+
   describe 'full attestation flow' do
     it 'constructs, signs, and serialises a transaction with P2PKH input, OP_RETURN, and change' do
       private_key = BSV::Primitives::PrivateKey.generate


### PR DESCRIPTION
## Summary
- Base58: empty decode raises ArgumentError (F1.2), check_encode/decode prefix parameter (F1.1)
- Digest: hash256 alias for sha256d (F1.7)
- Script: p2pkh_lock accepts address string (F3.18)
- Transaction: numeric fee .ceil documented and tested (F4.6), TransactionInput#sequence and TransactionOutput#locking_script now writable (F4.10/F4.11)
- MerklePath: coinbase 100-block maturity check in verify (F5.11) -- intentionally diverges from TS SDK bug
- ECIES: Electrum noKey and uncompressed ephemeral key support (F6.7)
- Messages: BSV::Messages namespace re-exporting SignedMessage/EncryptedMessage (F6.16)

## Test plan
- [ ] All SDK specs pass (`bundle exec rake spec:sdk`)
- [ ] RuboCop clean (SDK gem)
- [ ] Each finding has dedicated spec coverage
- [ ] Backwards compatibility verified -- no existing API signatures changed

Closes #377
