### PR TITLE
docs: repo consistency fixes — READMEs, wallet guide, nav, dependency floor

### DIFF
--- a/docs/guides/wallet-postgres.md
+++ b/docs/guides/wallet-postgres.md
@@ -43,7 +43,7 @@ to `PostgresStore` is a one-line change.
 
 ## Schema
 
-Five tables, all created by the shipped migration:
+Six tables created across migrations 001–006:
 
 | Table                 | Purpose                             | Key indexes                                       |
 |-----------------------|-------------------------------------|---------------------------------------------------|
@@ -52,6 +52,7 @@ Five tables, all created by the shipped migration:
 | `wallet_certificates` | Identity certificates               | unique `(type, serial_number, certifier)`         |
 | `wallet_proofs`       | Merkle proofs keyed by txid         | primary key `txid`                                |
 | `wallet_transactions` | Raw tx hex cache keyed by txid      | primary key `txid`                                |
+| `wallet_broadcast_jobs` | Async broadcast queue (SolidQueueAdapter) | unique `txid`, composite `(status, locked_at)` |
 
 Each table stores the full record as a JSONB blob in a `data` column.
 Dedicated indexed columns (`basket`, `tags`, `labels`, `certifier`, ...)
@@ -61,9 +62,8 @@ change.
 
 ### Running the migration
 
-The shipped migration lives at
-`lib/bsv/wallet_postgres/migrations/001_create_wallet_tables.rb`. Two
-ways to apply it:
+Migrations live at `lib/bsv/wallet_postgres/migrations/` (001 through 006).
+Two ways to apply them:
 
 **Convenience helper** — one-liner, uses `Sequel::Migrator` under the
 hood so the database tracks applied versions:
@@ -127,6 +127,79 @@ over `MemoryStore`, which is explicitly not thread-safe.
   `migrate!` (or run the migration yourself) explicitly before first
   use. Clear error on the first query if tables are missing.
 
+## Async broadcast queue
+
+The `SolidQueueAdapter` provides background transaction broadcasting backed
+by the `wallet_broadcast_jobs` table. Transactions are enqueued immediately
+and broadcast by a background worker thread — the caller doesn't block on
+ARC round-trips.
+
+### Setup
+
+```ruby
+require 'bsv-wallet-postgres'
+
+db    = Sequel.connect(ENV['DATABASE_URL'])
+store = BSV::Wallet::PostgresStore.new(db)
+
+adapter = BSV::Wallet::SolidQueueAdapter.new(
+  db: db,
+  storage: store,
+  broadcaster: BSV::Network::ARC.default
+)
+adapter.start
+
+wallet = BSV::Wallet::WalletClient.new(
+  key,
+  storage: store,
+  broadcast_queue: adapter
+)
+```
+
+### How it works
+
+1. `create_action` with `accept_delayed_broadcast: true` calls
+   `adapter.enqueue(payload)` which inserts a row into
+   `wallet_broadcast_jobs` with status `unsent` and returns immediately.
+2. The background worker polls every 8 seconds (configurable via
+   `poll_interval:`), claims a job using `SELECT ... FOR UPDATE SKIP LOCKED`,
+   and broadcasts via ARC.
+3. On success: inputs promoted to `spent`, change to `spendable`, action to
+   `completed`.
+4. On failure: inputs rolled back to `spendable`, change outputs deleted,
+   action marked `failed`.
+
+### Recovery
+
+Stale `sending` jobs (locked but not completed within 5 minutes) are
+automatically retried on the next poll. No special startup code is needed —
+the worker's first poll finds and reprocesses any stale jobs from a previous
+crash.
+
+Jobs that fail 5 times (`MAX_ATTEMPTS`) are left in `failed` state and not
+retried.
+
+### Shutdown
+
+```ruby
+adapter.drain  # stops the worker and blocks until the current cycle completes
+```
+
+Jobs enqueued after `drain` is called remain `unsent` until the next
+`adapter.start`.
+
+### Multi-process safety
+
+`FOR UPDATE SKIP LOCKED` ensures that multiple worker processes polling the
+same database each claim different jobs. No external coordination is needed.
+
+### Guards
+
+- Refuses to attach when storage is `MemoryStore` (raises `ArgumentError`)
+- Requires a `broadcaster` (raises `ArgumentError` if `nil`)
+- Idempotent enqueue: duplicate `txid` returns the existing job's status
+  instead of raising
+
 ## Relationship to `bsv-wallet`
 
 `bsv-wallet-postgres` is a drop-in implementation of
@@ -135,7 +208,7 @@ over `MemoryStore`, which is explicitly not thread-safe.
 `spec/support/shared_examples_for_storage_adapter.rb` runs against all
 three backends on every CI build, so behaviour stays aligned.
 
-Versioning tracks `bsv-wallet`: the gemspec pins `bsv-wallet >= 0.3.4,
+Versioning tracks `bsv-wallet`: the gemspec pins `bsv-wallet >= 0.6.0,
 < 1.0` so consumers pick up wallet security patches automatically.
 
 [wallet]: https://github.com/sgbett/bsv-ruby-sdk

--- a/docs/guides/wallet.md
+++ b/docs/guides/wallet.md
@@ -1,0 +1,254 @@
+# Wallet
+
+The `bsv-wallet` gem implements the
+[BRC-100](https://bsv.brc.dev/wallet/0100) standard wallet-to-application
+interface. It provides `WalletClient` — a local wallet that manages UTXOs,
+builds and signs transactions, broadcasts via ARC, and tracks certificates.
+
+## Installation
+
+```ruby
+# Gemfile
+gem 'bsv-wallet'
+```
+
+## Creating a wallet
+
+```ruby
+require 'bsv-wallet'
+
+key = BSV::Primitives::PrivateKey.from_wif(ENV['SERVER_WIF'])
+
+wallet = BSV::Wallet::WalletClient.new(
+  key,
+  broadcaster: BSV::Network::ARC.default
+)
+```
+
+### Constructor parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `key` | (required) | Private key, WIF string, or `KeyDeriver` |
+| `storage` | `FileStore.new` | Persistence adapter (`MemoryStore` for tests, `PostgresStore` for production) |
+| `network` | `'mainnet'` | `'mainnet'` or `'testnet'` |
+| `broadcaster` | `nil` | Any object responding to `#broadcast(tx)` — use `ARC.default` for GorillaPool ARCADE |
+| `broadcast_queue` | `InlineQueue` | Broadcast strategy — `InlineQueue` (synchronous) or `SolidQueueAdapter` (async, PostgreSQL-backed) |
+| `chain_provider` | `NullChainProvider` | Blockchain data provider (e.g. `WhatsOnChainProvider`) |
+| `fee_estimator` | auto | Custom fee estimator (defaults to `SatoshisPerKilobyte`) |
+| `coin_selector` | auto | Custom coin selection strategy |
+| `change_generator` | auto | Custom change output generation |
+
+## Core operations
+
+### create_action
+
+Builds, signs, and optionally broadcasts a transaction:
+
+```ruby
+result = wallet.create_action({
+  description: 'Pay invoice',
+  outputs: [{
+    locking_script: '76a914...88ac',
+    satoshis: 1000,
+    output_description: 'Payment',
+    basket: 'payments',
+    tags: ['invoice-42']
+  }]
+})
+
+result[:txid]     # => "abc123..."
+result[:tx]       # => [BEEF bytes as integers]
+```
+
+When a `broadcaster` is configured, `create_action` handles the full
+lifecycle: UTXO selection, transaction construction, signing, ARC broadcast,
+and state promotion. On broadcast failure, locked UTXOs are rolled back
+automatically.
+
+#### Auto-funding
+
+If no `inputs` are specified, the wallet selects spendable UTXOs
+automatically (coin selection), adds change outputs, and manages the
+`pending` → `spent`/`spendable` state transitions.
+
+#### Options
+
+```ruby
+wallet.create_action({
+  description: 'Payment',
+  outputs: [...],
+  options: {
+    accept_delayed_broadcast: true,  # defer broadcast to background queue
+    no_send: true                    # build tx but don't broadcast
+  }
+})
+```
+
+### sign_action
+
+Signs a previously created action (two-phase commit):
+
+```ruby
+result = wallet.sign_action({
+  reference: pending_reference,
+  spends: { '0' => { unlocking_script: '...' } }
+})
+```
+
+### abort_action
+
+Cancels a pending action and releases locked UTXOs:
+
+```ruby
+wallet.abort_action({ reference: pending_reference })
+```
+
+### list_actions
+
+Query stored actions with filtering and pagination:
+
+```ruby
+actions = wallet.list_actions({
+  labels: ['payments'],
+  label_query_mode: 'any',
+  include_labels: true,
+  limit: 10,
+  offset: 0
+})
+```
+
+### list_outputs
+
+Query tracked outputs:
+
+```ruby
+outputs = wallet.list_outputs({
+  basket: 'payments',
+  tags: ['invoice-42'],
+  include_spent: false,
+  limit: 50,
+  offset: 0
+})
+```
+
+### internalize_action
+
+Accept an incoming payment by internalising a BEEF transaction:
+
+```ruby
+wallet.internalize_action({
+  tx: beef_bytes,           # Atomic BEEF binary
+  outputs: [{
+    output_index: 0,
+    protocol: 'wallet payment',
+    payee: { derivation_prefix: '...', derivation_suffix: '...' }
+  }],
+  description: 'Received payment'
+})
+```
+
+## Balance and UTXOs
+
+```ruby
+wallet.balance                          # total sats across all baskets
+wallet.balance(basket: 'payments')      # sats in a specific basket
+wallet.spendable_balance                # only immediately spendable sats
+```
+
+## Certificates
+
+BRC-100 certificate operations for identity and credential management:
+
+```ruby
+# Acquire a certificate
+wallet.acquire_certificate({
+  type: 'identity',
+  certifier: '02abc...',
+  acquisitionProtocol: 'direct',
+  fields: { name: 'Alice' }
+})
+
+# List certificates
+wallet.list_certificates({
+  certifiers: ['02abc...'],
+  types: ['identity']
+})
+
+# Prove selective disclosure
+wallet.prove_certificate({
+  certificate: cert,
+  fields_to_reveal: ['name'],
+  verifier: '02def...'
+})
+```
+
+## Storage adapters
+
+The wallet persists UTXOs, actions, certificates, and proofs via a
+pluggable `StorageAdapter`:
+
+| Adapter | Gem | Persistence | Thread-safe | Use case |
+|---------|-----|-------------|-------------|----------|
+| `MemoryStore` | bsv-wallet | None | Yes | Tests |
+| `FileStore` | bsv-wallet | JSON files | No | Development |
+| `PostgresStore` | bsv-wallet-postgres | PostgreSQL | Yes | Production |
+
+```ruby
+# Production setup with PostgreSQL
+require 'bsv-wallet-postgres'
+
+db = Sequel.connect(ENV['DATABASE_URL'])
+BSV::Wallet::PostgresStore.migrate!(db)
+store = BSV::Wallet::PostgresStore.new(db)
+
+wallet = BSV::Wallet::WalletClient.new(
+  key,
+  storage: store,
+  broadcaster: BSV::Network::ARC.default
+)
+```
+
+See the [Wallet Postgres guide](wallet-postgres.md) for production
+deployment details.
+
+## Broadcast queue
+
+The `BroadcastQueue` interface controls how transactions are dispatched
+after construction:
+
+| Adapter | Gem | Async | Description |
+|---------|-----|-------|-------------|
+| `InlineQueue` | bsv-wallet | No | Default — broadcasts synchronously in `create_action` |
+| `SolidQueueAdapter` | bsv-wallet-postgres | Yes | Background worker with PostgreSQL job table |
+
+```ruby
+# Async broadcast with SolidQueueAdapter
+adapter = BSV::Wallet::SolidQueueAdapter.new(
+  db: db,
+  storage: store,
+  broadcaster: BSV::Network::ARC.default
+)
+adapter.start
+
+wallet = BSV::Wallet::WalletClient.new(
+  key,
+  storage: store,
+  broadcast_queue: adapter
+)
+
+# On shutdown:
+adapter.drain
+```
+
+See the [Wallet Postgres guide](wallet-postgres.md#async-broadcast-queue)
+for details.
+
+## Error handling
+
+| Error class | When |
+|-------------|------|
+| `InsufficientFundsError` | Not enough spendable UTXOs for the requested amount |
+| `WalletError` | General wallet operation failure |
+| `InvalidParameterError` | Invalid arguments to a wallet method |
+| `UnsupportedActionError` | Requested operation not supported |

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,9 @@ The SDK is organised into three top-level modules:
 
 ## Companion gems
 
-- **[bsv-wallet-postgres](guides/wallet-postgres.md)** — persistent PostgreSQL storage adapter for `bsv-wallet`, for production deployments that need state to survive restarts
+- **[bsv-wallet](guides/wallet.md)** — BRC-100 wallet interface with `WalletClient`, storage adapters, and broadcast queue
+- **[bsv-wallet-postgres](guides/wallet-postgres.md)** — PostgreSQL storage adapter and async broadcast queue for production deployments
+- **[bsv-attest](https://rubygems.org/gems/bsv-attest)** — document attestation via OP_RETURN on the BSV blockchain
 
 ## Quick Links
 

--- a/gem/bsv-attest/README.md
+++ b/gem/bsv-attest/README.md
@@ -1,0 +1,48 @@
+# bsv-attest
+
+Document attestation on the BSV Blockchain. Hash data, publish hashes
+via OP_RETURN using a BRC-100 wallet, and verify attestations on chain.
+
+Part of the [BSV Ruby SDK](https://github.com/sgbett/bsv-ruby-sdk)
+monorepo.
+
+## Installation
+
+```ruby
+# Gemfile
+gem 'bsv-attest'
+```
+
+Requires `bsv-sdk` and `bsv-wallet`.
+
+## Quick start
+
+```ruby
+require 'bsv-attest'
+
+BSV::Attest.configure do |c|
+  c.wallet = my_wallet  # BSV::Wallet::WalletClient with broadcaster
+end
+
+# Publish a document hash to the blockchain
+result = BSV::Attest.publish(data: File.read('document.pdf'))
+puts result.txid
+```
+
+## How it works
+
+1. SHA-256 hashes the input data
+2. Builds an OP_RETURN output containing the hash
+3. Broadcasts via `wallet.create_action` (the wallet handles UTXO
+   selection, signing, and ARC broadcast)
+4. Returns a `Response` with the transaction ID
+
+## Documentation
+
+- [Full documentation](https://sgbett.github.io/bsv-ruby-sdk/)
+- [Getting started guide](https://sgbett.github.io/bsv-ruby-sdk/guides/getting-started/)
+- [Changelog](CHANGELOG.md)
+
+## Licence
+
+[Open BSV Licence Version 5](LICENSE)

--- a/gem/bsv-wallet-postgres/README.md
+++ b/gem/bsv-wallet-postgres/README.md
@@ -1,0 +1,66 @@
+# bsv-wallet-postgres
+
+PostgreSQL storage adapter for
+[bsv-wallet](https://rubygems.org/gems/bsv-wallet). Persistent,
+multi-instance-safe, and thread-safe via Sequel's connection pool.
+
+Part of the [BSV Ruby SDK](https://github.com/sgbett/bsv-ruby-sdk)
+monorepo.
+
+## Installation
+
+```ruby
+# Gemfile
+gem 'bsv-wallet-postgres'
+```
+
+Requires `pg` and `sequel` (pulled in automatically).
+
+## Quick start
+
+```ruby
+require 'bsv-wallet-postgres'
+
+db = Sequel.connect(ENV['DATABASE_URL'])
+BSV::Wallet::PostgresStore.migrate!(db)
+
+store  = BSV::Wallet::PostgresStore.new(db)
+wallet = BSV::Wallet::WalletClient.new(key, storage: store)
+```
+
+## Async broadcast queue
+
+The `SolidQueueAdapter` provides background transaction broadcasting
+backed by a PostgreSQL job table:
+
+```ruby
+adapter = BSV::Wallet::SolidQueueAdapter.new(
+  db: db,
+  storage: store,
+  broadcaster: BSV::Network::ARC.default
+)
+adapter.start
+
+wallet = BSV::Wallet::WalletClient.new(
+  key,
+  storage: store,
+  broadcast_queue: adapter
+)
+
+# Transactions are enqueued and broadcast in the background.
+# On shutdown:
+adapter.drain
+```
+
+Features: stale job recovery, `FOR UPDATE SKIP LOCKED` multi-process
+safety, idempotent enqueue, configurable poll interval and retry limits.
+
+## Documentation
+
+- [Full documentation](https://sgbett.github.io/bsv-ruby-sdk/)
+- [Wallet Postgres guide](https://sgbett.github.io/bsv-ruby-sdk/guides/wallet-postgres/)
+- [Changelog](CHANGELOG.md)
+
+## Licence
+
+[Open BSV Licence Version 5](LICENSE)

--- a/gem/bsv-wallet/README.md
+++ b/gem/bsv-wallet/README.md
@@ -1,0 +1,68 @@
+# bsv-wallet
+
+BRC-100 wallet interface for the BSV Blockchain. Implements the standard
+wallet-to-application interface: `create_action`, `sign_action`,
+`list_actions`, `list_outputs`, certificates, and more.
+
+Part of the [BSV Ruby SDK](https://github.com/sgbett/bsv-ruby-sdk)
+monorepo.
+
+## Installation
+
+```ruby
+# Gemfile
+gem 'bsv-wallet'
+```
+
+## Quick start
+
+```ruby
+require 'bsv-wallet'
+
+key = BSV::Primitives::PrivateKey.from_wif(ENV['SERVER_WIF'])
+wallet = BSV::Wallet::WalletClient.new(key)
+
+# Create a simple payment
+result = wallet.create_action({
+  description: 'Pay invoice',
+  outputs: [{
+    locking_script: '76a914...88ac',
+    satoshis: 1000,
+    output_description: 'Payment'
+  }]
+})
+```
+
+## Broadcasting
+
+Pass a broadcaster to enable on-chain broadcast:
+
+```ruby
+wallet = BSV::Wallet::WalletClient.new(
+  key,
+  broadcaster: BSV::Network::ARC.default
+)
+```
+
+The wallet handles transaction construction, UTXO management, signing,
+broadcasting, and state promotion/rollback automatically.
+
+## Storage adapters
+
+| Adapter | Gem | Use case |
+|---------|-----|----------|
+| `MemoryStore` | bsv-wallet | Tests only |
+| `FileStore` | bsv-wallet | Development (default) |
+| `PostgresStore` | [bsv-wallet-postgres](https://rubygems.org/gems/bsv-wallet-postgres) | Production |
+
+## Documentation
+
+- [Full documentation](https://sgbett.github.io/bsv-ruby-sdk/)
+- [Getting started guide](https://sgbett.github.io/bsv-ruby-sdk/guides/getting-started/)
+- [Wallet guide](https://sgbett.github.io/bsv-ruby-sdk/guides/wallet/)
+- [API reference](https://sgbett.github.io/bsv-ruby-sdk/reference/)
+- [Changelog](CHANGELOG.md)
+
+## Licence
+
+[Open BSV Licence Version 5](LICENSE)

--- a/gem/bsv-wallet/bsv-wallet.gemspec
+++ b/gem/bsv-wallet/bsv-wallet.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
 
   # Floor raised with each paired release so consumers of bsv-wallet
   # also pick up the corresponding bsv-sdk correctness fixes.
-  spec.add_dependency 'bsv-sdk', '>= 0.10.0', '< 1.0'
+  spec.add_dependency 'bsv-sdk', '>= 0.11.0', '< 1.0'
 end

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,9 +51,10 @@ nav:
       - Script: guides/script.md
       - Transaction: guides/transaction.md
       - Network: guides/network.md
+      - Wallet: guides/wallet.md
+      - Wallet Postgres: guides/wallet-postgres.md
       - MCP Server: guides/mcp.md
       - Naming Conventions: guides/naming-conventions.md
-      - Wallet Postgres: guides/wallet-postgres.md
   - About:
       - Pure Ruby secp256k1: about/secp256k1.md
   - API Reference: reference/index.md


### PR DESCRIPTION
## Summary
- Add per-gem READMEs for bsv-wallet, bsv-wallet-postgres, bsv-attest (RubyGems now shows usage guidance)
- Add `docs/guides/wallet.md` — comprehensive WalletClient API guide (create_action, storage, broadcast queue, certificates)
- Update `docs/guides/wallet-postgres.md` with SolidQueueAdapter section from 0.4.0 release
- Update `docs/index.md` to list all companion gems
- Reorder mkdocs.yml nav: wallet guides grouped together
- Bump bsv-wallet dependency floor on bsv-sdk from `>= 0.10.0` to `>= 0.11.0`
- Enabled GitHub Pages (was disabled — `gh-pages` branch existed but Pages wasn't configured)

## Test plan
- [x] Full test suite passes
- [x] RuboCop clean
- [x] All mkdocs nav entries point to existing files
- [ ] Verify https://sgbett.github.io/bsv-ruby-sdk/ loads after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)