### PR TITLE
fix(wallet): broadcast/rollback state management gaps (#379)

### DIFF
--- a/gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/migrations/005_add_txid_unique_index.rb
+++ b/gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/migrations/005_add_txid_unique_index.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Add a unique index on wallet_actions.txid.
+#
+# Within a single wallet there should be at most one action per transaction.
+# Without this constraint, concurrent inserts or retries could create duplicate
+# rows sharing the same txid, causing +update_action_status+ to update multiple
+# rows unintentionally.
+#
+# The index also accelerates the +where(txid:)+ lookups performed by
+# +update_action_status+ and +delete_action+.
+#
+# === Backward compatibility
+#
+# The migration will fail if duplicate txids already exist in the table. Clean
+# up any duplicates before running this migration:
+#
+#   DELETE FROM wallet_actions a
+#   USING wallet_actions b
+#   WHERE a.id > b.id AND a.txid = b.txid;
+Sequel.migration do
+  change do
+    alter_table(:wallet_actions) do
+      add_index :txid, unique: true, name: :wallet_actions_txid_unique
+    end
+  end
+end

--- a/gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/postgres_store.rb
+++ b/gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/postgres_store.rb
@@ -103,16 +103,20 @@ module BSV
       end
 
       def update_action_status(txid, new_status)
-        ds = @db[:wallet_actions].where(txid: txid)
-        raise WalletError, "Action not found: #{txid}" if ds.empty?
+        # Fetch by txid first, then update by primary key so only exactly one
+        # row is targeted. The unique index on txid makes this unambiguous, but
+        # scoping to the id column makes the intent explicit and is safe even
+        # on databases where the migration has not yet been applied.
+        row = @db[:wallet_actions].where(txid: txid).first
+        raise WalletError, "Action not found: #{txid}" unless row
 
-        ds.update(
+        @db[:wallet_actions].where(id: row[:id]).update(
           data: Sequel.lit(
             "data || jsonb_build_object('status', ?)",
             new_status
           )
         )
-        symbolise_keys(ds.first[:data])
+        symbolise_keys(@db[:wallet_actions].where(id: row[:id]).first[:data])
       end
 
       def delete_action(txid)

--- a/gem/bsv-wallet-postgres/spec/bsv/wallet_postgres/postgres_store_spec.rb
+++ b/gem/bsv-wallet-postgres/spec/bsv/wallet_postgres/postgres_store_spec.rb
@@ -383,6 +383,28 @@ RSpec.describe BSV::Wallet::PostgresStore, :postgres do
       end
     end
 
+    describe '#update_action_status' do
+      it 'updates the status of the matching action' do
+        store.store_action(txid: 'abc123', status: 'pending', labels: [])
+        result = store.update_action_status('abc123', 'completed')
+        expect(result[:status]).to eq('completed')
+        expect(result[:txid]).to eq('abc123')
+      end
+
+      it 'raises WalletError when the txid does not exist' do
+        expect do
+          store.update_action_status('nonexistent', 'completed')
+        end.to raise_error(BSV::Wallet::WalletError, /nonexistent/)
+      end
+
+      it 'enforces uniqueness — a second store_action with the same txid raises a DB constraint' do
+        store.store_action(txid: 'unique123', status: 'pending', labels: [])
+        expect do
+          store.store_action(txid: 'unique123', status: 'pending', labels: [])
+        end.to raise_error(Sequel::UniqueConstraintViolation)
+      end
+    end
+
     describe '.migrate!' do
       it 'creates all five wallet tables' do
         described_class.migrate!(db)

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
@@ -689,22 +689,12 @@ module BSV
           @storage.store_transaction(txid, tx_hex)
 
           if no_send
-            # Leave inputs as :pending — the caller will either broadcast via
-            # send_with or cancel via abort_action.
-            store_change_outputs(txid, tx, change_outputs, tx_hex)
-
-            # Record change outpoint positions, then mark them :pending so they
-            # are not auto-selected by a concurrent create_action. This matches
-            # the TS SDK where noSend outputs have spendable: false.
-            change_outpoints = []
-            change_outputs.each do |spec|
-              idx = tx.outputs.index { |o| o.instance_variable_get(:@_spec).equal?(spec) }
-              next unless idx
-
-              op = "#{txid}.#{idx}"
-              change_outpoints << op
-              @storage.update_output_state(op, :pending, pending_reference: fund_ref, no_send: true)
-            end
+            # Store change outputs directly as :pending with no_send: true so a
+            # concurrent auto-fund cannot select them. No flip loop needed.
+            change_outpoints = store_change_outputs(
+              txid, tx, change_outputs, tx_hex,
+              state: :pending, pending_reference: fund_ref, no_send: true
+            )
 
             store_action(tx, args, status: 'nosend')
             store_tracked_outputs(txid, tx, caller_outputs)
@@ -724,20 +714,13 @@ module BSV
           else
             # Store everything in pending state first — inputs are already locked
             # as :pending by lock_utxos above, so we match that discipline here.
+            # Change outputs are stored directly as :pending to eliminate the
+            # TOCTOU window where a concurrent auto-fund could select them.
             store_action(tx, args, status: 'pending')
-            store_change_outputs(txid, tx, change_outputs, tx_hex)
-
-            # Record change outpoints and mark them :pending so a concurrent
-            # create_action cannot double-spend them before broadcast completes.
-            change_outpoints = []
-            change_outputs.each do |spec|
-              idx = tx.outputs.index { |o| o.instance_variable_get(:@_spec).equal?(spec) }
-              next unless idx
-
-              op = "#{txid}.#{idx}"
-              change_outpoints << op
-              @storage.update_output_state(op, :pending, pending_reference: fund_ref)
-            end
+            change_outpoints = store_change_outputs(
+              txid, tx, change_outputs, tx_hex,
+              state: :pending, pending_reference: fund_ref
+            )
 
             store_tracked_outputs(txid, tx, caller_outputs)
 
@@ -913,17 +896,24 @@ module BSV
         tx.add_output(output)
       end
 
-      # Persists change outputs in storage as new spendable UTXOs.
+      # Persists change outputs in storage with the specified state.
       #
       # Each output is stored with full BRC-29 derivation metadata so the
-      # wallet can derive the spending key later, and with +:state+ +:spendable+
-      # so it is eligible for future coin selection.
+      # wallet can derive the spending key later. The +:state+ parameter
+      # controls the initial state — pass +:pending+ with a +:pending_reference+
+      # to store outputs atomically in the correct state and avoid any TOCTOU
+      # window where a concurrent auto-fund could select them as spendable.
       #
       # @param txid [String] hex txid of the signed transaction
       # @param tx [BSV::Transaction::Transaction]
       # @param change_specs [Array<Hash>] change descriptors from {ChangeGenerator}
       # @param tx_hex [String] serialised transaction hex (used as source)
-      def store_change_outputs(txid, tx, change_specs, tx_hex)
+      # @param state [Symbol] initial output state (default: +:spendable+)
+      # @param pending_reference [String, nil] reference tag for pending outputs
+      # @param no_send [Boolean] when +true+, marks the output as no-send pending
+      # @return [Array<String>] list of stored outpoints ("txid.vout" format)
+      def store_change_outputs(txid, tx, change_specs, tx_hex, state: :spendable, pending_reference: nil, no_send: false)
+        outpoints = []
         change_specs.each do |spec|
           actual_idx = tx.outputs.index { |o| o.instance_variable_get(:@_spec).equal?(spec) }
           next unless actual_idx
@@ -934,19 +924,27 @@ module BSV
                                  spec[:locking_script]
                                end
 
-          @storage.store_output({
-                                  outpoint: "#{txid}.#{actual_idx}",
-                                  satoshis: spec[:satoshis],
-                                  locking_script: locking_script_hex,
-                                  basket: 'default',
-                                  tags: [],
-                                  derivation_prefix: spec[:derivation_prefix],
-                                  derivation_suffix: spec[:derivation_suffix],
-                                  sender_identity_key: spec[:sender_identity_key],
-                                  state: :spendable,
-                                  source_tx_hex: tx_hex
-                                })
+          entry = {
+            outpoint: "#{txid}.#{actual_idx}",
+            satoshis: spec[:satoshis],
+            locking_script: locking_script_hex,
+            basket: 'default',
+            tags: [],
+            derivation_prefix: spec[:derivation_prefix],
+            derivation_suffix: spec[:derivation_suffix],
+            sender_identity_key: spec[:sender_identity_key],
+            state: state,
+            source_tx_hex: tx_hex
+          }
+          if state == :pending
+            entry[:pending_since] = Time.now.utc.iso8601
+            entry[:pending_reference] = pending_reference if pending_reference
+            entry[:no_send] = true if no_send
+          end
+          @storage.store_output(entry)
+          outpoints << "#{txid}.#{actual_idx}"
         end
+        outpoints
       end
 
       # Lazy accessors for auto-fund components. Created on first use so the
@@ -1218,7 +1216,12 @@ module BSV
       end
 
       # Broadcasts the transaction and promotes storage state on success.
-      # On failure, rolls back all pending state changes.
+      # On broadcast failure, rolls back all pending state changes.
+      #
+      # INVARIANT: Only broadcast failure triggers rollback. If broadcast succeeds
+      # but promotion raises, the error propagates — confirmed on-chain outputs must
+      # never be deleted. Partial promotion failure is a "needs manual intervention"
+      # scenario; it is preferable to a rollback that silently destroys on-chain data.
       #
       # @param tx [Transaction] signed transaction to broadcast
       # @param txid [String] hex transaction id
@@ -1228,9 +1231,16 @@ module BSV
       # @param beef_binary [String] raw BEEF bytes
       # @return [Hash] result hash with :txid, :tx, :broadcast_result or :broadcast_error, and :broadcast_status
       def broadcast_and_promote(tx, txid, input_outpoints, change_outpoints, fund_ref, beef_binary)
-        broadcast_result = @broadcaster.broadcast(tx)
+        begin
+          broadcast_result = @broadcaster.broadcast(tx)
+        rescue StandardError => e
+          rollback_pending_action(input_outpoints, change_outpoints, txid, fund_ref, action_status: 'failed')
+          return { txid: txid, tx: beef_binary.unpack('C*'), broadcast_error: e.message, broadcast_status: broadcast_status_for(e) }
+        end
 
         # Broadcast succeeded — promote all pending state to final.
+        # Do NOT rescue here: if promotion fails, the transaction is confirmed on-chain
+        # and outputs must not be deleted. Let the error propagate to the caller.
         input_outpoints.each { |op| @storage.update_output_state(op, :spent) }
         change_outpoints.each { |op| @storage.update_output_state(op, :spendable) }
         @storage.update_action_status(txid, 'completed')
@@ -1238,9 +1248,6 @@ module BSV
         result = { txid: txid, tx: beef_binary.unpack('C*'), broadcast_result: broadcast_result, broadcast_status: 'success' }
         result[:competing_txs] = broadcast_result.competing_txs if broadcast_result.competing_txs
         result
-      rescue StandardError => e
-        rollback_pending_action(input_outpoints, change_outpoints, txid, fund_ref, action_status: 'failed')
-        { txid: txid, tx: beef_binary.unpack('C*'), broadcast_error: e.message, broadcast_status: broadcast_status_for(e) }
       end
 
       # Batch-broadcasts a list of previously no_send transactions.
@@ -1292,10 +1299,29 @@ module BSV
       # Attempts to broadcast and promote a single no_send transaction.
       # Action status is set to 'unproven' (matching TS SDK SendWithResult)
       # because the transaction has been submitted but not yet confirmed.
+      #
+      # INVARIANT: Only broadcast failure triggers rollback. If broadcast succeeds
+      # but promotion raises, the error propagates — confirmed on-chain outputs must
+      # never be deleted. See +broadcast_and_promote+ for the same invariant.
       def promote_no_send(tx, txid, fund_ref, pending_entry)
-        @broadcaster.broadcast(tx)
+        begin
+          @broadcaster.broadcast(tx)
+        rescue StandardError => e
+          rollback_pending_action(
+            pending_entry[:locked_outpoints],
+            pending_entry[:change_outpoints],
+            txid,
+            fund_ref,
+            action_status: 'failed'
+          )
+          @pending.delete(fund_ref)
+          @pending_by_txid.delete(txid)
+          return { txid: txid, status: 'failed', error: e.message }
+        end
 
         # Broadcast succeeded — promote state and remove from pending indices.
+        # Do NOT rescue here: if promotion fails, the transaction is confirmed on-chain
+        # and outputs must not be deleted. Let the error propagate to the caller.
         pending_entry[:locked_outpoints].each { |op| @storage.update_output_state(op, :spent) }
         pending_entry[:change_outpoints].each { |op| @storage.update_output_state(op, :spendable) }
         @storage.update_action_status(txid, 'unproven')
@@ -1303,18 +1329,6 @@ module BSV
         @pending_by_txid.delete(txid)
 
         { txid: txid, status: 'unproven' }
-      rescue StandardError => e
-        rollback_pending_action(
-          pending_entry[:locked_outpoints],
-          pending_entry[:change_outpoints],
-          txid,
-          fund_ref,
-          action_status: 'failed'
-        )
-        @pending.delete(fund_ref)
-        @pending_by_txid.delete(txid)
-
-        { txid: txid, status: 'failed', error: e.message }
       end
 
       # Maps a broadcast exception to a {ReviewActionResultStatus} string.
@@ -1357,7 +1371,6 @@ module BSV
           result[:no_send_change] = []
         elsif broadcast_enabled?
           # Broadcast and promote or rollback — same discipline as auto_fund path.
-          broadcast_result = nil
           begin
             broadcast_result = @broadcaster.broadcast(tx)
             @storage.update_action_status(txid, 'completed')

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
@@ -918,33 +918,33 @@ module BSV
           actual_idx = tx.outputs.index { |o| o.instance_variable_get(:@_spec).equal?(spec) }
           next unless actual_idx
 
-          locking_script_hex = if spec[:locking_script].is_a?(BSV::Script::Script)
-                                 spec[:locking_script].to_hex
-                               else
-                                 spec[:locking_script]
-                               end
-
-          entry = {
-            outpoint: "#{txid}.#{actual_idx}",
-            satoshis: spec[:satoshis],
-            locking_script: locking_script_hex,
-            basket: 'default',
-            tags: [],
-            derivation_prefix: spec[:derivation_prefix],
-            derivation_suffix: spec[:derivation_suffix],
-            sender_identity_key: spec[:sender_identity_key],
-            state: state,
-            source_tx_hex: tx_hex
-          }
-          if state == :pending
-            entry[:pending_since] = Time.now.utc.iso8601
-            entry[:pending_reference] = pending_reference if pending_reference
-            entry[:no_send] = true if no_send
-          end
+          entry = change_output_entry(txid, actual_idx, spec, tx_hex, state, pending_reference, no_send)
           @storage.store_output(entry)
           outpoints << "#{txid}.#{actual_idx}"
         end
         outpoints
+      end
+
+      def change_output_entry(txid, idx, spec, tx_hex, state, pending_reference, no_send)
+        locking_script_hex = spec[:locking_script].is_a?(BSV::Script::Script) ? spec[:locking_script].to_hex : spec[:locking_script]
+        entry = {
+          outpoint: "#{txid}.#{idx}",
+          satoshis: spec[:satoshis],
+          locking_script: locking_script_hex,
+          basket: 'default',
+          tags: [],
+          derivation_prefix: spec[:derivation_prefix],
+          derivation_suffix: spec[:derivation_suffix],
+          sender_identity_key: spec[:sender_identity_key],
+          state: state,
+          source_tx_hex: tx_hex
+        }
+        if state == :pending
+          entry[:pending_since] = Time.now.utc.iso8601
+          entry[:pending_reference] = pending_reference if pending_reference
+          entry[:no_send] = true if no_send
+        end
+        entry
       end
 
       # Lazy accessors for auto-fund components. Created on first use so the

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/auto_funding_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/auto_funding_spec.rb
@@ -513,6 +513,25 @@ RSpec.describe 'WalletClient auto-funding pipeline' do
                              })
       end.to raise_error(BSV::Wallet::InsufficientFundsError)
     end
+
+    it 'stores no_send change outputs as :pending immediately, with pending_reference set' do
+      result
+      change_ops = result[:no_send_change]
+      expect(change_ops).not_to be_empty
+
+      # Each change output must be :pending from the moment it is stored —
+      # never briefly :spendable. The pending_reference must match the
+      # fund reference returned with the result.
+      fund_ref = result[:reference]
+      all_outputs = storage.find_outputs({ include_spent: true })
+      change_ops.each do |op|
+        output = all_outputs.find { |o| o[:outpoint] == op }
+        expect(output).not_to be_nil
+        expect(output[:state]).to eq(:pending)
+        expect(output[:pending_reference]).to eq(fund_ref)
+        expect(output[:no_send]).to be(true)
+      end
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/broadcast_rollback_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/broadcast_rollback_spec.rb
@@ -1,0 +1,520 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+require 'securerandom'
+
+# Integration specs for broadcast_and_promote and promote_no_send flows.
+#
+# These specs exercise the combined behaviour introduced by Tasks 1-3 of HLR #379:
+#   - Task 1: change outputs stored as :pending immediately (TOCTOU fix)
+#   - Task 2: broadcast and promotion error handling are isolated
+#   - Task 3: per-tx rollback for send_with batch broadcasts
+#
+# All specs use a real MemoryStore and a mock broadcaster so state transitions
+# can be inspected directly without hitting the network.
+
+RSpec.describe 'broadcast_and_promote and promote_no_send integration' do
+  # --------------------------------------------------------------------------
+  # Shared helpers
+  # --------------------------------------------------------------------------
+
+  # Stores a real BRC-29-derivable UTXO in storage so auto-fund can select it.
+  def seed_payment_output(wallet, satoshis:)
+    deriver = wallet.key_deriver
+    prefix = SecureRandom.hex(8)
+    suffix = SecureRandom.hex(8)
+    sender_pub = deriver.identity_key
+
+    derived_pub = deriver.derive_public_key(
+      [2, '3241645161d8'],
+      "#{prefix} #{suffix}",
+      sender_pub,
+      for_self: true
+    )
+    locking_script = BSV::Script::Script.p2pkh_lock(derived_pub.hash160)
+
+    source_tx = BSV::Transaction::Transaction.new
+    source_tx.add_output(
+      BSV::Transaction::TransactionOutput.new(
+        satoshis: satoshis,
+        locking_script: locking_script
+      )
+    )
+    txid = source_tx.txid_hex
+    outpoint = "#{txid}.0"
+
+    wallet.storage.store_transaction(txid, source_tx.to_hex)
+    wallet.storage.store_output({
+                                  outpoint: outpoint,
+                                  satoshis: satoshis,
+                                  locking_script: locking_script.to_hex,
+                                  basket: 'default',
+                                  state: :spendable,
+                                  spendable: true,
+                                  derivation_prefix: prefix,
+                                  derivation_suffix: suffix,
+                                  sender_identity_key: sender_pub,
+                                  source_tx_hex: source_tx.to_hex
+                                })
+
+    { outpoint: outpoint, satoshis: satoshis }
+  end
+
+  # Returns a P2PKH locking script hex for an arbitrary recipient.
+  def recipient_lock_hex
+    BSV::Script::Script.p2pkh_lock(BSV::Primitives::PrivateKey.generate.public_key.hash160).to_hex
+  end
+
+  let(:private_key) { BSV::Primitives::PrivateKey.generate }
+  let(:storage)     { BSV::Wallet::MemoryStore.new }
+
+  # A successful broadcast response (no competing_txs).
+  let(:broadcast_ok) do
+    BSV::Network::BroadcastResponse.new(txid: 'aabbcc', tx_status: 'SEEN_ON_NETWORK')
+  end
+
+  # --------------------------------------------------------------------------
+  # 1. broadcast_and_promote — broadcast succeeds
+  # --------------------------------------------------------------------------
+  describe 'broadcast succeeds → state promoted to final' do
+    let(:broadcaster) { double('broadcaster') } # rubocop:disable RSpec/VerifiedDoubles
+    let(:wallet) do
+      BSV::Wallet::WalletClient.new(private_key, storage: storage, broadcaster: broadcaster)
+    end
+    let(:result) do
+      allow(broadcaster).to receive(:broadcast).and_return(broadcast_ok)
+
+      wallet.create_action({
+                             description: 'broadcast success integration',
+                             outputs: [{
+                               locking_script: recipient_lock_hex,
+                               satoshis: 1_000,
+                               output_description: 'payment to recipient'
+                             }]
+                           })
+    end
+
+    before { seed_payment_output(wallet, satoshis: 10_000) }
+
+    it 'returns a 64-char hex txid' do
+      expect(result[:txid]).to match(/\A[0-9a-f]{64}\z/)
+    end
+
+    it 'returns broadcast_status: "success"' do
+      expect(result[:broadcast_status]).to eq('success')
+    end
+
+    it 'marks the input UTXO as :spent' do
+      txid = result[:txid]
+      all = storage.find_outputs({ include_spent: true, limit: 1000, offset: 0 })
+      tx = BSV::Transaction::Transaction.from_hex(storage.find_transaction(txid))
+      # Each input outpoint in the transaction must be :spent in storage
+      tx.inputs.each do |inp|
+        source_txid = inp.prev_tx_id.reverse.unpack1('H*')
+        vout = inp.prev_tx_out_index
+        outpoint = "#{source_txid}.#{vout}"
+        stored = all.find { |o| o[:outpoint] == outpoint }
+        next unless stored # input may be external; only check wallet-tracked inputs
+
+        expect(stored[:state]).to eq(:spent)
+      end
+    end
+
+    it 'marks change outputs as :spendable' do
+      result
+      spendable = storage.find_spendable_outputs(basket: 'default')
+      # Change outputs (those with derivation metadata) must be :spendable
+      change = spendable.select { |o| o[:derivation_prefix] }
+      expect(change).not_to be_empty
+      change.each { |o| expect(o[:state]).to eq(:spendable) }
+    end
+
+    it 'stores the action with status "completed"' do
+      txid = result[:txid]
+      actions = storage.find_actions({ limit: 100, offset: 0 })
+      action = actions.find { |a| a[:txid] == txid }
+      expect(action[:status]).to eq('completed')
+    end
+  end
+
+  # --------------------------------------------------------------------------
+  # 2. broadcast_and_promote — broadcast fails → full rollback
+  # --------------------------------------------------------------------------
+  describe 'broadcast fails → full rollback' do
+    let(:broadcaster) { double('broadcaster') } # rubocop:disable RSpec/VerifiedDoubles
+    let(:wallet) do
+      BSV::Wallet::WalletClient.new(private_key, storage: storage, broadcaster: broadcaster)
+    end
+    let(:seeded_outpoint) { seed_payment_output(wallet, satoshis: 10_000)[:outpoint] }
+    let(:result) do
+      seeded_outpoint # ensure the UTXO is seeded before creating the action
+      allow(broadcaster).to receive(:broadcast).and_raise(
+        BSV::Network::BroadcastError.new('network unavailable', arc_status: nil)
+      )
+
+      wallet.create_action({
+                             description: 'broadcast failure rollback test',
+                             outputs: [{
+                               locking_script: recipient_lock_hex,
+                               satoshis: 1_000,
+                               output_description: 'payment attempted'
+                             }]
+                           })
+    end
+
+    it 'returns a result hash (does not raise)' do
+      expect { result }.not_to raise_error
+    end
+
+    it 'returns broadcast_error in the result' do
+      expect(result[:broadcast_error]).to be_a(String)
+    end
+
+    it 'returns broadcast_status "serviceError"' do
+      expect(result[:broadcast_status]).to eq('serviceError')
+    end
+
+    it 'releases input UTXOs back to :spendable' do
+      result
+      spendable = storage.find_spendable_outputs
+      spendable_outpoints = spendable.map { |o| o[:outpoint] }
+      expect(spendable_outpoints).to include(seeded_outpoint)
+    end
+
+    it 'removes change outputs from storage' do
+      result
+      all = storage.find_outputs({ include_spent: true, limit: 1000, offset: 0 })
+      # After rollback, only the original seeded UTXO should remain
+      expect(all.size).to eq(1)
+      expect(all.first[:outpoint]).to eq(seeded_outpoint)
+    end
+
+    it 'sets the action status to "failed"' do
+      txid = result[:txid]
+      all_actions = storage.find_actions({ limit: 100, offset: 0 })
+      action = all_actions.find { |a| a[:txid] == txid }
+      expect(action[:status]).to eq('failed')
+    end
+  end
+
+  # --------------------------------------------------------------------------
+  # 3. Promotion failure after successful broadcast → no rollback
+  #
+  # This validates the Task 2 invariant: only broadcast failure triggers rollback.
+  # If the broadcast succeeds but a subsequent promotion step raises (e.g. storage
+  # write failure), the error propagates and on-chain outputs are NOT deleted.
+  # --------------------------------------------------------------------------
+  describe 'promotion failure after successful broadcast → no rollback of on-chain outputs' do
+    let(:broadcaster) { double('broadcaster') } # rubocop:disable RSpec/VerifiedDoubles
+    let(:wallet) do
+      BSV::Wallet::WalletClient.new(private_key, storage: storage, broadcaster: broadcaster)
+    end
+
+    before { seed_payment_output(wallet, satoshis: 10_000) }
+
+    it 'propagates the promotion error without deleting change outputs' do
+      allow(broadcaster).to receive(:broadcast).and_return(broadcast_ok)
+
+      # Inject a failure in update_output_state — fires during promotion of inputs
+      # (first call after broadcast success). The broadcast has already succeeded
+      # so the transaction is on-chain; storage must not be rolled back.
+      call_count = 0
+      allow(storage).to receive(:update_output_state).and_wrap_original do |original, *args|
+        call_count += 1
+        raise 'simulated storage failure' if call_count == 1
+
+        original.call(*args)
+      end
+
+      expect do
+        wallet.create_action({
+                               description: 'promotion failure no rollback test',
+                               outputs: [{
+                                 locking_script: recipient_lock_hex,
+                                 satoshis: 1_000,
+                                 output_description: 'broadcast-then-promotion-failure'
+                               }]
+                             })
+      end.to raise_error(RuntimeError, 'simulated storage failure')
+
+      # Change outputs must still exist in storage — NOT deleted — because the
+      # transaction was already confirmed on-chain before the failure.
+      all = storage.find_outputs({ include_spent: true, limit: 1000, offset: 0 })
+      # At least 2 outputs: original input UTXO + change output(s)
+      expect(all.size).to be >= 2
+    end
+  end
+
+  # --------------------------------------------------------------------------
+  # 4. send_with broadcast succeeds → per-tx state promoted, pending cleaned up
+  # --------------------------------------------------------------------------
+  describe 'send_with broadcast succeeds → per-tx state promoted' do
+    let(:broadcaster) { double('broadcaster') } # rubocop:disable RSpec/VerifiedDoubles
+    let(:wallet) do
+      BSV::Wallet::WalletClient.new(private_key, storage: storage, broadcaster: broadcaster)
+    end
+    let(:first_no_send) do
+      wallet.create_action({
+                             description: 'first no send transaction one',
+                             outputs: [{
+                               locking_script: recipient_lock_hex,
+                               satoshis: 500,
+                               output_description: 'first no_send output'
+                             }],
+                             options: { no_send: true }
+                           })
+    end
+    let(:second_no_send) do
+      wallet.create_action({
+                             description: 'second no send transaction two',
+                             outputs: [{
+                               locking_script: recipient_lock_hex,
+                               satoshis: 500,
+                               output_description: 'second no_send output'
+                             }],
+                             options: { no_send: true }
+                           })
+    end
+
+    before do
+      seed_payment_output(wallet, satoshis: 10_000)
+      seed_payment_output(wallet, satoshis: 8_000)
+    end
+
+    it 'promotes both transactions to unproven after send_with succeeds' do
+      txid1 = first_no_send[:txid]
+      txid2 = second_no_send[:txid]
+
+      allow(broadcaster).to receive(:broadcast).and_return(broadcast_ok)
+
+      result = wallet.create_action({
+                                      description: 'send with batch broadcast test',
+                                      options: { send_with: [txid1, txid2] }
+                                    })
+
+      send_with_results = result[:send_with_results]
+      expect(send_with_results).to be_an(Array)
+      expect(send_with_results.size).to eq(2)
+      send_with_results.each do |r|
+        expect(r[:status]).to eq('unproven')
+      end
+    end
+
+    it 'promotes input UTXOs to :spent for both transactions' do
+      txid1 = first_no_send[:txid]
+      txid2 = second_no_send[:txid]
+
+      allow(broadcaster).to receive(:broadcast).and_return(broadcast_ok)
+
+      wallet.create_action({
+                             description: 'send with input state test',
+                             options: { send_with: [txid1, txid2] }
+                           })
+
+      # No original seeded UTXOs should remain spendable
+      spendable = storage.find_spendable_outputs
+      # Only change outputs (with derivation metadata) should be spendable
+      non_change_spendable = spendable.reject { |o| o[:derivation_prefix] }
+      expect(non_change_spendable).to be_empty
+    end
+
+    it 'promotes change outputs to :spendable for both transactions' do
+      txid1 = first_no_send[:txid]
+      txid2 = second_no_send[:txid]
+
+      allow(broadcaster).to receive(:broadcast).and_return(broadcast_ok)
+
+      wallet.create_action({
+                             description: 'send with change state test',
+                             options: { send_with: [txid1, txid2] }
+                           })
+
+      spendable = storage.find_spendable_outputs
+      change = spendable.select { |o| o[:derivation_prefix] }
+      expect(change).not_to be_empty
+    end
+
+    it 'sets action status to "unproven" for both transactions' do
+      txid1 = first_no_send[:txid]
+      txid2 = second_no_send[:txid]
+
+      allow(broadcaster).to receive(:broadcast).and_return(broadcast_ok)
+
+      wallet.create_action({
+                             description: 'send with action status test',
+                             options: { send_with: [txid1, txid2] }
+                           })
+
+      all_actions = storage.find_actions({ limit: 100, offset: 0 })
+      [txid1, txid2].each do |txid|
+        action = all_actions.find { |a| a[:txid] == txid }
+        expect(action[:status]).to eq('unproven')
+      end
+    end
+  end
+
+  # --------------------------------------------------------------------------
+  # 5. send_with broadcast fails → per-tx rollback, other txs unaffected
+  # --------------------------------------------------------------------------
+  describe 'send_with broadcast fails → per-tx rollback' do
+    let(:broadcaster) { double('broadcaster') } # rubocop:disable RSpec/VerifiedDoubles
+    let(:wallet) do
+      BSV::Wallet::WalletClient.new(private_key, storage: storage, broadcaster: broadcaster)
+    end
+    let(:first_no_send) do
+      wallet.create_action({
+                             description: 'first no send tx for fail test',
+                             outputs: [{
+                               locking_script: recipient_lock_hex,
+                               satoshis: 500,
+                               output_description: 'first no_send output'
+                             }],
+                             options: { no_send: true }
+                           })
+    end
+    let(:second_no_send) do
+      wallet.create_action({
+                             description: 'second no send tx for fail test',
+                             outputs: [{
+                               locking_script: recipient_lock_hex,
+                               satoshis: 500,
+                               output_description: 'second no_send output'
+                             }],
+                             options: { no_send: true }
+                           })
+    end
+
+    before do
+      seed_payment_output(wallet, satoshis: 10_000)
+      seed_payment_output(wallet, satoshis: 8_000)
+    end
+
+    it 'rolls back the failed tx and succeeds for the other' do
+      txid1 = first_no_send[:txid]
+      txid2 = second_no_send[:txid]
+
+      # First broadcast fails, second succeeds
+      call_count = 0
+      allow(broadcaster).to receive(:broadcast) do
+        call_count += 1
+        raise BSV::Network::BroadcastError.new('rejected', arc_status: nil) if call_count == 1
+
+        broadcast_ok
+      end
+
+      result = wallet.create_action({
+                                      description: 'send with partial failure test',
+                                      options: { send_with: [txid1, txid2] }
+                                    })
+
+      send_with_results = result[:send_with_results]
+      statuses = send_with_results.to_h { |r| [r[:txid], r[:status]] }
+      expect(statuses[txid1]).to eq('failed')
+      expect(statuses[txid2]).to eq('unproven')
+    end
+
+    it 'sets action status to "failed" for the rolled-back tx' do
+      txid1 = first_no_send[:txid]
+      txid2 = second_no_send[:txid]
+
+      call_count = 0
+      allow(broadcaster).to receive(:broadcast) do
+        call_count += 1
+        raise BSV::Network::BroadcastError.new('rejected', arc_status: nil) if call_count == 1
+
+        broadcast_ok
+      end
+
+      wallet.create_action({
+                             description: 'send with partial fail action status',
+                             options: { send_with: [txid1, txid2] }
+                           })
+
+      all_actions = storage.find_actions({ limit: 100, offset: 0 })
+      action_first = all_actions.find { |a| a[:txid] == txid1 }
+      action_second = all_actions.find { |a| a[:txid] == txid2 }
+      expect(action_first[:status]).to eq('failed')
+      expect(action_second[:status]).to eq('unproven')
+    end
+
+    it 'releases input UTXOs back to :spendable for the failed tx only' do
+      txid1 = first_no_send[:txid]
+      txid2 = second_no_send[:txid]
+
+      # Track the outpoints each no_send tx consumed
+      no_send_tx_first = BSV::Transaction::Transaction.from_hex(storage.find_transaction(txid1))
+      no_send_tx_second = BSV::Transaction::Transaction.from_hex(storage.find_transaction(txid2))
+
+      first_input_ops = no_send_tx_first.inputs.map { |i| "#{i.prev_tx_id.reverse.unpack1('H*')}.#{i.prev_tx_out_index}" }
+      second_input_ops = no_send_tx_second.inputs.map { |i| "#{i.prev_tx_id.reverse.unpack1('H*')}.#{i.prev_tx_out_index}" }
+
+      call_count = 0
+      allow(broadcaster).to receive(:broadcast) do
+        call_count += 1
+        raise BSV::Network::BroadcastError.new('rejected', arc_status: nil) if call_count == 1
+
+        broadcast_ok
+      end
+
+      wallet.create_action({
+                             description: 'send with per tx rollback state test',
+                             options: { send_with: [txid1, txid2] }
+                           })
+
+      spendable = storage.find_spendable_outputs
+      spendable_ops = spendable.map { |o| o[:outpoint] }
+
+      # Inputs of the failed tx are back to :spendable
+      first_input_ops.each { |op| expect(spendable_ops).to include(op) }
+
+      # Inputs of the successful tx are :spent (not spendable)
+      second_input_ops.each { |op| expect(spendable_ops).not_to include(op) }
+    end
+  end
+
+  # --------------------------------------------------------------------------
+  # 6. Concurrent auto-fund exclusion — pending change outputs are not selectable
+  #
+  # Validates the Task 1 fix: change outputs stored as :pending immediately
+  # cannot be selected by a concurrent auto-fund call.
+  # --------------------------------------------------------------------------
+  describe 'concurrent auto-fund exclusion of pending change outputs' do
+    let(:broadcaster) { double('broadcaster') } # rubocop:disable RSpec/VerifiedDoubles
+    let(:wallet) do
+      BSV::Wallet::WalletClient.new(private_key, storage: storage, broadcaster: broadcaster)
+    end
+
+    before { seed_payment_output(wallet, satoshis: 10_000) }
+
+    it 'raises InsufficientFundsError when the only spendable UTXO is locked as :pending' do
+      # Create a no_send transaction — the original UTXO becomes :pending and
+      # change is stored directly as :pending (Task 1 fix). Nothing is :spendable.
+      allow(broadcaster).to receive(:broadcast).and_return(broadcast_ok)
+
+      wallet.create_action({
+                             description: 'no send locks all utxos test',
+                             outputs: [{
+                               locking_script: recipient_lock_hex,
+                               satoshis: 1_000,
+                               output_description: 'no_send locks everything'
+                             }],
+                             options: { no_send: true }
+                           })
+
+      # Attempting to auto-fund at this point must fail — the pending change
+      # output is not selectable by design.
+      expect do
+        wallet.create_action({
+                               description: 'concurrent auto fund attempt test',
+                               auto_fund: true,
+                               outputs: [{
+                                 locking_script: recipient_lock_hex,
+                                 satoshis: 100,
+                                 output_description: 'attempt to spend pending change'
+                               }]
+                             })
+      end.to raise_error(BSV::Wallet::InsufficientFundsError)
+    end
+  end
+end

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_auto_fund_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_auto_fund_spec.rb
@@ -512,6 +512,24 @@ RSpec.describe 'WalletClient auto-fund mode' do
         actions = storage.find_actions({ limit: 10, offset: 0 })
         expect(actions.first[:status]).to eq('completed')
       end
+
+      it 'stores change outputs as :pending before broadcast is called (no TOCTOU window)' do
+        # Capture the state of change outputs at the moment broadcast is invoked.
+        # Change outputs must already be :pending — never briefly :spendable.
+        change_state_at_broadcast = nil
+        allow(broadcaster).to receive(:broadcast) do |_tx|
+          all_outputs = storage.find_outputs({ include_spent: true })
+          change_outputs = all_outputs.select { |o| o[:derivation_prefix] }
+          change_state_at_broadcast = change_outputs.map { |o| o[:state] }
+          broadcast_response
+        end
+
+        wallet.create_action(action_opts)
+
+        expect(change_state_at_broadcast).not_to be_nil
+        expect(change_state_at_broadcast).not_to be_empty
+        expect(change_state_at_broadcast).to all(eq(:pending))
+      end
     end
 
     describe 'failed broadcast (BroadcastError)' do


### PR DESCRIPTION
## Summary

- Change outputs now stored as `:pending` directly — eliminates TOCTOU window where concurrent `auto_fund` could select unbroadcast change (Finding 1, #392)
- `broadcast_and_promote` and `promote_no_send` rescue restructured — only broadcast failure triggers rollback; promotion failure after successful broadcast propagates instead of deleting confirmed on-chain outputs (Finding 3, #393)
- `PostgresStore#update_action_status` scoped to single row via unique index on `wallet_actions.txid` (Finding 5, #394)
- 20 new integration specs covering broadcast success/failure, promotion failure invariant, send_with flows, and concurrent exclusion (#395)

## Test plan

- [x] All wallet specs pass (`bundle exec rake spec:wallet`) — 1030 examples, 0 failures
- [x] RuboCop clean (all offences are pre-existing in unrelated files)
- [x] Acceptance criteria verified against code
- [ ] No regression in SDK specs

Closes #379

Generated with [Claude Code](https://claude.com/claude-code)
