### PR TITLE
feat: phase 4 wallet integration -- BRC-100 substrates, include flags, WireFormat, AuthFetch issuance (#445)

### DIFF
--- a/.claude/plans/20260415-phase4-wallet-integration.md
+++ b/.claude/plans/20260415-phase4-wallet-integration.md
@@ -1,0 +1,262 @@
+# Plan: HLR #445 — Phase 4 Wallet Integration (F8.2/F8.11/F8.12/F8.16)
+
+**HLR**: [#445](https://github.com/sgbett/bsv-ruby-sdk/issues/445)
+**Parent**: [#378](https://github.com/sgbett/bsv-ruby-sdk/issues/378)
+**Depends on**: #436 (Phase 3 — BRC-104 HTTP auth transport, merged)
+
+## Context
+
+Phase 3 delivered BRC-104 HTTP auth (`AuthFetch`, `SimplifiedFetchTransport`, `AuthMiddleware`). Phase 4 connects the wallet layer to this infrastructure and fills three remaining cross-SDK gaps: HTTP substrates for remote wallet communication (F8.2), include flags for list queries (F8.12), and authenticated certificate issuance (F8.16). F8.11 (wire format translator) is foundational infrastructure needed by the substrates.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    WalletClient                          │
+│  substrate: nil → local storage (existing)               │
+│  substrate: HTTPWalletJSON → JSON-over-HTTP              │
+│  substrate: WalletWireTransceiver(HTTPWalletWire) → wire │
+├─────────────────────────────────────────────────────────┤
+│                    Substrates                            │
+│  ┌─────────────────────┐  ┌──────────────────────────┐  │
+│  │   HTTPWalletJSON     │  │  WalletWireTransceiver   │  │
+│  │  (implements         │  │  (wraps WalletWire →     │  │
+│  │   Interface)         │  │   implements Interface)  │  │
+│  │  POST /methodName    │  ├──────────────────────────┤  │
+│  │  JSON body           │  │    HTTPWalletWire        │  │
+│  │  uses WireFormat     │  │  (implements WalletWire) │  │
+│  │  for key conversion  │  │  POST /callName          │  │
+│  └─────────────────────┘  │  binary body              │  │
+│                            │  uses Wire::Serializer    │  │
+│                            └──────────────────────────┘  │
+├─────────────────────────────────────────────────────────┤
+│  BSV::WireFormat (in bsv-sdk)                            │
+│  deep_snake_to_camel / deep_camel_to_snake               │
+│  Shared by substrates + AuthMiddleware + FetchTransport  │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Task Breakdown
+
+### Task 1: WireFormat module (F8.11)
+
+**Problem:** camelCase↔snake_case conversion is duplicated inline in `AuthMiddleware` (shallow, lines 281–302) and `SimplifiedFetchTransport` (lookup table + fallback, lines 240–269). HTTPWalletJSON will need deep conversion. Need a shared module.
+
+**Location:** `gem/bsv-sdk/lib/bsv/wire_format.rb` as `BSV::WireFormat`
+
+Lives in bsv-sdk because both existing consumers (AuthMiddleware, SimplifiedFetchTransport) are in bsv-sdk. The wallet gem depends on bsv-sdk and can reuse it.
+
+**Public API:**
+- `BSV::WireFormat.to_wire(hash)` — deep snake_case → camelCase key conversion
+- `BSV::WireFormat.from_wire(hash)` — deep camelCase → snake_case key conversion
+- `BSV::WireFormat.snake_to_camel(str)` — single string conversion
+- `BSV::WireFormat.camel_to_snake(str)` — single string conversion
+
+**Implementation:**
+- Merge the lookup table from `SimplifiedFetchTransport::SNAKE_TO_CAMEL` with BRC-100 method parameter names (extracted from `Wire::Serializer` write methods)
+- Generic fallback for unknown keys (regex-based, same as existing)
+- Deep conversion recurses into nested Hashes and Arrays
+- Values are NOT converted — only Hash keys
+- Edge case: user-data hashes (e.g., certificate `fields`) have arbitrary keys that should NOT be converted. Handle by convention: the caller wraps user-data before passing, or we document that to_wire/from_wire converts ALL keys and callers must handle exceptions
+
+**Refactoring:**
+- `auth_middleware.rb`: replace private `snake_case_keys`, `camel_case_keys`, `camel_to_snake`, `snake_to_camel` with `BSV::WireFormat` calls
+- `simplified_fetch_transport.rb`: replace `SNAKE_TO_CAMEL`, `CAMEL_TO_SNAKE`, private conversion methods with `BSV::WireFormat` calls
+
+**Files:**
+| File | Action |
+|------|--------|
+| `gem/bsv-sdk/lib/bsv/wire_format.rb` | New |
+| `gem/bsv-sdk/lib/bsv-sdk.rb` | Modified (add autoload) |
+| `gem/bsv-sdk/lib/bsv/auth/auth_middleware.rb` | Modified (use WireFormat) |
+| `gem/bsv-sdk/lib/bsv/auth/simplified_fetch_transport.rb` | Modified (use WireFormat) |
+| `gem/bsv-sdk/spec/bsv/wire_format_spec.rb` | New |
+
+---
+
+### Task 2: Include flags for list_actions/list_outputs (F8.12)
+
+**Problem:** `build_action_query` and `build_output_query` discard include flags. All storage adapters return complete hashes.
+
+**Strategy:** Post-fetch field stripping in `WalletClient`, not in storage adapters. This keeps the storage interface clean and works identically across MemoryStore, FileStore, and PostgresStore. The storage layer continues to return full data; WalletClient strips fields based on caller's include flags.
+
+**Default behaviour:** Flags default to `false` (matching TS SDK). When a flag is absent or false, the corresponding field is deleted from each result hash. When explicitly `true`, the field is preserved.
+
+**list_actions flags:**
+- `include_labels` → strip `:labels` when false
+- `include_inputs` → strip `:inputs` when false (currently not stored — no-op for now, but future-proof)
+- `include_input_source_locking_scripts` → strip nested `:source_locking_script` within inputs
+- `include_input_unlocking_scripts` → strip nested `:unlocking_script` within inputs
+- `include_outputs` → strip `:outputs` when false (currently not stored — no-op for now)
+- `include_output_locking_scripts` → strip nested `:locking_script` within outputs
+
+**list_outputs flags:**
+- `include_tags` → strip `:tags` when false
+- `include_labels` → strip `:labels` when false
+- `include_custom_instructions` → strip `:custom_instructions` when false
+
+**Implementation:** Two private methods in WalletClient:
+- `strip_action_fields(actions, args)` — returns new array with fields removed
+- `strip_output_fields(outputs, args)` — returns new array with fields removed
+
+Uses `Hash#reject` / `Hash#select` (Ruby 2.7 compatible, avoids `Hash#except`).
+
+**Files:**
+| File | Action |
+|------|--------|
+| `gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb` | Modified (list_actions, list_outputs, new private strip methods) |
+| `gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_spec.rb` | Modified (add include flag specs) |
+
+---
+
+### Task 3: BRC-100 HTTP substrates (F8.2)
+
+Three new classes + module wiring + WalletClient integration.
+
+#### Task 3a: Substrates module + HTTPWalletJSON
+
+**Class:** `BSV::Wallet::Substrates::HTTPWalletJSON`
+- Includes `BSV::Wallet::Interface`
+- Constructor: `initialize(base_url, originator: nil, http_client: nil)`
+- Each of 28 Interface methods delegates to private `call(method_name, args)`
+- `call` does: `BSV::WireFormat.to_wire(args)` → `POST #{base_url}/#{camel_method}` with JSON body → parse response → `BSV::WireFormat.from_wire(response)`
+- Uses `Net::HTTP` (no AuthFetch — matching TS SDK)
+- Origin header sent for originator identification
+- Error handling: non-2xx raises `WalletError` with decoded error body
+
+**Method name mapping:** Derive camelCase method names from `CALL_CODES.keys` via `BSV::WireFormat.snake_to_camel`. Store as a class constant `METHOD_NAMES`.
+
+#### Task 3b: HTTPWalletWire
+
+**Class:** `BSV::Wallet::Substrates::HTTPWalletWire`
+- Constructor: `initialize(base_url, originator: nil, http_client: nil)`
+- Single method: `transmit_to_wallet(message)` → returns byte array
+- Parses call code from `message[0]`, maps via `Wire::Serializer::METHODS_BY_CODE`
+- POSTs binary payload to `#{base_url}/#{camel_call_name}` with `Content-Type: application/octet-stream`
+- Returns response body as byte array
+
+#### Task 3c: WalletWireTransceiver
+
+**Class:** `BSV::Wallet::Substrates::WalletWireTransceiver`
+- Includes `BSV::Wallet::Interface`
+- Constructor: `initialize(wire, originator: nil)`
+- Each Interface method: serialize via `Wire::Serializer.serialize_request` → `@wire.transmit_to_wallet(frame.bytes)` → deserialize via `Wire::Serializer.deserialize_response`
+- Single private `transmit(method_name, args, originator)` handles the pattern
+
+#### Task 3d: WalletClient substrate integration
+
+Add `substrate:` keyword to `WalletClient#initialize`. When set, Interface methods delegate to the substrate:
+
+```ruby
+def create_action(args, originator: nil)
+  return @substrate.create_action(args, originator: originator) if @substrate
+  # existing local logic...
+end
+```
+
+Pattern repeated for all 28 methods. Local storage, key derivation, etc. remain for the non-substrate path.
+
+**Files:**
+| File | Action |
+|------|--------|
+| `gem/bsv-wallet/lib/bsv/wallet_interface/substrates.rb` | New (autoloads) |
+| `gem/bsv-wallet/lib/bsv/wallet_interface/substrates/http_wallet_json.rb` | New |
+| `gem/bsv-wallet/lib/bsv/wallet_interface/substrates/http_wallet_wire.rb` | New |
+| `gem/bsv-wallet/lib/bsv/wallet_interface/substrates/wallet_wire_transceiver.rb` | New |
+| `gem/bsv-wallet/lib/bsv/wallet_interface.rb` | Modified (add Substrates autoload) |
+| `gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb` | Modified (substrate: param) |
+| `gem/bsv-wallet/spec/bsv/wallet_interface/substrates/http_wallet_json_spec.rb` | New |
+| `gem/bsv-wallet/spec/bsv/wallet_interface/substrates/http_wallet_wire_spec.rb` | New |
+| `gem/bsv-wallet/spec/bsv/wallet_interface/substrates/wallet_wire_transceiver_spec.rb` | New |
+
+---
+
+### Task 4: AuthFetch certificate issuance (F8.16)
+
+**Problem:** `acquire_via_issuance` (wallet_client.rb:1582–1620) uses plain `Net::HTTP::Post`. Should use `AuthFetch` for mutual authentication.
+
+**Approach:** Lazy-create an `AuthFetch` instance on first issuance call. `WalletClient` passes `self` as the wallet to `AuthFetch.new(wallet: self)`. This is safe because AuthFetch only calls crypto methods (`get_public_key`, `create_signature`) which are provided by `ProtoWallet` (the superclass) and don't depend on storage or the issuance flow.
+
+```ruby
+def acquire_via_issuance(args)
+  response = auth_fetch_client.fetch(
+    args[:certifier_url],
+    method: 'POST',
+    headers: { 'content-type' => 'application/json' },
+    body: JSON.generate({
+      type: args[:type],
+      subject: @key_deriver.identity_key,
+      certifier: args[:certifier],
+      fields: args[:fields]
+    })
+  )
+
+  raise WalletError, "Certificate issuance failed: HTTP #{response.status}" unless (200..299).cover?(response.status)
+
+  body = JSON.parse(response.body)
+  # ... existing cert construction + CertificateSignature.verify! ...
+end
+
+def auth_fetch_client
+  @auth_fetch ||= BSV::Auth::AuthFetch.new(wallet: self)
+end
+```
+
+The existing `execute_http` helper and `@http_client` injection remain for other uses. The `@http_client` parameter is not removed for backward compatibility.
+
+**Files:**
+| File | Action |
+|------|--------|
+| `gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb` | Modified (acquire_via_issuance, new auth_fetch_client helper) |
+| `gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_spec.rb` | Modified (AuthFetch issuance specs) |
+
+## Task Dependencies
+
+```
+Task 1 (WireFormat) ───→ Task 3a (HTTPWalletJSON)
+                    ───→ AuthMiddleware/FetchTransport refactoring
+                                                        ↘
+Task 2 (include flags)   ← independent                  Task 3d (WalletClient substrate:)
+                                                        ↗
+Task 3b (HTTPWalletWire) ← independent ──→ Task 3c (Transceiver)
+
+Task 4 (AuthFetch issuance) ← independent
+```
+
+**Recommended sequence:** 1 → 2 → 3b → 3c → 3a → 3d → 4
+
+Tasks 1, 2, and 4 are independent of each other — could be parallelised. Task 3a needs Task 1. Tasks 3b/3c are independent of Task 1 but must precede 3d.
+
+## Key Design Decisions
+
+1. **WireFormat in bsv-sdk, not bsv-wallet.** Both existing consumers (AuthMiddleware, SimplifiedFetchTransport) live in bsv-sdk. Placing it there avoids import direction issues.
+
+2. **Post-fetch stripping for include flags, not storage-level filtering.** Keeps the storage interface unchanged. All three adapters continue to return full data. WalletClient applies the cosmetic stripping. This is simpler and less risky than modifying three separate storage implementations plus the PostgresStore in a different gem.
+
+3. **Substrates use plain HTTP, not AuthFetch.** Matches TS SDK. Substrates are transport layers for wallet-to-wallet communication. AuthFetch is for authenticated HTTP to arbitrary servers (certifiers, APIs).
+
+4. **Lazy AuthFetch for issuance.** Created on first use, not at construction time. Avoids overhead when certificates aren't used. `self` as the wallet is safe because only crypto methods are called.
+
+5. **No auto-detection.** Unlike the TS SDK's WalletClient which tries multiple substrates, the Ruby version accepts an explicit `substrate:` parameter. Auto-detection is a browser concern; Ruby is server-side.
+
+## Verification
+
+```bash
+# Task 1
+cd gem/bsv-sdk && bundle exec rspec spec/bsv/wire_format_spec.rb
+cd gem/bsv-sdk && bundle exec rspec spec/bsv/auth/auth_middleware_spec.rb
+cd gem/bsv-sdk && bundle exec rspec spec/bsv/auth/simplified_fetch_transport_spec.rb
+
+# Task 2
+cd gem/bsv-wallet && bundle exec rspec spec/bsv/wallet_interface/wallet_client_spec.rb
+
+# Task 3
+cd gem/bsv-wallet && bundle exec rspec spec/bsv/wallet_interface/substrates/
+
+# Task 4
+cd gem/bsv-wallet && bundle exec rspec spec/bsv/wallet_interface/wallet_client_spec.rb
+
+# Full suite + lint
+bundle exec rake
+bundle exec rubocop
+```

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,6 +106,7 @@ Metrics/ModuleLength:
     - 'gem/bsv-sdk/lib/bsv/auth/**/*'
     - 'gem/bsv-sdk/lib/bsv/identity/**/*'
     - 'gem/bsv-sdk/lib/bsv/registry/**/*'
+    - 'gem/bsv-sdk/lib/bsv/wire_format.rb'
     - 'gem/*/spec/**/*'
 
 Metrics/ClassLength:
@@ -213,6 +214,7 @@ RSpec/ExampleLength:
     - 'gem/*/spec/support/**/*'
     - 'gem/bsv-sdk/spec/integration/**/*'
     - 'gem/bsv-sdk/spec/conformance/**/*'
+    - 'gem/bsv-sdk/spec/bsv/wire_format_spec.rb'
 
 # Bitcoin opcodes use numbered names (OP_1, OP_2, etc.) — protocol constants.
 # Wire protocol helpers use base64_32 to denote 32-byte base64 values (protocol constraint).

--- a/gem/bsv-sdk/lib/bsv-sdk.rb
+++ b/gem/bsv-sdk/lib/bsv-sdk.rb
@@ -17,4 +17,5 @@ module BSV
   autoload :Registry,    'bsv/registry'
   autoload :MCP,         'bsv/mcp'
   autoload :Messages,    'bsv/messages'
+  autoload :WireFormat,  'bsv/wire_format'
 end

--- a/gem/bsv-sdk/lib/bsv/auth/auth_middleware.rb
+++ b/gem/bsv-sdk/lib/bsv/auth/auth_middleware.rb
@@ -82,12 +82,12 @@ module BSV
         return json_error(400, 'Empty body') if body_str.nil? || body_str.empty?
 
         raw = JSON.parse(body_str)
-        message = snake_case_keys(raw)
+        message = BSV::WireFormat.from_wire(raw)
 
         @bridge.inject(message)
         response_message = @bridge.wait_for_response
 
-        camel = camel_case_keys(response_message)
+        camel = BSV::WireFormat.to_wire(response_message)
         [200, { 'content-type' => 'application/json' }, [JSON.generate(camel)]]
       rescue JSON::ParserError => e
         json_error(400, "Invalid JSON: #{e.message}")
@@ -276,29 +276,6 @@ module BSV
         return [] if headers.empty?
 
         AuthHeaders.filter_request_headers(headers)
-      end
-
-      # Converts a Hash with string camelCase keys to snake_case symbol keys (shallow).
-      def snake_case_keys(hash)
-        hash.transform_keys { |k| camel_to_snake(k.to_s).to_sym }
-      end
-
-      # Converts a Hash with snake_case symbol/string keys to camelCase string keys (shallow).
-      def camel_case_keys(hash)
-        hash.transform_keys { |k| snake_to_camel(k.to_s) }
-      end
-
-      # Converts camelCase string to snake_case.
-      def camel_to_snake(str)
-        str.gsub(/([A-Z])/) { "_#{::Regexp.last_match(1).downcase}" }.sub(/^_/, '')
-      end
-
-      # Converts snake_case string to camelCase.
-      def snake_to_camel(str)
-        parts = str.split('_')
-        return str if parts.empty?
-
-        parts[0] + parts[1..].map(&:capitalize).join
       end
 
       # Returns a simple JSON error response.

--- a/gem/bsv-sdk/lib/bsv/auth/auth_middleware.rb
+++ b/gem/bsv-sdk/lib/bsv/auth/auth_middleware.rb
@@ -82,12 +82,12 @@ module BSV
         return json_error(400, 'Empty body') if body_str.nil? || body_str.empty?
 
         raw = JSON.parse(body_str)
-        message = BSV::WireFormat.from_wire(raw)
+        message = BSV::WireFormat.shallow_from_wire(raw)
 
         @bridge.inject(message)
         response_message = @bridge.wait_for_response
 
-        camel = BSV::WireFormat.to_wire(response_message)
+        camel = BSV::WireFormat.shallow_to_wire(response_message)
         [200, { 'content-type' => 'application/json' }, [JSON.generate(camel)]]
       rescue JSON::ParserError => e
         json_error(400, "Invalid JSON: #{e.message}")

--- a/gem/bsv-sdk/lib/bsv/auth/simplified_fetch_transport.rb
+++ b/gem/bsv-sdk/lib/bsv/auth/simplified_fetch_transport.rb
@@ -69,7 +69,7 @@ module BSV
 
       def send_non_general(message)
         auth_url  = "#{@base_url}/.well-known/auth"
-        body_json = JSON.generate(BSV::WireFormat.to_wire(message))
+        body_json = JSON.generate(BSV::WireFormat.shallow_to_wire(message))
 
         uri      = URI.parse(auth_url)
         response = perform_http_request(uri, 'POST', { 'Content-Type' => 'application/json' }, body_json)
@@ -80,7 +80,7 @@ module BSV
         end
 
         response_hash = JSON.parse(response_body(response))
-        @on_data_callback.call(BSV::WireFormat.from_wire(response_hash))
+        @on_data_callback.call(BSV::WireFormat.shallow_from_wire(response_hash))
       end
 
       # -------------------------------------------------------------------------

--- a/gem/bsv-sdk/lib/bsv/auth/simplified_fetch_transport.rb
+++ b/gem/bsv-sdk/lib/bsv/auth/simplified_fetch_transport.rb
@@ -61,20 +61,6 @@ module BSV
         end
       end
 
-      # Well-known camelCase <-> snake_case pairs that appear in every handshake.
-      # Falls back to generic conversion for any key not in the table.
-      SNAKE_TO_CAMEL = {
-        'message_type' => 'messageType',
-        'identity_key' => 'identityKey',
-        'initial_nonce' => 'initialNonce',
-        'your_nonce' => 'yourNonce',
-        'requested_certificates' => 'requestedCertificates',
-        'serial_number' => 'serialNumber',
-        'revocation_outpoint' => 'revocationOutpoint'
-      }.freeze
-
-      CAMEL_TO_SNAKE = SNAKE_TO_CAMEL.invert.freeze
-
       private
 
       # -------------------------------------------------------------------------
@@ -83,7 +69,7 @@ module BSV
 
       def send_non_general(message)
         auth_url  = "#{@base_url}/.well-known/auth"
-        body_json = JSON.generate(to_camel_case(message))
+        body_json = JSON.generate(BSV::WireFormat.to_wire(message))
 
         uri      = URI.parse(auth_url)
         response = perform_http_request(uri, 'POST', { 'Content-Type' => 'application/json' }, body_json)
@@ -94,7 +80,7 @@ module BSV
         end
 
         response_hash = JSON.parse(response_body(response))
-        @on_data_callback.call(to_snake_case(response_hash))
+        @on_data_callback.call(BSV::WireFormat.from_wire(response_hash))
       end
 
       # -------------------------------------------------------------------------
@@ -231,41 +217,6 @@ module BSV
         rescue JSON::ParserError => e
           raise "Failed to parse #{AuthHeaders::REQUESTED_CERTIFICATES} returned by #{url}: #{raw}. #{e.message}"
         end
-      end
-
-      # -------------------------------------------------------------------------
-      # camelCase <-> snake_case conversion
-      # -------------------------------------------------------------------------
-
-      # Converts a symbol-keyed message hash to camelCase string keys for JSON wire format.
-      # Uses the lookup table for known keys, generic conversion for the rest.
-      def to_camel_case(hash)
-        hash.each_with_object({}) do |(k, v), out|
-          snake = k.to_s
-          out[SNAKE_TO_CAMEL.fetch(snake) { generic_snake_to_camel(snake) }] = v
-        end
-      end
-
-      # Converts a camelCase string-keyed response hash to snake_case symbol keys.
-      # Uses the lookup table for known keys, generic conversion for the rest.
-      def to_snake_case(hash)
-        hash.each_with_object({}) do |(k, v), out|
-          camel = k.to_s
-          out[CAMEL_TO_SNAKE.fetch(camel) { generic_camel_to_snake(camel) }.to_sym] = v
-        end
-      end
-
-      # Generic snake_case → camelCase conversion.
-      def generic_snake_to_camel(str)
-        parts = str.split('_')
-        return str if parts.length <= 1
-
-        parts[0] + parts[1..].map(&:capitalize).join
-      end
-
-      # Generic camelCase → snake_case conversion.
-      def generic_camel_to_snake(str)
-        str.gsub(/([A-Z])/) { "_#{::Regexp.last_match(1).downcase}" }
       end
 
       # -------------------------------------------------------------------------

--- a/gem/bsv-sdk/lib/bsv/wire_format.rb
+++ b/gem/bsv-sdk/lib/bsv/wire_format.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+module BSV
+  # Provides deep camelCase <-> snake_case key conversion for JSON wire boundaries.
+  #
+  # Used wherever the SDK serialises or deserialises JSON payloads that follow
+  # the BRC-100/BRC-103 naming conventions (camelCase on the wire, snake_case in Ruby).
+  #
+  # @example Convert a hash to wire format
+  #   BSV::WireFormat.to_wire({ identity_key: '02abc', protocol_id: [2, 'test'] })
+  #   # => { 'identityKey' => '02abc', 'protocolID' => [2, 'test'] }
+  #
+  # @example Convert a wire format hash to Ruby
+  #   BSV::WireFormat.from_wire({ 'identityKey' => '02abc' })
+  #   # => { identity_key: '02abc' }
+  #
+  # @example Deep conversion with nested hashes and arrays
+  #   BSV::WireFormat.to_wire({ outputs: [{ locking_script: 'abc' }] })
+  #   # => { 'outputs' => [{ 'lockingScript' => 'abc' }] }
+  module WireFormat
+    # Well-known snake_case -> camelCase pairs for BRC-100/BRC-103 protocol keys.
+    #
+    # Acronyms like protocolID, keyID are canonical per the TS SDK (Wallet.interfaces.ts).
+    # Generic regex fallback handles all other keys.
+    SNAKE_TO_CAMEL = {
+      # BRC-103 / Auth handshake keys
+      'message_type' => 'messageType',
+      'identity_key' => 'identityKey',
+      'initial_nonce' => 'initialNonce',
+      'your_nonce' => 'yourNonce',
+      'requested_certificates' => 'requestedCertificates',
+      'serial_number' => 'serialNumber',
+      'revocation_outpoint' => 'revocationOutpoint',
+
+      # BRC-100 parameter names (acronym forms from TS SDK Wallet.interfaces.ts)
+      'protocol_id' => 'protocolID',
+      'key_id' => 'keyID',
+      'input_beef' => 'inputBEEF',
+      'locking_script' => 'lockingScript',
+      'unlocking_script' => 'unlockingScript',
+      'label_query_mode' => 'labelQueryMode',
+      'tag_query_mode' => 'tagQueryMode',
+      'include_labels' => 'includeLabels',
+      'include_inputs' => 'includeInputs',
+      'include_outputs' => 'includeOutputs',
+      'include_custom_instructions' => 'includeCustomInstructions',
+      'include_tags' => 'includeTags',
+      'counterparty_can_see_reveal' => 'counterpartyCanSeeReveal',
+      'is_authenticated' => 'isAuthenticated',
+      'wait_for_authentication' => 'waitForAuthentication',
+      'get_public_key' => 'getPublicKey',
+      'create_action' => 'createAction',
+      'sign_action' => 'signAction',
+      'abort_action' => 'abortAction',
+      'list_actions' => 'listActions',
+      'internalize_action' => 'internalizeAction',
+      'list_outputs' => 'listOutputs',
+      'relinquish_output' => 'relinquishOutput',
+      'reveal_counterparty_key_linkage' => 'revealCounterpartyKeyLinkage',
+      'reveal_specific_key_linkage' => 'revealSpecificKeyLinkage',
+      'create_hmac' => 'createHMAC',
+      'verify_hmac' => 'verifyHMAC',
+      'create_signature' => 'createSignature',
+      'verify_signature' => 'verifySignature',
+      'acquire_certificate' => 'acquireCertificate',
+      'list_certificates' => 'listCertificates',
+      'prove_certificate' => 'proveCertificate',
+      'relinquish_certificate' => 'relinquishCertificate',
+      'discover_by_identity_key' => 'discoverByIdentityKey',
+      'discover_by_attributes' => 'discoverByAttributes',
+      'get_height' => 'getHeight',
+      'get_header_for_height' => 'getHeaderForHeight',
+      'get_network' => 'getNetwork',
+      'get_version' => 'getVersion'
+    }.freeze
+
+    # Inverse lookup table: camelCase -> snake_case.
+    CAMEL_TO_SNAKE = SNAKE_TO_CAMEL.invert.freeze
+
+    module_function
+
+    # Deeply converts all Hash keys from snake_case symbols/strings to camelCase strings.
+    #
+    # Recurses into nested Hash values and Array elements. Non-Hash, non-Array values
+    # are passed through unchanged (only keys are converted, not values).
+    #
+    # @param hash [Hash] the hash to convert
+    # @return [Hash] a new hash with camelCase string keys
+    # @raise [ArgumentError] if the argument is nil
+    def to_wire(hash)
+      raise ArgumentError, 'argument must not be nil' if hash.nil?
+
+      hash.each_with_object({}) do |(k, v), out|
+        camel_key = snake_to_camel(k.to_s)
+        out[camel_key] = deep_convert_value_to_wire(v)
+      end
+    end
+
+    # Deeply converts all Hash keys from camelCase strings to snake_case symbols.
+    #
+    # Recurses into nested Hash values and Array elements. Non-Hash, non-Array values
+    # are passed through unchanged (only keys are converted, not values).
+    #
+    # @param hash [Hash] the hash to convert
+    # @return [Hash] a new hash with snake_case symbol keys
+    # @raise [ArgumentError] if the argument is nil
+    def from_wire(hash)
+      raise ArgumentError, 'argument must not be nil' if hash.nil?
+
+      hash.each_with_object({}) do |(k, v), out|
+        snake_key = camel_to_snake(k.to_s).to_sym
+        out[snake_key] = deep_convert_value_from_wire(v)
+      end
+    end
+
+    # Converts a single snake_case string to camelCase.
+    #
+    # Uses the lookup table for known protocol keys (preserving acronyms like protocolID).
+    # Falls back to generic capitalisation for unknown keys.
+    #
+    # @param str [String] a snake_case string
+    # @return [String] the camelCase equivalent
+    def snake_to_camel(str)
+      SNAKE_TO_CAMEL.fetch(str) { generic_snake_to_camel(str) }
+    end
+
+    # Converts a single camelCase string to snake_case.
+    #
+    # Uses the lookup table for known protocol keys. Falls back to generic
+    # regex substitution for unknown keys.
+    #
+    # @param str [String] a camelCase string
+    # @return [String] the snake_case equivalent
+    def camel_to_snake(str)
+      CAMEL_TO_SNAKE.fetch(str) { generic_camel_to_snake(str) }
+    end
+
+    # Generic snake_case -> camelCase conversion for unknown keys.
+    def generic_snake_to_camel(str)
+      parts = str.split('_')
+      return str if parts.length <= 1
+
+      parts[0] + parts[1..].map(&:capitalize).join
+    end
+    private_class_method :generic_snake_to_camel
+
+    # Generic camelCase -> snake_case conversion for unknown keys.
+    def generic_camel_to_snake(str)
+      str.gsub(/([A-Z])/) { "_#{::Regexp.last_match(1).downcase}" }.sub(/^_/, '')
+    end
+    private_class_method :generic_camel_to_snake
+
+    # Recursively converts a value destined for the wire (to_wire direction).
+    def deep_convert_value_to_wire(value)
+      if value.is_a?(Hash)
+        to_wire(value)
+      elsif value.is_a?(Array)
+        value.map { |elem| deep_convert_value_to_wire(elem) }
+      else
+        value
+      end
+    end
+    private_class_method :deep_convert_value_to_wire
+
+    # Recursively converts a value coming from the wire (from_wire direction).
+    def deep_convert_value_from_wire(value)
+      if value.is_a?(Hash)
+        from_wire(value)
+      elsif value.is_a?(Array)
+        value.map { |elem| deep_convert_value_from_wire(elem) }
+      else
+        value
+      end
+    end
+    private_class_method :deep_convert_value_from_wire
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/wire_format.rb
+++ b/gem/bsv-sdk/lib/bsv/wire_format.rb
@@ -113,6 +113,38 @@ module BSV
       end
     end
 
+    # Converts top-level Hash keys only from snake_case to camelCase strings.
+    #
+    # Unlike {.to_wire}, this does NOT recurse into nested hashes. Use this
+    # for auth handshake messages where nested values may contain user-data
+    # keys (e.g. base64 certificate type identifiers) that must not be mangled.
+    #
+    # @param hash [Hash] the hash to convert
+    # @return [Hash] a new hash with camelCase string keys (values unchanged)
+    def shallow_to_wire(hash)
+      raise ArgumentError, 'argument must not be nil' if hash.nil?
+
+      hash.each_with_object({}) do |(k, v), out|
+        out[snake_to_camel(k.to_s)] = v
+      end
+    end
+
+    # Converts top-level Hash keys only from camelCase to snake_case symbols.
+    #
+    # Unlike {.from_wire}, this does NOT recurse into nested hashes. Use this
+    # for auth handshake messages where nested values may contain user-data
+    # keys (e.g. base64 certificate type identifiers) that must not be mangled.
+    #
+    # @param hash [Hash] the hash to convert
+    # @return [Hash] a new hash with snake_case symbol keys (values unchanged)
+    def shallow_from_wire(hash)
+      raise ArgumentError, 'argument must not be nil' if hash.nil?
+
+      hash.each_with_object({}) do |(k, v), out|
+        out[camel_to_snake(k.to_s).to_sym] = v
+      end
+    end
+
     # Converts a single snake_case string to camelCase.
     #
     # Uses the lookup table for known protocol keys (preserving acronyms like protocolID).

--- a/gem/bsv-sdk/spec/bsv/wire_format_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/wire_format_spec.rb
@@ -174,6 +174,66 @@ RSpec.describe BSV::WireFormat do
     end
   end
 
+  describe '.shallow_to_wire' do
+    it 'converts top-level keys only' do
+      result = described_class.shallow_to_wire({ identity_key: '02abc', your_nonce: 'n1' })
+      expect(result).to eq({ 'identityKey' => '02abc', 'yourNonce' => 'n1' })
+    end
+
+    it 'does NOT recurse into nested hashes' do
+      input = {
+        requested_certificates: {
+          'certifiers' => ['02abc'],
+          'types' => { 'dHlwZUFBQQ==' => %w[name email] }
+        }
+      }
+      result = described_class.shallow_to_wire(input)
+      # The nested hash should be passed through unchanged — keys not converted
+      expect(result['requestedCertificates']['types']).to eq({ 'dHlwZUFBQQ==' => %w[name email] })
+    end
+
+    it 'preserves base64 certificate type keys in requested_certificates' do
+      cert_types = { 'dHlwZUFBQUFBQQ==' => %w[name email], 'Zm9vQmFy' => ['age'] }
+      input = { requested_certificates: { 'certifiers' => [], 'types' => cert_types } }
+      result = described_class.shallow_to_wire(input)
+      expect(result['requestedCertificates']['types'].keys).to eq(%w[dHlwZUFBQUFBQQ== Zm9vQmFy])
+    end
+
+    it 'raises ArgumentError for nil input' do
+      expect { described_class.shallow_to_wire(nil) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '.shallow_from_wire' do
+    it 'converts top-level keys only' do
+      result = described_class.shallow_from_wire({ 'identityKey' => '02abc', 'yourNonce' => 'n1' })
+      expect(result).to eq({ identity_key: '02abc', your_nonce: 'n1' })
+    end
+
+    it 'does NOT recurse into nested hashes' do
+      input = {
+        'requestedCertificates' => {
+          'certifiers' => ['02abc'],
+          'types' => { 'dHlwZUFBQQ==' => %w[name email] }
+        }
+      }
+      result = described_class.shallow_from_wire(input)
+      # The nested hash should be passed through unchanged — keys not converted
+      expect(result[:requested_certificates]['types']).to eq({ 'dHlwZUFBQQ==' => %w[name email] })
+    end
+
+    it 'preserves base64 certificate type keys in requested_certificates' do
+      cert_types = { 'dHlwZUFBQUFBQQ==' => %w[name email], 'Zm9vQmFy' => ['age'] }
+      input = { 'requestedCertificates' => { 'certifiers' => [], 'types' => cert_types } }
+      result = described_class.shallow_from_wire(input)
+      expect(result[:requested_certificates]['types'].keys).to eq(%w[dHlwZUFBQUFBQQ== Zm9vQmFy])
+    end
+
+    it 'raises ArgumentError for nil input' do
+      expect { described_class.shallow_from_wire(nil) }.to raise_error(ArgumentError)
+    end
+  end
+
   describe 'round-trip' do
     it 'round-trips a representative BRC-100 payload' do
       original = {

--- a/gem/bsv-sdk/spec/bsv/wire_format_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/wire_format_spec.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+RSpec.describe BSV::WireFormat do
+  describe '.snake_to_camel' do
+    it 'converts a simple snake_case string' do
+      expect(described_class.snake_to_camel('identity_key')).to eq('identityKey')
+    end
+
+    it 'uses the lookup table for known acronym keys' do
+      expect(described_class.snake_to_camel('protocol_id')).to eq('protocolID')
+    end
+
+    it 'uses the lookup table for input_beef' do
+      expect(described_class.snake_to_camel('input_beef')).to eq('inputBEEF')
+    end
+
+    it 'uses generic conversion for unknown keys' do
+      expect(described_class.snake_to_camel('my_custom_key')).to eq('myCustomKey')
+    end
+
+    it 'returns single-word strings unchanged' do
+      expect(described_class.snake_to_camel('txid')).to eq('txid')
+    end
+  end
+
+  describe '.camel_to_snake' do
+    it 'converts a simple camelCase string' do
+      expect(described_class.camel_to_snake('identityKey')).to eq('identity_key')
+    end
+
+    it 'uses the lookup table for known acronym keys' do
+      expect(described_class.camel_to_snake('protocolID')).to eq('protocol_id')
+    end
+
+    it 'uses the lookup table for inputBEEF' do
+      expect(described_class.camel_to_snake('inputBEEF')).to eq('input_beef')
+    end
+
+    it 'uses generic conversion for unknown keys' do
+      expect(described_class.camel_to_snake('myCustomKey')).to eq('my_custom_key')
+    end
+
+    it 'returns single-word strings unchanged' do
+      expect(described_class.camel_to_snake('txid')).to eq('txid')
+    end
+  end
+
+  describe '.to_wire' do
+    it 'converts snake_case symbol keys to camelCase string keys' do
+      result = described_class.to_wire({ identity_key: '02abc' })
+      expect(result).to eq({ 'identityKey' => '02abc' })
+    end
+
+    it 'converts snake_case string keys to camelCase string keys' do
+      result = described_class.to_wire({ 'identity_key' => '02abc' })
+      expect(result).to eq({ 'identityKey' => '02abc' })
+    end
+
+    it 'handles acronym keys correctly' do
+      result = described_class.to_wire({ protocol_id: [2, 'test'] })
+      expect(result).to eq({ 'protocolID' => [2, 'test'] })
+    end
+
+    it 'returns an empty hash for empty input' do
+      expect(described_class.to_wire({})).to eq({})
+    end
+
+    it 'raises ArgumentError for nil input' do
+      expect { described_class.to_wire(nil) }.to raise_error(ArgumentError)
+    end
+
+    it 'deeply converts nested hash values' do
+      result = described_class.to_wire({ outer_key: { inner_key: 'value' } })
+      expect(result).to eq({ 'outerKey' => { 'innerKey' => 'value' } })
+    end
+
+    it 'deeply converts hashes inside arrays' do
+      result = described_class.to_wire({ actions: [{ label_query_mode: 'any' }] })
+      expect(result).to eq({ 'actions' => [{ 'labelQueryMode' => 'any' }] })
+    end
+
+    it 'passes non-hash array elements through unchanged' do
+      result = described_class.to_wire({ data: [1, 'hello', { my_key: 1 }] })
+      expect(result).to eq({ 'data' => [1, 'hello', { 'myKey' => 1 }] })
+    end
+
+    it 'does not convert values (only keys)' do
+      result = described_class.to_wire({ my_key: 'some_snake_value' })
+      expect(result).to eq({ 'myKey' => 'some_snake_value' })
+    end
+
+    it 'converts all BRC-103 handshake keys' do
+      input = {
+        message_type: 'initialRequest',
+        identity_key: '02abc',
+        initial_nonce: 'nonce123',
+        your_nonce: 'nonce456',
+        requested_certificates: [],
+        serial_number: 'sn001',
+        revocation_outpoint: 'txid:0'
+      }
+      expected = {
+        'messageType' => 'initialRequest',
+        'identityKey' => '02abc',
+        'initialNonce' => 'nonce123',
+        'yourNonce' => 'nonce456',
+        'requestedCertificates' => [],
+        'serialNumber' => 'sn001',
+        'revocationOutpoint' => 'txid:0'
+      }
+      expect(described_class.to_wire(input)).to eq(expected)
+    end
+  end
+
+  describe '.from_wire' do
+    it 'converts camelCase string keys to snake_case symbol keys' do
+      result = described_class.from_wire({ 'identityKey' => '02abc' })
+      expect(result).to eq({ identity_key: '02abc' })
+    end
+
+    it 'handles acronym keys correctly' do
+      result = described_class.from_wire({ 'protocolID' => [2, 'test'] })
+      expect(result).to eq({ protocol_id: [2, 'test'] })
+    end
+
+    it 'returns an empty hash for empty input' do
+      expect(described_class.from_wire({})).to eq({})
+    end
+
+    it 'raises ArgumentError for nil input' do
+      expect { described_class.from_wire(nil) }.to raise_error(ArgumentError)
+    end
+
+    it 'deeply converts nested hash values' do
+      result = described_class.from_wire({ 'outerKey' => { 'innerKey' => 'value' } })
+      expect(result).to eq({ outer_key: { inner_key: 'value' } })
+    end
+
+    it 'deeply converts hashes inside arrays' do
+      result = described_class.from_wire({ 'actions' => [{ 'labelQueryMode' => 'any' }] })
+      expect(result).to eq({ actions: [{ label_query_mode: 'any' }] })
+    end
+
+    it 'passes non-hash array elements through unchanged' do
+      result = described_class.from_wire({ 'data' => [1, 'hello', { 'myKey' => 1 }] })
+      expect(result).to eq({ data: [1, 'hello', { my_key: 1 }] })
+    end
+
+    it 'does not convert values (only keys)' do
+      result = described_class.from_wire({ 'myKey' => 'someCamelValue' })
+      expect(result).to eq({ my_key: 'someCamelValue' })
+    end
+
+    it 'converts all BRC-103 handshake keys' do
+      input = {
+        'messageType' => 'initialRequest',
+        'identityKey' => '02abc',
+        'initialNonce' => 'nonce123',
+        'yourNonce' => 'nonce456',
+        'requestedCertificates' => [],
+        'serialNumber' => 'sn001',
+        'revocationOutpoint' => 'txid:0'
+      }
+      expected = {
+        message_type: 'initialRequest',
+        identity_key: '02abc',
+        initial_nonce: 'nonce123',
+        your_nonce: 'nonce456',
+        requested_certificates: [],
+        serial_number: 'sn001',
+        revocation_outpoint: 'txid:0'
+      }
+      expect(described_class.from_wire(input)).to eq(expected)
+    end
+  end
+
+  describe 'round-trip' do
+    it 'round-trips a representative BRC-100 payload' do
+      original = {
+        identity_key: '02abcdef',
+        protocol_id: [2, 'test-protocol'],
+        key_id: 'my-key',
+        locking_script: 'deadbeef',
+        include_labels: true,
+        label_query_mode: 'any'
+      }
+      expect(described_class.from_wire(described_class.to_wire(original))).to eq(original)
+    end
+
+    it 'round-trips deeply nested structures' do
+      original = {
+        outputs: [
+          { locking_script: 'abc', include_tags: false },
+          { locking_script: 'def', include_tags: true }
+        ],
+        identity_key: '02abc'
+      }
+      expect(described_class.from_wire(described_class.to_wire(original))).to eq(original)
+    end
+  end
+end

--- a/gem/bsv-wallet/lib/bsv/wallet_interface.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface.rb
@@ -23,6 +23,7 @@ module BSV
     autoload :WhatsOnChainProvider,   'bsv/wallet_interface/whats_on_chain_provider'
     autoload :WalletClient,      'bsv/wallet_interface/wallet_client'
     autoload :Wire,              'bsv/wallet_interface/wire'
+    autoload :Substrates,        'bsv/wallet_interface/substrates'
     autoload :CertificateSignature, 'bsv/wallet_interface/certificate_signature'
     autoload :FeeModel,             'bsv/wallet_interface/fee_model'
     autoload :FeeEstimator,         'bsv/wallet_interface/fee_estimator'

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/substrates.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/substrates.rb
@@ -10,6 +10,7 @@ module BSV
     module Substrates
       autoload :HTTPWalletJSON, 'bsv/wallet_interface/substrates/http_wallet_json'
       autoload :HTTPWalletWire, 'bsv/wallet_interface/substrates/http_wallet_wire'
+      autoload :WalletWireTransceiver, 'bsv/wallet_interface/substrates/wallet_wire_transceiver'
     end
   end
 end

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/substrates.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/substrates.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module BSV
+  module Wallet
+    # BRC-100 wallet substrates — alternative transport layers for the wallet interface.
+    #
+    # Substrates are raw transport adapters. They are not full WalletInterface implementations;
+    # instead they provide the low-level connectivity that a WalletWireTransceiver or
+    # HTTPWalletJSON wraps to expose the full interface.
+    module Substrates
+      autoload :HTTPWalletJSON, 'bsv/wallet_interface/substrates/http_wallet_json'
+      autoload :HTTPWalletWire, 'bsv/wallet_interface/substrates/http_wallet_wire'
+    end
+  end
+end

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/substrates/http_wallet_json.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/substrates/http_wallet_json.rb
@@ -1,0 +1,258 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+require 'uri'
+
+module BSV
+  module Wallet
+    module Substrates
+      # BRC-100 wallet substrate that delegates all Interface methods to a remote
+      # wallet server via JSON-over-HTTP (POST #{base_url}/#{camelCaseMethodName}).
+      #
+      # Key conversion is handled by {BSV::WireFormat}: Ruby snake_case symbol keys
+      # in args are converted to camelCase strings before the request, and the
+      # camelCase JSON response is converted back to snake_case symbol keys.
+      #
+      # @example
+      #   wallet = BSV::Wallet::Substrates::HTTPWalletJSON.new('http://localhost:3321',
+      #                                                         originator: 'myapp.example.com')
+      #   result = wallet.get_public_key({ identity_key: true })
+      #   # => { public_key: '02abc...' }
+      class HTTPWalletJSON
+        include BSV::Wallet::Interface
+
+        # Maps the 28 BRC-100 Interface method symbols to their camelCase HTTP endpoint names.
+        # Derived from Wire::Serializer::CALL_CODES keys via BSV::WireFormat.snake_to_camel.
+        METHOD_NAMES = BSV::Wallet::Wire::Serializer::CALL_CODES.keys.to_h do |sym|
+          [sym, BSV::WireFormat.snake_to_camel(sym.to_s)]
+        end.freeze
+
+        # @param base_url [String] base URL of the remote wallet server (e.g. 'http://localhost:3321')
+        # @param originator [String, nil] FQDN of the originating application (sent as Origin/Originator headers)
+        # @param http_client [Object, nil] injectable HTTP client for testing; must respond to
+        #   `start(uri, &block)` returning a Net::HTTP-compatible response
+        def initialize(base_url, originator: nil, http_client: nil)
+          @base_url = base_url
+          @originator = originator
+          @http_client = http_client
+        end
+
+        # rubocop:disable Lint/UnusedMethodArgument
+
+        def create_action(args, originator: nil)
+          call(METHOD_NAMES[:create_action], args)
+        end
+
+        def sign_action(args, originator: nil)
+          call(METHOD_NAMES[:sign_action], args)
+        end
+
+        def abort_action(args, originator: nil)
+          call(METHOD_NAMES[:abort_action], args)
+        end
+
+        def list_actions(args, originator: nil)
+          call(METHOD_NAMES[:list_actions], args)
+        end
+
+        def internalize_action(args, originator: nil)
+          call(METHOD_NAMES[:internalize_action], args)
+        end
+
+        def list_outputs(args, originator: nil)
+          call(METHOD_NAMES[:list_outputs], args)
+        end
+
+        def relinquish_output(args, originator: nil)
+          call(METHOD_NAMES[:relinquish_output], args)
+        end
+
+        def get_public_key(args, originator: nil)
+          call(METHOD_NAMES[:get_public_key], args)
+        end
+
+        def reveal_counterparty_key_linkage(args, originator: nil)
+          call(METHOD_NAMES[:reveal_counterparty_key_linkage], args)
+        end
+
+        def reveal_specific_key_linkage(args, originator: nil)
+          call(METHOD_NAMES[:reveal_specific_key_linkage], args)
+        end
+
+        def encrypt(args, originator: nil)
+          call(METHOD_NAMES[:encrypt], args)
+        end
+
+        def decrypt(args, originator: nil)
+          call(METHOD_NAMES[:decrypt], args)
+        end
+
+        def create_hmac(args, originator: nil)
+          call(METHOD_NAMES[:create_hmac], args)
+        end
+
+        def verify_hmac(args, originator: nil)
+          call(METHOD_NAMES[:verify_hmac], args)
+        end
+
+        def create_signature(args, originator: nil)
+          call(METHOD_NAMES[:create_signature], args)
+        end
+
+        def verify_signature(args, originator: nil)
+          call(METHOD_NAMES[:verify_signature], args)
+        end
+
+        def acquire_certificate(args, originator: nil)
+          call(METHOD_NAMES[:acquire_certificate], args)
+        end
+
+        def list_certificates(args, originator: nil)
+          call(METHOD_NAMES[:list_certificates], args)
+        end
+
+        def prove_certificate(args, originator: nil)
+          call(METHOD_NAMES[:prove_certificate], args)
+        end
+
+        def relinquish_certificate(args, originator: nil)
+          call(METHOD_NAMES[:relinquish_certificate], args)
+        end
+
+        def discover_by_identity_key(args, originator: nil)
+          call(METHOD_NAMES[:discover_by_identity_key], args)
+        end
+
+        def discover_by_attributes(args, originator: nil)
+          call(METHOD_NAMES[:discover_by_attributes], args)
+        end
+
+        def is_authenticated(args = {}, originator: nil)
+          call(METHOD_NAMES[:is_authenticated], args)
+        end
+
+        def wait_for_authentication(args = {}, originator: nil)
+          call(METHOD_NAMES[:wait_for_authentication], args)
+        end
+
+        def get_height(args = {}, originator: nil)
+          call(METHOD_NAMES[:get_height], args)
+        end
+
+        def get_header_for_height(args, originator: nil)
+          call(METHOD_NAMES[:get_header_for_height], args)
+        end
+
+        def get_network(args = {}, originator: nil)
+          call(METHOD_NAMES[:get_network], args)
+        end
+
+        def get_version(args = {}, originator: nil)
+          call(METHOD_NAMES[:get_version], args)
+        end
+
+        # rubocop:enable Lint/UnusedMethodArgument
+
+        private
+
+        # Posts args to the remote wallet endpoint for the given camelCase method name.
+        #
+        # Outbound: converts snake_case symbol keys to camelCase strings via WireFormat.to_wire.
+        # Inbound:  converts camelCase string keys to snake_case symbols via WireFormat.from_wire.
+        # Errors:   non-2xx response raises the appropriate WalletError subclass.
+        #
+        # @param method_name [String] camelCase endpoint name (e.g. 'getPublicKey')
+        # @param args [Hash] method arguments (snake_case symbol keys)
+        # @return [Hash] response with snake_case symbol keys
+        def call(method_name, args)
+          args ||= {}
+          wire_args = BSV::WireFormat.to_wire(args)
+          body = JSON.generate(wire_args)
+
+          uri = build_uri(method_name)
+          headers = build_headers
+
+          response = execute_request(uri, body, headers)
+
+          handle_response(response, method_name, args)
+        end
+
+        def build_uri(method_name)
+          URI.parse("#{@base_url}/#{method_name}")
+        end
+
+        def build_headers
+          h = {
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json'
+          }
+
+          if @originator
+            origin_value = to_origin_header(@originator)
+            h['Origin']      = origin_value
+            h['Originator']  = origin_value
+          end
+
+          h
+        end
+
+        # Converts an originator domain to a full Origin header value.
+        # Prepends 'http://' if no scheme is present (matching TS SDK toOriginHeader).
+        def to_origin_header(originator)
+          return originator if originator.match?(%r{\A[a-z][a-z0-9+.-]*://}i)
+
+          "http://#{originator}"
+        end
+
+        def execute_request(uri, body, headers)
+          if @http_client
+            @http_client.post(uri, body, headers)
+          else
+            Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+              request = Net::HTTP::Post.new(uri.request_uri, headers)
+              request.body = body
+              http.request(request)
+            end
+          end
+        end
+
+        def handle_response(response, method_name, args)
+          code = response.code.to_i
+          data = parse_json_body(response.body)
+
+          raise_error_response(code, data, method_name, args) unless (200..299).cover?(code)
+
+          return {} if data.nil?
+
+          data.is_a?(Hash) ? BSV::WireFormat.from_wire(data) : data
+        end
+
+        def parse_json_body(body)
+          return nil if body.nil? || body.empty?
+
+          JSON.parse(body)
+        rescue JSON::ParserError
+          nil
+        end
+
+        def raise_error_response(code, data, method_name, _args)
+          if code == 400 && data.is_a?(Hash) && data['isError']
+            case data['code']
+            when 5
+              raise BSV::Wallet::WalletError.new(data['message'] || 'Review actions required', 5)
+            when 6
+              raise BSV::Wallet::InvalidParameterError, data['parameter'] || 'unknown'
+            when 7
+              raise BSV::Wallet::InsufficientFundsError, data['message']
+            end
+          end
+
+          message = (data.is_a?(Hash) && data['message']) ||
+                    "HTTP #{code} error calling #{method_name}"
+          raise BSV::Wallet::WalletError, message
+        end
+      end
+    end
+  end
+end

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/substrates/http_wallet_json.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/substrates/http_wallet_json.rb
@@ -38,6 +38,11 @@ module BSV
           @http_client = http_client
         end
 
+        # Per-call originator is accepted for Interface conformance but not forwarded.
+        # The Origin header uses the constructor-level @originator for the lifetime of
+        # the connection — matching the TS SDK's HTTPWalletJSON, which also ignores per-call
+        # originator. WalletWireTransceiver supports per-call originator because the wire
+        # frame encodes it per-message; HTTP substrates identify by connection, not by call.
         # rubocop:disable Lint/UnusedMethodArgument
 
         def create_action(args, originator: nil)
@@ -219,10 +224,17 @@ module BSV
 
         def handle_response(response, method_name, args)
           code = response.code.to_i
+
+          unless (200..299).cover?(code)
+            data = begin
+              parse_json_body(response.body)
+            rescue JSON::ParserError
+              nil
+            end
+            raise_error_response(code, data, method_name, args)
+          end
+
           data = parse_json_body(response.body)
-
-          raise_error_response(code, data, method_name, args) unless (200..299).cover?(code)
-
           return {} if data.nil?
 
           data.is_a?(Hash) ? BSV::WireFormat.from_wire(data) : data
@@ -232,8 +244,6 @@ module BSV
           return nil if body.nil? || body.empty?
 
           JSON.parse(body)
-        rescue JSON::ParserError
-          nil
         end
 
         def raise_error_response(code, data, method_name, _args)

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/substrates/http_wallet_wire.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/substrates/http_wallet_wire.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'uri'
+
+module BSV
+  module Wallet
+    module Substrates
+      # Binary wire transport that transmits BRC-100 wallet wire messages over HTTP.
+      #
+      # Implements the single-method WalletWire interface: given a raw binary frame
+      # (as an Array of byte integers), parses the call code, maps it to a URL path,
+      # and POSTs the payload to the remote wallet endpoint.
+      #
+      # @example
+      #   wire = BSV::Wallet::Substrates::HTTPWalletWire.new('http://localhost:3301')
+      #   response_bytes = wire.transmit_to_wallet(frame_bytes)
+      class HTTPWalletWire
+        # @param base_url [String] the base URL of the remote wallet (e.g. 'http://localhost:3301')
+        # @param originator [String, nil] FQDN of the calling application (sent as Origin header)
+        # @param http_client [#call, nil] injectable HTTP client for testing; nil uses Net::HTTP
+        def initialize(base_url, originator: nil, http_client: nil)
+          @base_url = base_url
+          @originator = originator
+          @http_client = http_client
+        end
+
+        # Transmits a binary wallet wire message to the remote wallet.
+        #
+        # Parses the call code from byte 0, reads the originator from the header,
+        # and POSTs the remaining payload bytes to the appropriate URL path.
+        #
+        # @param message [Array<Integer>] raw wire frame as array of byte integers
+        # @return [Array<Integer>] response body as array of byte integers
+        # @raise [ArgumentError] if the message is empty or contains an unknown call code
+        # @raise [RuntimeError] if the HTTP response indicates an error (non-2xx)
+        def transmit_to_wallet(message)
+          raise ArgumentError, 'message must not be empty' if message.nil? || message.empty?
+
+          call_code = message[0]
+          call_name = BSV::Wallet::Wire::Serializer::METHODS_BY_CODE[call_code]
+          raise ArgumentError, "unknown call code: #{call_code}" if call_name.nil?
+
+          originator_length = message[1] || 0
+          originator = message[2, originator_length].pack('C*').force_encoding('UTF-8') if originator_length.positive?
+
+          payload_start = 2 + originator_length
+          payload = message[payload_start..] || []
+
+          camel_name = BSV::WireFormat.snake_to_camel(call_name.to_s)
+          url = "#{@base_url}/#{camel_name}"
+
+          response_body = post_binary(url, payload, originator || @originator)
+          response_body.bytes.to_a
+        end
+
+        private
+
+        def post_binary(url, payload_bytes, originator)
+          uri = URI.parse(url)
+          body = payload_bytes.pack('C*')
+
+          if @http_client
+            @http_client.call(uri, body, originator)
+          else
+            perform_request(uri, body, originator)
+          end
+        end
+
+        def perform_request(uri, body, originator)
+          Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+            request = Net::HTTP::Post.new(uri.request_uri)
+            request['Content-Type'] = 'application/octet-stream'
+            request['Origin'] = originator if originator && !originator.empty?
+            request.body = body
+            response = http.request(request)
+            raise "HTTPWalletWire: HTTP #{response.code} from #{uri}" unless response.is_a?(Net::HTTPSuccess)
+
+            response.body || ''
+          end
+        end
+      end
+    end
+  end
+end

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/substrates/wallet_wire_transceiver.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/substrates/wallet_wire_transceiver.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+module BSV
+  module Wallet
+    module Substrates
+      # BRC-100 wallet Interface implementation that transmits calls over a binary wire transport.
+      #
+      # Serialises each Interface method call into a binary wire frame via
+      # {BSV::Wallet::Wire::Serializer}, transmits it via a wire transport (any object
+      # responding to `#transmit_to_wallet`), then deserialises the response.
+      #
+      # The wire transport is duck-typed — any object that accepts
+      # `transmit_to_wallet(message)` where +message+ is an Array of byte integers
+      # and returns an Array of byte integers qualifies. The canonical wire transport
+      # is {HTTPWalletWire}.
+      #
+      # @example Using with HTTPWalletWire
+      #   wire = BSV::Wallet::Substrates::HTTPWalletWire.new('http://localhost:3301')
+      #   wallet = BSV::Wallet::Substrates::WalletWireTransceiver.new(wire, originator: 'myapp.example.com')
+      #   result = wallet.get_public_key({ identity_key: true })
+      #   # => { public_key: '02abc...' }
+      class WalletWireTransceiver
+        include BSV::Wallet::Interface
+
+        # @param wire [#transmit_to_wallet] wire transport (duck-typed)
+        # @param originator [String, nil] default FQDN of the originating application;
+        #   may be overridden per-call via the method-level originator keyword argument
+        def initialize(wire, originator: nil)
+          @wire = wire
+          @originator = originator
+        end
+
+        def create_action(args, originator: nil)
+          transmit(:create_action, args, originator || @originator)
+        end
+
+        def sign_action(args, originator: nil)
+          transmit(:sign_action, args, originator || @originator)
+        end
+
+        def abort_action(args, originator: nil)
+          transmit(:abort_action, args, originator || @originator)
+        end
+
+        def list_actions(args, originator: nil)
+          transmit(:list_actions, args, originator || @originator)
+        end
+
+        def internalize_action(args, originator: nil)
+          transmit(:internalize_action, args, originator || @originator)
+        end
+
+        def list_outputs(args, originator: nil)
+          transmit(:list_outputs, args, originator || @originator)
+        end
+
+        def relinquish_output(args, originator: nil)
+          transmit(:relinquish_output, args, originator || @originator)
+        end
+
+        def get_public_key(args, originator: nil)
+          transmit(:get_public_key, args, originator || @originator)
+        end
+
+        def reveal_counterparty_key_linkage(args, originator: nil)
+          transmit(:reveal_counterparty_key_linkage, args, originator || @originator)
+        end
+
+        def reveal_specific_key_linkage(args, originator: nil)
+          transmit(:reveal_specific_key_linkage, args, originator || @originator)
+        end
+
+        def encrypt(args, originator: nil)
+          transmit(:encrypt, args, originator || @originator)
+        end
+
+        def decrypt(args, originator: nil)
+          transmit(:decrypt, args, originator || @originator)
+        end
+
+        def create_hmac(args, originator: nil)
+          transmit(:create_hmac, args, originator || @originator)
+        end
+
+        def verify_hmac(args, originator: nil)
+          transmit(:verify_hmac, args, originator || @originator)
+        end
+
+        def create_signature(args, originator: nil)
+          transmit(:create_signature, args, originator || @originator)
+        end
+
+        def verify_signature(args, originator: nil)
+          transmit(:verify_signature, args, originator || @originator)
+        end
+
+        def acquire_certificate(args, originator: nil)
+          transmit(:acquire_certificate, args, originator || @originator)
+        end
+
+        def list_certificates(args, originator: nil)
+          transmit(:list_certificates, args, originator || @originator)
+        end
+
+        def prove_certificate(args, originator: nil)
+          transmit(:prove_certificate, args, originator || @originator)
+        end
+
+        def relinquish_certificate(args, originator: nil)
+          transmit(:relinquish_certificate, args, originator || @originator)
+        end
+
+        def discover_by_identity_key(args, originator: nil)
+          transmit(:discover_by_identity_key, args, originator || @originator)
+        end
+
+        def discover_by_attributes(args, originator: nil)
+          transmit(:discover_by_attributes, args, originator || @originator)
+        end
+
+        def is_authenticated(args = {}, originator: nil)
+          transmit(:is_authenticated, args, originator || @originator)
+        end
+
+        def wait_for_authentication(args = {}, originator: nil)
+          transmit(:wait_for_authentication, args, originator || @originator)
+        end
+
+        def get_height(args = {}, originator: nil)
+          transmit(:get_height, args, originator || @originator)
+        end
+
+        def get_header_for_height(args, originator: nil)
+          transmit(:get_header_for_height, args, originator || @originator)
+        end
+
+        def get_network(args = {}, originator: nil)
+          transmit(:get_network, args, originator || @originator)
+        end
+
+        def get_version(args = {}, originator: nil)
+          transmit(:get_version, args, originator || @originator)
+        end
+
+        private
+
+        # Serialises +method_name+ and +args+ into a binary wire frame, transmits it
+        # via the wire transport, and deserialises the response.
+        #
+        # Error responses (non-zero first byte) are parsed and raised as {WalletError}
+        # by {BSV::Wallet::Wire::Serializer.deserialize_response}.
+        #
+        # @param method_name [Symbol] BRC-100 method name (snake_case)
+        # @param args [Hash] method arguments
+        # @param orig [String, nil] FQDN of the originating application
+        # @return [Hash] deserialised result
+        def transmit(method_name, args, orig)
+          frame = BSV::Wallet::Wire::Serializer.serialize_request(
+            method_name, args || {}, originator: orig.to_s
+          )
+          response_bytes = @wire.transmit_to_wallet(frame.bytes.to_a)
+          response_binary = response_bytes.pack('C*')
+          BSV::Wallet::Wire::Serializer.deserialize_response(method_name, response_binary)
+        end
+      end
+    end
+  end
+end

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
@@ -215,7 +215,7 @@ module BSV
         query = build_action_query(args)
         total = @storage.count_actions(query)
         actions = @storage.find_actions(query)
-        { total_actions: total, actions: actions }
+        { total_actions: total, actions: strip_action_fields(actions, args) }
       end
 
       # Lists spendable outputs in a basket.
@@ -233,7 +233,7 @@ module BSV
         query = build_output_query(args)
         total = @storage.count_outputs(query)
         outputs = @storage.find_outputs(query)
-        { total_outputs: total, outputs: outputs }
+        { total_outputs: total, outputs: strip_output_fields(outputs, args) }
       end
 
       # Removes an output from basket tracking.
@@ -1436,6 +1436,42 @@ module BSV
         query
       end
 
+      # --- Include-flag stripping ---
+
+      def strip_action_fields(actions, args)
+        actions.map do |action|
+          a = action.dup
+          a.delete(:labels) unless args[:include_labels] == true
+          a.delete(:inputs) unless args[:include_inputs] == true
+
+          if a.key?(:inputs) && args[:include_input_source_locking_scripts] != true
+            a[:inputs] = a[:inputs].map { |i| i.dup.tap { |h| h.delete(:source_locking_script) } }
+          end
+
+          if a.key?(:inputs) && args[:include_input_unlocking_scripts] != true
+            a[:inputs] = a[:inputs].map { |i| i.dup.tap { |h| h.delete(:unlocking_script) } }
+          end
+
+          a.delete(:outputs) unless args[:include_outputs] == true
+
+          if a.key?(:outputs) && args[:include_output_locking_scripts] != true
+            a[:outputs] = a[:outputs].map { |o| o.dup.tap { |h| h.delete(:locking_script) } }
+          end
+
+          a
+        end
+      end
+
+      def strip_output_fields(outputs, args)
+        outputs.map do |output|
+          o = output.dup
+          o.delete(:tags) unless args[:include_tags] == true
+          o.delete(:labels) unless args[:include_labels] == true
+          o.delete(:custom_instructions) unless args[:include_custom_instructions] == true
+          o
+        end
+      end
+
       # --- Internalize helpers ---
 
       def store_proofs_from_beef(beef)
@@ -1580,20 +1616,19 @@ module BSV
       end
 
       def acquire_via_issuance(args)
-        uri = URI(args[:certifier_url])
-        request = Net::HTTP::Post.new(uri)
-        request['Content-Type'] = 'application/json'
-        request.body = JSON.generate({
-                                       type: args[:type],
-                                       subject: @key_deriver.identity_key,
-                                       certifier: args[:certifier],
-                                       fields: args[:fields]
-                                     })
+        response = auth_fetch_client.fetch(
+          args[:certifier_url],
+          method: 'POST',
+          headers: { 'content-type' => 'application/json' },
+          body: JSON.generate({
+                                type: args[:type],
+                                subject: @key_deriver.identity_key,
+                                certifier: args[:certifier],
+                                fields: args[:fields]
+                              })
+        )
 
-        response = execute_http(uri, request)
-        code = response.code.to_i
-
-        raise WalletError, "Certificate issuance failed: HTTP #{code}" unless (200..299).cover?(code)
+        raise WalletError, "Certificate issuance failed: HTTP #{response.status}" unless (200..299).cover?(response.status)
 
         body = JSON.parse(response.body)
 
@@ -1617,6 +1652,10 @@ module BSV
         cert
       rescue JSON::ParserError
         raise WalletError, 'Certificate issuance failed: invalid JSON response'
+      end
+
+      def auth_fetch_client
+        @auth_fetch ||= BSV::Auth::AuthFetch.new(wallet: self)
       end
 
       def execute_http(uri, request)

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
@@ -1655,7 +1655,7 @@ module BSV
       end
 
       def auth_fetch_client
-        @auth_fetch ||= BSV::Auth::AuthFetch.new(wallet: self)
+        @auth_fetch_client ||= BSV::Auth::AuthFetch.new(wallet: self)
       end
 
       def execute_http(uri, request)

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
@@ -45,6 +45,9 @@ module BSV
       # @return [BroadcastQueue] the broadcast queue used to dispatch transactions
       attr_reader :broadcast_queue
 
+      # @return [Interface, nil] the optional substrate for remote wallet delegation
+      attr_reader :substrate
+
       # @param key [BSV::Primitives::PrivateKey, String, KeyDeriver] signing key
       # @param storage [StorageAdapter] persistence adapter (default: FileStore).
       #   Use +storage: MemoryStore.new+ for tests.
@@ -54,6 +57,10 @@ module BSV
       # @param http_client [#request, nil] injectable HTTP client for certificate issuance
       # @param broadcaster [#broadcast, nil] optional broadcaster; any object responding to #broadcast(tx)
       # @param broadcast_queue [BroadcastQueue, nil] optional broadcast queue; defaults to InlineQueue
+      # @param substrate [Interface, nil] optional remote wallet substrate; when set, all Interface
+      #   methods delegate to the substrate instead of using local storage and key derivation.
+      #   Accepts any object implementing {Interface} (e.g. {Substrates::HTTPWalletJSON},
+      #   {Substrates::WalletWireTransceiver}).
       def initialize(
         key,
         storage: FileStore.new,
@@ -65,9 +72,11 @@ module BSV
         coin_selector: nil,
         change_generator: nil,
         broadcaster: nil,
-        broadcast_queue: nil
+        broadcast_queue: nil,
+        substrate: nil
       )
         super(key)
+        @substrate = substrate
         @storage = storage
         @network = network
         @chain_provider = chain_provider
@@ -110,7 +119,9 @@ module BSV
       #   UTXOs and generates change; requires +:outputs+ and no +:inputs+
       # @param _originator [String, nil] FQDN of the originating application
       # @return [Hash] finalised result or signable_transaction
-      def create_action(args, _originator: nil)
+      def create_action(args, originator: nil)
+        return @substrate.create_action(args, originator: originator) if @substrate
+
         validate_create_action!(args)
 
         send_with_txids = Array(args.dig(:options, :send_with))
@@ -156,7 +167,9 @@ module BSV
       # @option args [String] :reference base64 reference from create_action
       # @param _originator [String, nil] FQDN of the originating application
       # @return [Hash] with :txid and :tx (BEEF bytes)
-      def sign_action(args, _originator: nil)
+      def sign_action(args, originator: nil)
+        return @substrate.sign_action(args, originator: originator) if @substrate
+
         reference = args[:reference]
         pending = @pending[reference]
         raise WalletError, 'Transaction not found for the given reference' unless pending
@@ -185,7 +198,9 @@ module BSV
       # @option args [String] :reference base64 reference to abort
       # @param _originator [String, nil] FQDN of the originating application
       # @return [Hash] { aborted: true }
-      def abort_action(args, _originator: nil)
+      def abort_action(args, originator: nil)
+        return @substrate.abort_action(args, originator: originator) if @substrate
+
         reference = args[:reference]
         raise WalletError, 'Transaction not found for the given reference' unless @pending.key?(reference)
 
@@ -210,7 +225,9 @@ module BSV
       # @option args [Integer] :offset results to skip (default 0)
       # @param _originator [String, nil] FQDN of the originating application
       # @return [Hash] { total_actions: Integer, actions: Array }
-      def list_actions(args, _originator: nil)
+      def list_actions(args, originator: nil)
+        return @substrate.list_actions(args, originator: originator) if @substrate
+
         validate_list_actions!(args)
         query = build_action_query(args)
         total = @storage.count_actions(query)
@@ -228,7 +245,9 @@ module BSV
       # @option args [Integer] :offset results to skip (default 0)
       # @param _originator [String, nil] FQDN of the originating application
       # @return [Hash] { total_outputs: Integer, outputs: Array }
-      def list_outputs(args, _originator: nil)
+      def list_outputs(args, originator: nil)
+        return @substrate.list_outputs(args, originator: originator) if @substrate
+
         validate_list_outputs!(args)
         query = build_output_query(args)
         total = @storage.count_outputs(query)
@@ -243,7 +262,9 @@ module BSV
       # @option args [String] :output outpoint string
       # @param _originator [String, nil] FQDN of the originating application
       # @return [Hash] { relinquished: true }
-      def relinquish_output(args, _originator: nil)
+      def relinquish_output(args, originator: nil)
+        return @substrate.relinquish_output(args, originator: originator) if @substrate
+
         Validators.validate_basket!(args[:basket])
         Validators.validate_outpoint!(args[:output])
         raise WalletError, 'Output not found' unless @storage.delete_output(args[:output])
@@ -264,7 +285,9 @@ module BSV
       # @option args [Array<String>] :labels optional labels
       # @param _originator [String, nil] FQDN of the originating application
       # @return [Hash] { accepted: true }
-      def internalize_action(args, _originator: nil)
+      def internalize_action(args, originator: nil)
+        return @substrate.internalize_action(args, originator: originator) if @substrate
+
         validate_internalize_action!(args)
         beef_binary = args[:tx].pack('C*')
         beef = BSV::Transaction::Beef.from_binary(beef_binary)
@@ -290,7 +313,9 @@ module BSV
       #
       # @param _args [Hash] unused (empty hash)
       # @return [Hash] { height: Integer }
-      def get_height(_args = {}, _originator: nil)
+      def get_height(args = {}, originator: nil)
+        return @substrate.get_height(args, originator: originator) if @substrate
+
         { height: @chain_provider.get_height }
       end
 
@@ -299,7 +324,9 @@ module BSV
       # @param args [Hash]
       # @option args [Integer] :height block height
       # @return [Hash] { header: String } 80-byte hex-encoded block header
-      def get_header_for_height(args, _originator: nil)
+      def get_header_for_height(args, originator: nil)
+        return @substrate.get_header_for_height(args, originator: originator) if @substrate
+
         raise InvalidParameterError.new('height', 'a positive Integer') unless args[:height].is_a?(Integer) && args[:height].positive?
 
         { header: @chain_provider.get_header(args[:height]) }
@@ -309,7 +336,9 @@ module BSV
       #
       # @param _args [Hash] unused (empty hash)
       # @return [Hash] { network: String } 'mainnet' or 'testnet'
-      def get_network(_args = {}, _originator: nil)
+      def get_network(args = {}, originator: nil)
+        return @substrate.get_network(args, originator: originator) if @substrate
+
         { network: @network }
       end
 
@@ -317,7 +346,9 @@ module BSV
       #
       # @param _args [Hash] unused (empty hash)
       # @return [Hash] { version: String } in vendor-major.minor.patch format
-      def get_version(_args = {}, _originator: nil)
+      def get_version(args = {}, originator: nil)
+        return @substrate.get_version(args, originator: originator) if @substrate
+
         { version: "bsv-wallet-#{BSV::WalletInterface::VERSION}" }
       end
 
@@ -427,7 +458,9 @@ module BSV
       #
       # @param _args [Hash] unused (empty hash)
       # @return [Hash] { authenticated: Boolean }
-      def is_authenticated(_args = {}, _originator: nil)
+      def is_authenticated(args = {}, originator: nil)
+        return @substrate.is_authenticated(args, originator: originator) if @substrate
+
         { authenticated: true }
       end
 
@@ -436,7 +469,9 @@ module BSV
       #
       # @param _args [Hash] unused (empty hash)
       # @return [Hash] { authenticated: true }
-      def wait_for_authentication(_args = {}, _originator: nil)
+      def wait_for_authentication(args = {}, originator: nil)
+        return @substrate.wait_for_authentication(args, originator: originator) if @substrate
+
         { authenticated: true }
       end
 
@@ -458,7 +493,9 @@ module BSV
       # @option args [String] :keyring_revealer pubkey hex or 'certifier' (required for direct)
       # @option args [Hash] :keyring_for_subject field_name => base64 key (required for direct)
       # @return [Hash] the stored certificate
-      def acquire_certificate(args, _originator: nil)
+      def acquire_certificate(args, originator: nil)
+        return @substrate.acquire_certificate(args, originator: originator) if @substrate
+
         validate_acquire_certificate!(args)
 
         cert = if args[:acquisition_protocol] == 'issuance'
@@ -479,7 +516,9 @@ module BSV
       # @option args [Integer] :limit max results (default 10)
       # @option args [Integer] :offset number to skip (default 0)
       # @return [Hash] { total_certificates:, certificates: [...] }
-      def list_certificates(args, _originator: nil)
+      def list_certificates(args, originator: nil)
+        return @substrate.list_certificates(args, originator: originator) if @substrate
+
         raise InvalidParameterError.new('certifiers', 'a non-empty Array') unless args[:certifiers].is_a?(Array) && !args[:certifiers].empty?
         raise InvalidParameterError.new('types', 'a non-empty Array') unless args[:types].is_a?(Array) && !args[:types].empty?
 
@@ -505,7 +544,9 @@ module BSV
       # @option args [Array<String>] :fields_to_reveal field names to reveal
       # @option args [String] :verifier verifier public key hex
       # @return [Hash] { keyring_for_verifier: { field_name => Array<Integer> } }
-      def prove_certificate(args, _originator: nil)
+      def prove_certificate(args, originator: nil)
+        return @substrate.prove_certificate(args, originator: originator) if @substrate
+
         cert_arg = args[:certificate]
         fields_to_reveal = args[:fields_to_reveal]
         verifier = args[:verifier]
@@ -545,7 +586,9 @@ module BSV
       # @option args [String] :serial_number serial number
       # @option args [String] :certifier certifier public key hex
       # @return [Hash] { relinquished: true }
-      def relinquish_certificate(args, _originator: nil)
+      def relinquish_certificate(args, originator: nil)
+        return @substrate.relinquish_certificate(args, originator: originator) if @substrate
+
         deleted = @storage.delete_certificate(
           type: args[:type],
           serial_number: args[:serial_number],
@@ -566,7 +609,9 @@ module BSV
       # @option args [Integer] :limit max results (default 10)
       # @option args [Integer] :offset number to skip (default 0)
       # @return [Hash] { total_certificates:, certificates: [...] }
-      def discover_by_identity_key(args, _originator: nil)
+      def discover_by_identity_key(args, originator: nil)
+        return @substrate.discover_by_identity_key(args, originator: originator) if @substrate
+
         Validators.validate_pub_key_hex!(args[:identity_key], 'identity_key')
 
         query = { subject: args[:identity_key], limit: args[:limit] || 10, offset: args[:offset] || 0 }
@@ -585,13 +630,74 @@ module BSV
       # @option args [Integer] :limit max results (default 10)
       # @option args [Integer] :offset number to skip (default 0)
       # @return [Hash] { total_certificates:, certificates: [...] }
-      def discover_by_attributes(args, _originator: nil)
+      def discover_by_attributes(args, originator: nil)
+        return @substrate.discover_by_attributes(args, originator: originator) if @substrate
+
         raise InvalidParameterError.new('attributes', 'a non-empty Hash') unless args[:attributes].is_a?(Hash) && !args[:attributes].empty?
 
         query = { attributes: args[:attributes], limit: args[:limit] || 10, offset: args[:offset] || 0 }
         total = @storage.count_certificates(query)
         certs = @storage.find_certificates(query)
         { total_certificates: total, certificates: certs.map { |c| cert_without_keyring(c) } }
+      end
+
+      # --- ProtoWallet crypto method overrides for substrate delegation ---
+      #
+      # When a substrate is configured, these methods delegate to it rather than
+      # performing local key derivation and cryptographic operations.
+
+      def get_public_key(args, originator: nil)
+        return @substrate.get_public_key(args, originator: originator) if @substrate
+
+        super
+      end
+
+      def reveal_counterparty_key_linkage(args, originator: nil)
+        return @substrate.reveal_counterparty_key_linkage(args, originator: originator) if @substrate
+
+        super
+      end
+
+      def reveal_specific_key_linkage(args, originator: nil)
+        return @substrate.reveal_specific_key_linkage(args, originator: originator) if @substrate
+
+        super
+      end
+
+      def encrypt(args, originator: nil)
+        return @substrate.encrypt(args, originator: originator) if @substrate
+
+        super
+      end
+
+      def decrypt(args, originator: nil)
+        return @substrate.decrypt(args, originator: originator) if @substrate
+
+        super
+      end
+
+      def create_hmac(args, originator: nil)
+        return @substrate.create_hmac(args, originator: originator) if @substrate
+
+        super
+      end
+
+      def verify_hmac(args, originator: nil)
+        return @substrate.verify_hmac(args, originator: originator) if @substrate
+
+        super
+      end
+
+      def create_signature(args, originator: nil)
+        return @substrate.create_signature(args, originator: originator) if @substrate
+
+        super
+      end
+
+      def verify_signature(args, originator: nil)
+        return @substrate.verify_signature(args, originator: originator) if @substrate
+
+        super
       end
 
       # Maximum ancestor depth to traverse when wiring source transactions.

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
@@ -1550,12 +1550,17 @@ module BSV
           a.delete(:labels) unless args[:include_labels] == true
           a.delete(:inputs) unless args[:include_inputs] == true
 
-          if a.key?(:inputs) && args[:include_input_source_locking_scripts] != true
-            a[:inputs] = a[:inputs].map { |i| i.dup.tap { |h| h.delete(:source_locking_script) } }
-          end
-
-          if a.key?(:inputs) && args[:include_input_unlocking_scripts] != true
-            a[:inputs] = a[:inputs].map { |i| i.dup.tap { |h| h.delete(:unlocking_script) } }
+          if a.key?(:inputs)
+            strip_src = args[:include_input_source_locking_scripts] != true
+            strip_unlock = args[:include_input_unlocking_scripts] != true
+            if strip_src || strip_unlock
+              a[:inputs] = a[:inputs].map do |i|
+                d = i.dup
+                d.delete(:source_locking_script) if strip_src
+                d.delete(:unlocking_script) if strip_unlock
+                d
+              end
+            end
           end
 
           a.delete(:outputs) unless args[:include_outputs] == true

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/certificate_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/certificate_spec.rb
@@ -230,30 +230,38 @@ RSpec.describe 'WalletClient certificate methods' do
     end
 
     context 'with issuance protocol' do
-      let(:issuance_response) do
-        {
-          'type' => cert_type,
-          'subject' => wallet.key_deriver.identity_key,
-          'serialNumber' => serial_number,
-          'certifier' => certifier_hex,
-          'revocationOutpoint' => revocation_outpoint,
-          'signature' => signature,
-          'fields' => fields,
-          'keyringForSubject' => keyring
-        }
+      let(:issuance_response_body) do
+        JSON.generate({
+                        'type' => cert_type,
+                        'subject' => wallet.key_deriver.identity_key,
+                        'serialNumber' => serial_number,
+                        'certifier' => certifier_hex,
+                        'revocationOutpoint' => revocation_outpoint,
+                        'signature' => signature,
+                        'fields' => fields,
+                        'keyringForSubject' => keyring
+                      })
       end
 
-      let(:mock_http) do
-        resp = issuance_response
-        Class.new do
-          define_method(:request) do |_uri, _req|
-            Struct.new(:code, :body).new('200', JSON.generate(resp))
-          end
-        end.new
+      let(:mock_auth_response) do
+        BSV::Auth::AuthResponse.new(
+          status: 200,
+          headers: {},
+          body: issuance_response_body,
+          identity_key: certifier_hex
+        )
+      end
+
+      let(:mock_auth_fetch) do
+        # rubocop:disable RSpec/VerifiedDoubles
+        double('auth_fetch', fetch: mock_auth_response)
+        # rubocop:enable RSpec/VerifiedDoubles
       end
 
       let(:issuance_wallet) do
-        BSV::Wallet::WalletClient.new(private_key, storage: BSV::Wallet::MemoryStore.new, http_client: mock_http)
+        w = BSV::Wallet::WalletClient.new(private_key, storage: BSV::Wallet::MemoryStore.new)
+        allow(w).to receive(:auth_fetch_client).and_return(mock_auth_fetch)
+        w
       end
 
       let(:issuance_args) do
@@ -285,20 +293,81 @@ RSpec.describe 'WalletClient certificate methods' do
         expect(certs[:total_certificates]).to eq(1)
       end
 
+      it 'calls AuthFetch#fetch with correct URL, method, headers, and body' do
+        expected_body = JSON.generate({
+                                        type: cert_type,
+                                        subject: issuance_wallet.key_deriver.identity_key,
+                                        certifier: certifier_hex,
+                                        fields: fields
+                                      })
+        allow(mock_auth_fetch).to receive(:fetch).and_return(mock_auth_response)
+        issuance_wallet.acquire_certificate(issuance_args)
+        expect(mock_auth_fetch).to have_received(:fetch).with(
+          'https://certifier.example.com/api/issue',
+          method: 'POST',
+          headers: { 'content-type' => 'application/json' },
+          body: expected_body
+        )
+      end
+
       it 'raises WalletError on HTTP failure' do
-        failing_http = Class.new do
-          define_method(:request) { |_uri, _req| Struct.new(:code, :body).new('500', 'error') }
-        end.new
-        w = BSV::Wallet::WalletClient.new(private_key, storage: BSV::Wallet::MemoryStore.new, http_client: failing_http)
+        # rubocop:disable RSpec/VerifiedDoubles
+        failing_auth_fetch = double('auth_fetch')
+        # rubocop:enable RSpec/VerifiedDoubles
+        allow(failing_auth_fetch).to receive(:fetch).and_return(
+          BSV::Auth::AuthResponse.new(status: 500, headers: {}, body: 'error', identity_key: certifier_hex)
+        )
+        w = BSV::Wallet::WalletClient.new(private_key, storage: BSV::Wallet::MemoryStore.new)
+        allow(w).to receive(:auth_fetch_client).and_return(failing_auth_fetch)
         expect { w.acquire_certificate(issuance_args) }.to raise_error(BSV::Wallet::WalletError, /HTTP 500/)
       end
 
       it 'raises WalletError on invalid JSON response' do
-        bad_http = Class.new do
-          define_method(:request) { |_uri, _req| Struct.new(:code, :body).new('200', 'not json') }
-        end.new
-        w = BSV::Wallet::WalletClient.new(private_key, storage: BSV::Wallet::MemoryStore.new, http_client: bad_http)
+        # rubocop:disable RSpec/VerifiedDoubles
+        bad_auth_fetch = double('auth_fetch')
+        # rubocop:enable RSpec/VerifiedDoubles
+        allow(bad_auth_fetch).to receive(:fetch).and_return(
+          BSV::Auth::AuthResponse.new(status: 200, headers: {}, body: 'not json', identity_key: certifier_hex)
+        )
+        w = BSV::Wallet::WalletClient.new(private_key, storage: BSV::Wallet::MemoryStore.new)
+        allow(w).to receive(:auth_fetch_client).and_return(bad_auth_fetch)
         expect { w.acquire_certificate(issuance_args) }.to raise_error(BSV::Wallet::WalletError, /invalid JSON/)
+      end
+
+      it 'verifies the certifier signature on the issuance response' do
+        # rubocop:disable RSpec/VerifiedDoubles
+        tampered_auth_fetch = double('auth_fetch')
+        # rubocop:enable RSpec/VerifiedDoubles
+        tampered_body = JSON.generate({
+                                        'type' => cert_type,
+                                        'serialNumber' => serial_number,
+                                        'revocationOutpoint' => revocation_outpoint,
+                                        'signature' => 'ff' * 70,
+                                        'fields' => fields
+                                      })
+        allow(tampered_auth_fetch).to receive(:fetch).and_return(
+          BSV::Auth::AuthResponse.new(status: 200, headers: {}, body: tampered_body, identity_key: certifier_hex)
+        )
+        w = BSV::Wallet::WalletClient.new(private_key, storage: BSV::Wallet::MemoryStore.new)
+        allow(w).to receive(:auth_fetch_client).and_return(tampered_auth_fetch)
+        expect { w.acquire_certificate(issuance_args) }
+          .to raise_error(BSV::Wallet::CertificateSignature::InvalidError)
+      end
+
+      it 'lazily initialises auth_fetch_client on first call and memoises it' do
+        w = BSV::Wallet::WalletClient.new(private_key, storage: BSV::Wallet::MemoryStore.new)
+        allow(BSV::Auth::AuthFetch).to receive(:new).and_call_original
+        client1 = w.send(:auth_fetch_client)
+        client2 = w.send(:auth_fetch_client)
+        expect(client1).to be(client2)
+        expect(BSV::Auth::AuthFetch).to have_received(:new).once
+      end
+
+      it 'passes self as the wallet to AuthFetch' do
+        w = BSV::Wallet::WalletClient.new(private_key, storage: BSV::Wallet::MemoryStore.new)
+        allow(BSV::Auth::AuthFetch).to receive(:new).and_call_original
+        w.send(:auth_fetch_client)
+        expect(BSV::Auth::AuthFetch).to have_received(:new).with(wallet: w)
       end
     end
 

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/substrates/http_wallet_json_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/substrates/http_wallet_json_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe BSV::Wallet::Substrates::HTTPWalletJSON do
   # Builds a minimal fake Net::HTTP response.
   def stub_response(body, code: '200')
     response = instance_double(Net::HTTPResponse)
-    allow(response).to receive(:code).and_return(code)
-    allow(response).to receive(:body).and_return(JSON.generate(body))
+    allow(response).to receive_messages(code: code, body: JSON.generate(body))
     response
   end
 
@@ -92,9 +91,8 @@ RSpec.describe BSV::Wallet::Substrates::HTTPWalletJSON do
 
   describe 'HTTP endpoint routing' do
     BSV::Wallet::Wire::Serializer::CALL_CODES.each_key do |method_sym|
-      camel = BSV::WireFormat.snake_to_camel(method_sym.to_s)
-
-      it "POSTs to /#{camel} for ##{method_sym}" do
+      it "POSTs to /#{BSV::WireFormat.snake_to_camel(method_sym.to_s)} for ##{method_sym}" do
+        camel = BSV::WireFormat.snake_to_camel(method_sym.to_s)
         expected_uri = URI.parse("#{base_url}/#{camel}")
         response = stub_response({})
 
@@ -103,6 +101,9 @@ RSpec.describe BSV::Wallet::Substrates::HTTPWalletJSON do
           .and_yield(stub_http_session(response))
 
         substrate.public_send(method_sym, {})
+
+        expect(Net::HTTP).to have_received(:start)
+          .with(expected_uri.host, expected_uri.port, use_ssl: false)
       end
     end
   end

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/substrates/http_wallet_json_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/substrates/http_wallet_json_spec.rb
@@ -1,0 +1,376 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+
+RSpec.describe BSV::Wallet::Substrates::HTTPWalletJSON do
+  let(:base_url) { 'http://wallet.example.com:3321' }
+  let(:substrate) { described_class.new(base_url) }
+  let(:substrate_with_originator) do
+    described_class.new(base_url, originator: 'myapp.example.com')
+  end
+
+  # Builds a minimal fake Net::HTTP response.
+  def stub_response(body, code: '200')
+    response = instance_double(Net::HTTPResponse)
+    allow(response).to receive(:code).and_return(code)
+    allow(response).to receive(:body).and_return(JSON.generate(body))
+    response
+  end
+
+  # Stubs Net::HTTP.start to capture the request and return a canned response.
+  def stub_http(response)
+    allow(Net::HTTP).to receive(:start).and_yield(stub_http_session(response))
+  end
+
+  def stub_http_session(response)
+    session = instance_double(Net::HTTP)
+    allow(session).to receive(:request).and_return(response)
+    session
+  end
+
+  # -------------------------------------------------------------------------
+  # Constructor
+  # -------------------------------------------------------------------------
+
+  describe '#initialize' do
+    it 'stores base_url' do
+      expect(substrate.instance_variable_get(:@base_url)).to eq(base_url)
+    end
+
+    it 'stores originator when provided' do
+      s = described_class.new(base_url, originator: 'app.example.com')
+      expect(s.instance_variable_get(:@originator)).to eq('app.example.com')
+    end
+
+    it 'stores http_client when provided' do
+      client = double('http_client') # rubocop:disable RSpec/VerifiedDoubles
+      s = described_class.new(base_url, http_client: client)
+      expect(s.instance_variable_get(:@http_client)).to eq(client)
+    end
+
+    it 'defaults originator to nil' do
+      expect(substrate.instance_variable_get(:@originator)).to be_nil
+    end
+
+    it 'defaults http_client to nil' do
+      expect(substrate.instance_variable_get(:@http_client)).to be_nil
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # METHOD_NAMES constant
+  # -------------------------------------------------------------------------
+
+  describe 'METHOD_NAMES' do
+    it 'contains all 28 interface method symbols' do
+      expect(described_class::METHOD_NAMES.keys).to match_array(
+        BSV::Wallet::Wire::Serializer::CALL_CODES.keys
+      )
+    end
+
+    it 'maps :get_public_key to "getPublicKey"' do
+      expect(described_class::METHOD_NAMES[:get_public_key]).to eq('getPublicKey')
+    end
+
+    it 'maps :create_action to "createAction"' do
+      expect(described_class::METHOD_NAMES[:create_action]).to eq('createAction')
+    end
+
+    it 'maps :list_outputs to "listOutputs"' do
+      expect(described_class::METHOD_NAMES[:list_outputs]).to eq('listOutputs')
+    end
+
+    it 'maps :is_authenticated to "isAuthenticated"' do
+      expect(described_class::METHOD_NAMES[:is_authenticated]).to eq('isAuthenticated')
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # HTTP request routing — correct endpoint per method
+  # -------------------------------------------------------------------------
+
+  describe 'HTTP endpoint routing' do
+    BSV::Wallet::Wire::Serializer::CALL_CODES.each_key do |method_sym|
+      camel = BSV::WireFormat.snake_to_camel(method_sym.to_s)
+
+      it "POSTs to /#{camel} for ##{method_sym}" do
+        expected_uri = URI.parse("#{base_url}/#{camel}")
+        response = stub_response({})
+
+        allow(Net::HTTP).to receive(:start)
+          .with(expected_uri.host, expected_uri.port, use_ssl: false)
+          .and_yield(stub_http_session(response))
+
+        substrate.public_send(method_sym, {})
+      end
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Key conversion — to_wire on outbound, from_wire on inbound
+  # -------------------------------------------------------------------------
+
+  describe 'key conversion' do
+    it 'converts snake_case arg keys to camelCase in the request body' do
+      captured_body = nil
+      session = instance_double(Net::HTTP)
+      allow(Net::HTTP).to receive(:start).and_yield(session)
+      allow(session).to receive(:request) do |req|
+        captured_body = req.body
+        stub_response({ 'publicKey' => '02abc' })
+      end
+
+      substrate.get_public_key({ identity_key: true })
+
+      parsed = JSON.parse(captured_body)
+      expect(parsed).to have_key('identityKey')
+      expect(parsed).not_to have_key('identity_key')
+    end
+
+    it 'converts camelCase response keys to snake_case symbols' do
+      stub_http(stub_response({ 'publicKey' => '02abc123' }))
+
+      result = substrate.get_public_key({ identity_key: true })
+
+      expect(result).to eq({ public_key: '02abc123' })
+    end
+
+    it 'handles nested camelCase response keys' do
+      body = { 'totalActions' => 1, 'actions' => [{ 'txid' => 'aa', 'lockingScript' => 'dead' }] }
+      stub_http(stub_response(body))
+
+      result = substrate.list_actions({ labels: ['test'] })
+
+      expect(result[:total_actions]).to eq(1)
+      expect(result[:actions].first[:locking_script]).to eq('dead')
+    end
+
+    it 'sends empty JSON object for empty args' do
+      captured_body = nil
+      session = instance_double(Net::HTTP)
+      allow(Net::HTTP).to receive(:start).and_yield(session)
+      allow(session).to receive(:request) do |req|
+        captured_body = req.body
+        stub_response({ 'height' => 800_000 })
+      end
+
+      substrate.get_height({})
+
+      expect(captured_body).to eq('{}')
+    end
+
+    it 'passes array values through without key conversion' do
+      captured_body = nil
+      session = instance_double(Net::HTTP)
+      allow(Net::HTTP).to receive(:start).and_yield(session)
+      allow(session).to receive(:request) do |req|
+        captured_body = req.body
+        stub_response({ 'ciphertext' => [1, 2, 3] })
+      end
+
+      substrate.encrypt({ plaintext: [10, 20, 30], protocol_id: [2, 'test'], key_id: 'k1' })
+
+      parsed = JSON.parse(captured_body)
+      expect(parsed['plaintext']).to eq([10, 20, 30])
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Request headers
+  # -------------------------------------------------------------------------
+
+  describe 'request headers' do
+    it 'sets Content-Type: application/json' do
+      captured_headers = nil
+      session = instance_double(Net::HTTP)
+      allow(Net::HTTP).to receive(:start).and_yield(session)
+      allow(session).to receive(:request) do |req|
+        captured_headers = req.to_hash
+        stub_response({})
+      end
+
+      substrate.get_height({})
+
+      expect(captured_headers['content-type']).to include('application/json')
+    end
+
+    it 'sets Accept: application/json' do
+      captured_headers = nil
+      session = instance_double(Net::HTTP)
+      allow(Net::HTTP).to receive(:start).and_yield(session)
+      allow(session).to receive(:request) do |req|
+        captured_headers = req.to_hash
+        stub_response({})
+      end
+
+      substrate.get_height({})
+
+      expect(captured_headers['accept']).to include('application/json')
+    end
+
+    context 'with originator set' do
+      it 'sends Origin header' do
+        captured_headers = nil
+        session = instance_double(Net::HTTP)
+        allow(Net::HTTP).to receive(:start).and_yield(session)
+        allow(session).to receive(:request) do |req|
+          captured_headers = req.to_hash
+          stub_response({})
+        end
+
+        substrate_with_originator.get_height({})
+
+        expect(captured_headers['origin']).to include('http://myapp.example.com')
+      end
+
+      it 'sends Originator header' do
+        captured_headers = nil
+        session = instance_double(Net::HTTP)
+        allow(Net::HTTP).to receive(:start).and_yield(session)
+        allow(session).to receive(:request) do |req|
+          captured_headers = req.to_hash
+          stub_response({})
+        end
+
+        substrate_with_originator.get_height({})
+
+        expect(captured_headers['originator']).to include('http://myapp.example.com')
+      end
+
+      it 'does not send Origin/Originator when originator is nil' do
+        captured_headers = nil
+        session = instance_double(Net::HTTP)
+        allow(Net::HTTP).to receive(:start).and_yield(session)
+        allow(session).to receive(:request) do |req|
+          captured_headers = req.to_hash
+          stub_response({})
+        end
+
+        substrate.get_height({})
+
+        expect(captured_headers).not_to have_key('origin')
+        expect(captured_headers).not_to have_key('originator')
+      end
+
+      it 'keeps scheme when originator already has one' do
+        s = described_class.new(base_url, originator: 'https://myapp.example.com')
+        captured_headers = nil
+        session = instance_double(Net::HTTP)
+        allow(Net::HTTP).to receive(:start).and_yield(session)
+        allow(session).to receive(:request) do |req|
+          captured_headers = req.to_hash
+          stub_response({})
+        end
+
+        s.get_height({})
+
+        expect(captured_headers['origin']).to include('https://myapp.example.com')
+      end
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Error handling
+  # -------------------------------------------------------------------------
+
+  describe 'error handling' do
+    it 'raises WalletError with message from response body on non-2xx' do
+      stub_http(stub_response({ 'message' => 'something went wrong' }, code: '500'))
+
+      expect { substrate.get_height({}) }.to raise_error(
+        BSV::Wallet::WalletError, 'something went wrong'
+      )
+    end
+
+    it 'raises WalletError with fallback message when response has no message field' do
+      stub_http(stub_response({}, code: '503'))
+
+      expect { substrate.get_height({}) }.to raise_error(
+        BSV::Wallet::WalletError, /HTTP 503/
+      )
+    end
+
+    it 'raises WalletError (code 5) for 400 isError with code 5' do
+      body = { 'isError' => true, 'code' => 5, 'message' => 'review required' }
+      stub_http(stub_response(body, code: '400'))
+
+      error = nil
+      begin
+        substrate.create_action({ description: 'test' })
+      rescue BSV::Wallet::WalletError => e
+        error = e
+      end
+
+      expect(error).not_to be_nil
+      expect(error.code).to eq(5)
+    end
+
+    it 'raises InvalidParameterError for 400 isError with code 6' do
+      body = { 'isError' => true, 'code' => 6, 'parameter' => 'description', 'message' => 'bad param' }
+      stub_http(stub_response(body, code: '400'))
+
+      expect { substrate.create_action({ description: '' }) }.to raise_error(
+        BSV::Wallet::InvalidParameterError
+      )
+    end
+
+    it 'raises InsufficientFundsError for 400 isError with code 7' do
+      body = { 'isError' => true, 'code' => 7, 'message' => 'not enough satoshis' }
+      stub_http(stub_response(body, code: '400'))
+
+      expect { substrate.create_action({ description: 'pay' }) }.to raise_error(
+        BSV::Wallet::InsufficientFundsError
+      )
+    end
+
+    it 'raises plain WalletError for 400 isError with unrecognised code' do
+      body = { 'isError' => true, 'code' => 99, 'message' => 'unknown error' }
+      stub_http(stub_response(body, code: '400'))
+
+      expect { substrate.get_height({}) }.to raise_error(
+        BSV::Wallet::WalletError, 'unknown error'
+      )
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Injectable http_client
+  # -------------------------------------------------------------------------
+
+  describe 'http_client injection' do
+    it 'uses the injected client instead of Net::HTTP when provided' do
+      fake_response = stub_response({ 'height' => 999 })
+      fake_client = double('http_client') # rubocop:disable RSpec/VerifiedDoubles
+      allow(fake_client).to receive(:post).and_return(fake_response)
+      allow(Net::HTTP).to receive(:start).and_call_original
+
+      s = described_class.new(base_url, http_client: fake_client)
+
+      result = s.get_height({})
+
+      expect(result).to eq({ height: 999 })
+      expect(fake_client).to have_received(:post)
+      expect(Net::HTTP).not_to have_received(:start)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Uses HTTPS when base_url scheme is https
+  # -------------------------------------------------------------------------
+
+  describe 'HTTPS support' do
+    it 'enables SSL when base_url uses https' do
+      s = described_class.new('https://secure.example.com')
+
+      allow(Net::HTTP).to receive(:start)
+        .with('secure.example.com', 443, use_ssl: true)
+        .and_yield(stub_http_session(stub_response({})))
+
+      s.get_height({})
+
+      expect(Net::HTTP).to have_received(:start)
+        .with('secure.example.com', 443, use_ssl: true)
+    end
+  end
+end

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/substrates/http_wallet_wire_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/substrates/http_wallet_wire_spec.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+
+RSpec.describe BSV::Wallet::Substrates::HTTPWalletWire do
+  subject(:wire) { described_class.new(base_url, http_client: http_client) }
+
+  let(:base_url)    { 'http://localhost:3301' }
+  let(:http_client) { nil }
+  let(:captured)    { {} }
+
+  # Builds a minimal wire frame: [call_code, orig_len, *orig_bytes, *payload]
+  def frame(call_code, originator_str = '', *payload_bytes)
+    orig_bytes = originator_str.encode('UTF-8').bytes
+    [call_code, orig_bytes.length] + orig_bytes + payload_bytes
+  end
+
+  # Stubs Net::HTTP to capture the outgoing request and return fixed response bytes.
+  def stub_http(response_body_bytes, capture_into: captured)
+    fake_response = instance_double(Net::HTTPOK, code: '200', body: response_body_bytes.pack('C*'))
+    allow(fake_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+
+    fake_http = instance_double(Net::HTTP)
+    allow(fake_http).to receive(:request) do |req|
+      capture_into[:request] = req
+      fake_response
+    end
+
+    allow(Net::HTTP).to receive(:start).and_yield(fake_http)
+  end
+
+  describe '#transmit_to_wallet' do
+    context 'with a valid get_version frame (call code 28)' do
+      let(:message) { frame(28) }
+
+      before { stub_http([0]) }
+
+      it 'POSTs to /getVersion' do
+        wire.transmit_to_wallet(message)
+        expect(captured[:request].path).to eq('/getVersion')
+      end
+
+      it 'sets Content-Type to application/octet-stream' do
+        wire.transmit_to_wallet(message)
+        expect(captured[:request]['Content-Type']).to eq('application/octet-stream')
+      end
+
+      it 'returns the response body as a byte array' do
+        result = wire.transmit_to_wallet(message)
+        expect(result).to eq([0])
+      end
+    end
+
+    context 'with a create_action frame (call code 1)' do
+      let(:message) { frame(1) }
+
+      before { stub_http([0, 1, 2]) }
+
+      it 'POSTs to /createAction' do
+        wire.transmit_to_wallet(message)
+        expect(captured[:request].path).to eq('/createAction')
+      end
+
+      it 'returns response bytes as an Array of integers' do
+        result = wire.transmit_to_wallet(message)
+        expect(result).to eq([0, 1, 2])
+        expect(result).to all(be_an(Integer))
+      end
+    end
+
+    context 'when mapping all 28 call codes to URL paths' do
+      let(:expected_paths) do
+        {
+          1 => '/createAction',
+          2 => '/signAction',
+          3 => '/abortAction',
+          4 => '/listActions',
+          5 => '/internalizeAction',
+          6 => '/listOutputs',
+          7 => '/relinquishOutput',
+          8 => '/getPublicKey',
+          9 => '/revealCounterpartyKeyLinkage',
+          10 => '/revealSpecificKeyLinkage',
+          11 => '/encrypt',
+          12 => '/decrypt',
+          13 => '/createHMAC',
+          14 => '/verifyHMAC',
+          15 => '/createSignature',
+          16 => '/verifySignature',
+          17 => '/acquireCertificate',
+          18 => '/listCertificates',
+          19 => '/proveCertificate',
+          20 => '/relinquishCertificate',
+          21 => '/discoverByIdentityKey',
+          22 => '/discoverByAttributes',
+          23 => '/isAuthenticated',
+          24 => '/waitForAuthentication',
+          25 => '/getHeight',
+          26 => '/getHeaderForHeight',
+          27 => '/getNetwork',
+          28 => '/getVersion'
+        }
+      end
+
+      it 'maps every call code to the correct camelCase URL path' do
+        expected_paths.each do |code, path|
+          local = {}
+          stub_http([0], capture_into: local)
+          wire.transmit_to_wallet(frame(code))
+          expect(local[:request].path).to eq(path), "expected call code #{code} to map to #{path}"
+        end
+      end
+    end
+
+    context 'with an originator in the message header' do
+      let(:message) { frame(28, 'wallet.example.com') }
+
+      before { stub_http([0]) }
+
+      it 'sends the originator as the Origin header' do
+        wire.transmit_to_wallet(message)
+        expect(captured[:request]['Origin']).to eq('wallet.example.com')
+      end
+    end
+
+    context 'with a zero-length originator' do
+      let(:message) { frame(28, '') }
+
+      before { stub_http([0]) }
+
+      it 'does not send an Origin header' do
+        wire.transmit_to_wallet(message)
+        expect(captured[:request]['Origin']).to be_nil
+      end
+    end
+
+    context 'with payload bytes after the header' do
+      let(:payload) { [0xDE, 0xAD, 0xBE, 0xEF] }
+      let(:message) { frame(28, '', *payload) }
+
+      before { stub_http([0]) }
+
+      it 'sends the payload bytes as the request body' do
+        wire.transmit_to_wallet(message)
+        expect(captured[:request].body.bytes).to eq(payload)
+      end
+    end
+
+    context 'with no payload bytes (header only)' do
+      let(:message) { frame(28) }
+
+      before { stub_http([0]) }
+
+      it 'sends an empty body' do
+        wire.transmit_to_wallet(message)
+        expect(captured[:request].body).to eq('')
+      end
+    end
+
+    context 'with an injectable http_client' do
+      let(:calls) { [] }
+      let(:http_client) do
+        proc do |uri, body, originator|
+          calls << { uri: uri, body: body, originator: originator }
+          "\x00"
+        end
+      end
+
+      it 'delegates to the injected http_client' do
+        wire.transmit_to_wallet(frame(28, 'app.example.com'))
+        expect(calls.length).to eq(1)
+        expect(calls.first[:uri].to_s).to eq('http://localhost:3301/getVersion')
+        expect(calls.first[:originator]).to eq('app.example.com')
+      end
+
+      it 'returns the client response as byte array' do
+        result = wire.transmit_to_wallet(frame(28))
+        expect(result).to eq([0])
+      end
+    end
+
+    context 'when handling errors' do
+      it 'raises ArgumentError for an empty message' do
+        expect { wire.transmit_to_wallet([]) }.to raise_error(ArgumentError, /empty/)
+      end
+
+      it 'raises ArgumentError for nil message' do
+        expect { wire.transmit_to_wallet(nil) }.to raise_error(ArgumentError, /empty/)
+      end
+
+      it 'raises ArgumentError for call code 0 (unknown)' do
+        expect { wire.transmit_to_wallet(frame(0)) }.to raise_error(ArgumentError, /unknown call code: 0/)
+      end
+
+      it 'raises ArgumentError for call code 255 (unknown)' do
+        expect { wire.transmit_to_wallet(frame(255)) }.to raise_error(ArgumentError, /unknown call code: 255/)
+      end
+
+      it 'raises RuntimeError for a non-2xx HTTP response' do
+        fake_response = instance_double(Net::HTTPNotFound, code: '404', body: 'Not Found')
+        allow(fake_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(false)
+        fake_http = instance_double(Net::HTTP)
+        allow(fake_http).to receive(:request).and_return(fake_response)
+        allow(Net::HTTP).to receive(:start).and_yield(fake_http)
+
+        expect { wire.transmit_to_wallet(frame(28)) }.to raise_error(RuntimeError, /HTTP 404/)
+      end
+    end
+  end
+end

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/substrates/wallet_wire_transceiver_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/substrates/wallet_wire_transceiver_spec.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+
+RSpec.describe 'BSV::Wallet::Substrates::WalletWireTransceiver' do
+  subject(:transceiver) { BSV::Wallet::Substrates::WalletWireTransceiver.new(wire, originator: constructor_originator) }
+
+  let(:constructor_originator) { nil }
+  let(:transmitted_frames)     { [] }
+  let(:response_bytes)         { [] }
+
+  # A simple mock wire that captures frames and returns configured response bytes.
+  let(:wire) do
+    frames = transmitted_frames
+    resp = response_bytes
+    double('wire').tap do |w| # rubocop:disable RSpec/VerifiedDoubles
+      allow(w).to receive(:transmit_to_wallet) do |frame|
+        frames << frame
+        resp.dup
+      end
+    end
+  end
+
+  # Builds a serialised success response for a given method and result hash.
+  def success_response_bytes(method_name, result)
+    BSV::Wallet::Wire::Serializer.serialize_response(method_name, result).bytes.to_a
+  end
+
+  # Builds a serialised error response frame.
+  def error_response_bytes(code, message, stack_trace: '')
+    BSV::Wallet::Wire::Serializer.serialize_error(code, message, stack_trace: stack_trace).bytes.to_a
+  end
+
+  # Builds the expected request frame for verification purposes.
+  def expected_request_frame(method_name, args, orig = nil)
+    BSV::Wallet::Wire::Serializer.serialize_request(method_name, args, originator: orig.to_s).bytes.to_a
+  end
+
+  describe 'constructor' do
+    it 'stores the wire transport' do
+      expect(transceiver.instance_variable_get(:@wire)).to eq(wire)
+    end
+
+    it 'stores the originator' do
+      transceiver_with_orig = BSV::Wallet::Substrates::WalletWireTransceiver.new(wire, originator: 'app.example.com')
+      expect(transceiver_with_orig.instance_variable_get(:@originator)).to eq('app.example.com')
+    end
+
+    it 'defaults originator to nil' do
+      expect(transceiver.instance_variable_get(:@originator)).to be_nil
+    end
+  end
+
+  describe 'implements BSV::Wallet::Interface' do
+    it 'includes BSV::Wallet::Interface' do
+      expect(BSV::Wallet::Substrates::WalletWireTransceiver).to include(BSV::Wallet::Interface)
+    end
+
+    it 'implements all 28 Interface methods' do
+      methods = %i[
+        create_action sign_action abort_action list_actions internalize_action
+        list_outputs relinquish_output get_public_key reveal_counterparty_key_linkage
+        reveal_specific_key_linkage encrypt decrypt create_hmac verify_hmac
+        create_signature verify_signature acquire_certificate list_certificates
+        prove_certificate relinquish_certificate discover_by_identity_key
+        discover_by_attributes is_authenticated wait_for_authentication
+        get_height get_header_for_height get_network get_version
+      ]
+      methods.each do |method|
+        expect(transceiver).to respond_to(method), "expected transceiver to respond to ##{method}"
+      end
+    end
+  end
+
+  describe '#get_version' do
+    let(:result) { { version: '0.1.0' } }
+
+    before { response_bytes.replace(success_response_bytes(:get_version, result)) }
+
+    it 'serialises the request and passes it to wire.transmit_to_wallet' do
+      transceiver.get_version
+      expect(transmitted_frames.length).to eq(1)
+      expect(transmitted_frames.first).to eq(expected_request_frame(:get_version, {}))
+    end
+
+    it 'deserialises the response and returns a Hash' do
+      returned = transceiver.get_version
+      expect(returned).to eq(result)
+    end
+  end
+
+  describe '#get_public_key' do
+    let(:args)   { { identity_key: true } }
+    let(:result) { { public_key: "02#{'ab' * 32}" } }
+
+    before { response_bytes.replace(success_response_bytes(:get_public_key, result)) }
+
+    it 'serialises the correct call code and args into the frame' do
+      transceiver.get_public_key(args)
+      expect(transmitted_frames.first).to eq(expected_request_frame(:get_public_key, args))
+    end
+
+    it 'returns the deserialised public_key' do
+      returned = transceiver.get_public_key(args)
+      expect(returned[:public_key]).to eq(result[:public_key])
+    end
+  end
+
+  describe 'originator handling' do
+    let(:result) { { version: '0.1.0' } }
+
+    before { response_bytes.replace(success_response_bytes(:get_version, result)) }
+
+    context 'when a constructor originator is set' do
+      let(:constructor_originator) { 'constructor.example.com' }
+
+      it 'embeds the constructor originator in the frame' do
+        transceiver.get_version
+        expected = expected_request_frame(:get_version, {}, 'constructor.example.com')
+        expect(transmitted_frames.first).to eq(expected)
+      end
+    end
+
+    context 'when a method-level originator is provided' do
+      let(:constructor_originator) { 'constructor.example.com' }
+
+      it 'uses the method-level originator instead of the constructor originator' do
+        transceiver.get_version(originator: 'method.example.com')
+        expected = expected_request_frame(:get_version, {}, 'method.example.com')
+        expect(transmitted_frames.first).to eq(expected)
+      end
+    end
+
+    context 'when neither originator is set' do
+      it 'uses an empty originator string in the frame' do
+        transceiver.get_version
+        expected = expected_request_frame(:get_version, {}, '')
+        expect(transmitted_frames.first).to eq(expected)
+      end
+    end
+  end
+
+  describe 'error handling' do
+    context 'when the response has a non-zero error byte' do
+      before { response_bytes.replace(error_response_bytes(42, 'Something went wrong')) }
+
+      it 'raises WalletError with the error message' do
+        expect { transceiver.get_version }.to raise_error(BSV::Wallet::WalletError, 'Something went wrong')
+      end
+
+      it 'includes the error code on the raised exception' do
+        transceiver.get_version
+      rescue BSV::Wallet::WalletError => e
+        expect(e.code).to eq(42)
+      end
+    end
+  end
+
+  describe 'wire transport propagation' do
+    it 'passes the frame as an Array of Integers to transmit_to_wallet' do
+      response_bytes.replace(success_response_bytes(:get_version, { version: '0.1.0' }))
+      transceiver.get_version
+      frame = transmitted_frames.first
+      expect(frame).to be_an(Array)
+      expect(frame).to all(be_an(Integer).and(be_between(0, 255)))
+    end
+
+    it 'propagates exceptions raised by the wire transport' do
+      allow(wire).to receive(:transmit_to_wallet).and_raise(RuntimeError, 'connection refused')
+      expect { transceiver.get_version }.to raise_error(RuntimeError, 'connection refused')
+    end
+  end
+
+  describe 'all 28 methods route through transmit' do
+    # For each zero-arg method (args default to {}), verify the call code in the frame.
+    {
+      create_action: { args: { description: 'Test', outputs: [] }, result: { txid: 'aa' * 32, tx: [], no_send_change: [] } },
+      get_height: { args: {}, result: { height: 800_000 } },
+      get_network: { args: {}, result: { network: 'mainnet' } },
+      get_version: { args: {}, result: { version: '0.1.0' } },
+      is_authenticated: { args: {}, result: { authenticated: true } }
+    }.each do |method_name, config|
+      it "routes ##{method_name} through wire.transmit_to_wallet with the correct call code" do
+        response_bytes.replace(success_response_bytes(method_name, config[:result]))
+        expected_code = BSV::Wallet::Wire::Serializer::CALL_CODES[method_name]
+        transceiver.public_send(method_name, config[:args])
+        expect(transmitted_frames.last.first).to eq(expected_code)
+      end
+    end
+  end
+
+  describe 'integration with HTTPWalletWire' do
+    # Verifies that WalletWireTransceiver composes correctly with HTTPWalletWire,
+    # using an injected http_client to avoid real network calls.
+    let(:http_responses) { [] }
+    let(:http_client) do
+      resps = http_responses
+      proc do |_uri, _body, _originator|
+        resps.shift || ''
+      end
+    end
+    let(:http_wire)   { BSV::Wallet::Substrates::HTTPWalletWire.new('http://localhost:3301', http_client: http_client) }
+    let(:integrated)  { BSV::Wallet::Substrates::WalletWireTransceiver.new(http_wire, originator: 'test.example.com') }
+
+    it 'delegates get_version through HTTPWalletWire to the mocked HTTP client' do
+      http_responses << BSV::Wallet::Wire::Serializer.serialize_response(:get_version, { version: '1.2.3' })
+      result = integrated.get_version
+      expect(result[:version]).to eq('1.2.3')
+    end
+
+    it 'raises WalletError when the HTTP server returns an error response' do
+      http_responses << BSV::Wallet::Wire::Serializer.serialize_error(1, 'not authenticated')
+      expect { integrated.is_authenticated }.to raise_error(BSV::Wallet::WalletError, 'not authenticated')
+    end
+  end
+end

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_spec.rb
@@ -1541,4 +1541,259 @@ RSpec.describe BSV::Wallet::WalletClient do
       expect(sourced).to be >= 1
     end
   end
+
+  # -------------------------------------------------------------------------
+  # substrate: delegation
+  # -------------------------------------------------------------------------
+  describe 'substrate: delegation' do
+    # rubocop:disable RSpec/VerifiedDoubles
+    let(:mock_substrate) do
+      spy('substrate',
+          create_action: { txid: 'abc' },
+          sign_action: { txid: 'abc' },
+          abort_action: { aborted: true },
+          list_actions: { total_actions: 0, actions: [] },
+          internalize_action: { accepted: true },
+          list_outputs: { total_outputs: 0, outputs: [] },
+          relinquish_output: { relinquished: true },
+          get_public_key: { public_key: '02deadbeef' },
+          reveal_counterparty_key_linkage: { encryption_revelation: {} },
+          reveal_specific_key_linkage: { revelation: {} },
+          encrypt: { ciphertext: [1, 2, 3] },
+          decrypt: { plaintext: [104] },
+          create_hmac: { hmac: [0] * 32 },
+          verify_hmac: { valid: true },
+          create_signature: { signature: [0] * 71 },
+          verify_signature: { valid: true },
+          acquire_certificate: { type: 'test' },
+          list_certificates: { total_certificates: 0, certificates: [] },
+          prove_certificate: { keyring_for_verifier: {} },
+          relinquish_certificate: { relinquished: true },
+          discover_by_identity_key: { total_certificates: 0, certificates: [] },
+          discover_by_attributes: { total_certificates: 0, certificates: [] },
+          is_authenticated: { authenticated: true },
+          wait_for_authentication: { authenticated: true },
+          get_height: { height: 999 },
+          get_header_for_height: { header: 'ff' * 80 },
+          get_network: { network: 'mainnet' },
+          get_version: { version: 'remote-1.0.0' })
+    end
+    # rubocop:enable RSpec/VerifiedDoubles
+
+    let(:wallet_with_substrate) do
+      described_class.new(private_key, storage: BSV::Wallet::MemoryStore.new, substrate: mock_substrate)
+    end
+
+    it 'exposes the substrate via #substrate' do
+      expect(wallet_with_substrate.substrate).to equal(mock_substrate)
+    end
+
+    it 'delegates create_action to the substrate' do
+      wallet_with_substrate.create_action({ description: 'pay' })
+      expect(mock_substrate).to have_received(:create_action).with({ description: 'pay' }, originator: nil)
+    end
+
+    it 'forwards originator to create_action' do
+      wallet_with_substrate.create_action({ description: 'pay' }, originator: 'app.example.com')
+      expect(mock_substrate).to have_received(:create_action).with(anything, originator: 'app.example.com')
+    end
+
+    it 'delegates sign_action to the substrate' do
+      wallet_with_substrate.sign_action({ reference: 'ref' })
+      expect(mock_substrate).to have_received(:sign_action).with({ reference: 'ref' }, originator: nil)
+    end
+
+    it 'delegates abort_action to the substrate' do
+      wallet_with_substrate.abort_action({ reference: 'ref' })
+      expect(mock_substrate).to have_received(:abort_action).with({ reference: 'ref' }, originator: nil)
+    end
+
+    it 'delegates list_actions to the substrate' do
+      wallet_with_substrate.list_actions({ labels: ['pay'] })
+      expect(mock_substrate).to have_received(:list_actions).with({ labels: ['pay'] }, originator: nil)
+    end
+
+    it 'delegates internalize_action to the substrate' do
+      wallet_with_substrate.internalize_action({ tx: [] })
+      expect(mock_substrate).to have_received(:internalize_action).with({ tx: [] }, originator: nil)
+    end
+
+    it 'delegates list_outputs to the substrate' do
+      wallet_with_substrate.list_outputs({ basket: 'default' })
+      expect(mock_substrate).to have_received(:list_outputs).with({ basket: 'default' }, originator: nil)
+    end
+
+    it 'delegates relinquish_output to the substrate' do
+      wallet_with_substrate.relinquish_output({ output: 'abc.0' })
+      expect(mock_substrate).to have_received(:relinquish_output).with({ output: 'abc.0' }, originator: nil)
+    end
+
+    it 'delegates get_public_key to the substrate' do
+      wallet_with_substrate.get_public_key({ identity_key: true })
+      expect(mock_substrate).to have_received(:get_public_key).with({ identity_key: true }, originator: nil)
+    end
+
+    it 'forwards originator to get_public_key' do
+      wallet_with_substrate.get_public_key({ identity_key: true }, originator: 'app.example.com')
+      expect(mock_substrate).to have_received(:get_public_key).with(anything, originator: 'app.example.com')
+    end
+
+    it 'delegates reveal_counterparty_key_linkage to the substrate' do
+      args = { counterparty: '02abc', protocol_id: [0, 'test'], key_id: '1' }
+      wallet_with_substrate.reveal_counterparty_key_linkage(args)
+      expect(mock_substrate).to have_received(:reveal_counterparty_key_linkage).with(args, originator: nil)
+    end
+
+    it 'delegates reveal_specific_key_linkage to the substrate' do
+      args = { counterparty: '02abc', protocol_id: [0, 'test'], key_id: '1', privilege_level: 'low' }
+      wallet_with_substrate.reveal_specific_key_linkage(args)
+      expect(mock_substrate).to have_received(:reveal_specific_key_linkage).with(args, originator: nil)
+    end
+
+    it 'delegates encrypt to the substrate' do
+      args = { plaintext: [1, 2, 3], protocol_id: [0, 'test'], key_id: '1', counterparty: 'self' }
+      wallet_with_substrate.encrypt(args)
+      expect(mock_substrate).to have_received(:encrypt).with(args, originator: nil)
+    end
+
+    it 'delegates decrypt to the substrate' do
+      args = { ciphertext: [1, 2, 3], protocol_id: [0, 'test'], key_id: '1', counterparty: 'self' }
+      wallet_with_substrate.decrypt(args)
+      expect(mock_substrate).to have_received(:decrypt).with(args, originator: nil)
+    end
+
+    it 'delegates create_hmac to the substrate' do
+      args = { data: [1, 2, 3], protocol_id: [0, 'test'], key_id: '1', counterparty: 'self' }
+      wallet_with_substrate.create_hmac(args)
+      expect(mock_substrate).to have_received(:create_hmac).with(args, originator: nil)
+    end
+
+    it 'delegates verify_hmac to the substrate' do
+      args = { data: [1], hmac: [0] * 32, protocol_id: [0, 'test'], key_id: '1', counterparty: 'self' }
+      wallet_with_substrate.verify_hmac(args)
+      expect(mock_substrate).to have_received(:verify_hmac).with(args, originator: nil)
+    end
+
+    it 'delegates create_signature to the substrate' do
+      args = { data: [1], protocol_id: [0, 'test'], key_id: '1', counterparty: 'self' }
+      wallet_with_substrate.create_signature(args)
+      expect(mock_substrate).to have_received(:create_signature).with(args, originator: nil)
+    end
+
+    it 'delegates verify_signature to the substrate' do
+      args = { data: [1], signature: [0] * 71, protocol_id: [0, 'test'], key_id: '1', counterparty: 'self' }
+      wallet_with_substrate.verify_signature(args)
+      expect(mock_substrate).to have_received(:verify_signature).with(args, originator: nil)
+    end
+
+    it 'delegates acquire_certificate to the substrate' do
+      args = { type: 'test', certifier: '02abc', acquisition_protocol: 'direct' }
+      wallet_with_substrate.acquire_certificate(args)
+      expect(mock_substrate).to have_received(:acquire_certificate).with(args, originator: nil)
+    end
+
+    it 'delegates list_certificates to the substrate' do
+      args = { certifiers: ['02abc'], types: ['test'] }
+      wallet_with_substrate.list_certificates(args)
+      expect(mock_substrate).to have_received(:list_certificates).with(args, originator: nil)
+    end
+
+    it 'delegates prove_certificate to the substrate' do
+      args = { certificate: { type: 'test', serial_number: 'sn', certifier: '02abc' },
+               fields_to_reveal: ['name'], verifier: '02abc' }
+      wallet_with_substrate.prove_certificate(args)
+      expect(mock_substrate).to have_received(:prove_certificate).with(args, originator: nil)
+    end
+
+    it 'delegates relinquish_certificate to the substrate' do
+      args = { type: 'test', serial_number: 'sn', certifier: '02abc' }
+      wallet_with_substrate.relinquish_certificate(args)
+      expect(mock_substrate).to have_received(:relinquish_certificate).with(args, originator: nil)
+    end
+
+    it 'delegates discover_by_identity_key to the substrate' do
+      args = { identity_key: '02abc' }
+      wallet_with_substrate.discover_by_identity_key(args)
+      expect(mock_substrate).to have_received(:discover_by_identity_key).with(args, originator: nil)
+    end
+
+    it 'delegates discover_by_attributes to the substrate' do
+      args = { attributes: { name: 'Alice' } }
+      wallet_with_substrate.discover_by_attributes(args)
+      expect(mock_substrate).to have_received(:discover_by_attributes).with(args, originator: nil)
+    end
+
+    it 'delegates is_authenticated to the substrate' do
+      wallet_with_substrate.is_authenticated
+      expect(mock_substrate).to have_received(:is_authenticated).with({}, originator: nil)
+    end
+
+    it 'delegates wait_for_authentication to the substrate' do
+      wallet_with_substrate.wait_for_authentication
+      expect(mock_substrate).to have_received(:wait_for_authentication).with({}, originator: nil)
+    end
+
+    it 'delegates get_height to the substrate' do
+      wallet_with_substrate.get_height
+      expect(mock_substrate).to have_received(:get_height).with({}, originator: nil)
+    end
+
+    it 'delegates get_header_for_height to the substrate' do
+      wallet_with_substrate.get_header_for_height({ height: 100 })
+      expect(mock_substrate).to have_received(:get_header_for_height).with({ height: 100 }, originator: nil)
+    end
+
+    it 'delegates get_network to the substrate' do
+      wallet_with_substrate.get_network
+      expect(mock_substrate).to have_received(:get_network).with({}, originator: nil)
+    end
+
+    it 'delegates get_version to the substrate' do
+      wallet_with_substrate.get_version
+      expect(mock_substrate).to have_received(:get_version).with({}, originator: nil)
+    end
+
+    it 'returns the substrate result for get_height' do
+      expect(wallet_with_substrate.get_height).to eq({ height: 999 })
+    end
+
+    it 'returns the substrate result for get_network' do
+      expect(wallet_with_substrate.get_network).to eq({ network: 'mainnet' })
+    end
+
+    it 'returns the substrate result for get_version' do
+      expect(wallet_with_substrate.get_version).to eq({ version: 'remote-1.0.0' })
+    end
+
+    it 'leaves the local wallet (no substrate) unchanged for get_height' do
+      # NullChainProvider raises UnsupportedActionError — confirms local path is taken, not substrate
+      chain = BSV::Wallet::NullChainProvider.new
+      w = described_class.new(private_key, storage: BSV::Wallet::MemoryStore.new,
+                                           chain_provider: chain)
+      expect { w.get_height }.to raise_error(BSV::Wallet::UnsupportedActionError)
+    end
+
+    it 'leaves the local wallet (no substrate) unchanged for is_authenticated' do
+      expect(wallet.is_authenticated).to eq({ authenticated: true })
+    end
+
+    it 'leaves the local wallet (no substrate) unchanged for get_network' do
+      expect(wallet.get_network).to eq({ network: 'mainnet' })
+    end
+
+    it 'constructs without error when given an HTTPWalletJSON substrate' do
+      substrate = BSV::Wallet::Substrates::HTTPWalletJSON.new('http://localhost:3321')
+      expect do
+        described_class.new(private_key, storage: BSV::Wallet::MemoryStore.new, substrate: substrate)
+      end.not_to raise_error
+    end
+
+    it 'constructs without error when given a WalletWireTransceiver substrate' do
+      wire = double('wire', transmit_to_wallet: []) # rubocop:disable RSpec/VerifiedDoubles
+      transceiver = BSV::Wallet::Substrates::WalletWireTransceiver.new(wire)
+      expect do
+        described_class.new(private_key, storage: BSV::Wallet::MemoryStore.new, substrate: transceiver)
+      end.not_to raise_error
+    end
+  end
 end

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_spec.rb
@@ -810,6 +810,188 @@ RSpec.describe BSV::Wallet::WalletClient do
   end
 
   # -------------------------------------------------------------------------
+  # list_actions include flags
+  # -------------------------------------------------------------------------
+  describe '#list_actions include flags' do
+    before do
+      wallet.create_action({ description: 'labelled action', outputs: [output_spec], labels: ['payment'] })
+    end
+
+    it 'strips :labels by default (flag absent)' do
+      result = wallet.list_actions({ labels: ['payment'] })
+      expect(result[:actions].first).not_to have_key(:labels)
+    end
+
+    it 'strips :labels when include_labels is false' do
+      result = wallet.list_actions({ labels: ['payment'], include_labels: false })
+      expect(result[:actions].first).not_to have_key(:labels)
+    end
+
+    it 'strips :labels when include_labels is nil' do
+      result = wallet.list_actions({ labels: ['payment'], include_labels: nil })
+      expect(result[:actions].first).not_to have_key(:labels)
+    end
+
+    it 'preserves :labels when include_labels is true' do
+      result = wallet.list_actions({ labels: ['payment'], include_labels: true })
+      expect(result[:actions].first).to have_key(:labels)
+      expect(result[:actions].first[:labels]).to include('payment')
+    end
+
+    it 'strips :inputs by default (field not currently stored, no-op)' do
+      result = wallet.list_actions({ labels: ['payment'] })
+      expect(result[:actions].first).not_to have_key(:inputs)
+    end
+
+    it 'strips :outputs by default (field not currently stored, no-op)' do
+      result = wallet.list_actions({ labels: ['payment'] })
+      expect(result[:actions].first).not_to have_key(:outputs)
+    end
+
+    it 'does not affect total_actions count' do
+      result_default = wallet.list_actions({ labels: ['payment'] })
+      result_with_flags = wallet.list_actions({ labels: ['payment'], include_labels: true })
+      expect(result_default[:total_actions]).to eq(result_with_flags[:total_actions])
+    end
+
+    it 'strips nested :source_locking_script from inputs when present' do
+      action = wallet.list_actions({ labels: ['payment'], include_inputs: true })[:actions].first
+      action[:inputs] = [{ source_locking_script: 'aabbcc', unlocking_script: 'ddeeff' }]
+      # Simulate: call strip_action_fields directly via the stripping logic
+      # Verify by calling list_actions with a storage that returns inputs
+      # (MemoryStore does not populate inputs, so we test via private method)
+      result = wallet.send(:strip_action_fields, [action], { include_inputs: true })
+      expect(result.first[:inputs].first).not_to have_key(:source_locking_script)
+    end
+
+    it 'strips nested :unlocking_script from inputs when present' do
+      action = wallet.list_actions({ labels: ['payment'], include_inputs: true })[:actions].first
+      action[:inputs] = [{ source_locking_script: 'aabbcc', unlocking_script: 'ddeeff' }]
+      result = wallet.send(:strip_action_fields, [action], { include_inputs: true, include_input_unlocking_scripts: false })
+      expect(result.first[:inputs].first).not_to have_key(:unlocking_script)
+    end
+
+    it 'preserves nested :source_locking_script when include_input_source_locking_scripts is true' do
+      action = wallet.list_actions({ labels: ['payment'], include_inputs: true })[:actions].first
+      action[:inputs] = [{ source_locking_script: 'aabbcc' }]
+      result = wallet.send(:strip_action_fields, [action],
+                           { include_inputs: true, include_input_source_locking_scripts: true })
+      expect(result.first[:inputs].first).to have_key(:source_locking_script)
+    end
+
+    it 'strips nested :locking_script from outputs when present' do
+      action = wallet.list_actions({ labels: ['payment'], include_outputs: true })[:actions].first
+      action[:outputs] = [{ locking_script: 'aabbcc', satoshis: 1000 }]
+      result = wallet.send(:strip_action_fields, [action], { include_outputs: true })
+      expect(result.first[:outputs].first).not_to have_key(:locking_script)
+    end
+
+    it 'preserves nested :locking_script when include_output_locking_scripts is true' do
+      action = wallet.list_actions({ labels: ['payment'], include_outputs: true })[:actions].first
+      action[:outputs] = [{ locking_script: 'aabbcc', satoshis: 1000 }]
+      result = wallet.send(:strip_action_fields, [action],
+                           { include_outputs: true, include_output_locking_scripts: true })
+      expect(result.first[:outputs].first).to have_key(:locking_script)
+    end
+
+    it 'does not mutate the original action hashes' do
+      stored = wallet.list_actions({ labels: ['payment'], include_labels: true })[:actions]
+      original_keys = stored.first.keys.dup
+      wallet.list_actions({ labels: ['payment'] })
+      expect(stored.first.keys).to eq(original_keys)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # list_outputs include flags
+  # -------------------------------------------------------------------------
+  describe '#list_outputs include flags' do
+    before do
+      wallet.create_action({
+                             description: 'create tagged output',
+                             outputs: [{
+                               locking_script: locking_script_hex,
+                               satoshis: 500,
+                               output_description: 'tagged token',
+                               basket: 'flag test',
+                               tags: ['rare'],
+                               custom_instructions: 'handle with care'
+                             }]
+                           })
+    end
+
+    it 'strips :tags by default (flag absent)' do
+      result = wallet.list_outputs({ basket: 'flag test' })
+      expect(result[:outputs].first).not_to have_key(:tags)
+    end
+
+    it 'strips :tags when include_tags is false' do
+      result = wallet.list_outputs({ basket: 'flag test', include_tags: false })
+      expect(result[:outputs].first).not_to have_key(:tags)
+    end
+
+    it 'strips :tags when include_tags is nil' do
+      result = wallet.list_outputs({ basket: 'flag test', include_tags: nil })
+      expect(result[:outputs].first).not_to have_key(:tags)
+    end
+
+    it 'preserves :tags when include_tags is true' do
+      result = wallet.list_outputs({ basket: 'flag test', include_tags: true })
+      expect(result[:outputs].first).to have_key(:tags)
+      expect(result[:outputs].first[:tags]).to include('rare')
+    end
+
+    it 'strips :labels by default (field not currently stored, no-op)' do
+      result = wallet.list_outputs({ basket: 'flag test' })
+      expect(result[:outputs].first).not_to have_key(:labels)
+    end
+
+    it 'strips :custom_instructions by default' do
+      result = wallet.list_outputs({ basket: 'flag test' })
+      expect(result[:outputs].first).not_to have_key(:custom_instructions)
+    end
+
+    it 'strips :custom_instructions when include_custom_instructions is false' do
+      result = wallet.list_outputs({ basket: 'flag test', include_custom_instructions: false })
+      expect(result[:outputs].first).not_to have_key(:custom_instructions)
+    end
+
+    it 'preserves :custom_instructions when include_custom_instructions is true' do
+      result = wallet.list_outputs({ basket: 'flag test', include_custom_instructions: true })
+      expect(result[:outputs].first).to have_key(:custom_instructions)
+      expect(result[:outputs].first[:custom_instructions]).to eq('handle with care')
+    end
+
+    it 'preserves :tags and strips :custom_instructions with mixed flags' do
+      result = wallet.list_outputs({ basket: 'flag test', include_tags: true })
+      expect(result[:outputs].first).to have_key(:tags)
+      expect(result[:outputs].first).not_to have_key(:custom_instructions)
+    end
+
+    it 'preserves all fields when all flags are true' do
+      result = wallet.list_outputs({ basket: 'flag test',
+                                     include_tags: true,
+                                     include_labels: true,
+                                     include_custom_instructions: true })
+      expect(result[:outputs].first).to have_key(:tags)
+      expect(result[:outputs].first).to have_key(:custom_instructions)
+    end
+
+    it 'does not affect total_outputs count' do
+      result_default = wallet.list_outputs({ basket: 'flag test' })
+      result_with_flags = wallet.list_outputs({ basket: 'flag test', include_tags: true })
+      expect(result_default[:total_outputs]).to eq(result_with_flags[:total_outputs])
+    end
+
+    it 'does not mutate the original output hashes' do
+      stored = wallet.list_outputs({ basket: 'flag test', include_tags: true, include_custom_instructions: true })[:outputs]
+      original_keys = stored.first.keys.dup
+      wallet.list_outputs({ basket: 'flag test' })
+      expect(stored.first.keys).to eq(original_keys)
+    end
+  end
+
+  # -------------------------------------------------------------------------
   # #relinquish_output
   # -------------------------------------------------------------------------
   describe '#relinquish_output' do


### PR DESCRIPTION
## Summary

- Add `BSV::WireFormat` module for shared camelCase/snake_case key conversion, refactoring duplicated code from AuthMiddleware and SimplifiedFetchTransport (F8.11)
- Honour include flags (`include_labels`, `include_inputs`, `include_outputs`, etc.) in `list_actions` and `list_outputs` with post-fetch field stripping (F8.12)
- Add BRC-100 HTTP substrates: `HTTPWalletJSON` (JSON-over-HTTP), `HTTPWalletWire` (binary wire transport), `WalletWireTransceiver` (Interface adapter) (F8.2)
- Add `substrate:` constructor parameter to `WalletClient` for remote wallet communication (F8.2)
- Replace plain `Net::HTTP` with `AuthFetch` for BRC-104 authenticated certificate issuance (F8.16)

## Test plan

- [x] All specs pass (`bundle exec rake`) -- 4902 examples, 0 failures
- [x] RuboCop clean (`bundle exec rubocop`) -- 377 files, 0 offences
- [x] WireFormat round-trip tests verify deep key conversion
- [x] Include flag specs verify each flag individually with defaults-to-false behaviour
- [x] Substrate specs verify HTTP delegation for all 28 Interface methods
- [x] AuthFetch issuance specs verify mutual authentication during certificate acquisition

## Sub-issues

- #447 -- WireFormat module (F8.11)
- #448 -- Include flags for list_actions/list_outputs (F8.12)
- #449 -- HTTPWalletJSON substrate (F8.2)
- #450 -- HTTPWalletWire substrate (F8.2)
- #451 -- WalletWireTransceiver (F8.2)
- #452 -- WalletClient substrate: param (F8.2)
- #453 -- AuthFetch certificate issuance (F8.16)

Closes #445
