### PR TITLE
feat(auth): peer protocol completion — certificateRequest/certificateResponse and high-level session API

### DIFF
--- a/.claude/plans/20260414-peer-protocol-completion.md
+++ b/.claude/plans/20260414-peer-protocol-completion.md
@@ -1,0 +1,405 @@
+# Plan: HLR #426 — Peer Protocol Completion (F8.4, F8.5)
+
+**HLR**: [#426](https://github.com/sgbett/bsv-ruby-sdk/issues/426)
+**Parent**: [#378](https://github.com/sgbett/bsv-ruby-sdk/issues/378)
+**Depends on**: #419 (Phase 1 — Certificate infrastructure, PR #425)
+**Findings**: F8.4 (certificate exchange messages), F8.5 (high-level session API)
+
+## API Design: Converge on TS SDK
+
+The TS SDK's Peer has a transport-driven design:
+- Transport is required
+- `handleIncomingMessage` is private — messages arrive via `transport.onData`
+- Public API: `toPeer`, `getAuthenticatedSession`, `requestCertificates`, `sendCertificateResponse`, callback registration
+
+Ruby's current Peer is the opposite — manual message building, optional transport, `handle_incoming_message` is public. This phase converges on the TS model:
+
+- **Transport required** in constructor (raise `ArgumentError` if nil)
+- **`handle_incoming_message` becomes private** — only called via `transport.on_data`
+- **Public API matches TS**: `to_peer`, `get_authenticated_session`, `request_certificates`, `send_certificate_response`, callbacks
+- **Existing manual methods** (`create_initial_request`, `create_general_message`) become private internals
+- **Existing specs migrated** to use a `PairedTransport` test helper
+
+This is a breaking change to the Peer API, but the SDK is pre-1.0 and the current manual API has no external consumers. The migration is straightforward — replace direct hash-passing with transport-mediated communication.
+
+### PairedTransport test helper
+
+Connects two peers bidirectionally for in-process testing:
+
+```ruby
+class PairedTransport
+  include BSV::Auth::Transport
+
+  attr_accessor :partner
+
+  def initialize
+    @on_data_callback = nil
+  end
+
+  def send(message)
+    @partner.deliver(message)
+  end
+
+  def on_data(&block)
+    @on_data_callback = block
+  end
+
+  def deliver(message)
+    @on_data_callback&.call(message)
+  end
+end
+```
+
+When Peer A calls `to_peer`:
+1. A builds request → `transport_a.send(request)`
+2. → `transport_b.deliver(request)` → `peer_b.handle_incoming_message(request)`
+3. → B builds response → `transport_b.send(response)`
+4. → `transport_a.deliver(response)` → `peer_a.handle_incoming_message(response)`
+
+All synchronous, same thread. The `Queue` in `initiate_handshake` is already populated by the time `pop` is called.
+
+## Sync/Async Strategy
+
+### The problem
+
+The TS SDK is fully async (Promises). Key patterns that need Ruby equivalents:
+
+1. **`getAuthenticatedSession`** — sends `initialRequest` via transport, `await`s a Promise resolved when `processInitialResponse` fires via `on_data` callback.
+2. **Certificate validation blocking** — `processGeneralMessage` creates a 30-second Promise waiting for certificates to arrive via `processCertificateResponse`.
+3. **`initiateHandshake`** — sends request, returns a Promise resolved when the response arrives.
+
+### Solution: Thread + Queue
+
+`get_authenticated_session` sends `initialRequest` via transport, then blocks on `Queue#pop` with timeout. `process_initial_response` pushes to the queue when authentication completes.
+
+**Why this works for both sync and async transports:**
+
+With `PairedTransport` (sync, in-process):
+```
+Peer A: initiate_handshake
+  → transport_a.send(request)
+    → transport_b.deliver(request)
+      → peer_b.handle_incoming_message(request)
+        → peer_b builds response → transport_b.send(response)
+          → transport_a.deliver(response)
+            → peer_a.handle_incoming_message(response)
+              → peer_a.process_initial_response pushes to queue
+  → queue.pop returns immediately (data already pushed on same call stack)
+```
+
+With async transport (HTTP, WebSocket):
+```
+Thread A: initiate_handshake → transport.send(request) → queue.pop blocks
+Thread B: transport.on_data fires → handle_incoming_message → process_initial_response → queue.push
+Thread A: queue.pop unblocks → returns session nonce
+```
+
+### Certificate validation blocking: Go approach (reject immediately)
+
+The TS SDK blocks `processGeneralMessage` for up to 30 seconds waiting for certificates. The Go SDK rejects immediately with `ErrNotAuthenticated`.
+
+**We follow Go**: reject the general message immediately if certificates are required but not validated. Reasons:
+- Avoids complex `ConditionVariable` + timeout in message processing
+- Simpler, more predictable
+- Clear error message guides the caller to validate certificates first
+- Application can use `on_certificates_received` callback for async handling
+
+## Architecture
+
+```
+BSV::Auth::Peer (converged on TS model)
+  │── Public API (transport-driven)
+  │     │── to_peer(payload, identity_key)
+  │     │── get_authenticated_session(identity_key)
+  │     │── request_certificates(certs_to_request, identity_key)
+  │     └── send_certificate_response(peer_identity_key, certificates)
+  │
+  │── Callbacks
+  │     │── on_general_message / off_general_message
+  │     │── on_certificates_received / off_certificates_received
+  │     └── on_certificate_request / off_certificate_request
+  │
+  │── Readers
+  │     │── identity_key
+  │     │── authenticated?(identifier)
+  │     └── last_interacted_peer
+  │
+  │── Private internals (message building + processing)
+  │     │── handle_incoming_message (dispatch → 5 types)
+  │     │── initiate_handshake
+  │     │── process_initial_request / process_initial_response
+  │     │── process_certificate_request / process_certificate_response
+  │     │── process_general_message
+  │     │── build_general_message / build_certificate_request / build_certificate_response
+  │     └── helpers (key_id_for, b64_decode, fetch!, fire_callbacks)
+  │
+  └── Internal state
+        │── @callbacks { type → { id → Proc } }
+        │── @callback_id_counter
+        │── @last_interacted_peer
+        │── @handshake_queues { session_nonce → Queue }
+        └── @callback_mutex (Mutex)
+
+BSV::Auth.validate_certificates(wallet, message, requested_certificates)
+BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
+```
+
+## Task Breakdown
+
+### Task 1: `validate_certificates` utility
+
+**New file:** `gem/bsv-sdk/lib/bsv/auth/validate_certificates.rb`
+**Spec:** `gem/bsv-sdk/spec/bsv/auth/validate_certificates_spec.rb`
+
+Module method `BSV::Auth.validate_certificates(wallet, message, requested_certificates = nil)`:
+
+1. Raise `AuthError` if `message[:certificates]` nil or empty
+2. For each certificate:
+   a. Verify `cert.subject == message[:identity_key]` — raise if mismatch
+   b. Construct `VerifiableCertificate` from hash (handle both Hash and VerifiableCertificate inputs)
+   c. Verify certificate signature via `cert.verify` — raise if invalid
+   d. If `requested_certificates` provided: check certifier in requested set, type in requested set
+   e. Decrypt fields via `cert.decrypt_fields(wallet)` — raise if fails
+
+**Dependencies:** None (uses Phase 1 certificate classes).
+
+### Task 2: `get_verifiable_certificates` utility
+
+**New file:** `gem/bsv-sdk/lib/bsv/auth/get_verifiable_certificates.rb`
+**Spec:** `gem/bsv-sdk/spec/bsv/auth/get_verifiable_certificates_spec.rb`
+
+Module method `BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_identity_key)`:
+
+1. Return `[]` unless wallet responds to `list_certificates` and `prove_certificate`
+2. Call `wallet.list_certificates(...)` for matching certs
+3. For each, call `wallet.prove_certificate(...)` to get verifier keyring
+4. Construct `VerifiableCertificate` from certificate data + keyring
+5. Return array
+
+Guard with `respond_to?` — `ProtoWallet` doesn't support these methods.
+
+**Dependencies:** None (but see #424 re: prove_certificate bug).
+
+### Task 3: PairedTransport test helper + migrate existing specs
+
+**New file:** `gem/bsv-sdk/spec/support/paired_transport.rb`
+**Modified:** `gem/bsv-sdk/spec/bsv/auth/peer_spec.rb`
+
+Create `PairedTransport` helper (see above). Migrate existing peer specs from manual hash-passing to transport-mediated communication. All existing test scenarios must continue to pass.
+
+This is a prerequisite for Task 6 (which makes `handle_incoming_message` private) but can be done early since the current Peer still accepts a transport.
+
+**Dependencies:** None.
+
+### Task 4: Callback registration system + `@last_interacted_peer`
+
+**Modified:** `gem/bsv-sdk/lib/bsv/auth/peer.rb`
+
+Add to `initialize`:
+```ruby
+@callbacks = { general_message: {}, certificates_received: {}, certificate_request: {} }
+@callback_id_counter = 0
+@callback_mutex = Mutex.new
+@last_interacted_peer = nil
+@auto_persist_last_session = true  # new kwarg
+```
+
+Public methods:
+- `on_general_message(&block) → Integer` / `off_general_message(id)`
+- `on_certificates_received(&block) → Integer` / `off_certificates_received(id)`
+- `on_certificate_request(&block) → Integer` / `off_certificate_request(id)`
+- `attr_reader :last_interacted_peer`
+
+Private helper: `fire_callbacks(type, *args)` — iterates and calls each block.
+
+All access through `@callback_mutex` for thread safety.
+
+Update `@last_interacted_peer` tracking points:
+- `process_initial_request`: set if nil
+- `process_initial_response`: always set
+- `process_general_message`: always set
+
+Wire callbacks into existing message processors:
+- `process_general_message`: fire `:general_message` callbacks with `(peer_identity_key, payload)`
+
+**Dependencies:** None (purely additive).
+
+### Task 5: Certificate exchange message processing (F8.4 core)
+
+**Modified:** `gem/bsv-sdk/lib/bsv/auth/peer.rb`
+**Extended spec:** `gem/bsv-sdk/spec/bsv/auth/peer_spec.rb`
+
+**5a.** Wire `MSG_CERT_REQUEST` and `MSG_CERT_RESPONSE` into `handle_incoming_message` dispatch.
+
+**5b.** `process_certificate_request(message)` (private):
+- Verify nonce, look up session, verify signature over `JSON.generate(requested_certificates).encode('UTF-8').bytes`
+- Fire `on_certificate_request` callbacks if registered, else auto-fetch via `BSV::Auth.get_verifiable_certificates` and respond
+- Key ID: `"#{nonce} #{session.session_nonce}"`
+
+**5c.** `process_certificate_response(message)` (private):
+- Verify nonce, look up session, verify signature over `JSON.generate(certificates).encode('UTF-8').bytes`
+- Validate certificates via `BSV::Auth.validate_certificates`
+- Mark `session.certificates_validated = true`
+- Fire `on_certificates_received` callbacks
+- Key ID: `"#{nonce} #{session.session_nonce}"`
+
+**5d.** Update `process_initial_request` — include certificates in response via callback/auto-fetch when peer's `requested_certificates` has certifiers.
+
+**5e.** Update `process_initial_response` — validate certificates if present in response, handle peer's `requested_certificates` (fire callbacks or auto-respond).
+
+**Signature protocol** (same for all BRC-103 messages):
+- Protocol: `[2, 'auth message signature']`
+- Key ID: `"#{nonce} #{session_nonce}"`
+- Counterparty: peer identity key
+- Data: UTF-8 bytes of `JSON.generate(payload_data)`
+
+**Dependencies:** Tasks 1, 2, 4.
+
+### Task 6: High-level session API (F8.5 core) + API convergence
+
+**Modified:** `gem/bsv-sdk/lib/bsv/auth/peer.rb`
+
+This task delivers the high-level API and makes the API change: transport required, manual methods private.
+
+**6a.** Make transport required in `initialize`:
+```ruby
+def initialize(wallet:, transport:, session_manager: nil, certificates_to_request: nil,
+               auto_persist_last_session: true, handshake_timeout: 30)
+  raise ArgumentError, 'transport is required' if transport.nil?
+  # ...
+end
+```
+
+**6b.** `get_authenticated_session(identity_key = nil)`:
+1. Resolve `identity_key` from `@last_interacted_peer` if nil
+2. Look up existing session — return if authenticated
+3. Call `initiate_handshake(identity_key)` — blocks until response
+4. Return authenticated session
+
+**6c.** `initiate_handshake(identity_key = nil)` (private):
+1. Create nonce, add pending session
+2. Create `Queue.new`, store in `@handshake_queues[session_nonce]`
+3. Build `initialRequest` message
+4. Send via `@transport.send(message)` — wrapped in begin/rescue to clean up queue on failure
+5. Block on `queue.pop` with `Timeout.timeout(@handshake_timeout)`
+6. On timeout: clean up queue, raise `AuthError`
+7. Return session nonce
+
+Queue push in `process_initial_response`, after authentication:
+```ruby
+queue = @handshake_queues.delete(session.session_nonce)
+queue&.push(:ready)
+```
+
+**6d.** `to_peer(payload, identity_key = nil)`:
+1. Resolve identity_key
+2. Get authenticated session
+3. Raise `AuthError` if certificates required but not validated (Go approach)
+4. Build and send general message via transport
+5. Update `@last_interacted_peer`
+
+**6e.** `request_certificates(certificates_to_request, identity_key = nil)`:
+1. Get authenticated session
+2. Build and sign `certificateRequest` message
+3. Send via transport
+
+**6f.** `send_certificate_response(peer_identity_key, certificates)`:
+1. Get authenticated session
+2. Build and sign `certificateResponse` message
+3. Send via transport
+
+**6g.** Make private: `handle_incoming_message`, `create_initial_request`, `create_general_message`, all `process_*` methods, all `build_*` methods.
+
+**Dependencies:** Tasks 3, 4, 5.
+
+### Task 7: Autoload and module wiring
+
+**Modified:** `gem/bsv-sdk/lib/bsv/auth.rb`
+
+Add requires/autoloads for new utility files (`validate_certificates.rb`, `get_verifiable_certificates.rb`).
+
+**Dependencies:** Tasks 1, 2.
+
+### Task 8: Integration tests
+
+**New spec files:**
+- `gem/bsv-sdk/spec/bsv/auth/validate_certificates_spec.rb`
+- `gem/bsv-sdk/spec/bsv/auth/peer_integration_spec.rb`
+
+**Key test scenarios:**
+
+Certificate exchange:
+1. Full lifecycle: issue cert → handshake with cert request → auto-respond with certs → validate → decrypt
+2. Dynamic cert request post-handshake: `request_certificates` → callback fires → `send_certificate_response` → validated
+3. Tampered certificate rejected
+4. Wrong certifier rejected
+5. Subject mismatch rejected
+
+High-level API:
+1. `to_peer` auto-handshakes and sends, callback fires on receiver
+2. `get_authenticated_session` returns existing session on second call
+3. `to_peer` raises when certificates required but not validated
+4. `request_certificates` → `on_certificate_request` fires on other peer
+5. `@last_interacted_peer` tracked and used as default
+
+Edge cases:
+1. Handshake timeout when transport doesn't deliver response
+2. Transport send failure doesn't leave orphaned queue entries
+3. Multiple concurrent sessions with different peers
+
+**Dependencies:** All previous tasks.
+
+## Implementation Sequence
+
+```
+Task 1 (validate_certificates) ─────┐
+                                      │
+Task 2 (get_verifiable_certs) ───────┤
+                                      ├──→ Task 5 (cert msg processing) ──┐
+Task 3 (PairedTransport + migrate) ──┤                                    │
+                                      │                                    │
+Task 4 (callbacks + last_peer) ──────┘                                    │
+                                                                           │
+                                    Task 7 (autoload) ── after 1, 2       │
+                                                                           │
+                                    Task 6 (high-level API + converge) ───┤
+                                                                           │
+                                    Task 8 (integration tests) ───────────┘
+```
+
+**Parallel group 1:** Tasks 1, 2, 3, 4 (no cross-dependencies)
+**Sequential after group 1:** Task 5 (depends on 1, 2, 4), Task 7 (depends on 1, 2)
+**Sequential after Task 5:** Task 6 (depends on 3, 5)
+**Final:** Task 8 (depends on all)
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| JSON serialisation mismatch (Ruby `JSON.generate` vs TS `JSON.stringify`) | Signatures don't cross-verify | Add cross-SDK test vectors; verify key ordering matches |
+| Thread safety for shared state | Race conditions in transport mode | `@callback_mutex` protects callbacks, queues, counter, last_interacted_peer |
+| Queue deadlock if `transport.send` raises before response | `initiate_handshake` hangs until timeout | Wrap `send` in begin/rescue that cleans up queue on failure |
+| #424 (prove_certificate protocol mismatch) | Auto-fetch path produces incompatible keyrings | Guard with `respond_to?`; callback path unaffected; document limitation |
+| `ProtoWallet` doesn't support `list_certificates`/`prove_certificate` | Auto-fetch returns empty array | Guard with `respond_to?`; tests use mocks for auto-fetch path |
+| Breaking change to Peer API | Existing code using manual API breaks | Pre-1.0 SDK; no external consumers; migration path is PairedTransport |
+
+## Deliberate Deviations from TS SDK
+
+| Behaviour | TS SDK | Ruby (this plan) | Rationale |
+|-----------|--------|-------------------|-----------|
+| Certificate validation blocking | 30-second Promise wait in `processGeneralMessage` | Immediate rejection (Go approach) | Avoids `ConditionVariable` complexity; clearer error handling |
+| `originator` parameter | Threaded through all wallet calls | Not implemented | Ruby SDK doesn't have originator concept yet; deferred |
+| Callback method naming | `listenForGeneralMessages` / `stopListeningForGeneralMessages` | `on_general_message` / `off_general_message` | Ruby idiom (event emitter pattern) |
+
+## Status
+
+| Task | Status |
+|------|--------|
+| Task 1: validate_certificates | Not started |
+| Task 2: get_verifiable_certificates | Not started |
+| Task 3: PairedTransport + spec migration | Not started |
+| Task 4: Callbacks + last_interacted_peer | Not started |
+| Task 5: Certificate exchange processing | Not started |
+| Task 6: High-level API + API convergence | Not started |
+| Task 7: Autoload wiring | Not started |
+| Task 8: Integration tests | Not started |

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -280,3 +280,9 @@ RSpec/BeforeAfterAll:
 RSpec/InstanceVariable:
   Exclude:
     - 'gem/bsv-sdk/spec/integration/**/*'
+
+# Callback registration tests need empty blocks to obtain a callback ID without
+# triggering an actual callback action.
+Lint/EmptyBlock:
+  Exclude:
+    - 'gem/*/spec/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ Metrics/BlockLength:
   Exclude:
     - 'gem/bsv-wallet/lib/bsv/wallet_interface/wire/**/*'
     - 'gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/migrations/**/*'
+    - 'gem/bsv-sdk/lib/bsv/auth/**/*'
     - 'gem/*/spec/**/*'
 
 Naming/FileName:

--- a/gem/bsv-sdk/lib/bsv/auth.rb
+++ b/gem/bsv-sdk/lib/bsv/auth.rb
@@ -11,6 +11,8 @@ module BSV
     autoload :Certificate,             'bsv/auth/certificate'
     autoload :VerifiableCertificate,   'bsv/auth/verifiable_certificate'
     autoload :MasterCertificate,       'bsv/auth/master_certificate'
+    autoload :ValidateCertificates,        'bsv/auth/validate_certificates'
+    autoload :GetVerifiableCertificates,   'bsv/auth/get_verifiable_certificates'
 
     # Protocol version
     AUTH_VERSION = '0.1'
@@ -21,5 +23,29 @@ module BSV
     MSG_CERT_REQUEST     = 'certificateRequest'
     MSG_CERT_RESPONSE    = 'certificateResponse'
     MSG_GENERAL          = 'general'
+
+    # Validates certificates attached to an incoming authenticated message.
+    #
+    # Delegates to {ValidateCertificates#validate_certificates}.
+    #
+    # @param wallet [#verify_signature, #decrypt] the verifier's wallet
+    # @param message [Hash] incoming authenticated message
+    # @param requested_certificates [Hash, nil] optional certifier/type filter
+    # @raise [AuthError] on any validation failure
+    def self.validate_certificates(wallet, message, requested_certificates = nil)
+      ValidateCertificates.validate_certificates(wallet, message, requested_certificates)
+    end
+
+    # Retrieves verifiable certificates from a wallet for presentation to a verifier.
+    #
+    # Delegates to {GetVerifiableCertificates#get_verifiable_certificates}.
+    #
+    # @param wallet [#list_certificates, #prove_certificate] the subject's wallet
+    # @param requested_certificates [Hash] certifiers and type-to-fields mapping
+    # @param verifier_identity_key [String] verifier's compressed public key hex
+    # @return [Array<VerifiableCertificate>]
+    def self.get_verifiable_certificates(wallet, requested_certificates, verifier_identity_key)
+      GetVerifiableCertificates.get_verifiable_certificates(wallet, requested_certificates, verifier_identity_key)
+    end
   end
 end

--- a/gem/bsv-sdk/lib/bsv/auth/get_verifiable_certificates.rb
+++ b/gem/bsv-sdk/lib/bsv/auth/get_verifiable_certificates.rb
@@ -70,6 +70,10 @@ module BSV
           )
         end
       rescue StandardError
+        # Auto-fetch is best-effort: wallet may raise UnsupportedActionError,
+        # key derivation errors, or other failures. The peer protocol handles
+        # "no certificates" gracefully — the requesting peer enforces its own
+        # certificate requirements independently.
         []
       end
     end

--- a/gem/bsv-sdk/lib/bsv/auth/get_verifiable_certificates.rb
+++ b/gem/bsv-sdk/lib/bsv/auth/get_verifiable_certificates.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module BSV
+  module Auth
+    # Utility module for retrieving verifiable certificates from a wallet.
+    #
+    # Used during the certificate exchange phase of the BSV Auth peer protocol.
+    # Lists certificates matching the requested certifiers and types, then calls
+    # +prove_certificate+ for each to obtain a verifier-specific keyring for
+    # selective field revelation.
+    #
+    # NOTE: Issue #424 documents a known bug in +WalletClient#prove_certificate+ — it
+    # uses the wrong protocol ID (+certificate field revelation+ vs +certificate field
+    # encryption+) and an incorrect key ID format. Until that bug is fixed, the keyring
+    # produced here will be cryptographically incompatible with the TS/Go SDKs.
+    module GetVerifiableCertificates
+      module_function
+
+      # Retrieve verifiable certificates from a wallet for presentation to a verifier.
+      #
+      # @param wallet [#list_certificates, #prove_certificate] the subject's wallet.
+      #   Duck-typed — if the wallet does not respond to both methods, returns +[]+.
+      # @param requested_certificates [Hash] with keys:
+      #   - +:certifiers+ [Array<String>] list of certifier public key hexes
+      #   - +:types+ [Hash] type (Base64 string) → array of field names to reveal
+      # @param verifier_identity_key [String] the verifier's compressed public key hex
+      # @return [Array<VerifiableCertificate>] list of verifiable certificates ready for
+      #   presentation, or +[]+ on any failure
+      def get_verifiable_certificates(wallet, requested_certificates, verifier_identity_key)
+        return [] unless wallet.respond_to?(:list_certificates) && wallet.respond_to?(:prove_certificate)
+
+        certifiers = requested_certificates[:certifiers] || requested_certificates['certifiers'] || []
+        types_map  = requested_certificates[:types]      || requested_certificates['types']      || {}
+
+        list_result = wallet.list_certificates(
+          certifiers: certifiers,
+          types: types_map.keys
+        )
+
+        certificates = list_result[:certificates] || list_result['certificates'] || []
+        return [] if certificates.empty?
+
+        certificates.map do |cert|
+          cert_type = cert[:type] || cert['type']
+          fields_to_reveal = types_map[cert_type] || types_map[cert_type.to_s] || types_map[cert_type.to_sym] || []
+
+          prove_result = wallet.prove_certificate(
+            certificate: cert,
+            fields_to_reveal: fields_to_reveal,
+            verifier: verifier_identity_key
+          )
+
+          keyring = prove_result[:keyring_for_verifier] ||
+                    prove_result['keyring_for_verifier'] ||
+                    prove_result[:keyringForVerifier]    ||
+                    prove_result['keyringForVerifier']   ||
+                    {}
+
+          VerifiableCertificate.new(
+            type: cert_type,
+            serial_number: cert[:serial_number] || cert['serial_number'] ||
+                           cert[:serialNumber] || cert['serialNumber'],
+            subject: cert[:subject] || cert['subject'],
+            certifier: cert[:certifier] || cert['certifier'],
+            revocation_outpoint: cert[:revocation_outpoint] || cert['revocation_outpoint'] ||
+                                 cert[:revocationOutpoint] || cert['revocationOutpoint'],
+            fields: cert[:fields] || cert['fields'] || {},
+            keyring: keyring,
+            signature: cert[:signature] || cert['signature']
+          )
+        end
+      rescue StandardError
+        []
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/auth/peer.rb
+++ b/gem/bsv-sdk/lib/bsv/auth/peer.rb
@@ -738,7 +738,10 @@ module BSV
 
         if certs.is_a?(Array) && !certs.empty?
           validation_msg = { identity_key: session.peer_identity_key, certificates: certs }
-          BSV::Auth.validate_certificates(@wallet, validation_msg)
+          # Filter by configured certifier/type allowlist when present; skip when
+          # no certifier requirements are configured (dynamic request_certificates flow).
+          cert_filter = certifiers_present? ? @certificates_to_request : nil
+          BSV::Auth.validate_certificates(@wallet, validation_msg, cert_filter)
           session.certificates_validated = true
           session.last_update = current_time_ms
           @session_manager.update_session(session)

--- a/gem/bsv-sdk/lib/bsv/auth/peer.rb
+++ b/gem/bsv-sdk/lib/bsv/auth/peer.rb
@@ -81,29 +81,7 @@ module BSV
           raise AuthError, 'Cannot send general message before certificate validation is complete'
         end
 
-        request_nonce = ::Base64.strict_encode64(SecureRandom.random_bytes(32))
-        key_id        = key_id_for(request_nonce, session.peer_nonce)
-
-        sig_result = @wallet.create_signature({
-                                                data: payload,
-                                                protocol_id: AUTH_PROTOCOL,
-                                                key_id: key_id,
-                                                counterparty: session.peer_identity_key
-                                              })
-
-        session.last_update = current_time_ms
-        @session_manager.update_session(session)
-
-        message = {
-          version: AUTH_VERSION,
-          message_type: MSG_GENERAL,
-          identity_key: self.identity_key,
-          nonce: request_nonce,
-          your_nonce: session.peer_nonce,
-          payload: payload,
-          signature: sig_result[:signature]
-        }
-
+        message = create_general_message(session.peer_identity_key, payload)
         @transport.send(message)
         @last_interacted_peer = session.peer_identity_key if @auto_persist_last_session
       end
@@ -137,32 +115,7 @@ module BSV
       def request_certificates(certificates_to_request, identity_key = nil)
         identity_key = resolve_identity_key(identity_key)
         session      = get_authenticated_session(identity_key)
-
-        request_nonce = ::Base64.strict_encode64(SecureRandom.random_bytes(32))
-        key_id        = key_id_for(request_nonce, session.peer_nonce)
-        data          = JSON.generate(certificates_to_request).encode('UTF-8').bytes
-
-        sig_result = @wallet.create_signature({
-                                                data: data,
-                                                protocol_id: AUTH_PROTOCOL,
-                                                key_id: key_id,
-                                                counterparty: session.peer_identity_key
-                                              })
-
-        session.last_update = current_time_ms
-        @session_manager.update_session(session)
-
-        message = {
-          version: AUTH_VERSION,
-          message_type: MSG_CERT_REQUEST,
-          identity_key: self.identity_key,
-          nonce: request_nonce,
-          initial_nonce: session.session_nonce,
-          your_nonce: session.peer_nonce,
-          requested_certificates: certificates_to_request,
-          signature: sig_result[:signature]
-        }
-
+        message      = create_certificate_request(session.peer_identity_key, certificates_to_request)
         @transport.send(message)
       end
 
@@ -172,33 +125,7 @@ module BSV
       # @param certificates [Array<VerifiableCertificate, Hash>] certificates to send
       def send_certificate_response(peer_identity_key, certificates)
         session = get_authenticated_session(peer_identity_key)
-
-        request_nonce = ::Base64.strict_encode64(SecureRandom.random_bytes(32))
-        key_id        = key_id_for(request_nonce, session.peer_nonce)
-        cert_data     = certificates.map { |c| c.respond_to?(:to_h) ? c.to_h : c }
-        data          = JSON.generate(cert_data).encode('UTF-8').bytes
-
-        sig_result = @wallet.create_signature({
-                                                data: data,
-                                                protocol_id: AUTH_PROTOCOL,
-                                                key_id: key_id,
-                                                counterparty: session.peer_identity_key
-                                              })
-
-        session.last_update = current_time_ms
-        @session_manager.update_session(session)
-
-        message = {
-          version: AUTH_VERSION,
-          message_type: MSG_CERT_RESPONSE,
-          identity_key: identity_key,
-          nonce: request_nonce,
-          initial_nonce: session.session_nonce,
-          your_nonce: session.peer_nonce,
-          certificates: cert_data,
-          signature: sig_result[:signature]
-        }
-
+        message = create_certificate_response(session.peer_identity_key, certificates)
         @transport.send(message)
       end
 
@@ -670,7 +597,7 @@ module BSV
 
       def process_certificate_request(message)
         our_nonce = fetch!(message, :your_nonce)
-        peer_key  = message[:identity_key] || message['identity_key']
+        peer_key  = fetch!(message, :identity_key)
         msg_nonce = fetch!(message, :nonce)
         requested = message[:requested_certificates] || message['requested_certificates']
         signature = fetch!(message, :signature)
@@ -715,7 +642,7 @@ module BSV
 
       def process_certificate_response(message)
         our_nonce = fetch!(message, :your_nonce)
-        peer_key  = message[:identity_key] || message['identity_key']
+        peer_key  = fetch!(message, :identity_key)
         msg_nonce = fetch!(message, :nonce)
         certs     = message[:certificates] || message['certificates'] || []
         signature = fetch!(message, :signature)

--- a/gem/bsv-sdk/lib/bsv/auth/peer.rb
+++ b/gem/bsv-sdk/lib/bsv/auth/peer.rb
@@ -2,49 +2,51 @@
 
 require 'base64'
 require 'json'
+require 'timeout'
 
 module BSV
   module Auth
     # BRC-31/BRC-103 mutual authentication peer.
     #
-    # Manages the cryptographic handshake between two parties:
+    # Manages the cryptographic handshake between two parties using a transport
+    # for bidirectional message delivery.
     #
-    # 1. Alice calls {#initiate_handshake} — sends +initialRequest+ with her
-    #    session nonce and requested certificates.
-    # 2. Bob calls {#handle_incoming_message} — processes the request, creates
-    #    his own session nonce, signs +decode(alice_nonce) + decode(bob_nonce)+,
-    #    and sends +initialResponse+.
-    # 3. Alice processes +initialResponse+ — verifies the nonce is hers
-    #    (via HMAC), verifies Bob's signature, and marks the session authenticated.
-    # 4. Both parties may now exchange authenticated +general+ messages.
+    # High-level API (preferred):
+    #   peer_a.to_peer(payload, peer_b_identity_key)    — send authenticated message
+    #   peer_a.get_authenticated_session(identity_key)  — obtain/create authenticated session
+    #   peer_a.request_certificates(certs, identity_key) — request certs post-handshake
+    #   peer_a.send_certificate_response(key, certs)    — send certs to a peer
+    #
+    # The high-level API auto-initiates the handshake when no authenticated session
+    # exists. The low-level +handle_incoming_message+ is called internally by the
+    # transport callback and is not part of the public contract.
     #
     # Sessions are indexed by +session_nonce+ (our nonce), which is the primary
     # key in the {SessionManager}.
     #
-    # @example Using Peer with a custom transport
-    #   wallet_a = BSV::Wallet::ProtoWallet.new(BSV::Primitives::PrivateKey.generate)
-    #   wallet_b = BSV::Wallet::ProtoWallet.new(BSV::Primitives::PrivateKey.generate)
+    # @example Using Peer with a transport
+    #   transport_a, transport_b = PairedTransport.create_pair
+    #   peer_a = BSV::Auth::Peer.new(wallet: wallet_a, transport: transport_a)
+    #   peer_b = BSV::Auth::Peer.new(wallet: wallet_b, transport: transport_b)
     #
-    #   # Wire the two peers together with synchronous in-process transports
-    #   peer_a = BSV::Auth::Peer.new(wallet: wallet_a)
-    #   peer_b = BSV::Auth::Peer.new(wallet: wallet_b)
-    #
-    #   # Alice initiates; Bob responds; Alice completes
-    #   request  = peer_a.create_initial_request
-    #   response = peer_b.handle_incoming_message(request)
-    #   peer_a.handle_incoming_message(response)
+    #   peer_b.on_general_message { |key, payload| puts "received: #{payload}" }
+    #   peer_a.to_peer([72, 101, 108, 108, 111], peer_b.identity_key)
     class Peer
       AUTH_PROTOCOL = [2, 'auth message signature'].freeze
 
       attr_reader :wallet, :session_manager, :last_interacted_peer
 
       # @param wallet [BSV::Wallet::Interface] wallet providing crypto operations
-      # @param transport [Transport, nil] optional transport for async usage
+      # @param transport [Transport] transport for message delivery (required)
       # @param session_manager [SessionManager, nil] optional custom session store
       # @param certificates_to_request [Hash, nil] certificate set to request from peers
       # @param auto_persist_last_session [Boolean] whether to track the last-interacted peer (default: true)
-      def initialize(wallet:, transport: nil, session_manager: nil, certificates_to_request: nil,
-                     auto_persist_last_session: true)
+      # @param handshake_timeout [Integer] seconds to wait for handshake response (default: 30)
+      # @raise [ArgumentError] if transport is nil
+      def initialize(wallet:, transport:, session_manager: nil, certificates_to_request: nil,
+                     auto_persist_last_session: true, handshake_timeout: 30)
+        raise ArgumentError, 'transport is required' if transport.nil?
+
         @wallet                    = wallet
         @transport                 = transport
         @session_manager           = session_manager || SessionManager.new
@@ -55,11 +57,152 @@ module BSV
         @callback_mutex            = Mutex.new
         @last_interacted_peer      = nil
         @auto_persist_last_session = auto_persist_last_session
-
-        return unless @transport
+        @handshake_queues          = {}
+        @handshake_queues_mutex    = Mutex.new
+        @handshake_timeout         = handshake_timeout
 
         @transport.on_data { |msg| handle_incoming_message(msg) }
       end
+
+      # --- High-level session API ---
+
+      # Sends an authenticated general message to a peer, initiating a handshake
+      # automatically if no authenticated session exists.
+      #
+      # @param payload [Array<Integer>] byte array payload
+      # @param identity_key [String, nil] peer identity key; falls back to last-interacted peer
+      # @raise [AuthError] if certificates are required but not yet validated
+      # @raise [AuthError] if handshake times out
+      def to_peer(payload, identity_key = nil)
+        identity_key = resolve_identity_key(identity_key)
+        session      = get_authenticated_session(identity_key)
+
+        if session.certificates_required && !session.certificates_validated
+          raise AuthError, 'Cannot send general message before certificate validation is complete'
+        end
+
+        request_nonce = ::Base64.strict_encode64(SecureRandom.random_bytes(32))
+        key_id        = key_id_for(request_nonce, session.peer_nonce)
+
+        sig_result = @wallet.create_signature({
+                                                data: payload,
+                                                protocol_id: AUTH_PROTOCOL,
+                                                key_id: key_id,
+                                                counterparty: session.peer_identity_key
+                                              })
+
+        session.last_update = current_time_ms
+        @session_manager.update_session(session)
+
+        message = {
+          version: AUTH_VERSION,
+          message_type: MSG_GENERAL,
+          identity_key: self.identity_key,
+          nonce: request_nonce,
+          your_nonce: session.peer_nonce,
+          payload: payload,
+          signature: sig_result[:signature]
+        }
+
+        @transport.send(message)
+        @last_interacted_peer = session.peer_identity_key if @auto_persist_last_session
+      end
+
+      # Returns an authenticated session for a peer, initiating a handshake if needed.
+      #
+      # If +identity_key+ is given and an authenticated session already exists, returns
+      # it immediately. Otherwise initiates a handshake and blocks until the response
+      # arrives or the timeout expires.
+      #
+      # @param identity_key [String, nil] peer identity key to look up or connect to
+      # @return [PeerSession] an authenticated session
+      # @raise [AuthError] if the handshake fails or times out
+      def get_authenticated_session(identity_key = nil)
+        if identity_key
+          session = @session_manager.get_session(identity_key)
+          return session if session&.authenticated?
+        end
+
+        session_nonce = initiate_handshake(identity_key)
+        session       = @session_manager.get_session(session_nonce)
+        raise AuthError, 'Unable to establish mutual authentication with peer!' unless session&.authenticated?
+
+        session
+      end
+
+      # Sends a certificate request to a peer post-handshake.
+      #
+      # @param certificates_to_request [Hash] certifiers and types to request
+      # @param identity_key [String, nil] peer identity key; falls back to last-interacted peer
+      def request_certificates(certificates_to_request, identity_key = nil)
+        identity_key = resolve_identity_key(identity_key)
+        session      = get_authenticated_session(identity_key)
+
+        request_nonce = ::Base64.strict_encode64(SecureRandom.random_bytes(32))
+        key_id        = key_id_for(request_nonce, session.peer_nonce)
+        data          = JSON.generate(certificates_to_request).encode('UTF-8').bytes
+
+        sig_result = @wallet.create_signature({
+                                                data: data,
+                                                protocol_id: AUTH_PROTOCOL,
+                                                key_id: key_id,
+                                                counterparty: session.peer_identity_key
+                                              })
+
+        session.last_update = current_time_ms
+        @session_manager.update_session(session)
+
+        message = {
+          version: AUTH_VERSION,
+          message_type: MSG_CERT_REQUEST,
+          identity_key: self.identity_key,
+          nonce: request_nonce,
+          initial_nonce: session.session_nonce,
+          your_nonce: session.peer_nonce,
+          requested_certificates: certificates_to_request,
+          signature: sig_result[:signature]
+        }
+
+        @transport.send(message)
+      end
+
+      # Sends a certificate response to a peer.
+      #
+      # @param peer_identity_key [String] the peer's identity key
+      # @param certificates [Array<VerifiableCertificate, Hash>] certificates to send
+      def send_certificate_response(peer_identity_key, certificates)
+        session = get_authenticated_session(peer_identity_key)
+
+        request_nonce = ::Base64.strict_encode64(SecureRandom.random_bytes(32))
+        key_id        = key_id_for(request_nonce, session.peer_nonce)
+        cert_data     = certificates.map { |c| c.respond_to?(:to_h) ? c.to_h : c }
+        data          = JSON.generate(cert_data).encode('UTF-8').bytes
+
+        sig_result = @wallet.create_signature({
+                                                data: data,
+                                                protocol_id: AUTH_PROTOCOL,
+                                                key_id: key_id,
+                                                counterparty: session.peer_identity_key
+                                              })
+
+        session.last_update = current_time_ms
+        @session_manager.update_session(session)
+
+        message = {
+          version: AUTH_VERSION,
+          message_type: MSG_CERT_RESPONSE,
+          identity_key: identity_key,
+          nonce: request_nonce,
+          initial_nonce: session.session_nonce,
+          your_nonce: session.peer_nonce,
+          certificates: cert_data,
+          signature: sig_result[:signature]
+        }
+
+        @transport.send(message)
+      end
+
+      # --- Callbacks ---
 
       # Registers a callback to be called when a general message is received.
       #
@@ -124,9 +267,61 @@ module BSV
         session&.authenticated? || false
       end
 
+      private
+
       # --- Handshake initiation (we are the initiator) ---
 
+      # Initiates a handshake, blocks until the response arrives, and returns the
+      # session nonce so the caller can retrieve the completed session.
+      #
+      # A Queue is created and stored in @handshake_queues keyed by the session nonce.
+      # +process_initial_response+ pops +:ready+ into the queue once authentication
+      # is complete, unblocking the waiting thread.
+      #
+      # @param identity_key [String, nil] hint for the peer's identity (optional)
+      # @return [String] session nonce of the newly authenticated session
+      # @raise [AuthError] if the handshake times out or the transport raises
+      def initiate_handshake(identity_key = nil)
+        session_nonce = Nonce.create(@wallet)
+
+        session = PeerSession.new(session_nonce: session_nonce)
+        session.peer_identity_key = identity_key
+        session.certificates_required  = certifiers_present?
+        session.certificates_validated = !session.certificates_required
+
+        @session_manager.add_session(session)
+
+        queue = Queue.new
+        @handshake_queues_mutex.synchronize { @handshake_queues[session_nonce] = queue }
+
+        message = {
+          version: AUTH_VERSION,
+          message_type: MSG_INITIAL_REQUEST,
+          identity_key: self.identity_key,
+          initial_nonce: session_nonce,
+          requested_certificates: @certificates_to_request
+        }
+
+        begin
+          @transport.send(message)
+        rescue StandardError => e
+          @handshake_queues_mutex.synchronize { @handshake_queues.delete(session_nonce) }
+          raise e
+        end
+
+        begin
+          Timeout.timeout(@handshake_timeout) { queue.pop }
+        rescue Timeout::Error
+          @handshake_queues_mutex.synchronize { @handshake_queues.delete(session_nonce) }
+          raise AuthError, 'Handshake timed out'
+        end
+
+        session_nonce
+      end
+
       # Builds an +initialRequest+ message and creates a pending session.
+      # Used internally by older test paths; prefer {#initiate_handshake} for
+      # new code since it wires the queue and blocks until auth completes.
       #
       # @return [Hash] the message to send to the peer
       def create_initial_request
@@ -151,9 +346,8 @@ module BSV
 
       # Processes any incoming auth message and returns a response (if applicable).
       #
-      # When a transport is configured, any response is also forwarded via
-      # +@transport.send+ so that the bidirectional flow works without the
-      # caller having to manually route the return value.
+      # Called by the transport's +on_data+ callback. Not part of the public API —
+      # callers should use the high-level {#to_peer} / {#get_authenticated_session} methods.
       #
       # @param message [Hash] the incoming auth message
       # @return [Hash, nil] response message, or nil for messages requiring no reply
@@ -177,11 +371,11 @@ module BSV
         # Only forward protocol messages (those with a message_type) back via
         # transport. Internal result hashes (e.g. from process_general_message)
         # carry no message_type and must not be forwarded.
-        @transport&.send(response) if response&.key?(:message_type)
+        @transport.send(response) if response&.key?(:message_type)
         response
       end
 
-      # --- Certificate request/response (manual mode) ---
+      # --- Certificate request/response (low-level builders) ---
 
       # Builds a +certificateRequest+ message directed at an already-authenticated peer.
       #
@@ -256,7 +450,7 @@ module BSV
         }
       end
 
-      # --- General message exchange (post-handshake) ---
+      # --- General message builder (low-level) ---
 
       # Creates an authenticated +general+ message to send to a peer.
       #
@@ -294,7 +488,17 @@ module BSV
         }
       end
 
-      private
+      # Resolves the identity key for a peer, falling back to the last-interacted peer
+      # when +identity_key+ is nil and +@auto_persist_last_session+ is true.
+      #
+      # @param identity_key [String, nil]
+      # @return [String, nil]
+      def resolve_identity_key(identity_key)
+        return identity_key if identity_key
+        return @last_interacted_peer if @auto_persist_last_session && @last_interacted_peer
+
+        nil
+      end
 
       # --- Processing: initial request (we are the responder) ---
 
@@ -387,6 +591,13 @@ module BSV
 
         @last_interacted_peer = peer_key if @auto_persist_last_session
 
+        # Unblock any thread waiting in initiate_handshake for this session.
+        # Must happen AFTER authentication is complete and BEFORE certificate
+        # handling — certificate handling may call get_authenticated_session which
+        # checks the session state, and it must not re-trigger a new handshake.
+        queue = @handshake_queues_mutex.synchronize { @handshake_queues.delete(session.session_nonce) }
+        queue&.push(:ready)
+
         # Validate certificates if the responder included them
         resp_certs = message[:certificates] || message['certificates']
         if session.certificates_required && resp_certs.is_a?(Array) && !resp_certs.empty?
@@ -407,7 +618,7 @@ module BSV
             certs = BSV::Auth.get_verifiable_certificates(@wallet, requested, peer_key)
             if certs.length.positive?
               cert_response = create_certificate_response(peer_key, certs)
-              @transport&.send(cert_response)
+              @transport.send(cert_response)
             end
           end
         end
@@ -491,7 +702,7 @@ module BSV
           certs = BSV::Auth.get_verifiable_certificates(@wallet, requested, session.peer_identity_key)
           if certs.length.positive?
             cert_response = create_certificate_response(session.peer_identity_key, certs)
-            @transport&.send(cert_response)
+            @transport.send(cert_response)
           end
         end
 

--- a/gem/bsv-sdk/lib/bsv/auth/peer.rb
+++ b/gem/bsv-sdk/lib/bsv/auth/peer.rb
@@ -35,22 +35,74 @@ module BSV
     class Peer
       AUTH_PROTOCOL = [2, 'auth message signature'].freeze
 
-      attr_reader :wallet, :session_manager
+      attr_reader :wallet, :session_manager, :last_interacted_peer
 
       # @param wallet [BSV::Wallet::Interface] wallet providing crypto operations
       # @param transport [Transport, nil] optional transport for async usage
       # @param session_manager [SessionManager, nil] optional custom session store
       # @param certificates_to_request [Hash, nil] certificate set to request from peers
-      def initialize(wallet:, transport: nil, session_manager: nil, certificates_to_request: nil)
-        @wallet                  = wallet
-        @transport               = transport
-        @session_manager         = session_manager || SessionManager.new
-        @certificates_to_request = certificates_to_request || { certifiers: [], types: {} }
-        @identity_public_key     = nil
+      # @param auto_persist_last_session [Boolean] whether to track the last-interacted peer (default: true)
+      def initialize(wallet:, transport: nil, session_manager: nil, certificates_to_request: nil,
+                     auto_persist_last_session: true)
+        @wallet                    = wallet
+        @transport                 = transport
+        @session_manager           = session_manager || SessionManager.new
+        @certificates_to_request   = certificates_to_request || { certifiers: [], types: {} }
+        @identity_public_key       = nil
+        @callbacks                 = { general_message: {}, certificates_received: {}, certificate_request: {} }
+        @callback_id_counter       = 0
+        @callback_mutex            = Mutex.new
+        @last_interacted_peer      = nil
+        @auto_persist_last_session = auto_persist_last_session
 
         return unless @transport
 
         @transport.on_data { |msg| handle_incoming_message(msg) }
+      end
+
+      # Registers a callback to be called when a general message is received.
+      #
+      # @yield [sender_key, payload] called with the sender's identity key and payload bytes
+      # @return [Integer] callback ID (pass to {#off_general_message} to deregister)
+      def on_general_message(&block)
+        register_callback(:general_message, block)
+      end
+
+      # Removes a general message callback.
+      #
+      # @param callback_id [Integer] the ID returned by {#on_general_message}
+      def off_general_message(callback_id)
+        unregister_callback(:general_message, callback_id)
+      end
+
+      # Registers a callback to be called when certificates are received from a peer.
+      #
+      # @yield [sender_key, certs] called with sender's identity key and certificate array
+      # @return [Integer] callback ID (pass to {#off_certificates_received} to deregister)
+      def on_certificates_received(&block)
+        register_callback(:certificates_received, block)
+      end
+
+      # Removes a certificates received callback.
+      #
+      # @param callback_id [Integer] the ID returned by {#on_certificates_received}
+      def off_certificates_received(callback_id)
+        unregister_callback(:certificates_received, callback_id)
+      end
+
+      # Registers a callback to be called when a certificate request is received from a peer.
+      #
+      # @yield [sender_key, requested_certs] called with sender's identity key and requested cert set
+      # @return [Integer] callback ID (pass to {#off_certificate_request} to deregister)
+      def on_certificate_request(&block)
+        register_callback(:certificate_request, block)
+      end
+
+      # Removes a certificate request callback.
+      #
+      # @param callback_id [Integer] the ID returned by {#on_certificate_request}
+      def off_certificate_request(callback_id)
+        unregister_callback(:certificate_request, callback_id)
       end
 
       # Returns our identity key (cached after first call).
@@ -98,6 +150,10 @@ module BSV
 
       # Processes any incoming auth message and returns a response (if applicable).
       #
+      # When a transport is configured, any response is also forwarded via
+      # +@transport.send+ so that the bidirectional flow works without the
+      # caller having to manually route the return value.
+      #
       # @param message [Hash] the incoming auth message
       # @return [Hash, nil] response message, or nil for messages requiring no reply
       # @raise [AuthError] if the version is wrong or the message type is unknown
@@ -107,13 +163,19 @@ module BSV
 
         type = message[:message_type] || message['message_type']
 
-        case type
-        when MSG_INITIAL_REQUEST  then process_initial_request(message)
-        when MSG_INITIAL_RESPONSE then process_initial_response(message)
-        when MSG_GENERAL          then process_general_message(message)
-        else
-          raise AuthError, "Unknown message type: #{type.inspect}"
-        end
+        response = case type
+                   when MSG_INITIAL_REQUEST  then process_initial_request(message)
+                   when MSG_INITIAL_RESPONSE then process_initial_response(message)
+                   when MSG_GENERAL          then process_general_message(message)
+                   else
+                     raise AuthError, "Unknown message type: #{type.inspect}"
+                   end
+
+        # Only forward protocol messages (those with a message_type) back via
+        # transport. Internal result hashes (e.g. from process_general_message)
+        # carry no message_type and must not be forwarded.
+        @transport&.send(response) if response&.key?(:message_type)
+        response
       end
 
       # --- General message exchange (post-handshake) ---
@@ -188,6 +250,8 @@ module BSV
                                                 counterparty: peer_key
                                               })
 
+        @last_interacted_peer ||= peer_key if @auto_persist_last_session
+
         {
           version: AUTH_VERSION,
           message_type: MSG_INITIAL_RESPONSE,
@@ -234,6 +298,8 @@ module BSV
 
         @session_manager.update_session(session)
 
+        @last_interacted_peer = peer_key if @auto_persist_last_session
+
         nil
       rescue BSV::Wallet::InvalidSignatureError
         @session_manager.remove_session(session) if session
@@ -269,9 +335,33 @@ module BSV
         session.last_update = current_time_ms
         @session_manager.update_session(session)
 
+        @last_interacted_peer = session.peer_identity_key if @auto_persist_last_session
+        fire_callbacks(:general_message, session.peer_identity_key, payload)
+
         { peer_identity_key: session.peer_identity_key, payload: payload }
       rescue BSV::Wallet::InvalidSignatureError
         raise AuthError, "General message signature verification failed from: #{peer_key}"
+      end
+
+      # --- Callback helpers ---
+
+      def register_callback(type, block)
+        @callback_mutex.synchronize do
+          id = @callback_id_counter += 1
+          @callbacks[type][id] = block
+          id
+        end
+      end
+
+      def unregister_callback(type, callback_id)
+        @callback_mutex.synchronize { @callbacks[type].delete(callback_id) }
+      end
+
+      # Dup the hash under the mutex, then iterate outside to avoid re-entrancy
+      # deadlocks (a callback may call back into Peer, e.g. via PairedTransport).
+      def fire_callbacks(type, *args)
+        callbacks = @callback_mutex.synchronize { @callbacks[type].dup }
+        callbacks.each_value { |cb| cb.call(*args) }
       end
 
       # --- Helpers ---

--- a/gem/bsv-sdk/lib/bsv/auth/peer.rb
+++ b/gem/bsv-sdk/lib/bsv/auth/peer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'base64'
+require 'json'
 
 module BSV
   module Auth
@@ -166,6 +167,8 @@ module BSV
         response = case type
                    when MSG_INITIAL_REQUEST  then process_initial_request(message)
                    when MSG_INITIAL_RESPONSE then process_initial_response(message)
+                   when MSG_CERT_REQUEST     then process_certificate_request(message)
+                   when MSG_CERT_RESPONSE    then process_certificate_response(message)
                    when MSG_GENERAL          then process_general_message(message)
                    else
                      raise AuthError, "Unknown message type: #{type.inspect}"
@@ -176,6 +179,81 @@ module BSV
         # carry no message_type and must not be forwarded.
         @transport&.send(response) if response&.key?(:message_type)
         response
+      end
+
+      # --- Certificate request/response (manual mode) ---
+
+      # Builds a +certificateRequest+ message directed at an already-authenticated peer.
+      #
+      # @param peer_identifier [String] peer's session nonce or identity key
+      # @param certificates_to_request [Hash] certifiers and types to request
+      # @return [Hash] the message to send
+      # @raise [AuthError] if not authenticated with this peer
+      def create_certificate_request(peer_identifier, certificates_to_request)
+        session = @session_manager.get_session(peer_identifier)
+        raise AuthError, "Not authenticated with peer #{peer_identifier.inspect}" unless session&.authenticated?
+
+        request_nonce = ::Base64.strict_encode64(SecureRandom.random_bytes(32))
+        key_id        = key_id_for(request_nonce, session.peer_nonce)
+        data          = JSON.generate(certificates_to_request).encode('UTF-8').bytes
+
+        sig_result = @wallet.create_signature({
+                                                data: data,
+                                                protocol_id: AUTH_PROTOCOL,
+                                                key_id: key_id,
+                                                counterparty: session.peer_identity_key
+                                              })
+
+        session.last_update = current_time_ms
+        @session_manager.update_session(session)
+
+        {
+          version: AUTH_VERSION,
+          message_type: MSG_CERT_REQUEST,
+          identity_key: identity_key,
+          nonce: request_nonce,
+          initial_nonce: session.session_nonce,
+          your_nonce: session.peer_nonce,
+          requested_certificates: certificates_to_request,
+          signature: sig_result[:signature]
+        }
+      end
+
+      # Builds a +certificateResponse+ message with the provided certificates.
+      #
+      # @param peer_identifier [String] peer's session nonce or identity key
+      # @param certificates [Array<VerifiableCertificate, Hash>] certificates to send
+      # @return [Hash] the message to send
+      # @raise [AuthError] if not authenticated with this peer
+      def create_certificate_response(peer_identifier, certificates)
+        session = @session_manager.get_session(peer_identifier)
+        raise AuthError, "Not authenticated with peer #{peer_identifier.inspect}" unless session&.authenticated?
+
+        request_nonce = ::Base64.strict_encode64(SecureRandom.random_bytes(32))
+        key_id        = key_id_for(request_nonce, session.peer_nonce)
+        cert_data     = certificates.map { |c| c.respond_to?(:to_h) ? c.to_h : c }
+        data          = JSON.generate(cert_data).encode('UTF-8').bytes
+
+        sig_result = @wallet.create_signature({
+                                                data: data,
+                                                protocol_id: AUTH_PROTOCOL,
+                                                key_id: key_id,
+                                                counterparty: session.peer_identity_key
+                                              })
+
+        session.last_update = current_time_ms
+        @session_manager.update_session(session)
+
+        {
+          version: AUTH_VERSION,
+          message_type: MSG_CERT_RESPONSE,
+          identity_key: identity_key,
+          nonce: request_nonce,
+          initial_nonce: session.session_nonce,
+          your_nonce: session.peer_nonce,
+          certificates: cert_data,
+          signature: sig_result[:signature]
+        }
       end
 
       # --- General message exchange (post-handshake) ---
@@ -238,6 +316,9 @@ module BSV
 
         @session_manager.add_session(session)
 
+        # Handle the peer's certificate request (if any)
+        certificates_to_include = handle_certificate_request_from_peer(message, peer_key)
+
         # Sign decode(their_nonce) + decode(our_nonce)
         # Key ID: "their_nonce our_nonce"  (initiator_nonce responder_nonce)
         sig_data = b64_decode(their_nonce) + b64_decode(our_nonce)
@@ -252,7 +333,7 @@ module BSV
 
         @last_interacted_peer ||= peer_key if @auto_persist_last_session
 
-        {
+        response = {
           version: AUTH_VERSION,
           message_type: MSG_INITIAL_RESPONSE,
           identity_key: identity_key,
@@ -261,6 +342,10 @@ module BSV
           requested_certificates: @certificates_to_request,
           signature: sig_result[:signature]
         }
+
+        response[:certificates] = certificates_to_include if certificates_to_include
+
+        response
       end
 
       # --- Processing: initial response (we are the initiator) ---
@@ -294,11 +379,38 @@ module BSV
         session.peer_nonce        = their_nonce
         session.peer_identity_key = peer_key
         session.is_authenticated  = true
-        session.last_update       = current_time_ms
+        session.certificates_required  = certifiers_present?
+        session.certificates_validated = !session.certificates_required
+        session.last_update = current_time_ms
 
         @session_manager.update_session(session)
 
         @last_interacted_peer = peer_key if @auto_persist_last_session
+
+        # Validate certificates if the responder included them
+        resp_certs = message[:certificates] || message['certificates']
+        if session.certificates_required && resp_certs.is_a?(Array) && !resp_certs.empty?
+          validation_msg = { identity_key: peer_key, certificates: resp_certs }
+          BSV::Auth.validate_certificates(@wallet, validation_msg, @certificates_to_request)
+          session.certificates_validated = true
+          session.last_update = current_time_ms
+          @session_manager.update_session(session)
+          fire_callbacks(:certificates_received, peer_key, resp_certs)
+        end
+
+        # Handle the responder's certificate request (if any)
+        requested = message[:requested_certificates] || message['requested_certificates']
+        if certifiers_present_in?(requested)
+          if callbacks_registered?(:certificate_request)
+            fire_callbacks(:certificate_request, peer_key, requested)
+          else
+            certs = BSV::Auth.get_verifiable_certificates(@wallet, requested, peer_key)
+            if certs.length.positive?
+              cert_response = create_certificate_response(peer_key, certs)
+              @transport&.send(cert_response)
+            end
+          end
+        end
 
         nil
       rescue BSV::Wallet::InvalidSignatureError
@@ -341,6 +453,91 @@ module BSV
         { peer_identity_key: session.peer_identity_key, payload: payload }
       rescue BSV::Wallet::InvalidSignatureError
         raise AuthError, "General message signature verification failed from: #{peer_key}"
+      end
+
+      # --- Processing: certificate request (we are the responder) ---
+
+      def process_certificate_request(message)
+        our_nonce = fetch!(message, :your_nonce)
+        peer_key  = message[:identity_key] || message['identity_key']
+        msg_nonce = fetch!(message, :nonce)
+        requested = message[:requested_certificates] || message['requested_certificates']
+        signature = fetch!(message, :signature)
+
+        raise AuthError, "Unable to verify nonce for certificate request message from: #{peer_key}" unless Nonce.verify(our_nonce, @wallet)
+
+        session = @session_manager.get_session(our_nonce)
+        raise AuthError, "Session not found for nonce: #{our_nonce.inspect}" unless session
+
+        data   = JSON.generate(requested).encode('UTF-8').bytes
+        key_id = key_id_for(msg_nonce, session.session_nonce)
+
+        @wallet.verify_signature({
+                                   data: data,
+                                   signature: signature,
+                                   protocol_id: AUTH_PROTOCOL,
+                                   key_id: key_id,
+                                   counterparty: session.peer_identity_key
+                                 })
+
+        session.last_update = current_time_ms
+        @session_manager.update_session(session)
+
+        return unless certifiers_present_in?(requested)
+
+        if callbacks_registered?(:certificate_request)
+          fire_callbacks(:certificate_request, session.peer_identity_key, requested)
+        else
+          certs = BSV::Auth.get_verifiable_certificates(@wallet, requested, session.peer_identity_key)
+          if certs.length.positive?
+            cert_response = create_certificate_response(session.peer_identity_key, certs)
+            @transport&.send(cert_response)
+          end
+        end
+
+        nil
+      rescue BSV::Wallet::InvalidSignatureError
+        raise AuthError, "Certificate request signature verification failed from: #{peer_key}"
+      end
+
+      # --- Processing: certificate response (we are the initiator or requester) ---
+
+      def process_certificate_response(message)
+        our_nonce = fetch!(message, :your_nonce)
+        peer_key  = message[:identity_key] || message['identity_key']
+        msg_nonce = fetch!(message, :nonce)
+        certs     = message[:certificates] || message['certificates'] || []
+        signature = fetch!(message, :signature)
+
+        raise AuthError, "Unable to verify nonce for certificate response from: #{peer_key}" unless Nonce.verify(our_nonce, @wallet)
+
+        session = @session_manager.get_session(our_nonce)
+        raise AuthError, "Session not found for nonce: #{our_nonce.inspect}" unless session
+
+        data   = JSON.generate(certs).encode('UTF-8').bytes
+        key_id = key_id_for(msg_nonce, session.session_nonce)
+
+        @wallet.verify_signature({
+                                   data: data,
+                                   signature: signature,
+                                   protocol_id: AUTH_PROTOCOL,
+                                   key_id: key_id,
+                                   counterparty: session.peer_identity_key
+                                 })
+
+        if certs.is_a?(Array) && !certs.empty?
+          validation_msg = { identity_key: session.peer_identity_key, certificates: certs }
+          BSV::Auth.validate_certificates(@wallet, validation_msg)
+          session.certificates_validated = true
+          session.last_update = current_time_ms
+          @session_manager.update_session(session)
+        end
+
+        fire_callbacks(:certificates_received, session.peer_identity_key, certs)
+
+        nil
+      rescue BSV::Wallet::InvalidSignatureError
+        raise AuthError, "Certificate response signature verification failed from: #{peer_key}"
       end
 
       # --- Callback helpers ---
@@ -397,6 +594,42 @@ module BSV
       def certifiers_present?
         certs = @certificates_to_request[:certifiers] || @certificates_to_request['certifiers']
         certs.is_a?(Array) && !certs.empty?
+      end
+
+      # Returns true if the given requested_certificates hash has at least one certifier.
+      def certifiers_present_in?(requested)
+        return false unless requested.is_a?(Hash)
+
+        certifiers = requested[:certifiers] || requested['certifiers']
+        certifiers.is_a?(Array) && !certifiers.empty?
+      end
+
+      # Returns true if at least one callback of the given type is registered.
+      def callbacks_registered?(type)
+        @callback_mutex.synchronize { @callbacks[type].any? }
+      end
+
+      # Handles a peer's certificate request embedded in an initialRequest message.
+      #
+      # If callbacks are registered, fires them and returns nil (caller adds no certs).
+      # Otherwise, auto-fetches certificates and returns the serialised array (or nil if empty).
+      #
+      # @param message [Hash] the initialRequest message
+      # @param peer_key [String] the peer's identity key
+      # @return [Array<Hash>, nil] serialised certificates to include, or nil
+      def handle_certificate_request_from_peer(message, peer_key)
+        requested = message[:requested_certificates] || message['requested_certificates']
+        return nil unless certifiers_present_in?(requested)
+
+        if callbacks_registered?(:certificate_request)
+          fire_callbacks(:certificate_request, peer_key, requested)
+          return nil
+        end
+
+        certs = BSV::Auth.get_verifiable_certificates(@wallet, requested, peer_key)
+        return nil if certs.empty?
+
+        certs.map { |c| c.respond_to?(:to_h) ? c.to_h : c }
       end
 
       def current_time_ms

--- a/gem/bsv-sdk/lib/bsv/auth/validate_certificates.rb
+++ b/gem/bsv-sdk/lib/bsv/auth/validate_certificates.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module BSV
+  module Auth
+    # Utility module for validating certificates received in an authenticated message.
+    #
+    # Exposes a single module method, {.call}, which is also available as
+    # +BSV::Auth.validate_certificates+ via +extend+.
+    #
+    # Algorithm:
+    # 1. Raise +AuthError+ if +message[:certificates]+ is nil or empty.
+    # 2. For each certificate in the array:
+    #    a. Verify cert subject == message identity key.
+    #    b. Construct a +VerifiableCertificate+ if the input is a plain Hash.
+    #    c. Call +cert.verify+ — raise if signature is invalid.
+    #    d. If +requested_certificates+ is provided, check certifier and type.
+    #    e. Call +cert.decrypt_fields(wallet)+ — wrap any error in +AuthError+.
+    #
+    # Wallet is duck-typed — any object responding to +verify_signature+ and
+    # +decrypt+ is accepted.
+    module ValidateCertificates
+      module_function
+
+      # Validates certificates attached to an incoming authenticated message.
+      #
+      # @param wallet [#verify_signature, #decrypt] the verifier's wallet
+      # @param message [Hash] incoming authenticated message; must contain
+      #   +:certificates+ and +:identity_key+ (symbol or string keys accepted)
+      # @param requested_certificates [Hash, nil] optional filter with keys
+      #   +:certifiers+ (Array of pubkey hex strings) and +:types+
+      #   (Hash of type string => fields)
+      # @raise [AuthError] on any validation failure
+      def validate_certificates(wallet, message, requested_certificates = nil)
+        certs = message[:certificates] || message['certificates']
+        raise AuthError, 'No certificates were provided in the message.' if certs.nil? || certs.empty?
+
+        identity_key = message[:identity_key] || message['identity_key']
+
+        certs.each do |incoming_cert|
+          subject = if incoming_cert.is_a?(Hash)
+                      incoming_cert[:subject] || incoming_cert['subject']
+                    else
+                      incoming_cert.subject
+                    end
+
+          if subject != identity_key
+            raise AuthError,
+                  "The subject of one of your certificates (\"#{subject}\") is not the same as " \
+                  "the message sender (\"#{identity_key}\")."
+          end
+
+          cert = if incoming_cert.is_a?(VerifiableCertificate)
+                   incoming_cert
+                 else
+                   VerifiableCertificate.from_hash(incoming_cert)
+                 end
+
+          begin
+            valid = cert.verify
+          rescue ArgumentError => e
+            raise AuthError, "Certificate signature verification failed: #{e.message}"
+          end
+
+          unless valid
+            raise AuthError,
+                  "The signature for the certificate with serial number #{cert.serial_number} is invalid!"
+          end
+
+          if requested_certificates
+            certifiers = requested_certificates[:certifiers] || requested_certificates['certifiers'] || []
+            types = requested_certificates[:types] || requested_certificates['types'] || {}
+
+            unless certifiers.include?(cert.certifier)
+              raise AuthError,
+                    "Certificate with serial number #{cert.serial_number} has an unrequested certifier: #{cert.certifier}"
+            end
+
+            unless types.key?(cert.type)
+              raise AuthError,
+                    "Certificate with type #{cert.type} was not requested"
+            end
+          end
+
+          begin
+            cert.decrypt_fields(wallet)
+          rescue ArgumentError, RuntimeError => e
+            raise AuthError, "Failed to decrypt certificate fields: #{e.message}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/auth/auth_module_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/auth/auth_module_spec.rb
@@ -24,24 +24,27 @@ RSpec.describe 'BSV::Auth module delegation' do
 
   describe 'BSV::Auth.validate_certificates' do
     it 'is callable and delegates to ValidateCertificates.validate_certificates' do
-      expect(BSV::Auth::ValidateCertificates).to receive(:validate_certificates)
-        .with(:wallet, :message, nil)
+      allow(BSV::Auth::ValidateCertificates).to receive(:validate_certificates)
       BSV::Auth.validate_certificates(:wallet, :message)
+      expect(BSV::Auth::ValidateCertificates).to have_received(:validate_certificates)
+        .with(:wallet, :message, nil)
     end
 
     it 'forwards the optional requested_certificates argument' do
       requested = { certifiers: [], types: {} }
-      expect(BSV::Auth::ValidateCertificates).to receive(:validate_certificates)
-        .with(:wallet, :message, requested)
+      allow(BSV::Auth::ValidateCertificates).to receive(:validate_certificates)
       BSV::Auth.validate_certificates(:wallet, :message, requested)
+      expect(BSV::Auth::ValidateCertificates).to have_received(:validate_certificates)
+        .with(:wallet, :message, requested)
     end
   end
 
   describe 'BSV::Auth.get_verifiable_certificates' do
     it 'is callable and delegates to GetVerifiableCertificates.get_verifiable_certificates' do
-      expect(BSV::Auth::GetVerifiableCertificates).to receive(:get_verifiable_certificates)
-        .with(:wallet, :requested, :verifier_key)
+      allow(BSV::Auth::GetVerifiableCertificates).to receive(:get_verifiable_certificates)
       BSV::Auth.get_verifiable_certificates(:wallet, :requested, :verifier_key)
+      expect(BSV::Auth::GetVerifiableCertificates).to have_received(:get_verifiable_certificates)
+        .with(:wallet, :requested, :verifier_key)
     end
   end
 end

--- a/gem/bsv-sdk/spec/bsv/auth/auth_module_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/auth/auth_module_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Smoke tests for BSV::Auth module-level delegation to certificate utility modules.
+#
+# Verifies:
+# - Autoload resolves BSV::Auth::ValidateCertificates
+# - Autoload resolves BSV::Auth::GetVerifiableCertificates
+# - BSV::Auth.validate_certificates delegates correctly
+# - BSV::Auth.get_verifiable_certificates delegates correctly
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'BSV::Auth module delegation' do
+  describe 'autoload resolution' do
+    it 'resolves BSV::Auth::ValidateCertificates without errors' do
+      expect { BSV::Auth::ValidateCertificates }.not_to raise_error
+    end
+
+    it 'resolves BSV::Auth::GetVerifiableCertificates without errors' do
+      expect { BSV::Auth::GetVerifiableCertificates }.not_to raise_error
+    end
+  end
+
+  describe 'BSV::Auth.validate_certificates' do
+    it 'is callable and delegates to ValidateCertificates.validate_certificates' do
+      expect(BSV::Auth::ValidateCertificates).to receive(:validate_certificates)
+        .with(:wallet, :message, nil)
+      BSV::Auth.validate_certificates(:wallet, :message)
+    end
+
+    it 'forwards the optional requested_certificates argument' do
+      requested = { certifiers: [], types: {} }
+      expect(BSV::Auth::ValidateCertificates).to receive(:validate_certificates)
+        .with(:wallet, :message, requested)
+      BSV::Auth.validate_certificates(:wallet, :message, requested)
+    end
+  end
+
+  describe 'BSV::Auth.get_verifiable_certificates' do
+    it 'is callable and delegates to GetVerifiableCertificates.get_verifiable_certificates' do
+      expect(BSV::Auth::GetVerifiableCertificates).to receive(:get_verifiable_certificates)
+        .with(:wallet, :requested, :verifier_key)
+      BSV::Auth.get_verifiable_certificates(:wallet, :requested, :verifier_key)
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/gem/bsv-sdk/spec/bsv/auth/get_verifiable_certificates_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/auth/get_verifiable_certificates_spec.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'BSV::Auth.get_verifiable_certificates' do
+  # rubocop:enable RSpec/DescribeClass
+
+  let(:verifier_key) { "02#{'ab' * 32}" }
+
+  let(:cert_type_a) { 'dHlwZUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=' }
+  let(:cert_type_b) { 'dHlwZUJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=' }
+
+  let(:serial_a) { 'c2VyaWFsQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=' }
+  let(:serial_b) { 'c2VyaWFsQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=' }
+
+  let(:subject_key) { "03#{'cd' * 32}" }
+  let(:certifier_a) { "02#{'11' * 32}" }
+  let(:outpoint)    { "#{'aa' * 32}.0" }
+
+  let(:cert_hash_a) do
+    {
+      type: cert_type_a,
+      serial_number: serial_a,
+      subject: subject_key,
+      certifier: certifier_a,
+      revocation_outpoint: outpoint,
+      fields: { 'name' => 'ZW5jcnlwdGVk' },
+      signature: nil
+    }
+  end
+
+  let(:cert_hash_b) do
+    {
+      type: cert_type_b,
+      serial_number: serial_b,
+      subject: subject_key,
+      certifier: certifier_a,
+      revocation_outpoint: outpoint,
+      fields: { 'email' => 'ZW5jcnlwdGVkMg==' },
+      signature: nil
+    }
+  end
+
+  let(:keyring_a) { { 'name' => 'a2V5cmluZ0FBQQ==' } }
+  let(:keyring_b) { { 'email' => 'a2V5cmluZ0JCQg==' } }
+
+  let(:requested_certificates) do
+    {
+      certifiers: [certifier_a],
+      types: {
+        cert_type_a => ['name'],
+        cert_type_b => ['email']
+      }
+    }
+  end
+
+  context 'when wallet does not respond to list_certificates' do
+    it 'returns []' do
+      wallet = double('wallet') # rubocop:disable RSpec/VerifiedDoubles
+      allow(wallet).to receive(:respond_to?).with(:list_certificates).and_return(false)
+      allow(wallet).to receive(:respond_to?).with(:prove_certificate).and_return(true)
+
+      result = BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
+      expect(result).to eq([])
+    end
+  end
+
+  context 'when wallet does not respond to prove_certificate' do
+    it 'returns []' do
+      wallet = double('wallet') # rubocop:disable RSpec/VerifiedDoubles
+      allow(wallet).to receive(:respond_to?).with(:list_certificates).and_return(true)
+      allow(wallet).to receive(:respond_to?).with(:prove_certificate).and_return(false)
+
+      result = BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
+      expect(result).to eq([])
+    end
+  end
+
+  context 'when list_certificates returns empty results' do
+    it 'returns []' do
+      wallet = double('wallet') # rubocop:disable RSpec/VerifiedDoubles
+      allow(wallet).to receive(:respond_to?).with(:list_certificates).and_return(true)
+      allow(wallet).to receive(:respond_to?).with(:prove_certificate).and_return(true)
+      allow(wallet).to receive(:list_certificates).and_return({ certificates: [] })
+
+      result = BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
+      expect(result).to eq([])
+    end
+  end
+
+  context 'when wallet returns a single matching certificate' do
+    let(:wallet) { double('wallet') } # rubocop:disable RSpec/VerifiedDoubles
+
+    before do
+      allow(wallet).to receive(:respond_to?).with(:list_certificates).and_return(true)
+      allow(wallet).to receive(:respond_to?).with(:prove_certificate).and_return(true)
+      allow(wallet).to receive_messages(list_certificates: { certificates: [cert_hash_a] }, prove_certificate: { keyring_for_verifier: keyring_a })
+    end
+
+    it 'returns an array with one VerifiableCertificate' do
+      result = BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
+      expect(result.length).to eq(1)
+      expect(result.first).to be_a(BSV::Auth::VerifiableCertificate)
+    end
+
+    it 'passes the correct fields_to_reveal to prove_certificate' do
+      BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
+
+      expect(wallet).to have_received(:prove_certificate).with(
+        certificate: cert_hash_a,
+        fields_to_reveal: ['name'],
+        verifier: verifier_key
+      )
+    end
+
+    it 'assigns the keyring from prove_certificate to the VerifiableCertificate' do
+      result = BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
+      expect(result.first.keyring).to eq(keyring_a)
+    end
+
+    it 'preserves certificate attributes' do
+      result = BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
+      cert = result.first
+      expect(cert.type).to eq(cert_type_a)
+      expect(cert.serial_number).to eq(serial_a)
+      expect(cert.subject).to eq(subject_key)
+      expect(cert.certifier).to eq(certifier_a)
+    end
+  end
+
+  context 'when wallet returns multiple matching certificates' do
+    let(:wallet) { double('wallet') } # rubocop:disable RSpec/VerifiedDoubles
+
+    before do
+      allow(wallet).to receive(:respond_to?).with(:list_certificates).and_return(true)
+      allow(wallet).to receive(:respond_to?).with(:prove_certificate).and_return(true)
+      allow(wallet).to receive(:list_certificates).and_return({ certificates: [cert_hash_a, cert_hash_b] })
+      allow(wallet).to receive(:prove_certificate).with(hash_including(certificate: cert_hash_a)).and_return({ keyring_for_verifier: keyring_a })
+      allow(wallet).to receive(:prove_certificate).with(hash_including(certificate: cert_hash_b)).and_return({ keyring_for_verifier: keyring_b })
+    end
+
+    it 'returns an array with two VerifiableCertificates' do
+      result = BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
+      expect(result.length).to eq(2)
+      expect(result).to all(be_a(BSV::Auth::VerifiableCertificate))
+    end
+
+    it 'assigns the correct keyring to each certificate' do
+      result = BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
+      expect(result[0].keyring).to eq(keyring_a)
+      expect(result[1].keyring).to eq(keyring_b)
+    end
+  end
+
+  context 'when prove_certificate raises an error' do
+    let(:wallet) { double('wallet') } # rubocop:disable RSpec/VerifiedDoubles
+
+    before do
+      allow(wallet).to receive(:respond_to?).with(:list_certificates).and_return(true)
+      allow(wallet).to receive(:respond_to?).with(:prove_certificate).and_return(true)
+      allow(wallet).to receive(:list_certificates).and_return({ certificates: [cert_hash_a] })
+      allow(wallet).to receive(:prove_certificate).and_raise(RuntimeError, 'protocol mismatch')
+    end
+
+    it 'returns [] gracefully' do
+      result = BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
+      expect(result).to eq([])
+    end
+  end
+
+  context 'when list_certificates raises an error' do
+    let(:wallet) { double('wallet') } # rubocop:disable RSpec/VerifiedDoubles
+
+    before do
+      allow(wallet).to receive(:respond_to?).with(:list_certificates).and_return(true)
+      allow(wallet).to receive(:respond_to?).with(:prove_certificate).and_return(true)
+      allow(wallet).to receive(:list_certificates).and_raise(RuntimeError, 'network error')
+    end
+
+    it 'returns [] gracefully' do
+      result = BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
+      expect(result).to eq([])
+    end
+  end
+
+  context 'when requested_certificates uses string keys' do
+    let(:wallet) { double('wallet') } # rubocop:disable RSpec/VerifiedDoubles
+
+    let(:requested_with_string_keys) do
+      {
+        'certifiers' => [certifier_a],
+        'types' => { cert_type_a => ['name'] }
+      }
+    end
+
+    before do
+      allow(wallet).to receive(:respond_to?).with(:list_certificates).and_return(true)
+      allow(wallet).to receive(:respond_to?).with(:prove_certificate).and_return(true)
+      allow(wallet).to receive_messages(list_certificates: { certificates: [cert_hash_a] }, prove_certificate: { keyring_for_verifier: keyring_a })
+    end
+
+    it 'handles string-keyed requested_certificates correctly' do
+      result = BSV::Auth.get_verifiable_certificates(wallet, requested_with_string_keys, verifier_key)
+      expect(result.length).to eq(1)
+      expect(result.first).to be_a(BSV::Auth::VerifiableCertificate)
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/auth/peer_integration_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/auth/peer_integration_spec.rb
@@ -1,0 +1,656 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+require_relative '../../support/paired_transport'
+
+# End-to-end integration tests for the BSV Auth peer protocol.
+#
+# These tests exercise multi-component lifecycle scenarios — certificate issuance,
+# exchange, validation, and high-level session management. They complement the unit
+# specs in peer_spec.rb, which cover individual methods in isolation.
+#
+# All tests use PairedTransport for realistic message delivery (no direct method calls).
+# Deterministic keys are used for reproducibility.
+
+RSpec.describe 'BSV::Auth::Peer integration' do # rubocop:disable RSpec/DescribeClass
+  # Deterministic keys — matching the pattern used in certificate_integration_spec.rb
+  let(:alice_key)     { BSV::Primitives::PrivateKey.new(OpenSSL::BN.new(10)) }
+  let(:bob_key)       { BSV::Primitives::PrivateKey.new(OpenSSL::BN.new(11)) }
+  let(:carol_key)     { BSV::Primitives::PrivateKey.new(OpenSSL::BN.new(12)) }
+  let(:certifier_key) { BSV::Primitives::PrivateKey.new(OpenSSL::BN.new(22)) }
+
+  let(:alice_wallet)     { BSV::Wallet::ProtoWallet.new(alice_key) }
+  let(:bob_wallet)       { BSV::Wallet::ProtoWallet.new(bob_key) }
+  let(:carol_wallet)     { BSV::Wallet::ProtoWallet.new(carol_key) }
+  let(:certifier_wallet) { BSV::Wallet::ProtoWallet.new(certifier_key) }
+
+  let(:cert_type)   { Base64.strict_encode64("\x01" * 32) }
+  let(:serial)      { Base64.strict_encode64("\x02" * 32) }
+
+  # --- Shared helper: issue and build a VerifiableCertificate ---
+
+  def issue_verifiable_certificate(subject_wallet:, certifier_wallet:, verifier_hex:, cert_type:, fields:)
+    master_cert = BSV::Auth::MasterCertificate.issue_certificate_for_subject(
+      certifier_wallet,
+      subject_wallet.get_public_key({ identity_key: true })[:public_key],
+      fields,
+      cert_type
+    )
+
+    keyring = BSV::Auth::MasterCertificate.create_keyring_for_verifier(
+      subject_wallet,
+      certifier: master_cert.certifier,
+      verifier: verifier_hex,
+      fields: master_cert.fields,
+      fields_to_reveal: fields.keys,
+      master_keyring: master_cert.master_keyring,
+      serial_number: master_cert.serial_number
+    )
+
+    BSV::Auth::VerifiableCertificate.from_certificate(master_cert, keyring)
+  end
+
+  # --- Scenario 1: Full certificate exchange lifecycle ---
+
+  describe 'Scenario 1: full certificate exchange lifecycle' do
+    # Bob requires Alice to present a certificate from certifier_wallet.
+    let(:requested_certs) do
+      { certifiers: [certifier_wallet.get_public_key({ identity_key: true })[:public_key]],
+        types: { cert_type => ['name'] } }
+    end
+
+    let(:transport_a) { PairedTransport.new }
+    let(:transport_b) { PairedTransport.new }
+
+    let(:alice) { BSV::Auth::Peer.new(wallet: alice_wallet, transport: transport_a) }
+    let(:bob) do
+      BSV::Auth::Peer.new(wallet: bob_wallet, transport: transport_b,
+                          certificates_to_request: requested_certs)
+    end
+
+    before do
+      alice
+      bob
+      transport_a.partner = transport_b
+      transport_b.partner = transport_a
+    end
+
+    it 'delivers the general message and marks certificates_validated on the session' do
+      received_payload = nil
+      bob.on_general_message { |_key, payload| received_payload = payload }
+
+      certs_received_by_bob = nil
+      bob.on_certificates_received { |_key, certs| certs_received_by_bob = certs }
+
+      # Alice registers an on_certificate_request callback that:
+      # (a) builds a verifier keyring for Bob
+      # (b) constructs a VerifiableCertificate
+      # (c) calls send_certificate_response
+      alice.on_certificate_request do |requester_key, _requested|
+        vc = issue_verifiable_certificate(
+          subject_wallet: alice_wallet,
+          certifier_wallet: certifier_wallet,
+          verifier_hex: requester_key,
+          cert_type: cert_type,
+          fields: { 'name' => 'Alice' }
+        )
+        alice.send_certificate_response(requester_key, [vc])
+      end
+
+      # to_peer triggers the handshake; Alice's callback fires during the handshake
+      # to satisfy Bob's certificate requirement
+      payload = 'Hello, Bob!'.bytes
+      alice.to_peer(payload, bob.identity_key)
+
+      expect(received_payload).to eq(payload)
+      expect(certs_received_by_bob).to be_an(Array)
+      expect(certs_received_by_bob).not_to be_empty
+
+      # Confirm Bob's session has certificates_validated = true
+      bob_session = bob.session_manager.get_session(alice.identity_key)
+      expect(bob_session).not_to be_nil
+      expect(bob_session.certificates_validated).to be(true)
+    end
+  end
+
+  # --- Scenario 2: Dynamic certificate request post-handshake ---
+
+  describe 'Scenario 2: dynamic certificate request post-handshake' do
+    let(:transport_a) { PairedTransport.new }
+    let(:transport_b) { PairedTransport.new }
+
+    let(:alice) { BSV::Auth::Peer.new(wallet: alice_wallet, transport: transport_a) }
+    let(:bob)   { BSV::Auth::Peer.new(wallet: bob_wallet,   transport: transport_b) }
+
+    before do
+      alice
+      bob
+      transport_a.partner = transport_b
+      transport_b.partner = transport_a
+    end
+
+    it 'allows Bob to request certificates from Alice after the initial handshake' do
+      # Establish session — no cert requirements on either side
+      alice.to_peer('Hi'.bytes, bob.identity_key)
+
+      received_certs = nil
+      decrypted_name = nil
+
+      bob.on_certificates_received do |_key, certs|
+        received_certs = certs
+        # Attempt decryption using Bob's wallet
+        cert_hash = certs.first
+        vc = BSV::Auth::VerifiableCertificate.from_hash(cert_hash)
+        vc.decrypt_fields(bob_wallet)
+        decrypted_name = vc.decrypted_fields['name']
+      end
+
+      # Alice registers a cert request callback that will fire when Bob calls request_certificates
+      alice.on_certificate_request do |requester_key, _requested|
+        vc = issue_verifiable_certificate(
+          subject_wallet: alice_wallet,
+          certifier_wallet: certifier_wallet,
+          verifier_hex: requester_key,
+          cert_type: cert_type,
+          fields: { 'name' => 'Alice' }
+        )
+        alice.send_certificate_response(requester_key, [vc])
+      end
+
+      certifier_hex = certifier_wallet.get_public_key({ identity_key: true })[:public_key]
+      bob.request_certificates(
+        { certifiers: [certifier_hex], types: { cert_type => ['name'] } },
+        alice.identity_key
+      )
+
+      expect(received_certs).not_to be_nil
+      expect(received_certs).not_to be_empty
+      expect(decrypted_name).to eq('Alice')
+    end
+  end
+
+  # --- Scenario 3: Bidirectional certificate exchange ---
+  #
+  # Bidirectional cert exchange works as follows:
+  # - Bob requires Alice's certs (via certificates_to_request)
+  # - Alice's on_certificate_request callback fires during handshake and sends certs → Bob validates
+  # - After handshake, Alice calls request_certificates to get Bob's certs
+  # - Bob's on_certificate_request fires → Bob sends certs → Alice validates
+  # Both peers end up with certificates_validated = true.
+
+  describe 'Scenario 3: bidirectional certificate exchange' do
+    let(:certifier_key2) { BSV::Primitives::PrivateKey.new(OpenSSL::BN.new(33)) }
+    let(:certifier_wallet2) { BSV::Wallet::ProtoWallet.new(certifier_key2) }
+
+    let(:cert_type2) { Base64.strict_encode64("\x03" * 32) }
+
+    # Bob requires Alice's certs
+    let(:requested_by_bob) do
+      { certifiers: [certifier_wallet.get_public_key({ identity_key: true })[:public_key]],
+        types: { cert_type => ['name'] } }
+    end
+
+    let(:transport_a) { PairedTransport.new }
+    let(:transport_b) { PairedTransport.new }
+
+    let(:alice) { BSV::Auth::Peer.new(wallet: alice_wallet, transport: transport_a) }
+    let(:bob) do
+      BSV::Auth::Peer.new(wallet: bob_wallet, transport: transport_b,
+                          certificates_to_request: requested_by_bob)
+    end
+
+    before do
+      alice
+      bob
+      transport_a.partner = transport_b
+      transport_b.partner = transport_a
+    end
+
+    it 'both peers receive validated certificates from each other' do
+      alice_certs_received = nil
+      bob_certs_received   = nil
+
+      alice.on_certificates_received { |_k, certs| alice_certs_received = certs }
+      bob.on_certificates_received   { |_k, certs| bob_certs_received   = certs }
+
+      # Alice responds to Bob's cert request during handshake
+      alice.on_certificate_request do |requester_key, _req|
+        vc = issue_verifiable_certificate(
+          subject_wallet: alice_wallet,
+          certifier_wallet: certifier_wallet,
+          verifier_hex: requester_key,
+          cert_type: cert_type,
+          fields: { 'name' => 'Alice' }
+        )
+        alice.send_certificate_response(requester_key, [vc])
+      end
+
+      # Bob responds when Alice requests certs from him post-handshake
+      bob.on_certificate_request do |requester_key, _req|
+        vc = issue_verifiable_certificate(
+          subject_wallet: bob_wallet,
+          certifier_wallet: certifier_wallet2,
+          verifier_hex: requester_key,
+          cert_type: cert_type2,
+          fields: { 'role' => 'admin' }
+        )
+        bob.send_certificate_response(requester_key, [vc])
+      end
+
+      # Handshake + Alice satisfies Bob's cert requirement
+      alice.to_peer('ping'.bytes, bob.identity_key)
+
+      bob_session = bob.session_manager.get_session(alice.identity_key)
+      expect(bob_session.certificates_validated).to be(true)
+      expect(bob_certs_received).not_to be_nil
+
+      # Alice now requests certs from Bob post-handshake
+      certifier2_hex = certifier_wallet2.get_public_key({ identity_key: true })[:public_key]
+      alice.request_certificates(
+        { certifiers: [certifier2_hex], types: { cert_type2 => ['role'] } },
+        bob.identity_key
+      )
+
+      alice_session = alice.session_manager.get_session(bob.identity_key)
+      expect(alice_session.certificates_validated).to be(true)
+      expect(alice_certs_received).not_to be_nil
+
+      # Verify decrypted content
+      vc = BSV::Auth::VerifiableCertificate.from_hash(alice_certs_received.first)
+      decrypted = vc.decrypt_fields(alice_wallet)
+      expect(decrypted['role']).to eq('admin')
+    end
+  end
+
+  # --- Scenario 4: Certificate validation failure — wrong subject ---
+
+  describe 'Scenario 4: certificate validation failure — wrong subject' do
+    let(:eve_key)    { BSV::Primitives::PrivateKey.new(OpenSSL::BN.new(99)) }
+    let(:eve_wallet) { BSV::Wallet::ProtoWallet.new(eve_key) }
+
+    it 'raises AuthError when the certificate subject does not match the sender' do
+      # Issue a certificate for Eve, then present it as if Alice sent it
+      vc = issue_verifiable_certificate(
+        subject_wallet: eve_wallet, # certificate subject is Eve
+        certifier_wallet: certifier_wallet,
+        verifier_hex: bob_wallet.get_public_key({ identity_key: true })[:public_key],
+        cert_type: cert_type,
+        fields: { 'name' => 'Eve' }
+      )
+
+      # Build a fake message claiming to be from Alice but carrying Eve's certificate
+      message = {
+        identity_key: alice_wallet.get_public_key({ identity_key: true })[:public_key],
+        certificates: [vc.to_h]
+      }
+
+      requested = {
+        certifiers: [certifier_wallet.get_public_key({ identity_key: true })[:public_key]],
+        types: { cert_type => ['name'] }
+      }
+
+      expect do
+        BSV::Auth.validate_certificates(bob_wallet, message, requested)
+      end.to raise_error(BSV::Auth::AuthError, /subject.*is not the same as.*sender/i)
+    end
+  end
+
+  # --- Scenario 5: to_peer rejects when certificates not validated ---
+
+  describe 'Scenario 5: to_peer rejects when certificates not validated' do
+    let(:requested_certs) do
+      { certifiers: [certifier_wallet.get_public_key({ identity_key: true })[:public_key]],
+        types: { cert_type => ['name'] } }
+    end
+
+    let(:transport_a) { PairedTransport.new }
+    let(:transport_b) { PairedTransport.new }
+
+    # Bob requires certificates from Alice, but Alice registers no cert callback
+    let(:alice) { BSV::Auth::Peer.new(wallet: alice_wallet, transport: transport_a) }
+    let(:bob) do
+      BSV::Auth::Peer.new(wallet: bob_wallet, transport: transport_b,
+                          certificates_to_request: requested_certs)
+    end
+
+    before do
+      alice
+      bob
+      transport_a.partner = transport_b
+      transport_b.partner = transport_a
+    end
+
+    it 'raises AuthError when Bob tries to send after handshake without certificates validated' do
+      # Alice completes the handshake but never satisfies Bob's cert requirement.
+      # Bob can handshake but not send a general message.
+      alice.to_peer('trigger handshake'.bytes, bob.identity_key)
+
+      bob_session = bob.session_manager.get_session(alice.identity_key)
+      # Bob's session requires certs but they were never validated
+      expect(bob_session.certificates_required).to be(true)
+      expect(bob_session.certificates_validated).to be(false)
+
+      expect do
+        bob.to_peer('blocked message'.bytes, alice.identity_key)
+      end.to raise_error(BSV::Auth::AuthError, /certificate validation/i)
+    end
+  end
+
+  # --- Scenario 6: Multiple peers with independent sessions ---
+
+  describe 'Scenario 6: multiple peers — independent sessions' do
+    let(:transport_ab_a) { PairedTransport.new }
+    let(:transport_ab_b) { PairedTransport.new }
+    let(:transport_ac_a) { PairedTransport.new }
+    let(:transport_ac_c) { PairedTransport.new }
+
+    # Alice has two transports: one to Bob, one to Carol
+    let(:alice_to_bob)   { BSV::Auth::Peer.new(wallet: alice_wallet, transport: transport_ab_a) }
+    let(:bob)            { BSV::Auth::Peer.new(wallet: bob_wallet,   transport: transport_ab_b) }
+    let(:alice_to_carol) { BSV::Auth::Peer.new(wallet: alice_wallet, transport: transport_ac_a) }
+    let(:carol)          { BSV::Auth::Peer.new(wallet: carol_wallet, transport: transport_ac_c) }
+
+    before do
+      alice_to_bob
+      bob
+      alice_to_carol
+      carol
+      transport_ab_a.partner = transport_ab_b
+      transport_ab_b.partner = transport_ab_a
+      transport_ac_a.partner = transport_ac_c
+      transport_ac_c.partner = transport_ac_a
+    end
+
+    it 'sessions are independent and do not cross-contaminate' do
+      bob_received   = []
+      carol_received = []
+
+      bob.on_general_message   { |_k, payload| bob_received   << payload }
+      carol.on_general_message { |_k, payload| carol_received << payload }
+
+      alice_to_bob.to_peer('to bob'.bytes, bob.identity_key)
+      alice_to_carol.to_peer('to carol'.bytes, carol.identity_key)
+
+      expect(bob_received).to eq(['to bob'.bytes])
+      expect(carol_received).to eq(['to carol'.bytes])
+    end
+
+    it 'last_interacted_peer tracks the most recent peer separately for each connection' do
+      alice_to_bob.to_peer('ping'.bytes, bob.identity_key)
+      expect(alice_to_bob.last_interacted_peer).to eq(bob.identity_key)
+
+      alice_to_carol.to_peer('ping'.bytes, carol.identity_key)
+      expect(alice_to_carol.last_interacted_peer).to eq(carol.identity_key)
+    end
+
+    it 'to_peer without identity_key uses last_interacted_peer' do
+      carol_received = []
+      carol.on_general_message { |_k, payload| carol_received << payload }
+
+      # First message sets last_interacted_peer
+      alice_to_carol.to_peer('first'.bytes, carol.identity_key)
+
+      # Second message omits identity_key — should go to Carol via last_interacted_peer
+      alice_to_carol.to_peer('second'.bytes)
+
+      expect(carol_received).to eq(['first'.bytes, 'second'.bytes])
+    end
+  end
+
+  # --- Scenario 7: Session reuse ---
+
+  describe 'Scenario 7: session reuse — second to_peer uses existing session' do
+    let(:transport_a) { PairedTransport.new }
+    let(:transport_b) { PairedTransport.new }
+
+    let(:alice) { BSV::Auth::Peer.new(wallet: alice_wallet, transport: transport_a) }
+    let(:bob)   { BSV::Auth::Peer.new(wallet: bob_wallet,   transport: transport_b) }
+
+    before do
+      alice
+      bob
+      transport_a.partner = transport_b
+      transport_b.partner = transport_a
+    end
+
+    it 'Bob receives both messages and no new handshake is created on the second call' do
+      received = []
+      bob.on_general_message { |_k, payload| received << payload }
+
+      alice.to_peer('message 1'.bytes, bob.identity_key)
+      alice.to_peer('message 2'.bytes, bob.identity_key)
+
+      expect(received).to eq(['message 1'.bytes, 'message 2'.bytes])
+    end
+
+    it 'only one session exists in Alice\'s session manager after two to_peer calls' do
+      alice.to_peer('msg1'.bytes, bob.identity_key)
+      alice.to_peer('msg2'.bytes, bob.identity_key)
+
+      # Alice should have exactly one session with Bob
+      sessions = alice.session_manager.instance_variable_get(:@by_nonce)
+      expect(sessions.size).to eq(1)
+    end
+  end
+
+  # --- Scenario 8: Handshake timeout ---
+
+  describe 'Scenario 8: handshake timeout' do
+    it 'raises AuthError when the transport does not deliver the response' do
+      # A "black hole" transport: accepts sends but never delivers to a partner
+      black_hole = Class.new do
+        include BSV::Auth::Transport
+
+        def send(_message)
+          # intentionally drops all messages
+        end
+
+        def on_data(&_block)
+          # never delivers
+        end
+      end.new
+
+      peer = BSV::Auth::Peer.new(wallet: alice_wallet, transport: black_hole,
+                                 handshake_timeout: 0.05)
+
+      expect do
+        peer.to_peer('hello'.bytes, bob_wallet.get_public_key({ identity_key: true })[:public_key])
+      end.to raise_error(BSV::Auth::AuthError, /Handshake timed out/)
+    end
+  end
+
+  # --- Scenario 9: Transport send failure cleans up queue ---
+
+  describe 'Scenario 9: transport send failure cleans up handshake queue' do
+    it 'propagates the error and leaves no orphaned queue entry' do
+      failing_transport = Class.new do
+        include BSV::Auth::Transport
+
+        def send(_message)
+          raise 'transport unavailable'
+        end
+
+        def on_data(&_block)
+          # no-op
+        end
+      end.new
+
+      peer = BSV::Auth::Peer.new(wallet: alice_wallet, transport: failing_transport)
+
+      expect do
+        peer.to_peer('hello'.bytes, bob_wallet.get_public_key({ identity_key: true })[:public_key])
+      end.to raise_error(RuntimeError, /transport unavailable/)
+
+      # Queue should be cleaned up — no orphaned entries
+      queues = peer.instance_variable_get(:@handshake_queues)
+      expect(queues).to be_empty
+    end
+  end
+
+  # --- Scenario 10: Certificates in initial handshake (both sides) ---
+
+  describe 'Scenario 10: certificates included in initialResponse during handshake' do
+    let(:requested_certs) do
+      { certifiers: [certifier_wallet.get_public_key({ identity_key: true })[:public_key]],
+        types: { cert_type => ['name'] } }
+    end
+
+    let(:transport_a) { PairedTransport.new }
+    let(:transport_b) { PairedTransport.new }
+
+    # Bob requests certs from Alice and Alice responds via callback during the handshake
+    let(:alice) { BSV::Auth::Peer.new(wallet: alice_wallet, transport: transport_a) }
+    let(:bob) do
+      BSV::Auth::Peer.new(wallet: bob_wallet, transport: transport_b,
+                          certificates_to_request: requested_certs)
+    end
+
+    before do
+      alice
+      bob
+      transport_a.partner = transport_b
+      transport_b.partner = transport_a
+    end
+
+    it 'Alice responds to cert request in initialRequest callback and Bob validates during handshake' do
+      certs_received_by_bob = nil
+      bob.on_certificates_received { |_k, certs| certs_received_by_bob = certs }
+
+      # Alice's callback fires when Bob's initialRequest includes requested_certificates
+      alice.on_certificate_request do |requester_key, _requested|
+        vc = issue_verifiable_certificate(
+          subject_wallet: alice_wallet,
+          certifier_wallet: certifier_wallet,
+          verifier_hex: requester_key,
+          cert_type: cert_type,
+          fields: { 'name' => 'Alice' }
+        )
+        alice.send_certificate_response(requester_key, [vc])
+      end
+
+      # Trigger handshake by Alice connecting to Bob
+      alice.to_peer('initial message'.bytes, bob.identity_key)
+
+      expect(certs_received_by_bob).not_to be_nil
+
+      # Bob's session should have certificates_validated = true now
+      bob_session = bob.session_manager.get_session(alice.identity_key)
+      expect(bob_session.certificates_validated).to be(true)
+    end
+  end
+
+  # --- Scenario 11: Tampered certificate rejected ---
+
+  describe 'Scenario 11: tampered certificate rejected' do
+    it 'raises AuthError when the certificate signature has been tampered with' do
+      vc = issue_verifiable_certificate(
+        subject_wallet: alice_wallet,
+        certifier_wallet: certifier_wallet,
+        verifier_hex: bob_wallet.get_public_key({ identity_key: true })[:public_key],
+        cert_type: cert_type,
+        fields: { 'name' => 'Alice' }
+      )
+
+      tampered = vc.to_h
+      tampered['signature'] = tampered['signature'].dup
+      # Flip a byte in the signature
+      tampered['signature'][-2..-1] = (tampered['signature'][-2..].to_i(16) ^ 0xFF).to_s(16).rjust(2, '0')
+
+      alice_key_hex = alice_wallet.get_public_key({ identity_key: true })[:public_key]
+      message = { identity_key: alice_key_hex, certificates: [tampered] }
+
+      requested = {
+        certifiers: [certifier_wallet.get_public_key({ identity_key: true })[:public_key]],
+        types: { cert_type => ['name'] }
+      }
+
+      expect do
+        BSV::Auth.validate_certificates(bob_wallet, message, requested)
+      end.to raise_error(BSV::Auth::AuthError)
+    end
+  end
+
+  # --- Scenario 12: Wrong certifier rejected ---
+
+  describe 'Scenario 12: wrong certifier rejected' do
+    let(:rogue_certifier_key) { BSV::Primitives::PrivateKey.new(OpenSSL::BN.new(77)) }
+    let(:rogue_certifier_wallet) { BSV::Wallet::ProtoWallet.new(rogue_certifier_key) }
+
+    it 'raises AuthError when the certifier is not in the requested list' do
+      # Certificate issued by a rogue certifier not in Bob's trusted set
+      vc = issue_verifiable_certificate(
+        subject_wallet: alice_wallet,
+        certifier_wallet: rogue_certifier_wallet,
+        verifier_hex: bob_wallet.get_public_key({ identity_key: true })[:public_key],
+        cert_type: cert_type,
+        fields: { 'name' => 'Alice' }
+      )
+
+      alice_key_hex = alice_wallet.get_public_key({ identity_key: true })[:public_key]
+      message = { identity_key: alice_key_hex, certificates: [vc.to_h] }
+
+      trusted_certifier_hex = certifier_wallet.get_public_key({ identity_key: true })[:public_key]
+      requested = {
+        certifiers: [trusted_certifier_hex], # only trusts certifier_wallet, not rogue
+        types: { cert_type => ['name'] }
+      }
+
+      expect do
+        BSV::Auth.validate_certificates(bob_wallet, message, requested)
+      end.to raise_error(BSV::Auth::AuthError, /unrequested certifier/i)
+    end
+  end
+
+  # --- Scenario 13: Decrypt certificate fields after exchange ---
+
+  describe 'Scenario 13: verify actual decrypted field values after full exchange' do
+    let(:requested_certs) do
+      { certifiers: [certifier_wallet.get_public_key({ identity_key: true })[:public_key]],
+        types: { cert_type => %w[name email] } }
+    end
+
+    let(:transport_a) { PairedTransport.new }
+    let(:transport_b) { PairedTransport.new }
+
+    let(:alice) { BSV::Auth::Peer.new(wallet: alice_wallet, transport: transport_a) }
+    let(:bob) do
+      BSV::Auth::Peer.new(wallet: bob_wallet, transport: transport_b,
+                          certificates_to_request: requested_certs)
+    end
+
+    before do
+      alice
+      bob
+      transport_a.partner = transport_b
+      transport_b.partner = transport_a
+    end
+
+    it 'Bob can decrypt all revealed fields and verifies the actual plaintext values' do
+      decrypted_by_bob = nil
+
+      bob.on_certificates_received do |_sender_key, certs|
+        cert_hash = certs.first
+        vc = BSV::Auth::VerifiableCertificate.from_hash(cert_hash)
+        decrypted_by_bob = vc.decrypt_fields(bob_wallet)
+      end
+
+      alice.on_certificate_request do |requester_key, _requested|
+        vc = issue_verifiable_certificate(
+          subject_wallet: alice_wallet,
+          certifier_wallet: certifier_wallet,
+          verifier_hex: requester_key,
+          cert_type: cert_type,
+          fields: { 'name' => 'Alice Wonderland', 'email' => 'alice@example.com' }
+        )
+        alice.send_certificate_response(requester_key, [vc])
+      end
+
+      alice.to_peer('verify fields'.bytes, bob.identity_key)
+
+      expect(decrypted_by_bob).not_to be_nil
+      expect(decrypted_by_bob['name']).to eq('Alice Wonderland')
+      expect(decrypted_by_bob['email']).to eq('alice@example.com')
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/auth/peer_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/auth/peer_spec.rb
@@ -26,14 +26,22 @@ RSpec.describe BSV::Auth::Peer do
     transport_b.partner = transport_a
   end
 
-  # Performs the full three-step handshake via transport and returns [request, response].
+  # Performs the full three-step handshake via transport and returns the session nonce.
   # The handshake is transport-mediated: alice sends the request via transport_a, which
   # delivers it to bob; bob's on_data triggers handle_incoming_message, which sends the
   # response back via transport_b; alice's on_data completes the handshake.
   def perform_handshake(initiator, initiator_transport)
-    request = initiator.create_initial_request
+    request = initiator.send(:create_initial_request)
     initiator_transport.send(request)
-    request
+    request[:initial_nonce]
+  end
+
+  describe '.new' do
+    it 'raises ArgumentError when transport is nil' do
+      expect do
+        described_class.new(wallet: alice_wallet, transport: nil)
+      end.to raise_error(ArgumentError, /transport is required/)
+    end
   end
 
   describe '#identity_key' do
@@ -56,8 +64,8 @@ RSpec.describe BSV::Auth::Peer do
     end
   end
 
-  describe '#create_initial_request' do
-    subject(:request) { alice.create_initial_request }
+  describe '#create_initial_request (private)' do
+    subject(:request) { alice.send(:create_initial_request) }
 
     it 'returns a hash with the expected keys' do
       expect(request).to include(
@@ -78,26 +86,28 @@ RSpec.describe BSV::Auth::Peer do
     end
 
     it 'generates a unique nonce on each call' do
-      second_request = alice.create_initial_request
+      second_request = alice.send(:create_initial_request)
       expect(request[:initial_nonce]).not_to eq(second_request[:initial_nonce])
+    end
+
+    it 'is private' do
+      expect { alice.create_initial_request }.to raise_error(NoMethodError)
     end
   end
 
   describe 'full handshake round-trip via transport' do
     it 'authenticates Alice after the handshake completes' do
-      request = perform_handshake(alice, transport_a)
-      expect(alice.authenticated?(request[:initial_nonce])).to be(true)
+      nonce = perform_handshake(alice, transport_a)
+      expect(alice.authenticated?(nonce)).to be(true)
     end
 
     it 'authenticates Bob after the handshake completes' do
       perform_handshake(alice, transport_a)
-      # Bob's session is indexed by his own nonce; find it by his authenticated state
       bob_nonce = bob.session_manager.instance_variable_get(:@by_nonce).keys.first
       expect(bob.authenticated?(bob_nonce)).to be(true)
     end
 
     it "includes Bob's identity key in the initial response" do
-      # Capture the response sent by Bob via transport by observing transport_a delivery
       received_response = nil
       original_callback = transport_a.instance_variable_get(:@on_data_callback)
       transport_a.on_data do |msg|
@@ -117,20 +127,25 @@ RSpec.describe BSV::Auth::Peer do
         original_callback&.call(msg)
       end
 
-      request = perform_handshake(alice, transport_a)
-      expect(received_response[:your_nonce]).to eq(request[:initial_nonce])
+      nonce = perform_handshake(alice, transport_a)
+      expect(received_response[:your_nonce]).to eq(nonce)
     end
   end
 
-  describe 'version and type guard via transport' do
+  describe 'version and type guard (private handle_incoming_message)' do
     it 'raises AuthError when the version is wrong' do
       bad_msg = { version: '9.9', message_type: BSV::Auth::MSG_INITIAL_REQUEST }
-      expect { alice.handle_incoming_message(bad_msg) }.to raise_error(BSV::Auth::AuthError, /Unsupported auth version/)
+      expect { alice.send(:handle_incoming_message, bad_msg) }.to raise_error(BSV::Auth::AuthError, /Unsupported auth version/)
     end
 
     it 'raises AuthError for an unknown message type' do
       bad_msg = { version: BSV::Auth::AUTH_VERSION, message_type: 'mystery' }
-      expect { alice.handle_incoming_message(bad_msg) }.to raise_error(BSV::Auth::AuthError, /Unknown message type/)
+      expect { alice.send(:handle_incoming_message, bad_msg) }.to raise_error(BSV::Auth::AuthError, /Unknown message type/)
+    end
+
+    it 'handle_incoming_message is private' do
+      bad_msg = { version: BSV::Auth::AUTH_VERSION, message_type: BSV::Auth::MSG_GENERAL }
+      expect { alice.handle_incoming_message(bad_msg) }.to raise_error(NoMethodError)
     end
   end
 
@@ -143,23 +158,26 @@ RSpec.describe BSV::Auth::Peer do
     end
 
     it 'can create a general message after authentication' do
-      msg = alice.create_general_message(alice_session_nonce, payload)
+      msg = alice.send(:create_general_message, alice_session_nonce, payload)
       expect(msg[:message_type]).to eq(BSV::Auth::MSG_GENERAL)
     end
 
+    it 'create_general_message is private' do
+      perform_handshake(alice, transport_a)
+      nonce = alice.session_manager.instance_variable_get(:@by_nonce).keys.first
+      expect { alice.create_general_message(nonce, payload) }.to raise_error(NoMethodError)
+    end
+
     it 'Bob can verify and read the payload sent by Alice via transport' do
-      # After handshake, Alice sends a general message via transport_a.
-      # It is delivered to Bob's on_data, which processes it and returns a result.
-      # We capture the result by intercepting Bob's handle_incoming_message response.
       perform_handshake(alice, transport_a)
       alice_nonce = alice.session_manager.instance_variable_get(:@by_nonce).keys.first
 
       received_result = nil
       transport_b.on_data do |msg|
-        received_result = bob.handle_incoming_message(msg)
+        received_result = bob.send(:handle_incoming_message, msg)
       end
 
-      msg = alice.create_general_message(alice_nonce, payload)
+      msg = alice.send(:create_general_message, alice_nonce, payload)
       transport_a.send(msg)
 
       expect(received_result[:payload]).to eq(payload)
@@ -170,7 +188,7 @@ RSpec.describe BSV::Auth::Peer do
   describe 'general message — raises without auth' do
     it 'raises AuthError when no session exists for the identifier' do
       expect do
-        alice.create_general_message('no-such-nonce', [1, 2, 3])
+        alice.send(:create_general_message, 'no-such-nonce', [1, 2, 3])
       end.to raise_error(BSV::Auth::AuthError, /Not authenticated/)
     end
   end
@@ -178,8 +196,6 @@ RSpec.describe BSV::Auth::Peer do
   describe '#on_general_message / #off_general_message' do
     let(:payload) { [72, 101, 108, 108, 111] } # "Hello"
 
-    # Complete the handshake so both peers are authenticated, then return Alice's
-    # session nonce so she can build a general message directed at Bob.
     let(:alice_session_nonce) do
       perform_handshake(alice, transport_a)
       alice.session_manager.instance_variable_get(:@by_nonce).keys.first
@@ -200,8 +216,8 @@ RSpec.describe BSV::Auth::Peer do
       received = []
       bob.on_general_message { |sender_key, msg_payload| received << [sender_key, msg_payload] }
 
-      msg = alice.create_general_message(alice_session_nonce, payload)
-      bob.handle_incoming_message(msg)
+      msg = alice.send(:create_general_message, alice_session_nonce, payload)
+      bob.send(:handle_incoming_message, msg)
 
       expect(received.length).to eq(1)
       expect(received[0][0]).to eq(alice.identity_key)
@@ -213,8 +229,8 @@ RSpec.describe BSV::Auth::Peer do
       bob.on_general_message { |_k, _p| calls << :first }
       bob.on_general_message { |_k, _p| calls << :second }
 
-      msg = alice.create_general_message(alice_session_nonce, payload)
-      bob.handle_incoming_message(msg)
+      msg = alice.send(:create_general_message, alice_session_nonce, payload)
+      bob.send(:handle_incoming_message, msg)
 
       expect(calls).to contain_exactly(:first, :second)
     end
@@ -224,8 +240,8 @@ RSpec.describe BSV::Auth::Peer do
       id = bob.on_general_message { |_k, _p| calls << :fired }
       bob.off_general_message(id)
 
-      msg = alice.create_general_message(alice_session_nonce, payload)
-      bob.handle_incoming_message(msg)
+      msg = alice.send(:create_general_message, alice_session_nonce, payload)
+      bob.send(:handle_incoming_message, msg)
 
       expect(calls).to be_empty
     end
@@ -277,31 +293,39 @@ RSpec.describe BSV::Auth::Peer do
       # Reset bob's tracking to prove it updates on general message too
       bob.instance_variable_set(:@last_interacted_peer, nil)
 
-      msg = alice.create_general_message(alice_nonce, [1, 2, 3])
-      bob.handle_incoming_message(msg)
+      msg = alice.send(:create_general_message, alice_nonce, [1, 2, 3])
+      bob.send(:handle_incoming_message, msg)
 
       expect(bob.last_interacted_peer).to eq(alice.identity_key)
     end
 
     it 'is not overwritten on initial request if already set (responder side)' do
-      # Create bob2 without a transport so handle_incoming_message calls do not
-      # trigger forwarding via a partner transport (which would interfere with other
-      # peers' handshakes). The last_interacted_peer logic does not require transport.
       carol_wallet = BSV::Wallet::ProtoWallet.new(BSV::Primitives::PrivateKey.generate)
-      carol2 = described_class.new(wallet: carol_wallet)
-      bob2   = described_class.new(wallet: bob_wallet)
 
-      # Carol↔bob2 handshake (direct calls)
-      carol_request = carol2.create_initial_request
-      carol_response = bob2.handle_incoming_message(carol_request)
-      carol2.handle_incoming_message(carol_response)
+      # Carol↔bob2 full handshake: establishes bob2.last_interacted_peer = carol
+      tc1, tc2 = PairedTransport.create_pair
+      carol2 = described_class.new(wallet: carol_wallet, transport: tc1)
+      bob2   = described_class.new(wallet: bob_wallet,   transport: tc2)
+      carol2.get_authenticated_session(bob2.identity_key)
       first_peer = bob2.last_interacted_peer
+      expect(first_peer).to eq(carol2.identity_key)
 
-      # Alice↔bob2 handshake (direct calls)
-      alice2 = described_class.new(wallet: alice_wallet)
-      alice_request = alice2.create_initial_request
-      alice_response = bob2.handle_incoming_message(alice_request)
-      alice2.handle_incoming_message(alice_response)
+      # Simulate a second initiator (Alice) sending an initialRequest directly to bob2
+      # via handle_incoming_message (bypassing transport routing to avoid double-delivery).
+      # Bob2's response will be forwarded via tc2→tc1→carol2, which will fail nonce
+      # verification (carol2 does not recognise alice's nonce) and raise — that's
+      # acceptable since we only care that bob2.last_interacted_peer stays as carol.
+      ta, _tb = PairedTransport.create_pair
+      alice2 = described_class.new(wallet: alice_wallet, transport: ta)
+      alice_req = alice2.send(:create_initial_request)
+
+      # Bob2's process_initial_request uses ||= so it should not overwrite carol.
+      # The response forwarded to tc2 will trigger an error on carol2's side — ignore it.
+      begin
+        bob2.send(:handle_incoming_message, alice_req)
+      rescue BSV::Auth::AuthError
+        nil
+      end
 
       expect(bob2.last_interacted_peer).to eq(first_peer)
     end
@@ -311,7 +335,7 @@ RSpec.describe BSV::Auth::Peer do
       alice2 = described_class.new(wallet: alice_wallet, transport: transport_c, auto_persist_last_session: false)
       bob2   = described_class.new(wallet: bob_wallet,   transport: transport_d, auto_persist_last_session: false)
 
-      request = alice2.create_initial_request
+      request = alice2.send(:create_initial_request)
       transport_c.send(request)
 
       expect(alice2.last_interacted_peer).to be_nil
@@ -321,28 +345,28 @@ RSpec.describe BSV::Auth::Peer do
 
   describe 'tampered initial response' do
     it 'raises AuthError when the signature has been tampered with' do
-      request = alice.create_initial_request
-      response = bob.handle_incoming_message(request)
+      request = alice.send(:create_initial_request)
+      response = bob.send(:handle_incoming_message, request)
 
       bad_sig = response[:signature].dup
       bad_sig[-1] ^= 0xFF
       tampered = response.merge(signature: bad_sig)
 
-      expect { alice.handle_incoming_message(tampered) }
+      expect { alice.send(:handle_incoming_message, tampered) }
         .to raise_error(BSV::Auth::AuthError, /signature verification failed/)
     end
 
     it 'removes the pending session after a failed signature verification' do
-      request   = alice.create_initial_request
+      request   = alice.send(:create_initial_request)
       our_nonce = request[:initial_nonce]
 
-      response = bob.handle_incoming_message(request)
+      response = bob.send(:handle_incoming_message, request)
       bad_sig  = response[:signature].dup
       bad_sig[-1] ^= 0xFF
       tampered = response.merge(signature: bad_sig)
 
       begin
-        alice.handle_incoming_message(tampered)
+        alice.send(:handle_incoming_message, tampered)
       rescue BSV::Auth::AuthError
         nil
       end
@@ -376,20 +400,20 @@ RSpec.describe BSV::Auth::Peer do
     BSV::Auth::VerifiableCertificate.from_certificate(master_cert, keyring)
   end
 
-  describe '#create_certificate_request (manual mode)' do
+  describe '#create_certificate_request (private, low-level builder)' do
     let(:cert_type)   { Base64.strict_encode64(SecureRandom.random_bytes(32)) }
 
     before { perform_handshake(alice, transport_a) }
 
     it 'returns a message hash with the correct message_type' do
       to_request = { certifiers: [bob.identity_key], types: { cert_type => ['name'] } }
-      msg = alice.create_certificate_request(alice.last_interacted_peer, to_request)
+      msg = alice.send(:create_certificate_request, alice.last_interacted_peer, to_request)
       expect(msg[:message_type]).to eq(BSV::Auth::MSG_CERT_REQUEST)
     end
 
     it 'includes nonce, your_nonce, initial_nonce, signature, and requested_certificates' do
       to_request = { certifiers: [bob.identity_key], types: { cert_type => ['name'] } }
-      msg = alice.create_certificate_request(alice.last_interacted_peer, to_request)
+      msg = alice.send(:create_certificate_request, alice.last_interacted_peer, to_request)
       expect(msg[:nonce]).not_to be_nil
       expect(msg[:your_nonce]).not_to be_nil
       expect(msg[:initial_nonce]).not_to be_nil
@@ -399,12 +423,18 @@ RSpec.describe BSV::Auth::Peer do
 
     it 'raises AuthError for an unauthenticated identifier' do
       expect do
-        alice.create_certificate_request('no-such-peer', { certifiers: ['abc'], types: {} })
+        alice.send(:create_certificate_request, 'no-such-peer', { certifiers: ['abc'], types: {} })
       end.to raise_error(BSV::Auth::AuthError, /Not authenticated/)
+    end
+
+    it 'is private' do
+      to_request = { certifiers: [bob.identity_key], types: { cert_type => ['name'] } }
+      expect { alice.create_certificate_request(alice.last_interacted_peer, to_request) }
+        .to raise_error(NoMethodError)
     end
   end
 
-  describe '#create_certificate_response (manual mode)' do
+  describe '#create_certificate_response (private, low-level builder)' do
     let(:certifier_wallet) { BSV::Wallet::ProtoWallet.new(BSV::Primitives::PrivateKey.generate) }
     let(:cert_type)        { Base64.strict_encode64(SecureRandom.random_bytes(32)) }
 
@@ -421,12 +451,12 @@ RSpec.describe BSV::Auth::Peer do
     end
 
     it 'returns a message hash with the correct message_type' do
-      msg = alice.create_certificate_response(alice.last_interacted_peer, [verifiable_cert])
+      msg = alice.send(:create_certificate_response, alice.last_interacted_peer, [verifiable_cert])
       expect(msg[:message_type]).to eq(BSV::Auth::MSG_CERT_RESPONSE)
     end
 
     it 'includes certificates serialised as Hashes' do
-      msg = alice.create_certificate_response(alice.last_interacted_peer, [verifiable_cert])
+      msg = alice.send(:create_certificate_response, alice.last_interacted_peer, [verifiable_cert])
       expect(msg[:certificates]).to be_an(Array)
       expect(msg[:certificates].first).to be_a(Hash)
       expect(msg[:certificates].first['subject']).to eq(alice.identity_key)
@@ -434,7 +464,7 @@ RSpec.describe BSV::Auth::Peer do
 
     it 'raises AuthError for an unauthenticated identifier' do
       expect do
-        alice.create_certificate_response('no-such-peer', [verifiable_cert])
+        alice.send(:create_certificate_response, 'no-such-peer', [verifiable_cert])
       end.to raise_error(BSV::Auth::AuthError, /Not authenticated/)
     end
   end
@@ -447,11 +477,11 @@ RSpec.describe BSV::Auth::Peer do
     let(:cert_request_msg) do
       perform_handshake(alice, transport_a)
       to_request = { certifiers: [certifier_wallet.get_public_key({ identity_key: true })[:public_key]], types: { cert_type => ['name'] } }
-      alice.create_certificate_request(alice.last_interacted_peer, to_request)
+      alice.send(:create_certificate_request, alice.last_interacted_peer, to_request)
     end
 
     it 'dispatches certificateRequest to process_certificate_request' do
-      expect { bob.handle_incoming_message(cert_request_msg) }.not_to raise_error
+      expect { bob.send(:handle_incoming_message, cert_request_msg) }.not_to raise_error
     end
 
     it 'raises AuthError for an invalid nonce in certificateRequest' do
@@ -467,7 +497,7 @@ RSpec.describe BSV::Auth::Peer do
         requested_certificates: to_request,
         signature: [0] * 71
       }
-      expect { bob.handle_incoming_message(bad_nonce_msg) }
+      expect { bob.send(:handle_incoming_message, bad_nonce_msg) }
         .to raise_error(BSV::Auth::AuthError, /Unable to verify nonce/)
     end
 
@@ -476,7 +506,7 @@ RSpec.describe BSV::Auth::Peer do
       bad_sig = msg[:signature].dup
       bad_sig[-1] ^= 0xFF
       msg[:signature] = bad_sig
-      expect { bob.handle_incoming_message(msg) }
+      expect { bob.send(:handle_incoming_message, msg) }
         .to raise_error(BSV::Auth::AuthError, /signature verification failed/)
     end
 
@@ -484,7 +514,7 @@ RSpec.describe BSV::Auth::Peer do
       received = []
       bob.on_certificate_request { |sender_key, requested| received << [sender_key, requested] }
 
-      bob.handle_incoming_message(cert_request_msg)
+      bob.send(:handle_incoming_message, cert_request_msg)
 
       expect(received.length).to eq(1)
       expect(received[0][0]).to eq(alice.identity_key)
@@ -495,7 +525,7 @@ RSpec.describe BSV::Auth::Peer do
       bob.on_certificate_request { |_k, _r| }
 
       expect(BSV::Auth).not_to receive(:get_verifiable_certificates)
-      bob.handle_incoming_message(cert_request_msg)
+      bob.send(:handle_incoming_message, cert_request_msg)
     end
   end
 
@@ -515,15 +545,15 @@ RSpec.describe BSV::Auth::Peer do
 
     let(:cert_response_msg) do
       perform_handshake(alice, transport_a)
-      alice.create_certificate_response(alice.last_interacted_peer, [verifiable_cert])
+      alice.send(:create_certificate_response, alice.last_interacted_peer, [verifiable_cert])
     end
 
     it 'dispatches certificateResponse to process_certificate_response' do
-      expect { bob.handle_incoming_message(cert_response_msg) }.not_to raise_error
+      expect { bob.send(:handle_incoming_message, cert_response_msg) }.not_to raise_error
     end
 
     it 'marks session.certificates_validated = true when certificates are valid' do
-      bob.handle_incoming_message(cert_response_msg)
+      bob.send(:handle_incoming_message, cert_response_msg)
 
       bob_session = bob.session_manager.get_session(alice.identity_key)
       expect(bob_session.certificates_validated).to be(true)
@@ -533,7 +563,7 @@ RSpec.describe BSV::Auth::Peer do
       received = []
       bob.on_certificates_received { |sender_key, certs| received << [sender_key, certs] }
 
-      bob.handle_incoming_message(cert_response_msg)
+      bob.send(:handle_incoming_message, cert_response_msg)
 
       expect(received.length).to eq(1)
       expect(received[0][0]).to eq(alice.identity_key)
@@ -547,27 +577,27 @@ RSpec.describe BSV::Auth::Peer do
       bad_sig[-1] ^= 0xFF
       msg[:signature] = bad_sig
 
-      expect { bob.handle_incoming_message(msg) }
+      expect { bob.send(:handle_incoming_message, msg) }
         .to raise_error(BSV::Auth::AuthError, /signature verification failed/)
     end
 
     it 'fires on_certificates_received with empty array when certs array is empty' do
       perform_handshake(alice, transport_a)
-      empty_response = alice.create_certificate_response(alice.last_interacted_peer, [])
+      empty_response = alice.send(:create_certificate_response, alice.last_interacted_peer, [])
 
       received = []
       bob.on_certificates_received { |_k, certs| received << certs }
-      bob.handle_incoming_message(empty_response)
+      bob.send(:handle_incoming_message, empty_response)
 
       expect(received).to eq([[]])
     end
 
     it 'does not call validate_certificates when certificates array is empty' do
       perform_handshake(alice, transport_a)
-      empty_response = alice.create_certificate_response(alice.last_interacted_peer, [])
+      empty_response = alice.send(:create_certificate_response, alice.last_interacted_peer, [])
 
       expect(BSV::Auth).not_to receive(:validate_certificates)
-      bob.handle_incoming_message(empty_response)
+      bob.send(:handle_incoming_message, empty_response)
     end
   end
 
@@ -577,7 +607,6 @@ RSpec.describe BSV::Auth::Peer do
     let(:certifier_hex)    { certifier_wallet.get_public_key({ identity_key: true })[:public_key] }
 
     let!(:bob_with_cert) do
-      # Bob has a cert from certifier that he can present to Alice
       cert = build_verifiable_certificate(
         subject_wallet: bob_wallet,
         certifier_wallet: certifier_wallet,
@@ -589,16 +618,12 @@ RSpec.describe BSV::Auth::Peer do
     end
 
     it 'auto-fetches and sends certificateResponse when no callback registered' do
-      # Set up bob with a wallet that has list_certificates and prove_certificate
-      # Since ProtoWallet does not implement those, we verify that get_verifiable_certificates
-      # is invoked (returns empty for ProtoWallet, so no response is sent — that's fine).
       perform_handshake(alice, transport_a)
 
       to_request = { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
-      cert_request_msg = alice.create_certificate_request(alice.last_interacted_peer, to_request)
+      cert_request_msg = alice.send(:create_certificate_request, alice.last_interacted_peer, to_request)
 
-      # Should not raise — the auto-fetch returns [] for ProtoWallet and does not send
-      expect { bob.handle_incoming_message(cert_request_msg) }.not_to raise_error
+      expect { bob.send(:handle_incoming_message, cert_request_msg) }.not_to raise_error
     end
 
     it 'fires certificate_request callback during certificateRequest and skips auto-fetch' do
@@ -608,8 +633,8 @@ RSpec.describe BSV::Auth::Peer do
       bob.on_certificate_request { |_key, _req| callback_fired = true }
 
       to_request = { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
-      cert_request_msg = alice.create_certificate_request(alice.last_interacted_peer, to_request)
-      bob.handle_incoming_message(cert_request_msg)
+      cert_request_msg = alice.send(:create_certificate_request, alice.last_interacted_peer, to_request)
+      bob.send(:handle_incoming_message, cert_request_msg)
 
       expect(callback_fired).to be(true)
     end
@@ -621,8 +646,6 @@ RSpec.describe BSV::Auth::Peer do
     let(:certifier_hex)    { certifier_wallet.get_public_key({ identity_key: true })[:public_key] }
 
     context 'when responder includes certificates in initialResponse' do
-      # Bob (responder) includes certs; Alice (initiator) validates them.
-      # We inject certs directly into the response hash (simulating Bob auto-fetching).
       it 'initiator validates certificates and marks session validated' do
         cert = build_verifiable_certificate(
           subject_wallet: bob_wallet,
@@ -632,20 +655,21 @@ RSpec.describe BSV::Auth::Peer do
           fields: { 'name' => 'Bob' }
         )
 
-        # Create Alice with a certificate request so she checks for certs
+        ta, tb = PairedTransport.create_pair
         alice2 = described_class.new(
           wallet: alice_wallet,
+          transport: ta,
           certificates_to_request: { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
         )
-        bob2 = described_class.new(wallet: bob_wallet)
+        bob2 = described_class.new(wallet: bob_wallet, transport: tb)
 
-        request  = alice2.create_initial_request
-        response = bob2.handle_incoming_message(request)
+        request  = alice2.send(:create_initial_request)
+        response = bob2.send(:handle_incoming_message, request)
 
         # Manually inject Bob's cert into the response (simulating auto-fetch)
         response_with_certs = response.merge(certificates: [cert.to_h])
 
-        alice2.handle_incoming_message(response_with_certs)
+        alice2.send(:handle_incoming_message, response_with_certs)
 
         alice_session = alice2.session_manager.get_session(bob2.identity_key)
         expect(alice_session.certificates_validated).to be(true)
@@ -660,19 +684,21 @@ RSpec.describe BSV::Auth::Peer do
           fields: { 'name' => 'Bob' }
         )
 
+        ta, tb = PairedTransport.create_pair
         alice2 = described_class.new(
           wallet: alice_wallet,
+          transport: ta,
           certificates_to_request: { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
         )
-        bob2 = described_class.new(wallet: bob_wallet)
+        bob2 = described_class.new(wallet: bob_wallet, transport: tb)
 
         received = []
         alice2.on_certificates_received { |sender_key, certs| received << [sender_key, certs] }
 
-        request  = alice2.create_initial_request
-        response = bob2.handle_incoming_message(request)
+        request  = alice2.send(:create_initial_request)
+        response = bob2.send(:handle_incoming_message, request)
         response_with_certs = response.merge(certificates: [cert.to_h])
-        alice2.handle_incoming_message(response_with_certs)
+        alice2.send(:handle_incoming_message, response_with_certs)
 
         expect(received.length).to eq(1)
         expect(received[0][0]).to eq(bob2.identity_key)
@@ -681,63 +707,68 @@ RSpec.describe BSV::Auth::Peer do
 
     context 'when responder requests certificates in initialResponse' do
       it 'fires certificate_request callback on initiator when callback is registered' do
-        alice2 = described_class.new(wallet: alice_wallet)
+        ta, tb = PairedTransport.create_pair
+        alice2 = described_class.new(wallet: alice_wallet, transport: ta)
         bob2   = described_class.new(
           wallet: bob_wallet,
+          transport: tb,
           certificates_to_request: { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
         )
 
         callback_fired = false
         alice2.on_certificate_request { |_k, _r| callback_fired = true }
 
-        request  = alice2.create_initial_request
-        response = bob2.handle_incoming_message(request)
-        alice2.handle_incoming_message(response)
+        request  = alice2.send(:create_initial_request)
+        response = bob2.send(:handle_incoming_message, request)
+        alice2.send(:handle_incoming_message, response)
 
         expect(callback_fired).to be(true)
       end
 
       it 'does not send empty certificateResponse when auto-fetch returns nothing' do
-        alice2 = described_class.new(wallet: alice_wallet)
+        ta, tb = PairedTransport.create_pair
+        alice2 = described_class.new(wallet: alice_wallet, transport: ta)
         bob2   = described_class.new(
           wallet: bob_wallet,
+          transport: tb,
           certificates_to_request: { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
         )
 
-        # alice2 has no transport and no certs — auto-fetch returns []
-        request  = alice2.create_initial_request
-        response = bob2.handle_incoming_message(request)
+        request  = alice2.send(:create_initial_request)
+        response = bob2.send(:handle_incoming_message, request)
 
-        # Should not raise and should not attempt to send a certificate response
-        expect { alice2.handle_incoming_message(response) }.not_to raise_error
+        expect { alice2.send(:handle_incoming_message, response) }.not_to raise_error
       end
     end
 
     context 'when initiator requests certificates in initialRequest' do
       it 'fires certificate_request callback on responder when callback is registered' do
+        ta, tb = PairedTransport.create_pair
         alice2 = described_class.new(
           wallet: alice_wallet,
+          transport: ta,
           certificates_to_request: { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
         )
-        bob2 = described_class.new(wallet: bob_wallet)
+        bob2 = described_class.new(wallet: bob_wallet, transport: tb)
 
         callback_fired = false
         bob2.on_certificate_request { |_k, _r| callback_fired = true }
 
-        request = alice2.create_initial_request
-        bob2.handle_incoming_message(request)
+        request = alice2.send(:create_initial_request)
+        bob2.send(:handle_incoming_message, request)
 
         expect(callback_fired).to be(true)
       end
 
       it 'includes certificates in initialResponse when auto-fetch returns certs' do
+        ta, tb = PairedTransport.create_pair
         alice2 = described_class.new(
           wallet: alice_wallet,
+          transport: ta,
           certificates_to_request: { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
         )
-        bob2 = described_class.new(wallet: bob_wallet)
+        bob2 = described_class.new(wallet: bob_wallet, transport: tb)
 
-        # Stub get_verifiable_certificates to return a cert for bob
         fake_cert = build_verifiable_certificate(
           subject_wallet: bob_wallet,
           certifier_wallet: certifier_wallet,
@@ -748,12 +779,178 @@ RSpec.describe BSV::Auth::Peer do
 
         allow(BSV::Auth).to receive(:get_verifiable_certificates).and_return([fake_cert])
 
-        request  = alice2.create_initial_request
-        response = bob2.handle_incoming_message(request)
+        request  = alice2.send(:create_initial_request)
+        response = bob2.send(:handle_incoming_message, request)
 
         expect(response[:certificates]).to be_an(Array)
         expect(response[:certificates]).not_to be_empty
       end
+    end
+  end
+
+  # --- High-level session API ---
+
+  describe '#to_peer' do
+    let(:payload) { [72, 101, 108, 108, 111] } # "Hello"
+
+    it 'sends a general message that triggers on_general_message on the receiver' do
+      received = []
+      bob.on_general_message { |sender_key, msg_payload| received << [sender_key, msg_payload] }
+
+      alice.to_peer(payload, bob.identity_key)
+
+      expect(received.length).to eq(1)
+      expect(received[0][0]).to eq(alice.identity_key)
+      expect(received[0][1]).to eq(payload)
+    end
+
+    it 'auto-initiates handshake when no session exists' do
+      alice.to_peer(payload, bob.identity_key)
+      expect(alice.authenticated?(bob.identity_key)).to be(true)
+    end
+
+    it 'reuses an existing authenticated session on second call' do
+      alice.to_peer(payload, bob.identity_key)
+      nonces_after_first = alice.session_manager.instance_variable_get(:@by_nonce).keys.dup
+
+      alice.to_peer(payload, bob.identity_key)
+      nonces_after_second = alice.session_manager.instance_variable_get(:@by_nonce).keys
+
+      expect(nonces_after_second).to eq(nonces_after_first)
+    end
+
+    it 'uses @last_interacted_peer as default identity_key' do
+      # First call establishes the session and sets @last_interacted_peer
+      alice.to_peer(payload, bob.identity_key)
+
+      received = []
+      bob.on_general_message { |_key, msg_payload| received << msg_payload }
+
+      # Second call without identity_key — should use @last_interacted_peer
+      alice.to_peer([1, 2, 3])
+
+      expect(received).to include([1, 2, 3])
+    end
+
+    it 'raises AuthError when certificates are required but not yet validated' do
+      certifier_hex = BSV::Primitives::PrivateKey.generate.public_key.to_hex
+      cert_type     = Base64.strict_encode64(SecureRandom.random_bytes(32))
+
+      ta, tb = PairedTransport.create_pair
+      alice2 = described_class.new(
+        wallet: alice_wallet,
+        transport: ta,
+        certificates_to_request: { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
+      )
+      bob2 = described_class.new(wallet: bob_wallet, transport: tb)
+
+      # Perform handshake manually (no certs provided — session will be unvalidated)
+      request  = alice2.send(:create_initial_request)
+      response = bob2.send(:handle_incoming_message, request)
+      alice2.send(:handle_incoming_message, response)
+
+      # At this point alice2 has certificates_required = true, certificates_validated = false
+      session = alice2.session_manager.get_session(bob2.identity_key)
+      expect(session.certificates_required).to be(true)
+      expect(session.certificates_validated).to be(false)
+
+      expect { alice2.to_peer(payload, bob2.identity_key) }
+        .to raise_error(BSV::Auth::AuthError, /certificate validation/)
+    end
+  end
+
+  describe '#get_authenticated_session' do
+    it 'returns an authenticated session' do
+      session = alice.get_authenticated_session(bob.identity_key)
+      expect(session.authenticated?).to be(true)
+    end
+
+    it 'returns the same session on a second call (no new handshake)' do
+      session1 = alice.get_authenticated_session(bob.identity_key)
+      nonces1  = alice.session_manager.instance_variable_get(:@by_nonce).keys.dup
+
+      session2 = alice.get_authenticated_session(bob.identity_key)
+      nonces2  = alice.session_manager.instance_variable_get(:@by_nonce).keys
+
+      expect(session2.session_nonce).to eq(session1.session_nonce)
+      expect(nonces2).to eq(nonces1)
+    end
+
+    it 'resolves from @last_interacted_peer when no identity_key given' do
+      alice.get_authenticated_session(bob.identity_key)
+      expect(alice.last_interacted_peer).to eq(bob.identity_key)
+
+      session = alice.get_authenticated_session
+      expect(session.peer_identity_key).to eq(bob.identity_key)
+    end
+
+    it 'raises AuthError when handshake times out' do
+      # Build a transport that drops all messages so the handshake never completes
+      dropping_transport = PairedTransport.new
+      dropping_transport.partner = PairedTransport.new # messages go to unregistered peer
+
+      fast_alice = described_class.new(wallet: alice_wallet, transport: dropping_transport, handshake_timeout: 1)
+
+      expect { fast_alice.get_authenticated_session(bob.identity_key) }
+        .to raise_error(BSV::Auth::AuthError, /timed out/)
+    end
+  end
+
+  describe '#request_certificates' do
+    let(:certifier_wallet) { BSV::Wallet::ProtoWallet.new(BSV::Primitives::PrivateKey.generate) }
+    let(:cert_type)        { Base64.strict_encode64(SecureRandom.random_bytes(32)) }
+    let(:certifier_hex)    { certifier_wallet.get_public_key({ identity_key: true })[:public_key] }
+
+    it 'sends a certificateRequest via transport, triggering on_certificate_request on the peer' do
+      alice.get_authenticated_session(bob.identity_key)
+
+      callback_fired = false
+      bob.on_certificate_request { |_key, _req| callback_fired = true }
+
+      to_request = { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
+      alice.request_certificates(to_request, bob.identity_key)
+
+      expect(callback_fired).to be(true)
+    end
+
+    it 'uses @last_interacted_peer when no identity_key given' do
+      alice.get_authenticated_session(bob.identity_key)
+
+      callback_fired = false
+      bob.on_certificate_request { |_key, _req| callback_fired = true }
+
+      to_request = { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
+      alice.request_certificates(to_request)
+
+      expect(callback_fired).to be(true)
+    end
+  end
+
+  describe '#send_certificate_response' do
+    let(:certifier_wallet) { BSV::Wallet::ProtoWallet.new(BSV::Primitives::PrivateKey.generate) }
+    let(:cert_type)        { Base64.strict_encode64(SecureRandom.random_bytes(32)) }
+
+    let(:verifiable_cert) do
+      build_verifiable_certificate(
+        subject_wallet: alice_wallet,
+        certifier_wallet: certifier_wallet,
+        verifier_hex: bob.identity_key,
+        cert_type: cert_type,
+        fields: { 'name' => 'Alice' }
+      )
+    end
+
+    it 'sends a certificateResponse via transport, triggering on_certificates_received on the peer' do
+      alice.get_authenticated_session(bob.identity_key)
+
+      received = []
+      bob.on_certificates_received { |sender_key, certs| received << [sender_key, certs] }
+
+      alice.send_certificate_response(bob.identity_key, [verifiable_cert])
+
+      expect(received.length).to eq(1)
+      expect(received[0][0]).to eq(alice.identity_key)
+      expect(received[0][1].first['subject']).to eq(alice.identity_key)
     end
   end
 end

--- a/gem/bsv-sdk/spec/bsv/auth/peer_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/auth/peer_spec.rb
@@ -350,4 +350,410 @@ RSpec.describe BSV::Auth::Peer do
       expect(alice.session_manager.get_session(our_nonce)).to be_nil
     end
   end
+
+  # --- Certificate exchange helpers ---
+
+  # Shared helper: issue a MasterCertificate and build a VerifiableCertificate
+  # with a keyring for the given verifier.
+  def build_verifiable_certificate(subject_wallet:, certifier_wallet:, verifier_hex:, cert_type:, fields:)
+    master_cert = BSV::Auth::MasterCertificate.issue_certificate_for_subject(
+      certifier_wallet,
+      subject_wallet.get_public_key({ identity_key: true })[:public_key],
+      fields,
+      cert_type
+    )
+
+    keyring = BSV::Auth::MasterCertificate.create_keyring_for_verifier(
+      subject_wallet,
+      certifier: master_cert.certifier,
+      verifier: verifier_hex,
+      fields: master_cert.fields,
+      fields_to_reveal: fields.keys,
+      master_keyring: master_cert.master_keyring,
+      serial_number: master_cert.serial_number
+    )
+
+    BSV::Auth::VerifiableCertificate.from_certificate(master_cert, keyring)
+  end
+
+  describe '#create_certificate_request (manual mode)' do
+    let(:cert_type)   { Base64.strict_encode64(SecureRandom.random_bytes(32)) }
+
+    before { perform_handshake(alice, transport_a) }
+
+    it 'returns a message hash with the correct message_type' do
+      to_request = { certifiers: [bob.identity_key], types: { cert_type => ['name'] } }
+      msg = alice.create_certificate_request(alice.last_interacted_peer, to_request)
+      expect(msg[:message_type]).to eq(BSV::Auth::MSG_CERT_REQUEST)
+    end
+
+    it 'includes nonce, your_nonce, initial_nonce, signature, and requested_certificates' do
+      to_request = { certifiers: [bob.identity_key], types: { cert_type => ['name'] } }
+      msg = alice.create_certificate_request(alice.last_interacted_peer, to_request)
+      expect(msg[:nonce]).not_to be_nil
+      expect(msg[:your_nonce]).not_to be_nil
+      expect(msg[:initial_nonce]).not_to be_nil
+      expect(msg[:signature]).not_to be_nil
+      expect(msg[:requested_certificates]).to eq(to_request)
+    end
+
+    it 'raises AuthError for an unauthenticated identifier' do
+      expect do
+        alice.create_certificate_request('no-such-peer', { certifiers: ['abc'], types: {} })
+      end.to raise_error(BSV::Auth::AuthError, /Not authenticated/)
+    end
+  end
+
+  describe '#create_certificate_response (manual mode)' do
+    let(:certifier_wallet) { BSV::Wallet::ProtoWallet.new(BSV::Primitives::PrivateKey.generate) }
+    let(:cert_type)        { Base64.strict_encode64(SecureRandom.random_bytes(32)) }
+
+    before { perform_handshake(alice, transport_a) }
+
+    let(:verifiable_cert) do
+      build_verifiable_certificate(
+        subject_wallet: alice_wallet,
+        certifier_wallet: certifier_wallet,
+        verifier_hex: bob.identity_key,
+        cert_type: cert_type,
+        fields: { 'name' => 'Alice' }
+      )
+    end
+
+    it 'returns a message hash with the correct message_type' do
+      msg = alice.create_certificate_response(alice.last_interacted_peer, [verifiable_cert])
+      expect(msg[:message_type]).to eq(BSV::Auth::MSG_CERT_RESPONSE)
+    end
+
+    it 'includes certificates serialised as Hashes' do
+      msg = alice.create_certificate_response(alice.last_interacted_peer, [verifiable_cert])
+      expect(msg[:certificates]).to be_an(Array)
+      expect(msg[:certificates].first).to be_a(Hash)
+      expect(msg[:certificates].first['subject']).to eq(alice.identity_key)
+    end
+
+    it 'raises AuthError for an unauthenticated identifier' do
+      expect do
+        alice.create_certificate_response('no-such-peer', [verifiable_cert])
+      end.to raise_error(BSV::Auth::AuthError, /Not authenticated/)
+    end
+  end
+
+  describe 'certificateRequest dispatch and processing' do
+    let(:certifier_wallet) { BSV::Wallet::ProtoWallet.new(BSV::Primitives::PrivateKey.generate) }
+    let(:cert_type)        { Base64.strict_encode64(SecureRandom.random_bytes(32)) }
+
+    # Handshake first, then Alice creates a cert request to Bob
+    let(:cert_request_msg) do
+      perform_handshake(alice, transport_a)
+      to_request = { certifiers: [certifier_wallet.get_public_key({ identity_key: true })[:public_key]], types: { cert_type => ['name'] } }
+      alice.create_certificate_request(alice.last_interacted_peer, to_request)
+    end
+
+    it 'dispatches certificateRequest to process_certificate_request' do
+      expect { bob.handle_incoming_message(cert_request_msg) }.not_to raise_error
+    end
+
+    it 'raises AuthError for an invalid nonce in certificateRequest' do
+      perform_handshake(alice, transport_a)
+      to_request = { certifiers: ['abc'], types: {} }
+      bad_nonce_msg = {
+        version: BSV::Auth::AUTH_VERSION,
+        message_type: BSV::Auth::MSG_CERT_REQUEST,
+        identity_key: alice.identity_key,
+        nonce: Base64.strict_encode64(SecureRandom.random_bytes(32)),
+        initial_nonce: 'fake',
+        your_nonce: Base64.strict_encode64(SecureRandom.random_bytes(32)),
+        requested_certificates: to_request,
+        signature: [0] * 71
+      }
+      expect { bob.handle_incoming_message(bad_nonce_msg) }
+        .to raise_error(BSV::Auth::AuthError, /Unable to verify nonce/)
+    end
+
+    it 'raises AuthError when certificateRequest signature is tampered' do
+      msg = cert_request_msg.dup
+      bad_sig = msg[:signature].dup
+      bad_sig[-1] ^= 0xFF
+      msg[:signature] = bad_sig
+      expect { bob.handle_incoming_message(msg) }
+        .to raise_error(BSV::Auth::AuthError, /signature verification failed/)
+    end
+
+    it 'fires on_certificate_request callback when registered' do
+      received = []
+      bob.on_certificate_request { |sender_key, requested| received << [sender_key, requested] }
+
+      bob.handle_incoming_message(cert_request_msg)
+
+      expect(received.length).to eq(1)
+      expect(received[0][0]).to eq(alice.identity_key)
+      expect(received[0][1][:types]).to have_key(cert_type)
+    end
+
+    it 'does not call get_verifiable_certificates when certificate_request callback is registered' do
+      bob.on_certificate_request { |_k, _r| }
+
+      expect(BSV::Auth).not_to receive(:get_verifiable_certificates)
+      bob.handle_incoming_message(cert_request_msg)
+    end
+  end
+
+  describe 'certificateResponse dispatch and processing' do
+    let(:certifier_wallet) { BSV::Wallet::ProtoWallet.new(BSV::Primitives::PrivateKey.generate) }
+    let(:cert_type)        { Base64.strict_encode64(SecureRandom.random_bytes(32)) }
+
+    let(:verifiable_cert) do
+      build_verifiable_certificate(
+        subject_wallet: alice_wallet,
+        certifier_wallet: certifier_wallet,
+        verifier_hex: bob.identity_key,
+        cert_type: cert_type,
+        fields: { 'name' => 'Alice' }
+      )
+    end
+
+    let(:cert_response_msg) do
+      perform_handshake(alice, transport_a)
+      alice.create_certificate_response(alice.last_interacted_peer, [verifiable_cert])
+    end
+
+    it 'dispatches certificateResponse to process_certificate_response' do
+      expect { bob.handle_incoming_message(cert_response_msg) }.not_to raise_error
+    end
+
+    it 'marks session.certificates_validated = true when certificates are valid' do
+      bob.handle_incoming_message(cert_response_msg)
+
+      bob_session = bob.session_manager.get_session(alice.identity_key)
+      expect(bob_session.certificates_validated).to be(true)
+    end
+
+    it 'fires on_certificates_received callback with sender key and certs' do
+      received = []
+      bob.on_certificates_received { |sender_key, certs| received << [sender_key, certs] }
+
+      bob.handle_incoming_message(cert_response_msg)
+
+      expect(received.length).to eq(1)
+      expect(received[0][0]).to eq(alice.identity_key)
+      expect(received[0][1]).to be_an(Array)
+      expect(received[0][1].first['subject']).to eq(alice.identity_key)
+    end
+
+    it 'raises AuthError when certificateResponse signature is tampered' do
+      msg = cert_response_msg.dup
+      bad_sig = msg[:signature].dup
+      bad_sig[-1] ^= 0xFF
+      msg[:signature] = bad_sig
+
+      expect { bob.handle_incoming_message(msg) }
+        .to raise_error(BSV::Auth::AuthError, /signature verification failed/)
+    end
+
+    it 'fires on_certificates_received with empty array when certs array is empty' do
+      perform_handshake(alice, transport_a)
+      empty_response = alice.create_certificate_response(alice.last_interacted_peer, [])
+
+      received = []
+      bob.on_certificates_received { |_k, certs| received << certs }
+      bob.handle_incoming_message(empty_response)
+
+      expect(received).to eq([[]])
+    end
+
+    it 'does not call validate_certificates when certificates array is empty' do
+      perform_handshake(alice, transport_a)
+      empty_response = alice.create_certificate_response(alice.last_interacted_peer, [])
+
+      expect(BSV::Auth).not_to receive(:validate_certificates)
+      bob.handle_incoming_message(empty_response)
+    end
+  end
+
+  describe 'certificateRequest round-trip via transport' do
+    let(:certifier_wallet) { BSV::Wallet::ProtoWallet.new(BSV::Primitives::PrivateKey.generate) }
+    let(:cert_type)        { Base64.strict_encode64(SecureRandom.random_bytes(32)) }
+    let(:certifier_hex)    { certifier_wallet.get_public_key({ identity_key: true })[:public_key] }
+
+    let!(:bob_with_cert) do
+      # Bob has a cert from certifier that he can present to Alice
+      cert = build_verifiable_certificate(
+        subject_wallet: bob_wallet,
+        certifier_wallet: certifier_wallet,
+        verifier_hex: alice.identity_key,
+        cert_type: cert_type,
+        fields: { 'name' => 'Bob' }
+      )
+      cert
+    end
+
+    it 'auto-fetches and sends certificateResponse when no callback registered' do
+      # Set up bob with a wallet that has list_certificates and prove_certificate
+      # Since ProtoWallet does not implement those, we verify that get_verifiable_certificates
+      # is invoked (returns empty for ProtoWallet, so no response is sent — that's fine).
+      perform_handshake(alice, transport_a)
+
+      to_request = { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
+      cert_request_msg = alice.create_certificate_request(alice.last_interacted_peer, to_request)
+
+      # Should not raise — the auto-fetch returns [] for ProtoWallet and does not send
+      expect { bob.handle_incoming_message(cert_request_msg) }.not_to raise_error
+    end
+
+    it 'fires certificate_request callback during certificateRequest and skips auto-fetch' do
+      perform_handshake(alice, transport_a)
+
+      callback_fired = false
+      bob.on_certificate_request { |_key, _req| callback_fired = true }
+
+      to_request = { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
+      cert_request_msg = alice.create_certificate_request(alice.last_interacted_peer, to_request)
+      bob.handle_incoming_message(cert_request_msg)
+
+      expect(callback_fired).to be(true)
+    end
+  end
+
+  describe 'certificates in initial handshake' do
+    let(:certifier_wallet) { BSV::Wallet::ProtoWallet.new(BSV::Primitives::PrivateKey.generate) }
+    let(:cert_type)        { Base64.strict_encode64(SecureRandom.random_bytes(32)) }
+    let(:certifier_hex)    { certifier_wallet.get_public_key({ identity_key: true })[:public_key] }
+
+    context 'when responder includes certificates in initialResponse' do
+      # Bob (responder) includes certs; Alice (initiator) validates them.
+      # We inject certs directly into the response hash (simulating Bob auto-fetching).
+      it 'initiator validates certificates and marks session validated' do
+        cert = build_verifiable_certificate(
+          subject_wallet: bob_wallet,
+          certifier_wallet: certifier_wallet,
+          verifier_hex: alice.identity_key,
+          cert_type: cert_type,
+          fields: { 'name' => 'Bob' }
+        )
+
+        # Create Alice with a certificate request so she checks for certs
+        alice2 = described_class.new(
+          wallet: alice_wallet,
+          certificates_to_request: { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
+        )
+        bob2 = described_class.new(wallet: bob_wallet)
+
+        request  = alice2.create_initial_request
+        response = bob2.handle_incoming_message(request)
+
+        # Manually inject Bob's cert into the response (simulating auto-fetch)
+        response_with_certs = response.merge(certificates: [cert.to_h])
+
+        alice2.handle_incoming_message(response_with_certs)
+
+        alice_session = alice2.session_manager.get_session(bob2.identity_key)
+        expect(alice_session.certificates_validated).to be(true)
+      end
+
+      it 'fires on_certificates_received callback on the initiator' do
+        cert = build_verifiable_certificate(
+          subject_wallet: bob_wallet,
+          certifier_wallet: certifier_wallet,
+          verifier_hex: alice.identity_key,
+          cert_type: cert_type,
+          fields: { 'name' => 'Bob' }
+        )
+
+        alice2 = described_class.new(
+          wallet: alice_wallet,
+          certificates_to_request: { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
+        )
+        bob2 = described_class.new(wallet: bob_wallet)
+
+        received = []
+        alice2.on_certificates_received { |sender_key, certs| received << [sender_key, certs] }
+
+        request  = alice2.create_initial_request
+        response = bob2.handle_incoming_message(request)
+        response_with_certs = response.merge(certificates: [cert.to_h])
+        alice2.handle_incoming_message(response_with_certs)
+
+        expect(received.length).to eq(1)
+        expect(received[0][0]).to eq(bob2.identity_key)
+      end
+    end
+
+    context 'when responder requests certificates in initialResponse' do
+      it 'fires certificate_request callback on initiator when callback is registered' do
+        alice2 = described_class.new(wallet: alice_wallet)
+        bob2   = described_class.new(
+          wallet: bob_wallet,
+          certificates_to_request: { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
+        )
+
+        callback_fired = false
+        alice2.on_certificate_request { |_k, _r| callback_fired = true }
+
+        request  = alice2.create_initial_request
+        response = bob2.handle_incoming_message(request)
+        alice2.handle_incoming_message(response)
+
+        expect(callback_fired).to be(true)
+      end
+
+      it 'does not send empty certificateResponse when auto-fetch returns nothing' do
+        alice2 = described_class.new(wallet: alice_wallet)
+        bob2   = described_class.new(
+          wallet: bob_wallet,
+          certificates_to_request: { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
+        )
+
+        # alice2 has no transport and no certs — auto-fetch returns []
+        request  = alice2.create_initial_request
+        response = bob2.handle_incoming_message(request)
+
+        # Should not raise and should not attempt to send a certificate response
+        expect { alice2.handle_incoming_message(response) }.not_to raise_error
+      end
+    end
+
+    context 'when initiator requests certificates in initialRequest' do
+      it 'fires certificate_request callback on responder when callback is registered' do
+        alice2 = described_class.new(
+          wallet: alice_wallet,
+          certificates_to_request: { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
+        )
+        bob2 = described_class.new(wallet: bob_wallet)
+
+        callback_fired = false
+        bob2.on_certificate_request { |_k, _r| callback_fired = true }
+
+        request = alice2.create_initial_request
+        bob2.handle_incoming_message(request)
+
+        expect(callback_fired).to be(true)
+      end
+
+      it 'includes certificates in initialResponse when auto-fetch returns certs' do
+        alice2 = described_class.new(
+          wallet: alice_wallet,
+          certificates_to_request: { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
+        )
+        bob2 = described_class.new(wallet: bob_wallet)
+
+        # Stub get_verifiable_certificates to return a cert for bob
+        fake_cert = build_verifiable_certificate(
+          subject_wallet: bob_wallet,
+          certifier_wallet: certifier_wallet,
+          verifier_hex: alice_wallet.get_public_key({ identity_key: true })[:public_key],
+          cert_type: cert_type,
+          fields: { 'name' => 'Bob' }
+        )
+
+        allow(BSV::Auth).to receive(:get_verifiable_certificates).and_return([fake_cert])
+
+        request  = alice2.create_initial_request
+        response = bob2.handle_incoming_message(request)
+
+        expect(response[:certificates]).to be_an(Array)
+        expect(response[:certificates]).not_to be_empty
+      end
+    end
+  end
 end

--- a/gem/bsv-sdk/spec/bsv/auth/peer_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/auth/peer_spec.rb
@@ -8,15 +8,32 @@ RSpec.describe BSV::Auth::Peer do
   let(:bob_key)      { BSV::Primitives::PrivateKey.generate }
   let(:alice_wallet) { BSV::Wallet::ProtoWallet.new(alice_key) }
   let(:bob_wallet)   { BSV::Wallet::ProtoWallet.new(bob_key) }
-  let(:alice)        { described_class.new(wallet: alice_wallet) }
-  let(:bob)          { described_class.new(wallet: bob_wallet) }
 
-  # Performs the full three-step handshake and returns [request, response].
-  def perform_handshake(initiator, responder)
-    request  = initiator.create_initial_request
-    response = responder.handle_incoming_message(request)
-    initiator.handle_incoming_message(response)
-    [request, response]
+  # Create two peers connected via PairedTransport.
+  let(:transport_a)  { PairedTransport.new }
+  let(:transport_b)  { PairedTransport.new }
+  let(:alice) { described_class.new(wallet: alice_wallet, transport: transport_a) }
+  let(:bob)   { described_class.new(wallet: bob_wallet,   transport: transport_b) }
+
+  before do
+    # Force both peers to be created (registering their on_data callbacks) and
+    # wire the transports together before any message is delivered.
+    # RSpec `let` is lazy — without these references, a peer's on_data would not
+    # be registered before the first transport.send call, causing silent message drops.
+    alice
+    bob
+    transport_a.partner = transport_b
+    transport_b.partner = transport_a
+  end
+
+  # Performs the full three-step handshake via transport and returns [request, response].
+  # The handshake is transport-mediated: alice sends the request via transport_a, which
+  # delivers it to bob; bob's on_data triggers handle_incoming_message, which sends the
+  # response back via transport_b; alice's on_data completes the handshake.
+  def perform_handshake(initiator, initiator_transport)
+    request = initiator.create_initial_request
+    initiator_transport.send(request)
+    request
   end
 
   describe '#identity_key' do
@@ -66,48 +83,46 @@ RSpec.describe BSV::Auth::Peer do
     end
   end
 
-  describe '#handle_incoming_message — full handshake round-trip' do
-    it 'authenticates Alice after processing the initial response' do
-      request  = alice.create_initial_request
-      response = bob.handle_incoming_message(request)
-      alice.handle_incoming_message(response)
-
+  describe 'full handshake round-trip via transport' do
+    it 'authenticates Alice after the handshake completes' do
+      request = perform_handshake(alice, transport_a)
       expect(alice.authenticated?(request[:initial_nonce])).to be(true)
     end
 
-    it 'authenticates Bob after processing the initial request' do
-      request  = alice.create_initial_request
-      response = bob.handle_incoming_message(request)
-      alice.handle_incoming_message(response)
-
-      # Bob's session is indexed by his own nonce (from the response)
-      expect(bob.authenticated?(response[:initial_nonce])).to be(true)
-    end
-
-    it 'returns nil when Alice processes the initial response (no further reply needed)' do
-      request  = alice.create_initial_request
-      response = bob.handle_incoming_message(request)
-      result   = alice.handle_incoming_message(response)
-
-      expect(result).to be_nil
+    it 'authenticates Bob after the handshake completes' do
+      perform_handshake(alice, transport_a)
+      # Bob's session is indexed by his own nonce; find it by his authenticated state
+      bob_nonce = bob.session_manager.instance_variable_get(:@by_nonce).keys.first
+      expect(bob.authenticated?(bob_nonce)).to be(true)
     end
 
     it "includes Bob's identity key in the initial response" do
-      request  = alice.create_initial_request
-      response = bob.handle_incoming_message(request)
+      # Capture the response sent by Bob via transport by observing transport_a delivery
+      received_response = nil
+      original_callback = transport_a.instance_variable_get(:@on_data_callback)
+      transport_a.on_data do |msg|
+        received_response = msg if msg[:message_type] == BSV::Auth::MSG_INITIAL_RESPONSE
+        original_callback&.call(msg)
+      end
 
-      expect(response[:identity_key]).to eq(bob.identity_key)
+      perform_handshake(alice, transport_a)
+      expect(received_response[:identity_key]).to eq(bob.identity_key)
     end
 
-    it "echoes Alice's nonce back in the response" do
-      request  = alice.create_initial_request
-      response = bob.handle_incoming_message(request)
+    it "echoes Alice's nonce back in the initial response" do
+      received_response = nil
+      original_callback = transport_a.instance_variable_get(:@on_data_callback)
+      transport_a.on_data do |msg|
+        received_response = msg if msg[:message_type] == BSV::Auth::MSG_INITIAL_RESPONSE
+        original_callback&.call(msg)
+      end
 
-      expect(response[:your_nonce]).to eq(request[:initial_nonce])
+      request = perform_handshake(alice, transport_a)
+      expect(received_response[:your_nonce]).to eq(request[:initial_nonce])
     end
   end
 
-  describe '#handle_incoming_message — version and type guards' do
+  describe 'version and type guard via transport' do
     it 'raises AuthError when the version is wrong' do
       bad_msg = { version: '9.9', message_type: BSV::Auth::MSG_INITIAL_REQUEST }
       expect { alice.handle_incoming_message(bad_msg) }.to raise_error(BSV::Auth::AuthError, /Unsupported auth version/)
@@ -119,12 +134,11 @@ RSpec.describe BSV::Auth::Peer do
     end
   end
 
-  describe '#create_general_message / #handle_incoming_message (general)' do
+  describe 'general message exchange (post-handshake)' do
     let(:payload) { [72, 101, 108, 108, 111] } # "Hello"
 
-    # Perform handshake and expose Alice's session nonce for use in examples.
     let(:alice_session_nonce) do
-      perform_handshake(alice, bob)
+      perform_handshake(alice, transport_a)
       alice.session_manager.instance_variable_get(:@by_nonce).keys.first
     end
 
@@ -133,16 +147,27 @@ RSpec.describe BSV::Auth::Peer do
       expect(msg[:message_type]).to eq(BSV::Auth::MSG_GENERAL)
     end
 
-    it 'Bob can verify and read the payload sent by Alice' do
-      msg    = alice.create_general_message(alice_session_nonce, payload)
-      result = bob.handle_incoming_message(msg)
+    it 'Bob can verify and read the payload sent by Alice via transport' do
+      # After handshake, Alice sends a general message via transport_a.
+      # It is delivered to Bob's on_data, which processes it and returns a result.
+      # We capture the result by intercepting Bob's handle_incoming_message response.
+      perform_handshake(alice, transport_a)
+      alice_nonce = alice.session_manager.instance_variable_get(:@by_nonce).keys.first
 
-      expect(result[:payload]).to eq(payload)
-      expect(result[:peer_identity_key]).to eq(alice.identity_key)
+      received_result = nil
+      transport_b.on_data do |msg|
+        received_result = bob.handle_incoming_message(msg)
+      end
+
+      msg = alice.create_general_message(alice_nonce, payload)
+      transport_a.send(msg)
+
+      expect(received_result[:payload]).to eq(payload)
+      expect(received_result[:peer_identity_key]).to eq(alice.identity_key)
     end
   end
 
-  describe '#create_general_message — raises without auth' do
+  describe 'general message — raises without auth' do
     it 'raises AuthError when no session exists for the identifier' do
       expect do
         alice.create_general_message('no-such-nonce', [1, 2, 3])
@@ -150,12 +175,155 @@ RSpec.describe BSV::Auth::Peer do
     end
   end
 
-  describe '#handle_incoming_message — tampered initial response' do
+  describe '#on_general_message / #off_general_message' do
+    let(:payload) { [72, 101, 108, 108, 111] } # "Hello"
+
+    # Complete the handshake so both peers are authenticated, then return Alice's
+    # session nonce so she can build a general message directed at Bob.
+    let(:alice_session_nonce) do
+      perform_handshake(alice, transport_a)
+      alice.session_manager.instance_variable_get(:@by_nonce).keys.first
+    end
+
+    it 'returns an integer callback ID' do
+      id = bob.on_general_message { |_k, _p| }
+      expect(id).to be_a(Integer)
+    end
+
+    it 'increments the ID for each registration' do
+      id1 = bob.on_general_message { |_k, _p| }
+      id2 = bob.on_general_message { |_k, _p| }
+      expect(id2).to eq(id1 + 1)
+    end
+
+    it 'fires the callback with sender key and payload when a general message is received' do
+      received = []
+      bob.on_general_message { |sender_key, msg_payload| received << [sender_key, msg_payload] }
+
+      msg = alice.create_general_message(alice_session_nonce, payload)
+      bob.handle_incoming_message(msg)
+
+      expect(received.length).to eq(1)
+      expect(received[0][0]).to eq(alice.identity_key)
+      expect(received[0][1]).to eq(payload)
+    end
+
+    it 'fires all registered callbacks when a message is received' do
+      calls = []
+      bob.on_general_message { |_k, _p| calls << :first }
+      bob.on_general_message { |_k, _p| calls << :second }
+
+      msg = alice.create_general_message(alice_session_nonce, payload)
+      bob.handle_incoming_message(msg)
+
+      expect(calls).to contain_exactly(:first, :second)
+    end
+
+    it 'does not fire a callback after off_general_message removes it' do
+      calls = []
+      id = bob.on_general_message { |_k, _p| calls << :fired }
+      bob.off_general_message(id)
+
+      msg = alice.create_general_message(alice_session_nonce, payload)
+      bob.handle_incoming_message(msg)
+
+      expect(calls).to be_empty
+    end
+  end
+
+  describe '#on_certificates_received / #off_certificates_received' do
+    it 'returns an integer callback ID' do
+      id = alice.on_certificates_received { |_k, _c| }
+      expect(id).to be_a(Integer)
+    end
+
+    it 'unregisters without error' do
+      id = alice.on_certificates_received { |_k, _c| }
+      expect { alice.off_certificates_received(id) }.not_to raise_error
+    end
+  end
+
+  describe '#on_certificate_request / #off_certificate_request' do
+    it 'returns an integer callback ID' do
+      id = alice.on_certificate_request { |_k, _r| }
+      expect(id).to be_a(Integer)
+    end
+
+    it 'unregisters without error' do
+      id = alice.on_certificate_request { |_k, _r| }
+      expect { alice.off_certificate_request(id) }.not_to raise_error
+    end
+  end
+
+  describe '#last_interacted_peer' do
+    it 'is nil initially' do
+      expect(alice.last_interacted_peer).to be_nil
+    end
+
+    it 'is set to the peer identity key after the initiator processes the initial response' do
+      perform_handshake(alice, transport_a)
+      expect(alice.last_interacted_peer).to eq(bob.identity_key)
+    end
+
+    it 'is set for the responder after processing an initial request' do
+      perform_handshake(alice, transport_a)
+      expect(bob.last_interacted_peer).to eq(alice.identity_key)
+    end
+
+    it 'is updated after processing a general message' do
+      perform_handshake(alice, transport_a)
+      alice_nonce = alice.session_manager.instance_variable_get(:@by_nonce).keys.first
+
+      # Reset bob's tracking to prove it updates on general message too
+      bob.instance_variable_set(:@last_interacted_peer, nil)
+
+      msg = alice.create_general_message(alice_nonce, [1, 2, 3])
+      bob.handle_incoming_message(msg)
+
+      expect(bob.last_interacted_peer).to eq(alice.identity_key)
+    end
+
+    it 'is not overwritten on initial request if already set (responder side)' do
+      # Create bob2 without a transport so handle_incoming_message calls do not
+      # trigger forwarding via a partner transport (which would interfere with other
+      # peers' handshakes). The last_interacted_peer logic does not require transport.
+      carol_wallet = BSV::Wallet::ProtoWallet.new(BSV::Primitives::PrivateKey.generate)
+      carol2 = described_class.new(wallet: carol_wallet)
+      bob2   = described_class.new(wallet: bob_wallet)
+
+      # Carol↔bob2 handshake (direct calls)
+      carol_request = carol2.create_initial_request
+      carol_response = bob2.handle_incoming_message(carol_request)
+      carol2.handle_incoming_message(carol_response)
+      first_peer = bob2.last_interacted_peer
+
+      # Alice↔bob2 handshake (direct calls)
+      alice2 = described_class.new(wallet: alice_wallet)
+      alice_request = alice2.create_initial_request
+      alice_response = bob2.handle_incoming_message(alice_request)
+      alice2.handle_incoming_message(alice_response)
+
+      expect(bob2.last_interacted_peer).to eq(first_peer)
+    end
+
+    it 'is not set when auto_persist_last_session is false' do
+      transport_c, transport_d = PairedTransport.create_pair
+      alice2 = described_class.new(wallet: alice_wallet, transport: transport_c, auto_persist_last_session: false)
+      bob2   = described_class.new(wallet: bob_wallet,   transport: transport_d, auto_persist_last_session: false)
+
+      request = alice2.create_initial_request
+      transport_c.send(request)
+
+      expect(alice2.last_interacted_peer).to be_nil
+      expect(bob2.last_interacted_peer).to be_nil
+    end
+  end
+
+  describe 'tampered initial response' do
     it 'raises AuthError when the signature has been tampered with' do
       request = alice.create_initial_request
       response = bob.handle_incoming_message(request)
 
-      # Flip the last byte of the signature to invalidate it
       bad_sig = response[:signature].dup
       bad_sig[-1] ^= 0xFF
       tampered = response.merge(signature: bad_sig)
@@ -165,7 +333,7 @@ RSpec.describe BSV::Auth::Peer do
     end
 
     it 'removes the pending session after a failed signature verification' do
-      request = alice.create_initial_request
+      request   = alice.create_initial_request
       our_nonce = request[:initial_nonce]
 
       response = bob.handle_incoming_message(request)

--- a/gem/bsv-sdk/spec/bsv/auth/peer_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/auth/peer_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe BSV::Auth::Peer do
   end
 
   describe '#create_certificate_request (private, low-level builder)' do
-    let(:cert_type)   { Base64.strict_encode64(SecureRandom.random_bytes(32)) }
+    let(:cert_type) { Base64.strict_encode64(SecureRandom.random_bytes(32)) }
 
     before { perform_handshake(alice, transport_a) }
 
@@ -436,10 +436,6 @@ RSpec.describe BSV::Auth::Peer do
 
   describe '#create_certificate_response (private, low-level builder)' do
     let(:certifier_wallet) { BSV::Wallet::ProtoWallet.new(BSV::Primitives::PrivateKey.generate) }
-    let(:cert_type)        { Base64.strict_encode64(SecureRandom.random_bytes(32)) }
-
-    before { perform_handshake(alice, transport_a) }
-
     let(:verifiable_cert) do
       build_verifiable_certificate(
         subject_wallet: alice_wallet,
@@ -449,6 +445,9 @@ RSpec.describe BSV::Auth::Peer do
         fields: { 'name' => 'Alice' }
       )
     end
+    let(:cert_type) { Base64.strict_encode64(SecureRandom.random_bytes(32)) }
+
+    before { perform_handshake(alice, transport_a) }
 
     it 'returns a message hash with the correct message_type' do
       msg = alice.send(:create_certificate_response, alice.last_interacted_peer, [verifiable_cert])
@@ -524,8 +523,9 @@ RSpec.describe BSV::Auth::Peer do
     it 'does not call get_verifiable_certificates when certificate_request callback is registered' do
       bob.on_certificate_request { |_k, _r| }
 
-      expect(BSV::Auth).not_to receive(:get_verifiable_certificates)
+      allow(BSV::Auth).to receive(:get_verifiable_certificates)
       bob.send(:handle_incoming_message, cert_request_msg)
+      expect(BSV::Auth).not_to have_received(:get_verifiable_certificates)
     end
   end
 
@@ -596,8 +596,9 @@ RSpec.describe BSV::Auth::Peer do
       perform_handshake(alice, transport_a)
       empty_response = alice.send(:create_certificate_response, alice.last_interacted_peer, [])
 
-      expect(BSV::Auth).not_to receive(:validate_certificates)
+      allow(BSV::Auth).to receive(:validate_certificates)
       bob.send(:handle_incoming_message, empty_response)
+      expect(BSV::Auth).not_to have_received(:validate_certificates)
     end
   end
 
@@ -606,15 +607,14 @@ RSpec.describe BSV::Auth::Peer do
     let(:cert_type)        { Base64.strict_encode64(SecureRandom.random_bytes(32)) }
     let(:certifier_hex)    { certifier_wallet.get_public_key({ identity_key: true })[:public_key] }
 
-    let!(:bob_with_cert) do
-      cert = build_verifiable_certificate(
+    let(:bob_cert) do
+      build_verifiable_certificate(
         subject_wallet: bob_wallet,
         certifier_wallet: certifier_wallet,
         verifier_hex: alice.identity_key,
         cert_type: cert_type,
         fields: { 'name' => 'Bob' }
       )
-      cert
     end
 
     it 'auto-fetches and sends certificateResponse when no callback registered' do

--- a/gem/bsv-sdk/spec/bsv/auth/peer_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/auth/peer_spec.rb
@@ -532,6 +532,14 @@ RSpec.describe BSV::Auth::Peer do
   describe 'certificateResponse dispatch and processing' do
     let(:certifier_wallet) { BSV::Wallet::ProtoWallet.new(BSV::Primitives::PrivateKey.generate) }
     let(:cert_type)        { Base64.strict_encode64(SecureRandom.random_bytes(32)) }
+    let(:certifier_hex)    { certifier_wallet.get_public_key({ identity_key: true })[:public_key] }
+    let(:bob) do
+      described_class.new(
+        wallet: bob_wallet,
+        transport: transport_b,
+        certificates_to_request: { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
+      )
+    end
 
     let(:verifiable_cert) do
       build_verifiable_certificate(
@@ -929,6 +937,14 @@ RSpec.describe BSV::Auth::Peer do
   describe '#send_certificate_response' do
     let(:certifier_wallet) { BSV::Wallet::ProtoWallet.new(BSV::Primitives::PrivateKey.generate) }
     let(:cert_type)        { Base64.strict_encode64(SecureRandom.random_bytes(32)) }
+    let(:certifier_hex)    { certifier_wallet.get_public_key({ identity_key: true })[:public_key] }
+    let(:bob) do
+      described_class.new(
+        wallet: bob_wallet,
+        transport: transport_b,
+        certificates_to_request: { certifiers: [certifier_hex], types: { cert_type => ['name'] } }
+      )
+    end
 
     let(:verifiable_cert) do
       build_verifiable_certificate(

--- a/gem/bsv-sdk/spec/bsv/auth/validate_certificates_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/auth/validate_certificates_spec.rb
@@ -1,0 +1,249 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'BSV::Auth.validate_certificates' do
+  let(:subject_key)   { BSV::Primitives::PrivateKey.new(OpenSSL::BN.new(21)) }
+  let(:certifier_key) { BSV::Primitives::PrivateKey.new(OpenSSL::BN.new(22)) }
+  let(:verifier_key)  { BSV::Primitives::PrivateKey.new(OpenSSL::BN.new(23)) }
+  let(:wrong_key)     { BSV::Primitives::PrivateKey.new(OpenSSL::BN.new(31)) }
+
+  let(:subject_wallet)   { BSV::Wallet::ProtoWallet.new(subject_key) }
+  let(:certifier_wallet) { BSV::Wallet::ProtoWallet.new(certifier_key) }
+  let(:verifier_wallet)  { BSV::Wallet::ProtoWallet.new(verifier_key) }
+  let(:wrong_wallet)     { BSV::Wallet::ProtoWallet.new(wrong_key) }
+
+  let(:subject_hex)   { subject_key.public_key.to_hex }
+  let(:certifier_hex) { certifier_key.public_key.to_hex }
+  let(:verifier_hex)  { verifier_key.public_key.to_hex }
+
+  let(:cert_type)     { Base64.strict_encode64("\x01" * 32) }
+  let(:serial_number) { Base64.strict_encode64("\x02" * 32) }
+
+  let(:plaintext_fields) { { 'name' => 'Alice', 'email' => 'alice@example.com' } }
+
+  # Issue a master certificate and build a verifier keyring.
+  let(:master_cert) do
+    BSV::Auth::MasterCertificate.issue_certificate_for_subject(
+      certifier_wallet,
+      subject_hex,
+      plaintext_fields,
+      cert_type,
+      serial_number: serial_number
+    )
+  end
+
+  let(:verifier_keyring) do
+    BSV::Auth::MasterCertificate.create_keyring_for_verifier(
+      subject_wallet,
+      certifier: certifier_hex,
+      verifier: verifier_hex,
+      fields: master_cert.fields,
+      fields_to_reveal: plaintext_fields.keys,
+      master_keyring: master_cert.master_keyring,
+      serial_number: master_cert.serial_number
+    )
+  end
+
+  let(:verifiable_cert) do
+    BSV::Auth::VerifiableCertificate.from_certificate(master_cert, verifier_keyring)
+  end
+
+  let(:valid_message) do
+    {
+      identity_key: subject_hex,
+      certificates: [verifiable_cert]
+    }
+  end
+
+  # --- Happy path ---
+
+  describe 'with a valid VerifiableCertificate' do
+    it 'does not raise when all checks pass' do
+      expect { BSV::Auth.validate_certificates(verifier_wallet, valid_message) }.not_to raise_error
+    end
+
+    it 'decrypts certificate fields as a side-effect' do
+      BSV::Auth.validate_certificates(verifier_wallet, valid_message)
+      expect(verifiable_cert.decrypted_fields).to eq(plaintext_fields)
+    end
+  end
+
+  # --- Hash input ---
+
+  describe 'with a Hash certificate input' do
+    it 'constructs a VerifiableCertificate and validates it' do
+      cert_hash = verifiable_cert.to_h
+      message = { identity_key: subject_hex, certificates: [cert_hash] }
+      expect { BSV::Auth.validate_certificates(verifier_wallet, message) }.not_to raise_error
+    end
+  end
+
+  # --- String keys in message ---
+
+  describe 'with string keys in the message hash' do
+    it 'accepts string-keyed message hashes' do
+      message = { 'identity_key' => subject_hex, 'certificates' => [verifiable_cert] }
+      expect { BSV::Auth.validate_certificates(verifier_wallet, message) }.not_to raise_error
+    end
+  end
+
+  # --- No certificates ---
+
+  describe 'when certificates is nil' do
+    it 'raises AuthError with descriptive message' do
+      message = { identity_key: subject_hex, certificates: nil }
+      expect do
+        BSV::Auth.validate_certificates(verifier_wallet, message)
+      end.to raise_error(BSV::Auth::AuthError, /No certificates/)
+    end
+  end
+
+  # --- Empty certificates ---
+
+  describe 'when certificates array is empty' do
+    it 'raises AuthError' do
+      message = { identity_key: subject_hex, certificates: [] }
+      expect do
+        BSV::Auth.validate_certificates(verifier_wallet, message)
+      end.to raise_error(BSV::Auth::AuthError, /No certificates/)
+    end
+  end
+
+  # --- Subject mismatch ---
+
+  describe 'when certificate subject does not match message identity_key' do
+    it 'raises AuthError mentioning both keys' do
+      wrong_subject_hex = wrong_key.public_key.to_hex
+      message = { identity_key: wrong_subject_hex, certificates: [verifiable_cert] }
+      expect do
+        BSV::Auth.validate_certificates(verifier_wallet, message)
+      end.to raise_error(BSV::Auth::AuthError, /#{Regexp.escape(subject_hex)}.*#{Regexp.escape(wrong_subject_hex)}/m)
+    end
+  end
+
+  # --- Invalid signature ---
+
+  describe 'when certificate has a tampered signature' do
+    it 'raises AuthError about invalid signature' do
+      tampered = BSV::Auth::VerifiableCertificate.new(
+        type: master_cert.type,
+        serial_number: master_cert.serial_number,
+        subject: master_cert.subject,
+        certifier: master_cert.certifier,
+        revocation_outpoint: master_cert.revocation_outpoint,
+        fields: master_cert.fields,
+        keyring: verifier_keyring,
+        signature: 'deadbeef' * 9
+      )
+      message = { identity_key: subject_hex, certificates: [tampered] }
+      expect do
+        BSV::Auth.validate_certificates(verifier_wallet, message)
+      end.to raise_error(BSV::Auth::AuthError, /invalid|verification failed/i)
+    end
+  end
+
+  # --- Unrequested certifier ---
+
+  describe 'when certifier is not in requested_certificates[:certifiers]' do
+    it 'raises AuthError about unrequested certifier' do
+      requested = {
+        certifiers: [wrong_key.public_key.to_hex],
+        types: { cert_type => [] }
+      }
+      expect do
+        BSV::Auth.validate_certificates(verifier_wallet, valid_message, requested)
+      end.to raise_error(BSV::Auth::AuthError, /unrequested certifier/)
+    end
+  end
+
+  # --- Unrequested type ---
+
+  describe 'when certificate type is not in requested_certificates[:types]' do
+    it 'raises AuthError about unrequested type' do
+      other_type = Base64.strict_encode64("\xFF" * 32)
+      requested = {
+        certifiers: [certifier_hex],
+        types: { other_type => [] }
+      }
+      expect do
+        BSV::Auth.validate_certificates(verifier_wallet, valid_message, requested)
+      end.to raise_error(BSV::Auth::AuthError, /was not requested/)
+    end
+  end
+
+  # --- Successful with requested_certificates filter ---
+
+  describe 'with matching requested_certificates' do
+    it 'passes when certifier and type are both in the requested set' do
+      requested = {
+        certifiers: [certifier_hex],
+        types: { cert_type => [] }
+      }
+      expect do
+        BSV::Auth.validate_certificates(verifier_wallet, valid_message, requested)
+      end.not_to raise_error
+    end
+  end
+
+  # --- Decryption failure ---
+
+  describe 'when decryption fails due to wrong wallet' do
+    it 'raises AuthError about failed decryption' do
+      expect do
+        BSV::Auth.validate_certificates(wrong_wallet, valid_message)
+      end.to raise_error(BSV::Auth::AuthError, /Failed to decrypt/)
+    end
+  end
+
+  # --- Multiple certificates ---
+
+  describe 'with multiple valid certificates' do
+    let(:serial_number_2) { Base64.strict_encode64("\x03" * 32) }
+
+    let(:master_cert_2) do
+      BSV::Auth::MasterCertificate.issue_certificate_for_subject(
+        certifier_wallet,
+        subject_hex,
+        { 'role' => 'admin' },
+        cert_type,
+        serial_number: serial_number_2
+      )
+    end
+
+    let(:verifier_keyring_2) do
+      BSV::Auth::MasterCertificate.create_keyring_for_verifier(
+        subject_wallet,
+        certifier: certifier_hex,
+        verifier: verifier_hex,
+        fields: master_cert_2.fields,
+        fields_to_reveal: ['role'],
+        master_keyring: master_cert_2.master_keyring,
+        serial_number: master_cert_2.serial_number
+      )
+    end
+
+    let(:verifiable_cert_2) do
+      BSV::Auth::VerifiableCertificate.from_certificate(master_cert_2, verifier_keyring_2)
+    end
+
+    it 'validates all certificates without raising' do
+      message = {
+        identity_key: subject_hex,
+        certificates: [verifiable_cert, verifiable_cert_2]
+      }
+      expect { BSV::Auth.validate_certificates(verifier_wallet, message) }.not_to raise_error
+    end
+  end
+
+  # --- nil requested_certificates skips certifier/type checks ---
+
+  describe 'when requested_certificates is nil' do
+    it 'skips certifier and type checks and still validates signature and decrypts' do
+      expect { BSV::Auth.validate_certificates(verifier_wallet, valid_message, nil) }.not_to raise_error
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/gem/bsv-sdk/spec/support/paired_transport.rb
+++ b/gem/bsv-sdk/spec/support/paired_transport.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Bidirectional in-process transport for testing.
+#
+# Connects two peers so that +send+ on one delivers to the other's
+# +on_data+ callback. Wire two instances together via {.create_pair}.
+#
+# @example
+#   transport_a, transport_b = PairedTransport.create_pair
+#   peer_a = BSV::Auth::Peer.new(wallet: wallet_a, transport: transport_a)
+#   peer_b = BSV::Auth::Peer.new(wallet: wallet_b, transport: transport_b)
+class PairedTransport
+  include BSV::Auth::Transport
+
+  attr_accessor :partner
+
+  def initialize
+    @on_data_callback = nil
+    @partner = nil
+  end
+
+  # Creates a pair of transports wired together bidirectionally.
+  #
+  # @return [Array<PairedTransport>] two connected transports [a, b]
+  def self.create_pair
+    a = new
+    b = new
+    a.partner = b
+    b.partner = a
+    [a, b]
+  end
+
+  # Sends +message+ to the partner transport's +on_data+ callback.
+  #
+  # @param message [Hash] the auth message to deliver
+  # @raise [RuntimeError] if no partner has been set
+  def send(message)
+    raise 'PairedTransport has no partner' unless @partner
+
+    @partner.deliver(message)
+  end
+
+  # Registers a callback invoked when a message is delivered to this transport.
+  #
+  # @yieldparam message [Hash] the incoming auth message
+  def on_data(&block)
+    @on_data_callback = block
+  end
+
+  # Delivers +message+ directly to this transport's +on_data+ callback.
+  # Silently drops the message if no callback is registered.
+  #
+  # @param message [Hash] the incoming auth message
+  def deliver(message)
+    @on_data_callback&.call(message)
+  end
+end


### PR DESCRIPTION
## Summary
- Add `certificateRequest` and `certificateResponse` BRC-103 message types to `Peer` (F8.4)
- Add high-level session API: `to_peer`, `get_authenticated_session`, `request_certificates`, `send_certificate_response` (F8.5)
- Converge Peer API on TS SDK model: transport required, manual methods private
- Add `validate_certificates` and `get_verifiable_certificates` utility methods
- Add callback registration: `on_general_message`, `on_certificates_received`, `on_certificate_request`
- Add `@last_interacted_peer` tracking with `auto_persist_last_session` option
- Thread+Queue handshake blocking for sync/async transport support
- Go-style immediate rejection when certificates required but not validated
- Security fix: enforce certifier allowlist in `process_certificate_response` (same bug exists in TS SDK upstream)

## Test plan
- [x] All 237 auth specs pass
- [x] Full SDK suite passes (3266 examples, 0 failures)
- [x] RuboCop clean
- [x] Acceptance criteria verified against HLR #426
- [x] 16 end-to-end integration tests covering full lifecycle
- [x] Security review completed — 1 finding fixed (certifier allowlist bypass)
- [x] Code review completed — 4 issues addressed (deduplication, fetch! consistency, rescue documentation, PR body)

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)