### PR TITLE
fix: persist BEEF ancestry through the wallet lifecycle

### DIFF
--- a/.claude/drafts/upstream-wallet-toolbox-149-comment.md
+++ b/.claude/drafts/upstream-wallet-toolbox-149-comment.md
@@ -30,10 +30,7 @@ The fix was to go through `findAtomicTransaction` / `find_atomic_transaction` ra
 
 The end-to-end symptom is: `internaliseAction` runs fine, the UTXO lands in the wallet, but when you try to spend it in a later `createAction`, the broadcast silently falls back to raw hex (or fails to build EF), and ARC rejects it with "must be valid transaction on chain".
 
-The fix in the Ruby SDK is in [PR #N] (sgbett/bsv-ruby-sdk) if it's useful as a reference.
+The fix in the Ruby SDK is in [sgbett/bsv-ruby-sdk#473](https://github.com/sgbett/bsv-ruby-sdk/pull/473) if it's useful as a reference.
 
 Whether the TS SDK has the same gap in `fromBEEF` / `fromAtomicBEEF` is worth a look — if `writeEF` already handles the `sourceTransaction` fallback correctly (which it looks like it does), the TS issue might be narrower than "persist ancestors in `internaliseAction`". Happy to dig into it further if that's useful.
 
----
-
-*[Team lead: fill in PR #N before posting. Remove this line.]*

--- a/.claude/drafts/upstream-wallet-toolbox-149-comment.md
+++ b/.claude/drafts/upstream-wallet-toolbox-149-comment.md
@@ -1,0 +1,39 @@
+# Draft comment for bsv-blockchain/wallet-toolbox#149
+
+**Not yet posted.** Review before posting. Attribution note: same reporter
+as upstream issue (sgbett / Simon Bettison), so tone can be direct and
+technical.
+
+---
+
+## Comment body
+
+Hi — just a note that I hit the same issue while porting the wallet to Ruby (sgbett/bsv-ruby-sdk, HLR #466), and the investigation turned up a slightly different shape to what I originally thought when I filed this.
+
+My initial instinct (and the workaround in the fork) was that `internaliseAction` wasn't persisting BEEF ancestors. After going deeper, that turned out not to be quite right — `storeProofsFromBeef` was already walking the full BEEF and storing every ancestor transaction. The storage side was fine.
+
+The real issue was in two other places:
+
+**1. EF serialisation (`toHexEF` / `writeEF`)**
+
+When a transaction is built using inputs from `fromBEEF`, those inputs have their `sourceTransaction` wired up but `sourceSatoshis` and `sourceLockingScript` aren't set as explicit properties on the input object. In the Ruby port, `toEF` wasn't falling back to `input.sourceTransaction.outputs[i]` when those explicit fields were missing — it just raised and the caller silently fell back to broadcasting plain hex. ARC then rejected that hex because the parent was unconfirmed.
+
+I had a look at the TS `writeEF` (Transaction.ts ~L672–713) and it accesses `i.sourceTransaction.outputs[i.sourceOutputIndex]` directly, so it should handle this correctly. The Ruby implementation was the divergent one here — the fix was to derive from `sourceTransaction` when explicit fields aren't set, non-mutating, matching the TS behaviour.
+
+**2. `fromBEEF` ancestry wiring**
+
+The second, subtler issue: `Transaction.fromBEEF` (Ruby's `from_beef`) wasn't routing through `Beef#findAtomicTransaction` (our `find_atomic_transaction`). That method does the extra step of attaching late-bound BUMPs to `FORMAT_RAW_TX` ancestors whose txid appears as a leaf elsewhere in the BUMP tree — a pass that `wireSourceTransactions` alone doesn't cover. So the returned transaction had some ancestors without `merklePath` attached even when the BEEF contained the proof.
+
+The fix was to go through `findAtomicTransaction` / `find_atomic_transaction` rather than the simpler path, so every ancestor in the returned tx has its proof wired before you try to broadcast.
+
+---
+
+The end-to-end symptom is: `internaliseAction` runs fine, the UTXO lands in the wallet, but when you try to spend it in a later `createAction`, the broadcast silently falls back to raw hex (or fails to build EF), and ARC rejects it with "must be valid transaction on chain".
+
+The fix in the Ruby SDK is in [PR #N] (sgbett/bsv-ruby-sdk) if it's useful as a reference.
+
+Whether the TS SDK has the same gap in `fromBEEF` / `fromAtomicBEEF` is worth a look — if `writeEF` already handles the `sourceTransaction` fallback correctly (which it looks like it does), the TS issue might be narrower than "persist ancestors in `internaliseAction`". Happy to dig into it further if that's useful.
+
+---
+
+*[Team lead: fill in PR #N before posting. Remove this line.]*

--- a/docs/gems/wallet.md
+++ b/docs/gems/wallet.md
@@ -148,6 +148,12 @@ wallet.internalize_action({
 })
 ```
 
+The full internalize → create → broadcast round-trip is exercised by the integration
+spec suite. `internalize_action` persists every transaction in the BEEF (not just the
+subject), so ancestor chain data is available when the wallet later builds a new
+transaction spending the internalised UTXO. This ensures `to_ef_hex` can serialise the
+spending transaction correctly for ARC broadcast, even when the parent is unconfirmed.
+
 ## Status meanings
 
 Each action stored by the wallet carries a `status` field that reflects its

--- a/docs/sdk/transaction.md
+++ b/docs/sdk/transaction.md
@@ -193,6 +193,20 @@ tx = beef.find_transaction(txid_bytes)
 
 BEEF automatically wires source transactions: inputs that reference other transactions in the bundle will have their `source_transaction` set.
 
+### Extracting a transaction from a BEEF
+
+`Transaction.from_beef` returns the subject transaction with full ancestry wired, including late-bound BUMP attachment for ancestors stored as raw transactions alongside a separately-bundled merkle proof:
+
+```ruby
+tx = BSV::Transaction::Transaction.from_beef(beef_bytes)
+
+# Source data is derived from the wired ancestry — no need to set
+# source_satoshis or source_locking_script explicitly.
+ef_bytes = tx.to_ef_hex  # ready for ARC broadcast
+```
+
+This is the canonical flow for re-broadcasting a received BEEF (e.g. after `internalize_action`). `to_ef_hex` resolves source satoshis and locking scripts directly from `source_transaction.outputs[prev_tx_out_index]` when the explicit fields are not set on an input.
+
 ### Transaction Entries
 
 Each entry in a BEEF bundle has a format:

--- a/gem/bsv-sdk/CHANGELOG.md
+++ b/gem/bsv-sdk/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to the `bsv-sdk` gem are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this gem adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `Transaction#to_ef` now derives `source_satoshis` and `source_locking_script`
+  from `input.source_transaction.outputs[input.prev_tx_out_index]` when the
+  explicit fields are unset. Previously `to_ef` raised `ArgumentError` on inputs
+  wired via `Transaction.from_beef`, causing `ARC#broadcast` to silently fall back
+  to raw hex — which ARC rejects when parent transactions are unconfirmed.
+  Consumer impact: recently-received UTXOs that previously could not be
+  re-broadcast now can. Matches TS SDK `writeEF` behaviour. (#467, HLR #466)
+- `Transaction.from_beef` and `from_beef_hex` now use `Beef#find_atomic_transaction`
+  to locate the subject transaction, ensuring that `FORMAT_RAW_TX` ancestors whose
+  txid appears as a leaf in a separately-stored BUMP have their `merkle_path`
+  attached. Covers a late-bound BUMP attachment gap not handled by the initial
+  `wire_source_transactions` pass. Matches `Transaction.fromAtomicBEEF` semantics
+  in the TS SDK. (#468, HLR #466)
+
+**Related upstream issue:** [wallet-toolbox#149](https://github.com/bsv-blockchain/wallet-toolbox/issues/149) — same architectural gap in the TS SDK.
+
 ## 0.12.0 — 2026-04-15
 
 ### Added

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -102,19 +102,29 @@ module BSV
       # EF embeds source satoshis and source locking scripts in each input,
       # allowing ARC to validate sighashes without fetching parent transactions.
       #
+      # Source data is resolved in priority order:
+      # 1. Explicit +source_satoshis+ / +source_locking_script+ on the input.
+      # 2. Derived from +input.source_transaction.outputs[input.prev_tx_out_index]+.
+      #
+      # Source fields on input objects are never mutated — derivation happens on
+      # each call, so calling +to_ef+ twice produces identical output.
+      #
       # @return [String] raw EF transaction bytes
-      # @raise [ArgumentError] if any input is missing source_satoshis or source_locking_script
+      # @raise [ArgumentError] if any input cannot supply source_satoshis or
+      #   source_locking_script via either mechanism
       def to_ef
         buf = [@version].pack('V')
         buf << "\x00\x00\x00\x00\x00\xEF".b
         buf << VarInt.encode(@inputs.length)
-        @inputs.each do |input|
-          raise ArgumentError, 'inputs must have source_satoshis for EF' if input.source_satoshis.nil?
-          raise ArgumentError, 'inputs must have source_locking_script for EF' if input.source_locking_script.nil?
+        @inputs.each_with_index do |input, idx|
+          source_output = ef_source_output(input, idx)
+
+          satoshis = input.source_satoshis || source_output.satoshis
+          locking_script = input.source_locking_script || source_output.locking_script
 
           buf << input.to_binary
-          buf << [input.source_satoshis].pack('Q<')
-          lock_bytes = input.source_locking_script.to_binary
+          buf << [satoshis].pack('Q<')
+          lock_bytes = locking_script.to_binary
           buf << VarInt.encode(lock_bytes.bytesize)
           buf << lock_bytes
         end
@@ -343,21 +353,35 @@ module BSV
         to_beef.unpack1('H*')
       end
 
-      # Parse a BEEF binary bundle and return the subject transaction
-      # (the last transaction in the bundle).
+      # Parse a BEEF binary bundle and return the subject transaction with
+      # full ancestry wired, including late-bound BUMP attachment.
+      #
+      # For Atomic BEEFs (BRC-95), the subject transaction is identified by
+      # the embedded subject_txid field. For plain BEEFs, the last transaction
+      # with a raw tx entry is used as the subject.
+      #
+      # Uses +find_atomic_transaction+ so that FORMAT_RAW_TX ancestors whose
+      # txid appears as a leaf in a separately-stored BUMP get their
+      # +merkle_path+ wired correctly — a gap not covered by the initial
+      # +wire_source_transactions+ pass in +Beef.from_binary+.
       #
       # @param data [String] raw BEEF binary
-      # @return [Transaction] the subject transaction with ancestry wired
+      # @return [Transaction, nil] the subject transaction with ancestry wired,
+      #   or nil if the BEEF is empty or contains no raw transaction entries
       def self.from_beef(data)
         beef = Beef.from_binary(data)
-        last_tx_entry = beef.transactions.reverse.find(&:transaction)
-        last_tx_entry&.transaction
+        subject_txid = beef.subject_txid ||
+                       beef.transactions.reverse.find(&:transaction)&.transaction&.txid
+        return nil unless subject_txid
+
+        beef.find_atomic_transaction(subject_txid)
       end
 
       # Parse a BEEF hex string and return the subject transaction.
       #
       # @param hex [String] hex-encoded BEEF
-      # @return [Transaction] the subject transaction with ancestry wired
+      # @return [Transaction, nil] the subject transaction with ancestry wired,
+      #   or nil if the BEEF is empty or contains no raw transaction entries
       def self.from_beef_hex(hex)
         from_beef(BSV::Primitives::Hex.decode(hex, name: 'BEEF hex'))
       end
@@ -682,6 +706,39 @@ module BSV
       end
 
       private
+
+      # Resolve the source TransactionOutput for EF serialisation.
+      #
+      # Returns nil when both explicit fields (+source_satoshis+ and
+      # +source_locking_script+) are already set on the input, so no derivation
+      # is required. Otherwise, requires a wired +source_transaction+ and a
+      # valid output at +prev_tx_out_index+.
+      #
+      # @param input [TransactionInput]
+      # @param idx [Integer] input index, used in error messages
+      # @return [TransactionOutput, nil]
+      def ef_source_output(input, idx)
+        return nil if input.source_satoshis && input.source_locking_script
+
+        unless input.source_transaction
+          missing = []
+          missing << 'source_satoshis' unless input.source_satoshis
+          missing << 'source_locking_script' unless input.source_locking_script
+          raise ArgumentError,
+                "input #{idx} is missing #{missing.join(' and ')} and has no wired source_transaction"
+        end
+
+        if input.prev_tx_out_index.nil?
+          raise ArgumentError,
+                "input #{idx} has no prev_tx_out_index — cannot derive EF source data"
+        end
+
+        output = input.source_transaction.outputs[input.prev_tx_out_index]
+        return output if output
+
+        raise ArgumentError,
+              "input #{idx} source_transaction has no output at index #{input.prev_tx_out_index}"
+      end
 
       def verify_input_requirements(tx, input, index)
         tx_id = tx.txid_hex

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_ef_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_ef_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe BSV::Transaction::Transaction do
         expect(ef.bytesize).to be > tx.to_binary.bytesize
       end
 
-      it 'raises on missing source_satoshis' do
+      it 'raises when source_satoshis and source_locking_script both absent and no source_transaction' do
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
           prev_tx_id: "\x01".b * 32,
@@ -58,10 +58,10 @@ RSpec.describe BSV::Transaction::Transaction do
         )
         tx.add_input(input)
 
-        expect { tx.to_ef }.to raise_error(ArgumentError, /source_satoshis/)
+        expect { tx.to_ef }.to raise_error(ArgumentError, /source_satoshis.*source_locking_script|no wired source_transaction/)
       end
 
-      it 'raises on missing source_locking_script' do
+      it 'raises when source_locking_script absent and no source_transaction' do
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
           prev_tx_id: "\x01".b * 32,
@@ -70,7 +70,184 @@ RSpec.describe BSV::Transaction::Transaction do
         input.source_satoshis = 1000
         tx.add_input(input)
 
-        expect { tx.to_ef }.to raise_error(ArgumentError, /source_locking_script/)
+        expect { tx.to_ef }.to raise_error(ArgumentError, /source_locking_script.*no wired source_transaction/)
+      end
+
+      it 'derives source_satoshis from wired source_transaction when only source_locking_script is explicit' do
+        priv = BSV::Primitives::PrivateKey.generate
+        lock_script = BSV::Script::Script.p2pkh_lock(priv.public_key.hash160)
+
+        source_tx = described_class.new
+        source_tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 75_000, locking_script: lock_script))
+
+        # Build unlocking script with full explicit fields, then strip source_satoshis
+        prep_tx = described_class.new
+        prep_input = BSV::Transaction::TransactionInput.new(
+          prev_tx_id: "\x02".b * 32,
+          prev_tx_out_index: 0
+        )
+        prep_input.source_satoshis = 75_000
+        prep_input.source_locking_script = lock_script
+        prep_tx.add_input(prep_input)
+        prep_tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 74_000, locking_script: lock_script))
+        prep_tx.sign(0, priv)
+
+        tx = described_class.new
+        input = BSV::Transaction::TransactionInput.new(
+          prev_tx_id: "\x02".b * 32,
+          prev_tx_out_index: 0
+        )
+        input.unlocking_script = prep_tx.inputs[0].unlocking_script
+        input.source_transaction = source_tx
+        # source_locking_script explicit, source_satoshis nil — to_ef derives satoshis
+        input.source_locking_script = lock_script
+        tx.add_input(input)
+        tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 74_000, locking_script: lock_script))
+
+        ef = tx.to_ef
+        expect(ef.byteslice(4, 6)).to eq("\x00\x00\x00\x00\x00\xEF".b)
+
+        restored = described_class.from_ef(ef)
+        expect(restored.inputs[0].source_satoshis).to eq(75_000)
+        expect(restored.inputs[0].source_locking_script.to_hex).to eq(lock_script.to_hex)
+      end
+
+      it 'derives both source fields from source_transaction when input has a pre-built unlocking_script' do
+        priv = BSV::Primitives::PrivateKey.generate
+        lock_script = BSV::Script::Script.p2pkh_lock(priv.public_key.hash160)
+
+        source_tx = described_class.new
+        source_tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 75_000, locking_script: lock_script))
+
+        # Build and sign a tx with explicit fields, then strip them to simulate a BEEF-parsed input
+        prep_tx = described_class.new
+        prep_input = BSV::Transaction::TransactionInput.new(
+          prev_tx_id: "\x05".b * 32,
+          prev_tx_out_index: 0
+        )
+        prep_input.source_satoshis = 75_000
+        prep_input.source_locking_script = lock_script
+        prep_tx.add_input(prep_input)
+        prep_tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 74_000, locking_script: lock_script))
+        prep_tx.sign(0, priv)
+
+        # Simulate BEEF-parsed input: has unlocking_script + source_transaction, no explicit source fields
+        tx = described_class.new
+        input = BSV::Transaction::TransactionInput.new(
+          prev_tx_id: "\x05".b * 32,
+          prev_tx_out_index: 0
+        )
+        input.unlocking_script = prep_tx.inputs[0].unlocking_script
+        input.source_transaction = source_tx
+        tx.add_input(input)
+        tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 74_000, locking_script: lock_script))
+
+        ef = tx.to_ef
+        expect(ef.byteslice(4, 6)).to eq("\x00\x00\x00\x00\x00\xEF".b)
+
+        restored = described_class.from_ef(ef)
+        expect(restored.inputs[0].source_satoshis).to eq(75_000)
+        expect(restored.inputs[0].source_locking_script.to_hex).to eq(lock_script.to_hex)
+      end
+
+      it 'does not mutate input when deriving from source_transaction' do
+        priv = BSV::Primitives::PrivateKey.generate
+        lock_script = BSV::Script::Script.p2pkh_lock(priv.public_key.hash160)
+
+        source_tx = described_class.new
+        source_tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 50_000, locking_script: lock_script))
+
+        # Build unlocking script using a separate signed tx
+        prep_tx = described_class.new
+        prep_input = BSV::Transaction::TransactionInput.new(
+          prev_tx_id: "\x03".b * 32,
+          prev_tx_out_index: 0
+        )
+        prep_input.source_satoshis = 50_000
+        prep_input.source_locking_script = lock_script
+        prep_tx.add_input(prep_input)
+        prep_tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 49_000, locking_script: lock_script))
+        prep_tx.sign(0, priv)
+
+        tx = described_class.new
+        input = BSV::Transaction::TransactionInput.new(
+          prev_tx_id: "\x03".b * 32,
+          prev_tx_out_index: 0
+        )
+        input.unlocking_script = prep_tx.inputs[0].unlocking_script
+        input.source_transaction = source_tx
+        tx.add_input(input)
+        tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 49_000, locking_script: lock_script))
+
+        ef1 = tx.to_ef
+        expect(input.source_satoshis).to be_nil
+        expect(input.source_locking_script).to be_nil
+
+        ef2 = tx.to_ef
+        expect(ef1).to eq(ef2)
+      end
+
+      it 'handles mixed inputs: some with explicit fields, some derived from source_transaction' do
+        priv = BSV::Primitives::PrivateKey.generate
+        lock_script = BSV::Script::Script.p2pkh_lock(priv.public_key.hash160)
+
+        source_tx = described_class.new
+        source_tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 30_000, locking_script: lock_script))
+
+        # Prepare a signed unlocking script for input1
+        prep_tx = described_class.new
+        prep_input = BSV::Transaction::TransactionInput.new(
+          prev_tx_id: "\x02".b * 32,
+          prev_tx_out_index: 0
+        )
+        prep_input.source_satoshis = 30_000
+        prep_input.source_locking_script = lock_script
+        prep_tx.add_input(prep_input)
+        prep_tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 29_000, locking_script: lock_script))
+        prep_tx.sign(0, priv)
+
+        tx = described_class.new
+
+        # Input 0: explicit fields
+        input0 = BSV::Transaction::TransactionInput.new(prev_tx_id: "\x01".b * 32, prev_tx_out_index: 0)
+        input0.source_satoshis = 20_000
+        input0.source_locking_script = lock_script
+        input0.unlocking_script_template = BSV::Transaction::P2PKH.new(priv)
+        tx.add_input(input0)
+
+        # Input 1: only source_transaction (no explicit source_satoshis / source_locking_script)
+        input1 = BSV::Transaction::TransactionInput.new(prev_tx_id: "\x02".b * 32, prev_tx_out_index: 0)
+        input1.source_transaction = source_tx
+        input1.unlocking_script = prep_tx.inputs[0].unlocking_script
+        tx.add_input(input1)
+
+        tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 49_000, locking_script: lock_script))
+        tx.sign_all
+
+        ef = tx.to_ef
+        restored = described_class.from_ef(ef)
+
+        expect(restored.inputs[0].source_satoshis).to eq(20_000)
+        expect(restored.inputs[1].source_satoshis).to eq(30_000)
+        expect(restored.inputs[1].source_locking_script.to_hex).to eq(lock_script.to_hex)
+      end
+
+      it 'raises when source_output_index is out of range' do
+        priv = BSV::Primitives::PrivateKey.generate
+        lock_script = BSV::Script::Script.p2pkh_lock(priv.public_key.hash160)
+
+        source_tx = described_class.new
+        source_tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 10_000, locking_script: lock_script))
+
+        tx = described_class.new
+        input = BSV::Transaction::TransactionInput.new(
+          prev_tx_id: "\x04".b * 32,
+          prev_tx_out_index: 99 # out of range
+        )
+        input.source_transaction = source_tx
+        tx.add_input(input)
+
+        expect { tx.to_ef }.to raise_error(ArgumentError, /no output at index 99/)
       end
     end
 

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
@@ -700,6 +700,150 @@ RSpec.describe BSV::Transaction::Transaction do
     end
   end
 
+  describe '.from_beef' do
+    # Shared helpers for building synthetic BEEF fixtures.
+    let(:lock) { BSV::Script::Script.new }
+    let(:pe)   { BSV::Transaction::MerklePath::PathElement }
+
+    # Build a minimal proven ancestor with a synthetic merkle path.
+    #
+    # PathElement hashes must be raw binary in internal byte order
+    # (i.e. txid.reverse — the wire order used by MerklePath serialisation).
+    def proven_tx(satoshis: 1000, block_height: 800_000, offset: 0)
+      tx = BSV::Transaction::Transaction.new
+      tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: satoshis, locking_script: lock))
+      txid_internal = tx.txid.reverse # internal (wire) byte order
+      sibling_hash  = BSV::Primitives::Digest.sha256("sibling_#{offset}") # 32 raw bytes
+      tx.merkle_path = BSV::Transaction::MerklePath.new(
+        block_height: block_height,
+        path: [[pe.new(offset: offset, hash: txid_internal, txid: true),
+                pe.new(offset: offset ^ 1, hash: sibling_hash)]]
+      )
+      tx
+    end
+
+    # Wire an input from parent_tx output 0 into child_tx.
+    # prev_tx_id must be in internal byte order (wire order = txid.reverse).
+    def add_input(child_tx, parent_tx)
+      inp = BSV::Transaction::TransactionInput.new(
+        prev_tx_id: parent_tx.txid.reverse, prev_tx_out_index: 0
+      )
+      inp.source_transaction = parent_tx
+      inp.source_satoshis = parent_tx.outputs[0].satoshis
+      inp.source_locking_script = lock
+      child_tx.add_input(inp)
+    end
+
+    it 'returns nil for an empty BEEF' do
+      # Build a minimal BEEF with no transactions
+      empty_beef = BSV::Transaction::Beef.new
+      binary = empty_beef.to_binary
+      expect(described_class.from_beef(binary)).to be_nil
+    end
+
+    it 'returns the subject tx for a plain BEEF (no subject_txid)' do
+      ancestor = proven_tx(satoshis: 2000)
+      subject  = described_class.new
+      subject.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 100, locking_script: lock))
+      add_input(subject, ancestor)
+
+      beef = BSV::Transaction::Beef.new
+      beef.merge_transaction(subject)
+      binary = beef.to_binary
+
+      result = described_class.from_beef(binary)
+      expect(result).not_to be_nil
+      expect(result.txid).to eq(subject.txid)
+    end
+
+    it 'wires source_transaction on every input when ancestry is present' do
+      ancestor = proven_tx(satoshis: 3000)
+      subject  = described_class.new
+      subject.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 200, locking_script: lock))
+      add_input(subject, ancestor)
+
+      beef = BSV::Transaction::Beef.new
+      beef.merge_transaction(subject)
+      binary = beef.to_binary
+
+      result = described_class.from_beef(binary)
+      expect(result.inputs.all?(&:source_transaction)).to be true
+    end
+
+    it 'wires ancestry across 2 generations' do
+      grandparent = proven_tx(satoshis: 5000, block_height: 700_000, offset: 0)
+
+      parent = described_class.new
+      parent.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 4000, locking_script: lock))
+      add_input(parent, grandparent)
+
+      subject = described_class.new
+      subject.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 3000, locking_script: lock))
+      add_input(subject, parent)
+
+      beef = BSV::Transaction::Beef.new
+      beef.merge_transaction(subject)
+      binary = beef.to_binary
+
+      result = described_class.from_beef(binary)
+      expect(result.inputs[0].source_transaction).not_to be_nil
+      parent_recovered = result.inputs[0].source_transaction
+      expect(parent_recovered.inputs[0].source_transaction).not_to be_nil
+      expect(parent_recovered.inputs[0].source_transaction.txid).to eq(grandparent.txid)
+    end
+
+    it 'attaches late-bound BUMPs on FORMAT_RAW_TX ancestors' do
+      # Build a transaction with no merkle_path (raw tx only).
+      ancestor = described_class.new
+      ancestor.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 1500, locking_script: lock))
+
+      subject = described_class.new
+      subject.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 500, locking_script: lock))
+      add_input(subject, ancestor)
+
+      # Build a BEEF manually: ancestor as FORMAT_RAW_TX, then add a BUMP
+      # whose level-0 leaf matches the ancestor's txid — the late-bound case.
+      # PathElement hashes use internal (wire) byte order: txid.reverse.
+      ancestor_txid_internal = ancestor.txid.reverse
+      sibling_hash           = BSV::Primitives::Digest.sha256('late_sibling')
+      bump = BSV::Transaction::MerklePath.new(
+        block_height: 850_000,
+        path: [[pe.new(offset: 0, hash: ancestor_txid_internal, txid: true),
+                pe.new(offset: 1, hash: sibling_hash)]]
+      )
+
+      beef = BSV::Transaction::Beef.new
+      beef.merge_transaction(subject)
+      # merge_bump after merge_transaction to trigger the F5.6 retroactive upgrade
+      # from FORMAT_RAW_TX to FORMAT_RAW_TX_AND_BUMP for the ancestor entry.
+      beef.merge_bump(bump)
+      binary = beef.to_binary
+
+      result = described_class.from_beef(binary)
+      expect(result).not_to be_nil
+      ancestor_recovered = result.inputs[0].source_transaction
+      expect(ancestor_recovered).not_to be_nil
+      expect(ancestor_recovered.merkle_path).not_to be_nil
+    end
+
+    it 'returns the subject tx for an Atomic BEEF (subject_txid set)' do
+      ancestor = proven_tx(satoshis: 4000, offset: 2)
+      subject  = described_class.new
+      subject.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 500, locking_script: lock))
+      add_input(subject, ancestor)
+
+      beef = BSV::Transaction::Beef.new
+      beef.merge_transaction(subject)
+      # Serialise as Atomic BEEF so subject_txid is embedded
+      binary = beef.to_atomic_binary(subject.txid)
+
+      result = described_class.from_beef(binary)
+      expect(result).not_to be_nil
+      expect(result.txid).to eq(subject.txid)
+      expect(result.inputs.all?(&:source_transaction)).to be true
+    end
+  end
+
   describe 'full attestation flow' do
     it 'constructs, signs, and serialises a transaction with P2PKH input, OP_RETURN, and change' do
       private_key = BSV::Primitives::PrivateKey.generate

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
@@ -311,7 +311,6 @@ module BSV
         tx = extract_subject_transaction(beef)
 
         store_proofs_from_beef(beef)
-        @storage.store_transaction(tx.txid_hex, tx.to_hex)
         process_internalize_outputs(tx, args[:outputs])
         has_proof = !beef.find_bump(tx.txid).nil?
         store_action(tx, args, status: has_proof ? 'completed' : 'unproven')

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/beef_ancestry_round_trip_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/beef_ancestry_round_trip_spec.rb
@@ -1,0 +1,306 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+
+# End-to-end round-trip spec for HLR #466.
+#
+# Exercises the full lifecycle:
+#   1. Build a synthetic 2-generation BEEF (grandparent confirmed, parent raw).
+#   2. internalize_action — wallet stores the BEEF contents (subject output + ancestors).
+#   3. create_action — spend the internalised output; wallet builds a new tx with ancestry.
+#   4. Mocked ARC accepts the broadcast by calling tx.to_ef_hex — proves EF serialises.
+#
+# The spec fails intentionally when Tasks 1 or 2 are absent:
+#   - Without Task 1 (to_ef fallback): to_ef_hex raises because source data is missing.
+#   - Without Task 2 (from_beef wiring): ancestry is not wired, source_transaction is nil,
+#     and to_ef_hex raises for the same reason.
+RSpec.describe 'BEEF ancestry round-trip (HLR #466)' do
+  let(:private_key) { BSV::Primitives::PrivateKey.generate }
+  let(:pub_key) { private_key.public_key }
+  let(:storage) { BSV::Wallet::MemoryStore.new }
+  let(:broadcaster) { double('broadcaster') } # rubocop:disable RSpec/VerifiedDoubles
+  let(:wallet) do
+    BSV::Wallet::WalletClient.new(private_key, storage: storage, broadcaster: broadcaster)
+  end
+
+  # -------------------------------------------------------------------------
+  # BEEF construction helpers
+  # -------------------------------------------------------------------------
+
+  # Grandparent transaction — confirmed on-chain (has a merkle proof).
+  # Outputs a simple coin; the parent tx will spend it.
+  let(:grandparent_tx) do
+    tx = BSV::Transaction::Transaction.new
+    tx.add_output(
+      BSV::Transaction::TransactionOutput.new(
+        satoshis: 10_000,
+        locking_script: BSV::Script::Script.p2pkh_lock(pub_key.hash160)
+      )
+    )
+    tx
+  end
+
+  # Merkle proof for the grandparent tx (simulated, structurally valid).
+  let(:grandparent_merkle_path) do
+    txid_bytes = grandparent_tx.txid.reverse # display → internal byte order
+    sibling    = ("\xAB" * 32).b
+    tx_elem      = BSV::Transaction::MerklePath::PathElement.new(
+      offset: 0, hash: txid_bytes, txid: true
+    )
+    sibling_elem = BSV::Transaction::MerklePath::PathElement.new(
+      offset: 1, hash: sibling
+    )
+    BSV::Transaction::MerklePath.new(block_height: 850_000, path: [[tx_elem, sibling_elem]])
+  end
+
+  # Parent transaction — raw only (no BUMP).  Spends the grandparent output
+  # and creates an output that the subject tx will spend.
+  let(:parent_tx) do
+    tx = BSV::Transaction::Transaction.new
+    tx.add_input(
+      BSV::Transaction::TransactionInput.new(
+        prev_tx_id: BSV::Transaction::TransactionInput.txid_from_hex(grandparent_tx.txid_hex),
+        prev_tx_out_index: 0,
+        unlocking_script: BSV::Script::Script.new
+      )
+    )
+    tx.add_output(
+      BSV::Transaction::TransactionOutput.new(
+        satoshis: 9_000,
+        locking_script: BSV::Script::Script.p2pkh_lock(pub_key.hash160)
+      )
+    )
+    tx
+  end
+
+  # Subject transaction — the payment arriving at the wallet.
+  # Spends the parent output and creates a wallet-addressable output.
+  let(:subject_tx) do
+    tx = BSV::Transaction::Transaction.new
+    tx.add_input(
+      BSV::Transaction::TransactionInput.new(
+        prev_tx_id: BSV::Transaction::TransactionInput.txid_from_hex(parent_tx.txid_hex),
+        prev_tx_out_index: 0,
+        unlocking_script: BSV::Script::Script.new
+      )
+    )
+    tx.add_output(
+      BSV::Transaction::TransactionOutput.new(
+        satoshis: 8_000,
+        locking_script: BSV::Script::Script.p2pkh_lock(pub_key.hash160)
+      )
+    )
+    tx
+  end
+
+  # Assemble a 2-generation BEEF:
+  #   grandparent (FORMAT_RAW_TX_AND_BUMP) → parent (FORMAT_RAW_TX) → subject (FORMAT_RAW_TX)
+  let(:incoming_beef_binary) do
+    grandparent_tx.merkle_path = grandparent_merkle_path
+
+    beef     = BSV::Transaction::Beef.new
+    bump_idx = beef.merge_bump(grandparent_merkle_path)
+    beef.transactions << BSV::Transaction::Beef::BeefTx.new(
+      format: BSV::Transaction::Beef::FORMAT_RAW_TX_AND_BUMP,
+      transaction: grandparent_tx,
+      bump_index: bump_idx
+    )
+    beef.transactions << BSV::Transaction::Beef::BeefTx.new(
+      format: BSV::Transaction::Beef::FORMAT_RAW_TX,
+      transaction: parent_tx
+    )
+    beef.transactions << BSV::Transaction::Beef::BeefTx.new(
+      format: BSV::Transaction::Beef::FORMAT_RAW_TX,
+      transaction: subject_tx
+    )
+    beef.to_binary
+  end
+
+  let(:subject_txid) { subject_tx.txid_hex }
+
+  let(:internalize_args) do
+    {
+      tx: incoming_beef_binary.unpack('C*'),
+      description: 'BEEF ancestry round-trip — incoming payment',
+      outputs: [
+        {
+          output_index: 0,
+          protocol: 'basket insertion',
+          insertion_remittance: { basket: 'beef ancestry test' }
+        }
+      ]
+    }
+  end
+
+  # -------------------------------------------------------------------------
+  # Happy path
+  # -------------------------------------------------------------------------
+
+  context 'with a correctly wired BEEF' do
+    # broadcasted_txs collects every tx object passed to broadcaster.broadcast
+    # so examples can assert on EF serialisation after the fact.
+    let(:broadcasted_txs) { [] }
+
+    before do
+      allow(broadcaster).to receive(:broadcast) do |tx|
+        broadcasted_txs << tx
+        BSV::Network::BroadcastResponse.new(txid: tx.txid_hex, tx_status: 'SEEN_ON_NETWORK')
+      end
+    end
+
+    it 'internalises the incoming BEEF and stores the ancestor transactions' do
+      wallet.internalize_action(internalize_args)
+
+      expect(storage.find_transaction(subject_txid)).not_to be_nil
+      expect(storage.find_transaction(parent_tx.txid_hex)).not_to be_nil
+      expect(storage.find_transaction(grandparent_tx.txid_hex)).not_to be_nil
+    end
+
+    it 'stores the merkle proof for the confirmed grandparent' do
+      wallet.internalize_action(internalize_args)
+
+      proof = wallet.proof_store.resolve_proof(grandparent_tx.txid_hex)
+      expect(proof).to be_a(BSV::Transaction::MerklePath)
+      expect(proof.block_height).to eq(850_000)
+    end
+
+    it 'spend of the internalised output broadcasts with valid EF (full ancestry wired)' do
+      wallet.internalize_action(internalize_args)
+
+      result = wallet.create_action({
+                                      description: 'spend internalised output — HLR #466',
+                                      inputs: [
+                                        {
+                                          outpoint: "#{subject_txid}.0",
+                                          input_description: 'internalised basket output',
+                                          unlocking_script: BSV::Script::Script.new.to_hex
+                                        }
+                                      ],
+                                      outputs: [
+                                        {
+                                          locking_script: BSV::Script::Script.p2pkh_lock(pub_key.hash160).to_hex,
+                                          satoshis: 7_000,
+                                          output_description: 'recipient output'
+                                        }
+                                      ]
+                                    })
+
+      expect(broadcaster).to have_received(:broadcast).once
+      expect(result[:txid]).to match(/\A[0-9a-f]{64}\z/)
+      expect(result[:tx]).to be_a(Array)
+      # EF marker: 4-byte version + 6-byte marker (00 00 00 00 00 EF).
+      # This call raises ArgumentError if ancestry is not wired — that is the fix under test.
+      ef_hex = broadcasted_txs.last.to_ef_hex
+      ef_bytes = [ef_hex].pack('H*')
+      expect(ef_bytes.byteslice(4, 6)).to eq("\x00\x00\x00\x00\x00\xEF".b)
+    end
+
+    it 'resulting BEEF from create_action contains ancestor transactions' do
+      wallet.internalize_action(internalize_args)
+
+      result = wallet.create_action({
+                                      description: 'check BEEF ancestry — HLR #466',
+                                      inputs: [
+                                        {
+                                          outpoint: "#{subject_txid}.0",
+                                          input_description: 'internalised basket output',
+                                          unlocking_script: BSV::Script::Script.new.to_hex
+                                        }
+                                      ],
+                                      outputs: [
+                                        {
+                                          locking_script: BSV::Script::Script.p2pkh_lock(pub_key.hash160).to_hex,
+                                          satoshis: 7_000,
+                                          output_description: 'recipient output'
+                                        }
+                                      ]
+                                    })
+
+      new_beef = BSV::Transaction::Beef.from_binary(result[:tx].pack('C*'))
+      tx_txids = new_beef.transactions.filter_map { |bt| bt.transaction&.txid_hex }
+      # The new tx's immediate parent (subject_tx) must be present in the new BEEF.
+      expect(tx_txids).to include(subject_txid)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Sanity check — regression defence
+  #
+  # Verify the test genuinely exercises the fix: when source_transaction is
+  # stripped from inputs before broadcasting, to_ef_hex raises ArgumentError.
+  # -------------------------------------------------------------------------
+
+  context 'when ancestry is stripped (regression defence)' do
+    it 'to_ef_hex raises ArgumentError when source_transaction is not wired' do
+      wallet.internalize_action(internalize_args)
+
+      # Build the spending tx manually without wiring ancestry.
+      bare_input = BSV::Transaction::TransactionInput.new(
+        prev_tx_id: BSV::Transaction::TransactionInput.txid_from_hex(subject_txid),
+        prev_tx_out_index: 0,
+        unlocking_script: BSV::Script::Script.new
+      )
+      # Explicitly do NOT set source_satoshis, source_locking_script, or source_transaction.
+      bare_tx = BSV::Transaction::Transaction.new
+      bare_tx.add_input(bare_input)
+      bare_tx.add_output(
+        BSV::Transaction::TransactionOutput.new(
+          satoshis: 7_000,
+          locking_script: BSV::Script::Script.p2pkh_lock(pub_key.hash160)
+        )
+      )
+
+      expect { bare_tx.to_ef_hex }.to raise_error(ArgumentError, /source_satoshis/)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Edge case — parent unproven (raw only)
+  #
+  # The parent tx has no BUMP — only a raw tx entry.  EF must still serialise
+  # because source data is derivable from the wired source_transaction chain.
+  # -------------------------------------------------------------------------
+
+  context 'with parent tx unproven (raw only, no BUMP)' do
+    let(:broadcasted_txs) { [] }
+
+    before do
+      allow(broadcaster).to receive(:broadcast) do |tx|
+        broadcasted_txs << tx
+        BSV::Network::BroadcastResponse.new(txid: tx.txid_hex, tx_status: 'SEEN_ON_NETWORK')
+      end
+    end
+
+    it 'EF serialises when immediate parent has no BUMP' do
+      # The incoming_beef_binary already has subject_tx and parent_tx as raw-only
+      # (no BUMP); only grandparent has a proof.  This is exactly the edge case.
+      wallet.internalize_action(internalize_args)
+
+      result = wallet.create_action({
+                                      description: 'unproven parent EF test — HLR #466',
+                                      inputs: [
+                                        {
+                                          outpoint: "#{subject_txid}.0",
+                                          input_description: 'internalised basket output',
+                                          unlocking_script: BSV::Script::Script.new.to_hex
+                                        }
+                                      ],
+                                      outputs: [
+                                        {
+                                          locking_script: BSV::Script::Script.p2pkh_lock(pub_key.hash160).to_hex,
+                                          satoshis: 7_000,
+                                          output_description: 'recipient output'
+                                        }
+                                      ]
+                                    })
+
+      expect(broadcaster).to have_received(:broadcast).once
+      expect(result[:txid]).to match(/\A[0-9a-f]{64}\z/)
+      # EF marker check — raises if ancestry not wired (parent unproven edge case).
+      ef_hex = broadcasted_txs.last.to_ef_hex
+      ef_bytes = [ef_hex].pack('H*')
+      expect(ef_bytes.byteslice(4, 6)).to eq("\x00\x00\x00\x00\x00\xEF".b)
+    end
+  end
+end

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/wallet_client_spec.rb
@@ -1993,4 +1993,222 @@ RSpec.describe BSV::Wallet::WalletClient do
       end.not_to raise_error
     end
   end
+
+  # -------------------------------------------------------------------------
+  # HLR #466 / Task 3 — internalize_action persists all BEEF ancestors (#469)
+  # Regression spec: ensures store_proofs_from_beef covers every tx in the
+  # bundle, including multi-generation ancestors, not just the subject.
+  # -------------------------------------------------------------------------
+  describe '#internalize_action — ancestor persistence (HLR #466)' do
+    # Build a helper MerklePath for a given transaction.
+    def build_merkle_path(tx, block_height: 800_000)
+      txid_bytes = tx.txid.reverse
+      sibling = ("\xAB" * 32).b
+      tx_elem = BSV::Transaction::MerklePath::PathElement.new(
+        offset: 0, hash: txid_bytes, txid: true
+      )
+      sibling_elem = BSV::Transaction::MerklePath::PathElement.new(
+        offset: 1, hash: sibling
+      )
+      BSV::Transaction::MerklePath.new(block_height: block_height, path: [[tx_elem, sibling_elem]])
+    end
+
+    # Build a minimal transaction with one P2PKH output.
+    def build_tx(satoshis: 5000)
+      tx = BSV::Transaction::Transaction.new
+      tx.add_output(
+        BSV::Transaction::TransactionOutput.new(
+          satoshis: satoshis,
+          locking_script: BSV::Script::Script.p2pkh_lock(pub_key.hash160)
+        )
+      )
+      tx
+    end
+
+    # Wire tx as spending output 0 of parent_tx.
+    def wire_input(tx, parent_tx)
+      tx.add_input(
+        BSV::Transaction::TransactionInput.new(
+          prev_tx_id: [parent_tx.txid_hex].pack('H*').reverse,
+          prev_tx_out_index: 0,
+          unlocking_script: BSV::Script::Script.new
+        )
+      )
+    end
+
+    let(:storage) { BSV::Wallet::MemoryStore.new }
+    let(:wallet_instance) do
+      described_class.new(private_key, storage: storage, broadcaster: broadcaster)
+    end
+
+    let(:grandparent_tx) { build_tx(satoshis: 10_000) }
+    let(:parent_tx) do
+      tx = build_tx(satoshis: 8_000)
+      wire_input(tx, grandparent_tx)
+      tx
+    end
+    let(:subject_tx) do
+      tx = build_tx(satoshis: 6_000)
+      wire_input(tx, parent_tx)
+      tx
+    end
+    let(:grandparent_merkle_path) { build_merkle_path(grandparent_tx) }
+
+    # BEEF with 3 generations: grandparent (FORMAT_RAW_TX_AND_BUMP), parent
+    # (FORMAT_RAW_TX), subject (FORMAT_RAW_TX — no proof, so status = unproven).
+    let(:three_generation_beef) do
+      grandparent_tx.merkle_path = grandparent_merkle_path
+
+      beef = BSV::Transaction::Beef.new
+      bump_idx = beef.merge_bump(grandparent_merkle_path)
+      beef.transactions << BSV::Transaction::Beef::BeefTx.new(
+        format: BSV::Transaction::Beef::FORMAT_RAW_TX_AND_BUMP,
+        transaction: grandparent_tx,
+        bump_index: bump_idx
+      )
+      beef.transactions << BSV::Transaction::Beef::BeefTx.new(
+        format: BSV::Transaction::Beef::FORMAT_RAW_TX,
+        transaction: parent_tx
+      )
+      beef.transactions << BSV::Transaction::Beef::BeefTx.new(
+        format: BSV::Transaction::Beef::FORMAT_RAW_TX,
+        transaction: subject_tx
+      )
+      beef.to_binary
+    end
+
+    let(:internalize_args) do
+      {
+        tx: three_generation_beef.unpack('C*'),
+        description: 'three generation ancestry test',
+        outputs: [{
+          output_index: 0,
+          protocol: 'basket insertion',
+          insertion_remittance: { basket: 'ancestry test funds' }
+        }]
+      }
+    end
+
+    it 'persists every ancestor raw tx from the BEEF (grandparent, parent, subject)' do
+      wallet_instance.internalize_action(internalize_args)
+
+      expect(storage.find_transaction(grandparent_tx.txid_hex)).not_to be_nil
+      expect(storage.find_transaction(parent_tx.txid_hex)).not_to be_nil
+      expect(storage.find_transaction(subject_tx.txid_hex)).not_to be_nil
+    end
+
+    it 'stores the correct raw tx hex for each ancestor' do
+      wallet_instance.internalize_action(internalize_args)
+
+      expect(storage.find_transaction(grandparent_tx.txid_hex)).to eq(grandparent_tx.to_hex)
+      expect(storage.find_transaction(parent_tx.txid_hex)).to eq(parent_tx.to_hex)
+      expect(storage.find_transaction(subject_tx.txid_hex)).to eq(subject_tx.to_hex)
+    end
+
+    it 'persists the merkle proof for the proven ancestor (grandparent)' do
+      wallet_instance.internalize_action(internalize_args)
+
+      proof = wallet_instance.proof_store.resolve_proof(grandparent_tx.txid_hex)
+      expect(proof).to be_a(BSV::Transaction::MerklePath)
+      expect(proof.block_height).to eq(800_000)
+      expect(proof.to_hex).to eq(grandparent_merkle_path.to_hex)
+    end
+
+    it 'does not store a proof for ancestors without a BUMP (parent, subject)' do
+      wallet_instance.internalize_action(internalize_args)
+
+      expect(wallet_instance.proof_store.resolve_proof(parent_tx.txid_hex)).to be_nil
+      expect(wallet_instance.proof_store.resolve_proof(subject_tx.txid_hex)).to be_nil
+    end
+
+    it 'stores the action with status "unproven" when subject has no BUMP' do
+      wallet_instance.internalize_action(internalize_args)
+
+      actions = storage.find_actions({ limit: 10, offset: 0 })
+      expect(actions).not_to be_empty
+      expect(actions.last[:status]).to eq('unproven')
+    end
+
+    context 'when BEEF contains FORMAT_TXID_ONLY entries' do
+      let(:txid_only_beef) do
+        # Build a BEEF where the grandparent is represented as TXID_ONLY.
+        # store_proofs_from_beef skips entries with no .transaction — must not raise.
+        # FORMAT_TXID_ONLY requires BEEF V2 (BRC-96) for serialisation.
+        known_txid = grandparent_tx.txid
+
+        beef = BSV::Transaction::Beef.new
+        beef.transactions << BSV::Transaction::Beef::BeefTx.new(
+          format: BSV::Transaction::Beef::FORMAT_TXID_ONLY,
+          known_txid: known_txid
+        )
+        beef.transactions << BSV::Transaction::Beef::BeefTx.new(
+          format: BSV::Transaction::Beef::FORMAT_RAW_TX,
+          transaction: parent_tx
+        )
+        beef.transactions << BSV::Transaction::Beef::BeefTx.new(
+          format: BSV::Transaction::Beef::FORMAT_RAW_TX,
+          transaction: subject_tx
+        )
+        beef.to_binary(version: BSV::Transaction::Beef::BEEF_V2)
+      end
+
+      # A BEEF with TXID_ONLY entries fails structural validation by default
+      # (Beef#valid? requires allow_txid_only: true). For these edge-case tests
+      # we stub Beef#verify to bypass the gate and exercise store_proofs_from_beef
+      # directly — the method under test.
+      before do
+        allow_any_instance_of(BSV::Transaction::Beef).to receive(:verify).and_return(true) # rubocop:disable RSpec/AnyInstance
+      end
+
+      it 'does not raise when the BEEF has TXID_ONLY ancestor entries' do
+        args = {
+          tx: txid_only_beef.unpack('C*'),
+          description: 'txid only ancestor test ok',
+          outputs: [{
+            output_index: 0,
+            protocol: 'basket insertion',
+            insertion_remittance: { basket: 'txid only funds' }
+          }]
+        }
+        expect { wallet_instance.internalize_action(args) }.not_to raise_error
+      end
+
+      it 'persists the raw txs that are present (parent and subject), but not the TXID_ONLY entry' do
+        args = {
+          tx: txid_only_beef.unpack('C*'),
+          description: 'txid only ancestor store ok',
+          outputs: [{
+            output_index: 0,
+            protocol: 'basket insertion',
+            insertion_remittance: { basket: 'txid only funds' }
+          }]
+        }
+        wallet_instance.internalize_action(args)
+
+        # TXID_ONLY entry has no raw tx to store
+        expect(storage.find_transaction(grandparent_tx.txid_hex)).to be_nil
+        # Entries with raw txs are stored
+        expect(storage.find_transaction(parent_tx.txid_hex)).to eq(parent_tx.to_hex)
+        expect(storage.find_transaction(subject_tx.txid_hex)).to eq(subject_tx.to_hex)
+      end
+    end
+
+    context 'when called twice with the same BEEF (idempotency)' do
+      it 'does not raise on the second call' do
+        expect do
+          wallet_instance.internalize_action(internalize_args)
+          wallet_instance.internalize_action(internalize_args)
+        end.not_to raise_error
+      end
+
+      it 'leaves storage in a consistent state after two identical calls' do
+        wallet_instance.internalize_action(internalize_args)
+        wallet_instance.internalize_action(internalize_args)
+
+        expect(storage.find_transaction(grandparent_tx.txid_hex)).to eq(grandparent_tx.to_hex)
+        expect(storage.find_transaction(parent_tx.txid_hex)).to eq(parent_tx.to_hex)
+        expect(storage.find_transaction(subject_tx.txid_hex)).to eq(subject_tx.to_hex)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes the architectural gap that caused x402-rack phantom-payment failures and the same class of bug reported upstream in [wallet-toolbox#149](https://github.com/bsv-blockchain/wallet-toolbox/issues/149). Closes #466.

### The real bug (after investigation)

Not what the HLR initially described. The storage side of `internalize_action` was fine. The failures came from two places:

1. **`Transaction#to_ef` too strict** — required explicit `source_satoshis`/`source_locking_script` on every input, rather than deriving from wired `source_transaction`. This caused silent fallback to plain hex, which ARC rejects for tx with unconfirmed parents. Ruby was stricter than TS.
2. **`Transaction.from_beef` didn't wire ancestry via `find_atomic_transaction`** — late-bound BUMPs on `FORMAT_RAW_TX` ancestors weren't attached.

### Fix

- `to_ef` now derives source data from wired `source_transaction` when unset (matches TS `writeEF`). Non-mutating — source fields on input objects remain untouched.
- `from_beef` uses `Beef#find_atomic_transaction` so ancestry is wired recursively including late-bound BUMPs.
- Regression spec confirms `internalize_action` persists all ancestors (was already correct — spec cements the guarantee).
- Removed redundant `store_transaction` call in `internalize_action` (duplicated work done by `store_proofs_from_beef`).
- End-to-end round-trip spec proves the full fix, including a sanity-check that strips ancestry and asserts `to_ef_hex` raises.

### Consumer impact

Consumers doing `Transaction.from_beef(bytes)` then `ARC#broadcast(tx)` — or receiving a BEEF via `internalize_action` and later spending via `create_action` — now work correctly. Previously these silently failed or produced invalid EF.

## Test plan

- [x] 6 round-trip examples pass (sanity check included — strips ancestry and expects failure)
- [x] `to_ef` fallback covered with EF-specific specs
- [x] `from_beef` ancestry wiring covered with new specs
- [x] `internalize_action` ancestor persistence covered with regression specs
- [x] Full suite: bsv-sdk (3459 examples), bsv-wallet (1257 examples), bsv-wallet-postgres (174 pending — Postgres unavailable in this env), bsv-attest (30 examples) all pass
- [x] RuboCop clean (346 files inspected, no offences)

Closes #466, #467, #468, #469, #470, #471, #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)
