### PR TITLE
feat(wallet): UTXO pool management for high-frequency transactions

### DIFF
--- a/.claude/plans/20260417-474-utxo-pool-management.md
+++ b/.claude/plans/20260417-474-utxo-pool-management.md
@@ -1,0 +1,159 @@
+# Plan: HLR #474 — UTXO Pool Management (REDO at High Effort)
+
+## Context
+
+High-frequency transaction use cases (x420-Doom) are bottlenecked by UTXO contention. This is a redo of the previous implementation which was done at medium effort and had 9 bugs found in review. This time we incorporate BRC-122 (basket namespace framework) from the start and address every known bug proactively.
+
+### Bugs from round 1 (all must be prevented)
+
+| # | Bug | Fix task |
+|---|-----|----------|
+| 1 | Pool locks lacked `no_send: true` — stale recovery released them at 300s | Task 5 |
+| 2 | Basket validator rejected colons in `pool:doom` | Task 1 |
+| 3 | Signal off-by-one: `<` should be `<=` for watermark | Task 5 |
+| 4 | `store_tracked_outputs` didn't persist derivation metadata | Task 3 |
+| 5 | `create_action` keyword-vs-positional-hash in Ruby 3.x | Task 6 |
+| 6 | Missing `output_description` on split outputs | Task 6 |
+| 7 | Missing `auto_fund: true` on split create_action | Task 6 |
+| 8 | Missing `storage` attr_reader on pool | Task 5 |
+| 9 | Scavenge TOCTOU race (benign, document only) | Task 2 |
+
+## Tasks
+
+### Task 1: Two-zone basket validation (BRC-122)
+
+**Files:** `gem/bsv-wallet/lib/bsv/wallet_interface/validators.rb`
+
+Replace `validate_basket!` with a two-zone branch:
+- Colon present → `validate_structured_basket!`: trim, downcase, 1-300 bytes, valid namespace prefix before colon, content after colon, no consecutive colons/spaces
+- No colon → `validate_flat_basket!`: extracted current logic unchanged (5-300 chars, `[a-z0-9 ]`, reserved prefixes)
+
+Key: the structured zone uses characters (`:`+`.`+`-`) that are invalid in BRC-100 flat zone, so zero backwards compatibility risk. Non-implementing wallets reject structured names at the character check.
+
+**Spec additions to `validators_spec.rb`:** `pool:doom` passes, `pool:` fails, `:orphan` fails, `pool::x` fails, case normalisation, existing flat-zone tests unchanged.
+
+### Task 2: `update_output_basket` storage method
+
+**Files:** `storage_adapter.rb` (abstract), `memory_store.rb` (mutex impl), `file_store.rb` (super + save_outputs)
+
+Add `update_output_basket(outpoint, new_basket)` — moves an output between baskets as metadata-only (BRC-66 principle). Raises WalletError if outpoint not found. Document the benign TOCTOU race (bug #9).
+
+**Shared examples:** basket change, return value, not-found error, state preservation.
+
+### Task 3: Fix `store_tracked_outputs` derivation metadata
+
+**File:** `wallet_client.rb` lines 1541-1550
+
+Add `derivation_prefix`, `derivation_suffix`, `sender_identity_key` to the hash passed to `store_output`. These propagate from the output spec — nil for ordinary basket outputs (harmless), present for pool split outputs (essential for later spending via auto-fund).
+
+Do NOT add `state: :spendable` — keep legacy `spendable: true` for backwards compat.
+
+### Task 4: UTXOPool interface + PoolDepletedError
+
+**New files:** `utxo_pool.rb` (module), `errors/pool_depleted_error.rb`
+**Modified:** `wallet_interface.rb` (autoloads for UTXOPool, LocalPool, ReplenishmentWorker, PoolDepletedError)
+
+UTXOPool module defines `acquire`, `release`, `status`, `shutdown` — all raise NotImplementedError. Defines `MAX_RETRIES = 3`. Follows BroadcastQueue pattern.
+
+PoolDepletedError < WalletError, takes pool name in constructor.
+
+### Task 5: LocalPool concrete implementation
+
+**New file:** `local_pool.rb`
+
+`class LocalPool; include UTXOPool`
+
+Constructor: `name:, storage:, wallet_client:, target_count:, target_satoshis:, low_water_mark:`
+- Basket derived as `"pool:#{name}"` (structured zone)
+- `attr_reader :storage, :basket, :name` (bug #8 fix)
+
+`acquire`:
+- `find_spendable_outputs(basket:)` → `lock_utxos([outpoint], reference:, no_send: true)` (bug #1 fix)
+- Retry up to MAX_RETRIES on contention
+- Signal replenisher when `count <= watermark_threshold` (bug #3 fix: `<=` not `<`)
+- Raise PoolDepletedError on exhaustion
+
+`release(outpoint)`: `update_output_state(outpoint, :spendable)`
+
+`status`: `{ available:, target:, satoshis_committed:, state: }` — `:healthy`/`:replenishing`/`:depleted`/`:shutdown`
+
+`shutdown`: stop replenisher, idempotent
+
+### Task 6: ReplenishmentWorker
+
+**New file:** `replenishment_worker.rb`
+
+Background Thread with Mutex + ConditionVariable. `start`/`stop`/`signal`.
+
+`replenish`: calculates deficit, builds output specs via `ChangeGenerator#build_output` (gets BRC-29 derivation), converts Script to hex, calls `create_action` with:
+- `auto_fund: true` (bug #7 fix)
+- `output_description: 'utxo pool replenishment'` (bug #6 fix, 25 chars)
+- `basket: pool.basket` (passes structured-zone validation per bug #2 fix)
+- Explicit `{...}` hash wrapping (bug #5 fix)
+- `derivation_prefix`/`suffix`/`sender_identity_key` on each output spec (bug #4 flows through Task 3 fix)
+
+Error handling: rescue WalletError (log, retry next cycle), rescue StandardError (log, don't crash thread).
+
+### Task 7: WalletClient `utxo_pool` factory
+
+**File:** `wallet_client.rb` (add after `set_wallet_change_params`)
+
+```ruby
+def utxo_pool(name:, target_count: 20, target_satoshis: 10_000, low_water_mark: 0.5)
+```
+
+Creates LocalPool + ReplenishmentWorker, wires them, starts worker. Returns pool. Caller responsible for `pool.shutdown`.
+
+### Task 8: Comprehensive specs
+
+**New files:** `utxo_pool_spec.rb`, `local_pool_spec.rb`, `replenishment_worker_spec.rb`
+**Modified:** `validators_spec.rb`, `shared_examples_for_storage_adapter.rb`
+
+Every bug from round 1 has a regression test:
+- Bug #1: acquired output survives `release_stale_pending!`
+- Bug #2: `pool:doom` passes validator
+- Bug #3: pool-of-1 signals replenisher
+- Bug #4: basket outputs persist derivation metadata
+- Bug #5-7: create_action args are valid (tested via replenishment worker spec)
+- Bug #8: `pool.storage` returns adapter
+
+Plus: concurrent acquire (barrier pattern), status state machine, shutdown idempotency, factory integration.
+
+## Dependency order
+
+```
+Tasks 1, 2, 3, 4 — independent, can parallelise
+  → Task 5 (depends on 1, 2, 4)
+    → Task 6 (depends on 3, 5)
+      → Task 7 (depends on 5, 6)
+        → Task 8 (depends on all)
+```
+
+Recommended sequential: 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8
+
+## Verification
+
+```bash
+bundle exec rake spec:wallet           # all specs pass
+bundle exec rubocop gem/bsv-wallet/    # no offences
+```
+
+## Key files
+
+| File | Action | Task |
+|------|--------|------|
+| `lib/bsv/wallet_interface/validators.rb` | Modify | 1 |
+| `lib/bsv/wallet_interface/storage_adapter.rb` | Modify | 2 |
+| `lib/bsv/wallet_interface/memory_store.rb` | Modify | 2 |
+| `lib/bsv/wallet_interface/file_store.rb` | Modify | 2 |
+| `lib/bsv/wallet_interface/wallet_client.rb` | Modify | 3, 7 |
+| `lib/bsv/wallet_interface/utxo_pool.rb` | Create | 4 |
+| `lib/bsv/wallet_interface/errors/pool_depleted_error.rb` | Create | 4 |
+| `lib/bsv/wallet_interface/local_pool.rb` | Create | 5 |
+| `lib/bsv/wallet_interface/replenishment_worker.rb` | Create | 6 |
+| `lib/bsv/wallet_interface.rb` | Modify | 4 |
+| `spec/bsv/wallet_interface/validators_spec.rb` | Modify | 8 |
+| `spec/support/shared_examples_for_storage_adapter.rb` | Modify | 8 |
+| `spec/bsv/wallet_interface/utxo_pool_spec.rb` | Create | 8 |
+| `spec/bsv/wallet_interface/local_pool_spec.rb` | Create | 8 |
+| `spec/bsv/wallet_interface/replenishment_worker_spec.rb` | Create | 8 |

--- a/gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/postgres_store.rb
+++ b/gem/bsv-wallet-postgres/lib/bsv/wallet_postgres/postgres_store.rb
@@ -236,6 +236,26 @@ module BSV
         symbolise_keys(row[:data])
       end
 
+      # Moves an output from one basket to another (metadata-only).
+      #
+      # Updates both the +basket+ column and the JSONB +data+ blob.
+      # Does not affect the output's state or pending metadata.
+      #
+      # @param outpoint [String] the outpoint identifier
+      # @param new_basket [String] the destination basket name
+      # @raise [BSV::Wallet::WalletError] if the outpoint is not found
+      # @return [Hash] the updated output hash
+      def update_output_basket(outpoint, new_basket)
+        ds = @db[:wallet_outputs].where(outpoint: outpoint)
+        rows_updated = ds.update(
+          basket: new_basket,
+          data: Sequel.lit("data || jsonb_build_object('basket', ?)", new_basket)
+        )
+        raise WalletError, "Output not found: #{outpoint}" if rows_updated.zero?
+
+        symbolise_keys(ds.first[:data])
+      end
+
       # Atomically marks a set of outpoints as +:pending+.
       #
       # Uses +UPDATE ... WHERE state = 'spendable' ... RETURNING outpoint+ so that

--- a/gem/bsv-wallet/lib/bsv/wallet_interface.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface.rb
@@ -27,6 +27,9 @@ module BSV
     autoload :FeeEstimator,         'bsv/wallet_interface/fee_estimator'
     autoload :CoinSelector,         'bsv/wallet_interface/coin_selector'
     autoload :ChangeGenerator,      'bsv/wallet_interface/change_generator'
+    autoload :UTXOPool,             'bsv/wallet_interface/utxo_pool'
+    autoload :LocalPool,            'bsv/wallet_interface/local_pool'
+    autoload :ReplenishmentWorker,  'bsv/wallet_interface/replenishment_worker'
 
     # Error classes
     autoload :InsufficientFundsError, 'bsv/wallet/insufficient_funds_error'
@@ -35,5 +38,6 @@ module BSV
     autoload :InvalidHmacError,       'bsv/wallet_interface/errors/invalid_hmac_error'
     autoload :InvalidSignatureError,  'bsv/wallet_interface/errors/invalid_signature_error'
     autoload :UnsupportedActionError, 'bsv/wallet_interface/errors/unsupported_action_error'
+    autoload :PoolDepletedError,      'bsv/wallet_interface/errors/pool_depleted_error'
   end
 end

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/errors/pool_depleted_error.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/errors/pool_depleted_error.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module BSV
+  module Wallet
+    # Raised when a UTXO pool has no available outputs for acquisition.
+    class PoolDepletedError < WalletError
+      def initialize(pool_name)
+        super("UTXO pool '#{pool_name}' is depleted; no outputs available for acquisition")
+      end
+    end
+  end
+end

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/file_store.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/file_store.rb
@@ -72,6 +72,12 @@ module BSV
         result
       end
 
+      def update_output_basket(outpoint, new_basket)
+        result = super
+        save_outputs
+        result
+      end
+
       def update_output_state(outpoint, new_state, pending_reference: nil, no_send: nil)
         result = super
         save_outputs

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/local_pool.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/local_pool.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+module BSV
+  module Wallet
+    # In-process UTXO pool backed by the wallet's own +StorageAdapter+.
+    #
+    # +LocalPool+ maintains a named basket of pre-funded outputs that callers
+    # can acquire for use as inputs in transactions. Acquired outputs are locked
+    # via +lock_utxos+ with +no_send: true+, making them exempt from
+    # +release_stale_pending!+ sweeps (bug #1 fix). Releasing an output
+    # returns it to +:spendable+ state.
+    #
+    # When the available count drops to or below the low-water mark, +acquire+
+    # signals the optional replenishment worker to top up the pool. The signal
+    # uses +=+ (not +<+) so the worker is triggered exactly at the boundary
+    # (bug #3 fix).
+    #
+    # == Thread safety
+    #
+    # All public methods are safe to call concurrently. +acquire+ holds the
+    # storage-level mutex via +lock_utxos+, which performs an atomic
+    # find-and-lock. The pool-level +@mutex+ guards +@state+ and +@replenisher+.
+    #
+    # == Pool basket naming
+    #
+    # The basket name is derived as <tt>"pool:#{name}"</tt>, placing all pool
+    # outputs in the structured +pool:+ zone.
+    #
+    # == State values
+    #
+    # +status[:state]+ is one of:
+    #
+    #   :healthy       — pool has outputs above the low-water mark
+    #   :replenishing  — pool is below low-water mark and worker is running
+    #   :depleted      — pool is empty and worker cannot replenish
+    #   :shutdown      — pool has been shut down
+    class LocalPool
+      include UTXOPool
+
+      attr_reader :storage, :basket, :name, :target_count, :target_satoshis
+      attr_writer :replenisher
+
+      # @param name [String] pool identifier; basket becomes <tt>"pool:#{name}"</tt>
+      # @param storage [StorageAdapter] wallet storage adapter
+      # @param wallet_client [#create_action] wallet client for replenishment
+      # @param target_count [Integer] desired number of UTXOs in the pool
+      # @param target_satoshis [Integer] satoshi value per pool output
+      # @param low_water_mark [Integer] available count at or below which replenishment is triggered
+      def initialize(name:, storage:, wallet_client:, target_count:, target_satoshis:, low_water_mark:)
+        @name             = name
+        @basket           = "pool:#{name}"
+        @storage          = storage
+        @wallet_client    = wallet_client
+        @target_count     = target_count
+        @target_satoshis  = target_satoshis
+        @low_water_mark   = low_water_mark
+        @replenisher      = nil
+        @state            = :healthy
+        @mutex            = Mutex.new
+      end
+
+      # Acquires an available output from the pool and locks it.
+      #
+      # Finds spendable outputs in the pool basket, then atomically locks the
+      # first candidate via +lock_utxos+ with +no_send: true+. On contention
+      # (another thread claimed the output first), retries up to
+      # {UTXOPool::MAX_RETRIES} times before raising {PoolDepletedError}.
+      #
+      # After a successful acquisition, signals the replenisher if the
+      # available count has dropped to or below the low-water mark.
+      #
+      # @return [String] the locked outpoint string (<tt>"txid.vout"</tt>)
+      # @raise [PoolDepletedError] when the pool is empty or all retries fail
+      def acquire
+        @mutex.synchronize { raise PoolDepletedError, @name if @state == :shutdown }
+
+        MAX_RETRIES.times do
+          candidates = @storage.find_spendable_outputs(basket: @basket)
+          raise PoolDepletedError, @name if candidates.empty?
+
+          outpoint  = candidates.first[:outpoint]
+          reference = "pool-acquire-#{SecureRandom.hex(8)}"
+          locked    = @storage.lock_utxos([outpoint], reference: reference, no_send: true)
+
+          next if locked.empty?
+
+          maybe_signal_replenisher(candidates.size - 1)
+          return outpoint
+        end
+
+        raise PoolDepletedError, @name
+      end
+
+      # Releases a previously acquired output back to +:spendable+ state.
+      #
+      # @param outpoint [String] the outpoint string to release
+      # @return [void]
+      # @raise [BSV::Wallet::WalletError] if the outpoint is not found in storage
+      def release(outpoint)
+        @storage.update_output_state(outpoint, :spendable)
+      end
+
+      # Returns a summary of the pool's current state.
+      #
+      # @return [Hash] status hash with keys +:available+, +:target+,
+      #   +:satoshis_committed+, and +:state+
+      def status
+        spendable = @storage.find_spendable_outputs(basket: @basket)
+        {
+          available: spendable.size,
+          target: @target_count,
+          satoshis_committed: spendable.sum { |o| o[:satoshis].to_i },
+          state: current_state(spendable.size)
+        }
+      end
+
+      # Shuts down the pool.
+      #
+      # Stops the replenishment worker if one is running and marks the pool as
+      # +:shutdown+. Idempotent — safe to call more than once.
+      #
+      # @return [void]
+      def shutdown
+        @mutex.synchronize do
+          return if @state == :shutdown
+
+          @replenisher&.stop
+          @state = :shutdown
+        end
+      end
+
+      private
+
+      # Signals the replenisher if the available count is at or below the
+      # low-water mark.
+      #
+      # Uses +=+ (bug #3 fix: was +<+ in earlier versions).
+      #
+      # @param available [Integer] current available count after acquisition
+      def maybe_signal_replenisher(available)
+        return unless available <= @low_water_mark
+
+        @mutex.synchronize do
+          @state = :replenishing if @state == :healthy
+          @replenisher&.signal
+        end
+      end
+
+      # Resolves the effective pool state based on available count.
+      #
+      # Returns the stored +@state+ when +:shutdown+ or +:replenishing+;
+      # otherwise derives +:healthy+ or +:depleted+ from the count.
+      #
+      # @param available [Integer]
+      # @return [Symbol]
+      def current_state(available)
+        @mutex.synchronize do
+          return @state if @state == :shutdown
+
+          if available <= @low_water_mark
+            @state == :replenishing ? :replenishing : :depleted
+          else
+            @state = :healthy
+            :healthy
+          end
+        end
+      end
+    end
+  end
+end

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/memory_store.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/memory_store.rb
@@ -144,6 +144,22 @@ module BSV
         end
       end
 
+      # Reassigns the basket of an existing output without altering any other field.
+      #
+      # @param outpoint [String] the outpoint identifier
+      # @param new_basket [String] the target basket name
+      # @return [Hash] the updated output hash
+      # @raise [BSV::Wallet::WalletError] if the outpoint is not found
+      def update_output_basket(outpoint, new_basket)
+        @mutex.synchronize do
+          output = @outputs.find { |o| o[:outpoint] == outpoint }
+          raise WalletError, "Output not found: #{outpoint}" unless output
+
+          output[:basket] = new_basket
+          output
+        end
+      end
+
       # Atomically locks the specified outpoints as +:pending+.
       #
       # Holds the mutex for the entire operation so no other thread can

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/replenishment_worker.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/replenishment_worker.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+module BSV
+  module Wallet
+    # Background thread that replenishes a {LocalPool} when it runs low.
+    #
+    # +ReplenishmentWorker+ loops on a condition variable with a configurable
+    # interval timeout. It wakes either on timeout or when signalled by
+    # {LocalPool#acquire} (via {#signal}).
+    #
+    # Each wake cycle computes the deficit between the pool's target count and
+    # its current available count. When a deficit exists, it calls
+    # {WalletClient#create_action} to fund new pool outputs.
+    #
+    # == BRC-29 derivation
+    #
+    # Pool outputs are created with fresh BRC-29 derivation metadata so
+    # +auto_fund_and_create+ can later identify and spend them. The logic is
+    # inlined (not delegated to {ChangeGenerator}) to keep the public API
+    # surface of that class clean and avoid coupling to its private internals.
+    #
+    # == Thread safety
+    #
+    # +@mutex+ and +@cv+ guard +@running+ and the condition variable. All
+    # external entry points (+start+, +stop+, +signal+) are safe to call from
+    # any thread.
+    #
+    # == Error handling
+    #
+    # +replenish+ rescues both {BSV::Wallet::WalletError} and +StandardError+.
+    # Errors are logged to +$stderr+ and the cycle continues — a transient
+    # failure (e.g. insufficient funds) does not crash the worker thread.
+    class ReplenishmentWorker
+      # BRC-29 protocol identifier — matches {ChangeGenerator::BRC29_PROTOCOL_ID}.
+      BRC29_PROTOCOL_ID = [2, '3241645161d8'].freeze
+
+      # @param pool [LocalPool] the pool to replenish
+      # @param wallet_client [WalletClient] wallet used to fund new outputs
+      # @param interval [Integer, Float] seconds between replenishment checks (default: 60)
+      def initialize(pool:, wallet_client:, interval: 60)
+        @pool          = pool
+        @wallet_client = wallet_client
+        @interval      = interval
+        @mutex         = Mutex.new
+        @cv            = ConditionVariable.new
+        @running       = false
+        @thread        = nil
+      end
+
+      # Starts the background replenishment thread.
+      #
+      # Idempotent — calling +start+ when already running has no effect.
+      #
+      # @return [self]
+      def start
+        @mutex.synchronize do
+          return self if @running
+
+          @running = true
+          @thread  = Thread.new { run_loop }
+          @thread.abort_on_exception = false
+        end
+        self
+      end
+
+      # Stops the background thread.
+      #
+      # Sets +@running+ to +false+, wakes the thread via the condition
+      # variable, and joins it with a 5-second timeout.
+      #
+      # @return [void]
+      def stop
+        @mutex.synchronize do
+          @running = false
+          @cv.signal
+        end
+        @thread&.join(5)
+      end
+
+      # Wakes the worker for an immediate replenishment check.
+      #
+      # Non-blocking — returns immediately whether or not the thread is sleeping.
+      # Safe to call before +start+ or after +stop+.
+      #
+      # @return [void]
+      def signal
+        @mutex.synchronize { @cv.signal }
+      end
+
+      private
+
+      # Main loop executed inside the background thread.
+      #
+      # Waits on the condition variable for up to +@interval+ seconds, then
+      # checks whether replenishment is needed. Breaks as soon as +@running+
+      # is +false+.
+      #
+      # Each replenishment cycle is wrapped in a rescue so that a single
+      # error never kills the thread.
+      def run_loop
+        loop do
+          @mutex.synchronize { @cv.wait(@mutex, @interval) }
+          break unless @running
+
+          begin
+            replenish
+          rescue BSV::Wallet::WalletError => e
+            warn "[ReplenishmentWorker] WalletError during replenishment: #{e.message}"
+          rescue StandardError => e
+            warn "[ReplenishmentWorker] Unexpected error during replenishment: #{e.message}"
+          end
+        end
+      end
+
+      # Calculates the pool deficit and funds new outputs when needed.
+      #
+      # Returns immediately when the pool already meets its target.
+      #
+      # @return [void]
+      def replenish
+        pool_status = @pool.status
+        deficit     = @pool.target_count - pool_status[:available]
+        return if deficit <= 0
+
+        outputs = Array.new(deficit) { build_pool_output(@pool.target_satoshis) }
+
+        @wallet_client.create_action({
+                                       description: 'UTXO pool replenishment',
+                                       outputs: outputs,
+                                       auto_fund: true,
+                                       labels: ['utxo-pool-replenishment']
+                                     })
+      end
+
+      # Builds a single pool output hash with freshly derived BRC-29 metadata.
+      #
+      # Derivation logic is inlined from {ChangeGenerator#build_output} (which
+      # is private) to avoid coupling to that class's internals. The algorithm
+      # is identical: random hex prefix/suffix, derive child public key via
+      # the wallet's key deriver, build a P2PKH locking script.
+      #
+      # The +locking_script+ value is a hex string, not a {BSV::Script::Script}
+      # object, because +create_action+ validates and serialises the value as
+      # hex (bug #5 / #round-1 fix).
+      #
+      # @param satoshis [Integer] satoshi value for the new output
+      # @return [Hash]
+      def build_pool_output(satoshis)
+        prefix       = SecureRandom.hex(16)
+        suffix       = SecureRandom.hex(16)
+        identity_key = @wallet_client.key_deriver.identity_key
+        key_id       = "#{prefix} #{suffix}"
+        protocol_id  = BRC29_PROTOCOL_ID
+
+        pub_key        = @wallet_client.key_deriver.derive_public_key(protocol_id, key_id, identity_key, for_self: true)
+        locking_script = BSV::Script::Script.p2pkh_lock(pub_key.hash160).to_hex
+
+        {
+          locking_script: locking_script,
+          satoshis: satoshis,
+          output_description: 'utxo pool replenishment',
+          basket: @pool.basket,
+          tags: ['pool'],
+          derivation_prefix: prefix,
+          derivation_suffix: suffix,
+          sender_identity_key: identity_key
+        }
+      end
+    end
+  end
+end

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/replenishment_worker.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/replenishment_worker.rb
@@ -100,18 +100,28 @@ module BSV
       # Each replenishment cycle is wrapped in a rescue so that a single
       # error never kills the thread.
       def run_loop
+        # Replenish immediately on start — do not sleep first.
+        # A newly created pool has zero outputs; sleeping before the first
+        # cycle creates a chicken-and-egg deadlock where acquire raises
+        # PoolDepletedError and the signal path is never reached.
+        safe_replenish
+
         loop do
           @mutex.synchronize { @cv.wait(@mutex, @interval) }
           break unless @running
 
-          begin
-            replenish
-          rescue BSV::Wallet::WalletError => e
-            warn "[ReplenishmentWorker] WalletError during replenishment: #{e.message}"
-          rescue StandardError => e
-            warn "[ReplenishmentWorker] Unexpected error during replenishment: #{e.message}"
-          end
+          safe_replenish
         end
+      end
+
+      # Wraps a single replenishment cycle in error handling so that
+      # transient failures never kill the background thread.
+      def safe_replenish
+        replenish
+      rescue BSV::Wallet::WalletError => e
+        warn "[ReplenishmentWorker] WalletError during replenishment: #{e.message}"
+      rescue StandardError => e
+        warn "[ReplenishmentWorker] Unexpected error during replenishment: #{e.message}"
       end
 
       # Calculates the pool deficit and funds new outputs when needed.

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/storage_adapter.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/storage_adapter.rb
@@ -87,6 +87,27 @@ module BSV
         raise NotImplementedError, "#{self.class}#delete_action not implemented"
       end
 
+      # Reassigns the basket of an existing output without altering any other field.
+      #
+      # This is a metadata-only operation (BRC-66 principle): it does not affect
+      # the output's lock state, satoshis, locking script, or derivation fields.
+      #
+      # NOTE: There is a benign TOCTOU race between a caller checking that an
+      # output belongs to a particular basket (e.g. via +find_spendable_outputs+)
+      # and calling +update_output_basket+ to move it. A concurrent thread could
+      # have spent or re-locked the output in between. This is benign because any
+      # downstream consumer (e.g. a scavenge path) must re-check the output's state
+      # before use and will self-correct on the next cycle.
+      #
+      # @param _outpoint [String] the outpoint identifier (e.g. "txid.vout")
+      # @param _new_basket [String] the target basket name
+      # @return [Hash] the updated output hash
+      # @raise [BSV::Wallet::WalletError] if no output with the given outpoint is found
+      # @raise [NotImplementedError]
+      def update_output_basket(_outpoint, _new_basket)
+        raise NotImplementedError, "#{self.class}#update_output_basket not implemented"
+      end
+
       # Transitions the state of an existing output.
       #
       # When +new_state+ is +:pending+, pass a +pending_reference:+ string to

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/utxo_pool.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/utxo_pool.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module BSV
+  module Wallet
+    # Duck-typed UTXO pool interface for managing pre-funded outputs.
+    #
+    # Include this module in UTXO pool implementations and override all instance
+    # methods that raise +NotImplementedError+. Implementations should follow the
+    # BRC-123 UTXO management protocol.
+    #
+    # == State lifecycle
+    #
+    # Outputs in the pool transition through the following states:
+    #
+    #   :available  — output is ready for acquisition
+    #   :locked     — output has been acquired and is reserved for a transaction
+    #   :spent      — output has been confirmed spent on-chain
+    #   :expired    — lock has timed out without a corresponding spend; returns to :available
+    #
+    # == Status return contract
+    #
+    # The +status+ method must return a +Hash+ with at minimum the following keys:
+    #
+    #   {
+    #     pool_name:  String,  # identifier for this pool instance
+    #     available:  Integer, # count of outputs in :available state
+    #     locked:     Integer, # count of outputs in :locked state
+    #     total:      Integer  # total managed outputs (available + locked + other)
+    #   }
+    #
+    # == Example
+    #
+    #   class MyPool
+    #     include BSV::Wallet::UTXOPool
+    #
+    #     def acquire
+    #       output = @store.next_available or raise BSV::Wallet::PoolDepletedError, pool_name
+    #       @store.lock(output)
+    #       output
+    #     end
+    #
+    #     def release(outpoint)
+    #       @store.unlock(outpoint)
+    #     end
+    #
+    #     def status
+    #       { pool_name: pool_name, available: @store.available_count,
+    #         locked: @store.locked_count, total: @store.total_count }
+    #     end
+    #
+    #     def shutdown
+    #       @store.flush
+    #     end
+    #   end
+    module UTXOPool
+      # Maximum number of acquisition retries before raising +PoolDepletedError+.
+      MAX_RETRIES = 3
+
+      # Acquires an available output from the pool, marking it as locked.
+      #
+      # Implementations must be safe to call concurrently. If no output is
+      # available after exhausting retries, raise {PoolDepletedError}.
+      #
+      # @return [Hash] outpoint hash with at minimum +:txid+ (String) and
+      #   +:vout+ (Integer) keys
+      # @raise [PoolDepletedError] when no outputs are available
+      # @raise [NotImplementedError] unless overridden by the including class
+      def acquire
+        raise NotImplementedError, "#{self.class}#acquire not implemented"
+      end
+
+      # Releases a previously acquired output back to the pool.
+      #
+      # Called when a transaction using this output is rolled back or when the
+      # lock period expires. The output transitions from +:locked+ back to
+      # +:available+.
+      #
+      # @param _outpoint [Hash] outpoint hash with +:txid+ and +:vout+ keys
+      # @return [void]
+      # @raise [NotImplementedError] unless overridden by the including class
+      def release(_outpoint)
+        raise NotImplementedError, "#{self.class}#release not implemented"
+      end
+
+      # Returns a status summary for this pool instance.
+      #
+      # The returned hash must include at minimum the keys documented in the
+      # module-level status contract.
+      #
+      # @return [Hash] pool status summary (see module-level doc for keys)
+      # @raise [NotImplementedError] unless overridden by the including class
+      def status
+        raise NotImplementedError, "#{self.class}#status not implemented"
+      end
+
+      # Shuts down the pool, releasing all held resources.
+      #
+      # Called during graceful shutdown to flush pending state, close
+      # connections, and stop background threads. After +shutdown+, the pool
+      # must not be used.
+      #
+      # @return [void]
+      # @raise [NotImplementedError] unless overridden by the including class
+      def shutdown
+        raise NotImplementedError, "#{self.class}#shutdown not implemented"
+      end
+    end
+  end
+end

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/validators.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/validators.rb
@@ -81,16 +81,34 @@ module BSV
         raise InvalidParameterError.new(name, 'between 5 and 50 characters') if description.length < 5 || description.length > 50
       end
 
-      # Basket name rules (BRC-99):
-      # - 5-300 chars
-      # - lowercase letters, numbers, and spaces only
+      # Basket name rules — two-zone model (BRC-99 flat zone, BRC-122 structured zone):
+      #
+      # Flat zone (no colon):
+      # - 5-300 chars, lowercase letters, numbers, and spaces only
       # - no consecutive spaces
       # - must not end with ' basket'
-      # - must not start with 'admin'
+      # - must not start with 'admin' or 'p ' (reserved prefixes)
       # - must not be 'default'
-      # - must not start with 'p ' (BRC-99 reserved)
+      #
+      # Structured zone (contains a colon):
+      # - normalised (stripped and downcased) before validation
+      # - 1-300 bytes after normalisation
+      # - valid characters: lowercase letters, digits, spaces, colons, dots, hyphens, underscores
+      # - no consecutive spaces or consecutive colons
+      # - prefix before the first colon must match [a-z][a-z0-9]*
+      # - content after the first colon must be non-empty after strip
+      # - reserved prefixes apply: must not start with 'admin' or 'p '
       def validate_basket!(basket)
         raise InvalidParameterError.new('basket', 'a String') unless basket.is_a?(String)
+
+        if basket.include?(':')
+          validate_structured_basket!(basket)
+        else
+          validate_flat_basket!(basket)
+        end
+      end
+
+      def validate_flat_basket!(basket)
         raise InvalidParameterError.new('basket', 'between 5 and 300 characters') if basket.length < 5 || basket.length > 300
         raise InvalidParameterError.new('basket', 'lowercase letters, numbers, and spaces only') unless basket.match?(/\A[a-z0-9 ]+\z/)
         raise InvalidParameterError.new('basket', 'free of consecutive spaces') if basket.include?('  ')
@@ -101,6 +119,34 @@ module BSV
         end
         raise InvalidParameterError.new('basket', "not equal to \"#{RESERVED_BASKET_NAME}\"") if basket == RESERVED_BASKET_NAME
       end
+
+      def validate_structured_basket!(basket)
+        normalised = basket.strip.downcase
+
+        raise InvalidParameterError.new('basket', 'between 1 and 300 bytes') if normalised.bytesize < 1 || normalised.bytesize > 300
+        unless normalised.match?(/\A[a-z0-9 :.\-_]+\z/)
+          raise InvalidParameterError.new('basket',
+                                          'lowercase letters, digits, spaces, colons, dots, hyphens, and underscores only')
+        end
+        raise InvalidParameterError.new('basket', 'free of consecutive spaces') if normalised.include?('  ')
+        raise InvalidParameterError.new('basket', 'free of consecutive colons') if normalised.include?('::')
+
+        colon_pos = normalised.index(':')
+        prefix = normalised[0, colon_pos]
+        content = normalised[(colon_pos + 1)..].strip
+
+        unless prefix.match?(/\A[a-z][a-z0-9]*\z/)
+          raise InvalidParameterError.new('basket',
+                                          'a valid namespace prefix before the colon ([a-z][a-z0-9]*)')
+        end
+        raise InvalidParameterError.new('basket', 'non-empty content after the colon') if content.empty?
+
+        RESERVED_BASKET_PREFIXES.each do |rp|
+          raise InvalidParameterError.new('basket', "not starting with \"#{rp}\"") if normalised.start_with?(rp)
+        end
+      end
+
+      private_class_method :validate_flat_basket!, :validate_structured_basket!
 
       # Label: 1-300 characters
       def validate_label!(label)

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/validators.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/validators.rb
@@ -123,6 +123,11 @@ module BSV
       def validate_structured_basket!(basket)
         normalised = basket.strip.downcase
 
+        unless basket == normalised
+          raise InvalidParameterError.new('basket',
+                                          'already normalised (lowercase, trimmed) — received mixed-case or padded input')
+        end
+
         raise InvalidParameterError.new('basket', 'between 1 and 300 bytes') if normalised.bytesize < 1 || normalised.bytesize > 300
         unless normalised.match?(/\A[a-z0-9 :.\-_]+\z/)
           raise InvalidParameterError.new('basket',

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
@@ -479,6 +479,10 @@ module BSV
       #   <tt>(target_count * low_water_mark).ceil</tt>
       # @return [LocalPool]
       def utxo_pool(name:, target_count: 20, target_satoshis: 10_000, low_water_mark: 0.5)
+        basket = "pool:#{name}"
+        Validators.validate_basket!(basket)
+        raise WalletError, 'utxo_pool requires a broadcaster for replenishment' unless broadcast_enabled?
+
         threshold = (target_count * low_water_mark).ceil
         pool = LocalPool.new(
           name: name,

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
@@ -1546,7 +1546,10 @@ module BSV
                                   tags: spec[:tags] || [],
                                   custom_instructions: spec[:custom_instructions],
                                   spendable: true,
-                                  source_tx_hex: tx_hex
+                                  source_tx_hex: tx_hex,
+                                  derivation_prefix: spec[:derivation_prefix],
+                                  derivation_suffix: spec[:derivation_suffix],
+                                  sender_identity_key: spec[:sender_identity_key]
                                 })
         end
       end

--- a/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet_interface/wallet_client.rb
@@ -461,6 +461,42 @@ module BSV
         @storage.store_setting('change_params', { count: count, satoshis: satoshis })
       end
 
+      # Creates a UTXO pool for high-frequency transaction pre-allocation.
+      #
+      # The pool maintains a basket of pre-funded outputs (e.g. +'pool:doom'+)
+      # that can be acquired and released without the overhead of full coin
+      # selection. A background {ReplenishmentWorker} keeps the pool at
+      # target capacity.
+      #
+      # The caller is responsible for calling +pool.shutdown+ when the pool
+      # is no longer needed to stop the background worker.
+      #
+      # @param name [String] pool identifier (basket will be +"pool:<name>"+)
+      # @param target_count [Integer] desired number of UTXOs (default 20)
+      # @param target_satoshis [Integer] desired satoshis per UTXO (default 10_000)
+      # @param low_water_mark [Float] replenishment trigger as a fraction of
+      #   +target_count+ (0.0-1.0, default 0.5); threshold is
+      #   <tt>(target_count * low_water_mark).ceil</tt>
+      # @return [LocalPool]
+      def utxo_pool(name:, target_count: 20, target_satoshis: 10_000, low_water_mark: 0.5)
+        threshold = (target_count * low_water_mark).ceil
+        pool = LocalPool.new(
+          name: name,
+          storage: @storage,
+          wallet_client: self,
+          target_count: target_count,
+          target_satoshis: target_satoshis,
+          low_water_mark: threshold
+        )
+        worker = ReplenishmentWorker.new(
+          pool: pool,
+          wallet_client: self
+        )
+        pool.replenisher = worker
+        worker.start
+        pool
+      end
+
       # --- Authentication ---
 
       # Checks whether the user is authenticated.

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/local_pool_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/local_pool_spec.rb
@@ -1,0 +1,397 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+require 'securerandom'
+
+RSpec.describe 'BSV::Wallet::LocalPool' do
+  let(:store) { BSV::Wallet::MemoryStore.new }
+
+  # Build a pool with sensible defaults. Replenisher is nil unless set explicitly.
+  def build_pool(name: 'test', target_count: 5, target_satoshis: 10_000, low_water_mark: 2)
+    BSV::Wallet::LocalPool.new(
+      name: name,
+      storage: store,
+      wallet_client: nil,
+      target_count: target_count,
+      target_satoshis: target_satoshis,
+      low_water_mark: low_water_mark
+    )
+  end
+
+  # Seeds a spendable output directly into the store for the pool basket.
+  def seed_pool_output(outpoint:, satoshis: 10_000, basket: 'pool:test')
+    store.store_output(
+      outpoint: outpoint,
+      satoshis: satoshis,
+      basket: basket,
+      state: :spendable,
+      derivation_prefix: SecureRandom.hex(16),
+      derivation_suffix: SecureRandom.hex(16),
+      sender_identity_key: "02#{'ab' * 32}"
+    )
+  end
+
+  # -----------------------------------------------------------------------
+  # Attributes and factory basics
+  # -----------------------------------------------------------------------
+
+  describe 'attributes' do
+    it 'derives the basket name as pool:<name>' do
+      pool = build_pool(name: 'doom')
+      expect(pool.basket).to eq('pool:doom')
+    end
+
+    it 'exposes the name' do
+      pool = build_pool(name: 'payments')
+      expect(pool.name).to eq('payments')
+    end
+
+    it 'exposes the storage adapter (bug #8 regression)' do
+      pool = build_pool
+      expect(pool.storage).to eq(store)
+    end
+
+    it 'exposes target_count' do
+      pool = build_pool(target_count: 10)
+      expect(pool.target_count).to eq(10)
+    end
+
+    it 'exposes target_satoshis' do
+      pool = build_pool(target_satoshis: 5_000)
+      expect(pool.target_satoshis).to eq(5_000)
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # acquire
+  # -----------------------------------------------------------------------
+
+  describe '#acquire' do
+    let(:pool) { build_pool }
+
+    before do
+      seed_pool_output(outpoint: "#{'aa' * 32}.0")
+    end
+
+    it 'returns the outpoint string of the acquired output' do
+      result = pool.acquire
+      expect(result).to be_a(String)
+      expect(result).to match(/\A[0-9a-f]{64}\.\d+\z/)
+    end
+
+    it 'acquired output is no longer in find_spendable_outputs' do
+      outpoint = pool.acquire
+      spendable = store.find_spendable_outputs(basket: 'pool:test')
+      expect(spendable.map { |o| o[:outpoint] }).not_to include(outpoint)
+    end
+
+    it 'multiple sequential acquires return distinct outpoints' do
+      seed_pool_output(outpoint: "#{'bb' * 32}.0")
+      first  = pool.acquire
+      second = pool.acquire
+      expect(first).not_to eq(second)
+    end
+
+    it 'raises PoolDepletedError when the pool is empty' do
+      store.update_output_state("#{'aa' * 32}.0", :spent)
+      expect { pool.acquire }.to raise_error(BSV::Wallet::PoolDepletedError)
+    end
+
+    it 'raises PoolDepletedError when all outputs are already pending' do
+      outpoint = "#{'aa' * 32}.0"
+      store.update_output_state(outpoint, :pending, pending_reference: 'held-externally')
+      expect { pool.acquire }.to raise_error(BSV::Wallet::PoolDepletedError)
+    end
+
+    # Bug #1 regression: pool-acquired locks must use no_send: true so they
+    # are exempt from release_stale_pending! sweeps.
+    it 'acquires with no_send: true so the lock survives release_stale_pending! (bug #1)' do
+      outpoint = pool.acquire
+
+      # Zero-timeout forces any non-exempt lock to be released immediately.
+      released = store.release_stale_pending!(timeout: 0)
+      expect(released).to eq(0)
+
+      # The output must still be locked (not spendable).
+      spendable = store.find_spendable_outputs(basket: 'pool:test')
+      expect(spendable.map { |o| o[:outpoint] }).not_to include(outpoint)
+    end
+
+    it 'the acquired output carries no_send: true in storage' do
+      outpoint = pool.acquire
+      raw = store.find_outputs({ outpoint: outpoint, include_spent: true, limit: 1, offset: 0 })
+      expect(raw.first[:no_send]).to be true
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # Bug #3 regression: signal at <= low_water_mark
+  # -----------------------------------------------------------------------
+
+  describe '#acquire signals replenisher at exactly the low-water mark (bug #3)' do
+    let(:replenisher) { double('replenisher', signal: nil, stop: nil) } # rubocop:disable RSpec/VerifiedDoubles
+
+    # Pool of 2 with low_water_mark of 2: after first acquire, 1 output remains
+    # which is <= 2, so the replenisher must be signalled.
+    it 'signals when remaining count equals low_water_mark' do
+      pool = build_pool(target_count: 3, low_water_mark: 2)
+      pool.replenisher = replenisher
+
+      seed_pool_output(outpoint: "#{'cc' * 32}.0")
+      seed_pool_output(outpoint: "#{'dd' * 32}.0")
+
+      # After the first acquire there is 1 output left, which is <= low_water_mark (2).
+      pool.acquire
+      expect(replenisher).to have_received(:signal).at_least(:once)
+    end
+
+    # Pool of 1 with low_water_mark of 1: after acquire, 0 remain which is still <= 1.
+    it 'signals when pool drops to zero at low_water_mark of 1 (pool-of-1 edge case)' do
+      pool = build_pool(target_count: 1, low_water_mark: 1)
+      pool.replenisher = replenisher
+
+      seed_pool_output(outpoint: "#{'ee' * 32}.0")
+
+      pool.acquire
+      expect(replenisher).to have_received(:signal).at_least(:once)
+    end
+
+    it 'does not signal when remaining count is above low_water_mark' do
+      pool = build_pool(target_count: 10, low_water_mark: 2)
+      pool.replenisher = replenisher
+
+      # Seed 5 outputs; after one acquire 4 remain, which is > 2.
+      5.times { |i| seed_pool_output(outpoint: "#{"f#{i}" * 32}.0") }
+
+      pool.acquire
+      expect(replenisher).not_to have_received(:signal)
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # release
+  # -----------------------------------------------------------------------
+
+  describe '#release' do
+    let(:pool) { build_pool }
+
+    before { seed_pool_output(outpoint: "#{'aa' * 32}.0") }
+
+    it 'returns the output to spendable state' do
+      outpoint = pool.acquire
+      pool.release(outpoint)
+      spendable = store.find_spendable_outputs(basket: 'pool:test')
+      expect(spendable.map { |o| o[:outpoint] }).to include(outpoint)
+    end
+
+    it 'a released output can be re-acquired' do
+      outpoint = pool.acquire
+      pool.release(outpoint)
+      re_acquired = pool.acquire
+      expect(re_acquired).to eq(outpoint)
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # status
+  # -----------------------------------------------------------------------
+
+  describe '#status' do
+    it 'returns :healthy state when available count is above low_water_mark' do
+      pool = build_pool(target_count: 5, low_water_mark: 2)
+      3.times { |i| seed_pool_output(outpoint: "#{"a#{i}" * 32}.0") }
+      result = pool.status
+      expect(result[:state]).to eq(:healthy)
+    end
+
+    it 'returns :depleted state when pool is empty and no replenisher is running' do
+      pool = build_pool(target_count: 5, low_water_mark: 2)
+      # No outputs seeded — pool is empty.
+      result = pool.status
+      expect(result[:state]).to eq(:depleted)
+    end
+
+    it 'includes correct available count' do
+      pool = build_pool
+      seed_pool_output(outpoint: "#{'aa' * 32}.0")
+      seed_pool_output(outpoint: "#{'bb' * 32}.0")
+      expect(pool.status[:available]).to eq(2)
+    end
+
+    it 'includes target count' do
+      pool = build_pool(target_count: 7)
+      expect(pool.status[:target]).to eq(7)
+    end
+
+    it 'includes satoshis_committed as the sum of spendable satoshis' do
+      pool = build_pool
+      seed_pool_output(outpoint: "#{'aa' * 32}.0", satoshis: 10_000)
+      seed_pool_output(outpoint: "#{'bb' * 32}.0", satoshis: 20_000)
+      expect(pool.status[:satoshis_committed]).to eq(30_000)
+    end
+
+    it 'returns :replenishing after acquire triggers replenisher signal' do
+      replenisher = double('replenisher', signal: nil, stop: nil) # rubocop:disable RSpec/VerifiedDoubles
+      pool = build_pool(target_count: 2, low_water_mark: 2)
+      pool.replenisher = replenisher
+
+      seed_pool_output(outpoint: "#{'aa' * 32}.0")
+      seed_pool_output(outpoint: "#{'bb' * 32}.0")
+
+      # After acquire the pool drops to 1 which is <= 2, triggering replenishment.
+      pool.acquire
+      expect(pool.status[:state]).to eq(:replenishing)
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # Basket isolation
+  # -----------------------------------------------------------------------
+
+  describe 'basket isolation' do
+    it 'pool outputs are not returned by find_spendable_outputs for the default basket' do
+      seed_pool_output(outpoint: "#{'aa' * 32}.0", basket: 'pool:test')
+      default_outputs = store.find_spendable_outputs(basket: 'default')
+      expect(default_outputs.map { |o| o[:outpoint] }).not_to include("#{'aa' * 32}.0")
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # shutdown
+  # -----------------------------------------------------------------------
+
+  describe '#shutdown' do
+    let(:pool) { build_pool }
+
+    it 'sets status to :shutdown' do
+      pool.shutdown
+      expect(pool.status[:state]).to eq(:shutdown)
+    end
+
+    it 'is idempotent (calling shutdown twice does not raise)' do
+      pool.shutdown
+      expect { pool.shutdown }.not_to raise_error
+    end
+
+    it 'raises PoolDepletedError on acquire after shutdown' do
+      pool.shutdown
+      expect { pool.acquire }.to raise_error(BSV::Wallet::PoolDepletedError)
+    end
+
+    it 'stops the replenisher if one is set' do
+      replenisher = double('replenisher', stop: nil) # rubocop:disable RSpec/VerifiedDoubles
+      pool.replenisher = replenisher
+      pool.shutdown
+      expect(replenisher).to have_received(:stop)
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # Concurrent acquire (barrier pattern)
+  # -----------------------------------------------------------------------
+
+  describe 'concurrent acquire' do
+    it '2 threads competing for 1 output: exactly 1 succeeds, the other gets PoolDepletedError' do
+      pool = build_pool
+      seed_pool_output(outpoint: "#{'aa' * 32}.0")
+
+      results  = Array.new(2)
+      barrier  = Queue.new
+      acquired = []
+
+      threads = 2.times.map do |i|
+        Thread.new do
+          barrier.pop # wait until both threads are ready
+
+          begin
+            results[i] = pool.acquire
+            acquired << results[i]
+          rescue BSV::Wallet::PoolDepletedError
+            results[i] = :depleted
+          end
+        end
+      end
+
+      2.times { barrier.push(:go) }
+      threads.each(&:join)
+
+      depleted_count = results.count(:depleted)
+      success_count  = results.count { |r| r != :depleted }
+
+      expect(success_count).to eq(1), "Expected exactly 1 acquire to succeed; got #{results.inspect}"
+      expect(depleted_count).to eq(1)
+    end
+
+    it '5 threads competing for 5 outputs: all 5 get distinct outpoints' do
+      pool = build_pool(target_count: 5)
+      5.times { |i| seed_pool_output(outpoint: "#{SecureRandom.hex(32)}.#{i}") }
+
+      results = Array.new(5)
+      barrier = Queue.new
+
+      threads = 5.times.map do |i|
+        Thread.new do
+          barrier.pop
+          results[i] = pool.acquire
+        rescue BSV::Wallet::PoolDepletedError
+          results[i] = :depleted
+        end
+      end
+
+      5.times { barrier.push(:go) }
+      threads.each(&:join)
+
+      expect(results).not_to include(:depleted)
+      expect(results.uniq.length).to eq(5), "Expected all 5 distinct outpoints; got #{results.inspect}"
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # WalletClient#utxo_pool factory integration
+  # -----------------------------------------------------------------------
+
+  describe 'WalletClient#utxo_pool factory' do
+    let(:private_key) { BSV::Primitives::PrivateKey.generate }
+    let(:storage)     { BSV::Wallet::MemoryStore.new }
+    let(:broadcaster) { double('broadcaster') } # rubocop:disable RSpec/VerifiedDoubles
+    let(:wallet) do
+      BSV::Wallet::WalletClient.new(private_key, storage: storage, broadcaster: broadcaster)
+    end
+    let(:pool) { wallet.utxo_pool(name: 'test') }
+
+    after { pool.shutdown }
+
+    before do
+      allow(broadcaster).to receive(:broadcast).and_return(
+        BSV::Network::BroadcastResponse.new(txid: 'stub', tx_status: 'SEEN_ON_NETWORK')
+      )
+    end
+
+    it 'returns a LocalPool instance' do
+      expect(pool).to be_a(BSV::Wallet::LocalPool)
+    end
+
+    it 'pool basket is pool:<name>' do
+      named_pool = wallet.utxo_pool(name: 'payments')
+      named_pool.shutdown
+      expect(named_pool.basket).to eq('pool:payments')
+    end
+
+    it 'pool has a replenisher attached (not nil)' do
+      replenisher = pool.instance_variable_get(:@replenisher)
+      expect(replenisher).not_to be_nil
+    end
+
+    it 'pool.storage returns the wallet storage adapter (bug #8 regression)' do
+      expect(pool.storage).to eq(storage)
+    end
+
+    it 'shutdown marks the replenisher as stopped' do
+      replenisher = pool.instance_variable_get(:@replenisher)
+      pool.shutdown
+      running = replenisher.instance_variable_get(:@running)
+      expect(running).to be false
+    end
+  end
+end

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/replenishment_worker_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/replenishment_worker_spec.rb
@@ -1,0 +1,329 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+require 'securerandom'
+
+RSpec.describe 'BSV::Wallet::ReplenishmentWorker' do
+  let(:private_key) { BSV::Primitives::PrivateKey.generate }
+  let(:store)       { BSV::Wallet::MemoryStore.new }
+  let(:broadcaster) { double('broadcaster') } # rubocop:disable RSpec/VerifiedDoubles
+  let(:wallet) do
+    BSV::Wallet::WalletClient.new(private_key, storage: store, broadcaster: broadcaster)
+  end
+
+  before do
+    allow(broadcaster).to receive(:broadcast).and_return(
+      BSV::Network::BroadcastResponse.new(txid: 'stub', tx_status: 'SEEN_ON_NETWORK')
+    )
+  end
+
+  # Seeds a spendable output into the default basket with full BRC-29 derivation
+  # metadata so auto_fund_and_create can spend it.
+  def seed_payment_output(satoshis:)
+    deriver      = wallet.key_deriver
+    prefix       = SecureRandom.hex(16)
+    suffix       = SecureRandom.hex(16)
+    identity_key = deriver.identity_key
+    key_id       = "#{prefix} #{suffix}"
+    protocol_id  = [2, '3241645161d8']
+
+    pub_key        = deriver.derive_public_key(protocol_id, key_id, identity_key, for_self: true)
+    locking_script = BSV::Script::Script.p2pkh_lock(pub_key.hash160)
+
+    source_tx = BSV::Transaction::Transaction.new
+    source_tx.add_output(
+      BSV::Transaction::TransactionOutput.new(
+        satoshis: satoshis,
+        locking_script: locking_script
+      )
+    )
+    txid     = source_tx.txid_hex
+    outpoint = "#{txid}.0"
+
+    store.store_transaction(txid, source_tx.to_hex)
+    store.store_output({
+                         outpoint: outpoint,
+                         satoshis: satoshis,
+                         locking_script: locking_script.to_hex,
+                         basket: 'default',
+                         state: :spendable,
+                         spendable: true,
+                         derivation_prefix: prefix,
+                         derivation_suffix: suffix,
+                         sender_identity_key: identity_key,
+                         source_tx_hex: source_tx.to_hex
+                       })
+    outpoint
+  end
+
+  # Build a pool and an attached worker without starting the background thread.
+  def build_pool_and_worker(name: 'test', target_count: 3, target_satoshis: 1_000, low_water_mark: 1,
+                            interval: 60)
+    pool = BSV::Wallet::LocalPool.new(
+      name: name,
+      storage: store,
+      wallet_client: wallet,
+      target_count: target_count,
+      target_satoshis: target_satoshis,
+      low_water_mark: low_water_mark
+    )
+    worker = BSV::Wallet::ReplenishmentWorker.new(
+      pool: pool,
+      wallet_client: wallet,
+      interval: interval
+    )
+    pool.replenisher = worker
+    [pool, worker]
+  end
+
+  # -----------------------------------------------------------------------
+  # Lifecycle
+  # -----------------------------------------------------------------------
+
+  describe 'lifecycle' do
+    let(:worker) { build_pool_and_worker.last }
+
+    after { worker.stop }
+
+    it 'start returns self' do
+      expect(worker.start).to equal(worker)
+    end
+
+    it 'stop signals the worker to terminate' do
+      worker.start
+      worker.stop
+      running = worker.instance_variable_get(:@running)
+      expect(running).to be false
+    end
+
+    it 'stop is idempotent' do
+      worker.start
+      worker.stop
+      expect { worker.stop }.not_to raise_error
+    end
+
+    it 'start is idempotent (calling start twice does not spawn extra threads)' do
+      worker.start
+      first_thread = worker.instance_variable_get(:@thread)
+      worker.start
+      second_thread = worker.instance_variable_get(:@thread)
+      expect(first_thread).to equal(second_thread)
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # replenish (invoked directly to avoid thread-timing dependence)
+  # -----------------------------------------------------------------------
+
+  describe '#replenish (invoked directly)' do
+    it 'does nothing when pool is already at target' do
+      _, worker = build_pool_and_worker(target_count: 2)
+      seed_payment_output(satoshis: 100_000)
+
+      # Seed pool outputs directly so the pool considers itself full.
+      store.store_output(
+        outpoint: "#{SecureRandom.hex(32)}.0",
+        satoshis: 1_000,
+        basket: 'pool:test',
+        state: :spendable
+      )
+      store.store_output(
+        outpoint: "#{SecureRandom.hex(32)}.0",
+        satoshis: 1_000,
+        basket: 'pool:test',
+        state: :spendable
+      )
+
+      allow(wallet).to receive(:create_action)
+      worker.send(:replenish)
+      expect(wallet).not_to have_received(:create_action)
+    end
+
+    context 'when pool is empty and funds are available' do
+      let(:worker) { build_pool_and_worker(target_count: 3, target_satoshis: 1_000).last }
+
+      before { seed_payment_output(satoshis: 100_000) }
+
+      it 'creates pool outputs to fill the deficit' do
+        worker.send(:replenish)
+        pool_outputs = store.find_spendable_outputs(basket: 'pool:test')
+        expect(pool_outputs.length).to be >= 1
+      end
+
+      it 'pool outputs are stored with BRC-29 derivation metadata (bug #4 regression)' do
+        worker.send(:replenish)
+        pool_outputs = store.find_spendable_outputs(basket: 'pool:test')
+        expect(pool_outputs).not_to be_empty
+
+        pool_outputs.each do |o|
+          expect(o[:derivation_prefix]).not_to be_nil, "Output #{o[:outpoint]} missing :derivation_prefix"
+          expect(o[:derivation_suffix]).not_to be_nil, "Output #{o[:outpoint]} missing :derivation_suffix"
+          expect(o[:sender_identity_key]).not_to be_nil, "Output #{o[:outpoint]} missing :sender_identity_key"
+        end
+      end
+
+      it 'calls create_action with auto_fund: true (bug #7 regression)' do
+        captured_args = nil
+        allow(wallet).to receive(:create_action) do |args|
+          captured_args = args
+          { txid: 'stub' }
+        end
+
+        worker.send(:replenish)
+        expect(captured_args).not_to be_nil
+        expect(captured_args[:auto_fund]).to be true
+      end
+
+      it 'calls create_action with a valid output_description (5-50 chars) per output spec (bug #6 regression)' do
+        captured_args = nil
+        allow(wallet).to receive(:create_action) do |args|
+          captured_args = args
+          { txid: 'stub' }
+        end
+
+        worker.send(:replenish)
+        expect(captured_args).not_to be_nil
+
+        output_specs = captured_args[:outputs] || []
+        output_specs.each do |spec|
+          desc = spec[:output_description]
+          expect(desc).to be_a(String)
+          expect(desc.length).to be >= 5,  "output_description '#{desc}' is shorter than 5 chars"
+          expect(desc.length).to be <= 50, "output_description '#{desc}' is longer than 50 chars"
+        end
+      end
+
+      it 'calls create_action with a Hash argument (no ArgumentError in Ruby 3.x) (bug #5 regression)' do
+        expect { worker.send(:replenish) }.not_to raise_error
+      end
+
+      it 'basket name in each output spec passes validate_basket! (bug #2 regression)' do
+        captured_args = nil
+        allow(wallet).to receive(:create_action) do |args|
+          captured_args = args
+          { txid: 'stub' }
+        end
+
+        worker.send(:replenish)
+        expect(captured_args).not_to be_nil
+
+        output_specs = captured_args[:outputs] || []
+        output_specs.each do |spec|
+          expect do
+            BSV::Wallet::Validators.validate_basket!(spec[:basket])
+          end.not_to raise_error, "basket '#{spec[:basket]}' should be valid but raised"
+        end
+      end
+    end
+
+    context 'when the worker thread encounters an error' do
+      # replenish itself does NOT rescue — the rescue lives in run_loop.
+      # Test that the thread survives errors by checking @running stays true
+      # through several fast cycles.
+
+      it 'thread survives a WalletError raised inside replenish' do
+        _, worker = build_pool_and_worker(target_count: 2, target_satoshis: 1_000, interval: 0.05)
+        allow(wallet).to receive(:create_action).and_raise(
+          BSV::Wallet::InsufficientFundsError.new('not enough')
+        )
+        worker.start
+        sleep 0.15 # allow at least two cycles to run
+        running = worker.instance_variable_get(:@running)
+        thread  = worker.instance_variable_get(:@thread)
+        worker.stop
+        expect(running).to be true
+        expect(thread).to be_a(Thread)
+      end
+
+      it 'thread survives a StandardError raised inside replenish' do
+        _, worker = build_pool_and_worker(target_count: 2, target_satoshis: 1_000, interval: 0.05)
+        allow(wallet).to receive(:create_action).and_raise(StandardError, 'unexpected')
+        worker.start
+        sleep 0.15
+        running = worker.instance_variable_get(:@running)
+        thread  = worker.instance_variable_get(:@thread)
+        worker.stop
+        expect(running).to be true
+        expect(thread).to be_a(Thread)
+      end
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # store_tracked_outputs derivation fields (bug #4 regression)
+  # -----------------------------------------------------------------------
+
+  describe 'store_tracked_outputs derivation fields (bug #4 regression)' do
+    it 'persists derivation_prefix, derivation_suffix, and sender_identity_key from output spec' do
+      prefix       = SecureRandom.hex(16)
+      suffix       = SecureRandom.hex(16)
+      identity_key = wallet.key_deriver.identity_key
+      txid         = 'a' * 64
+      fake_tx      = BSV::Transaction::Transaction.new
+
+      locking_script = BSV::Script::Script.p2pkh_lock(
+        wallet.key_deriver.derive_public_key(
+          [2, '3241645161d8'],
+          "#{prefix} #{suffix}",
+          identity_key,
+          for_self: true
+        ).hash160
+      )
+
+      fake_tx.add_output(
+        BSV::Transaction::TransactionOutput.new(
+          satoshis: 1_000,
+          locking_script: locking_script
+        )
+      )
+
+      output_spec = {
+        satoshis: 1_000,
+        locking_script: locking_script.to_hex,
+        basket: 'pool:test',
+        output_description: 'utxo pool test',
+        derivation_prefix: prefix,
+        derivation_suffix: suffix,
+        sender_identity_key: identity_key
+      }
+
+      fake_tx.outputs.first.instance_variable_set(:@_spec, output_spec)
+      wallet.send(:store_tracked_outputs, txid, fake_tx, [output_spec])
+
+      stored_outputs = store.find_outputs({ basket: 'pool:test', include_spent: true, limit: 10, offset: 0 })
+      expect(stored_outputs).not_to be_empty
+
+      stored = stored_outputs.first
+      expect(stored[:derivation_prefix]).to eq(prefix)
+      expect(stored[:derivation_suffix]).to eq(suffix)
+      expect(stored[:sender_identity_key]).to eq(identity_key)
+    end
+
+    it 'stores nil derivation fields when the spec omits them (no error)' do
+      txid = 'b' * 64
+
+      locking_script = BSV::Script::Script.p2pkh_lock(private_key.public_key.hash160)
+      fake_tx = BSV::Transaction::Transaction.new
+      fake_tx.add_output(
+        BSV::Transaction::TransactionOutput.new(
+          satoshis: 500,
+          locking_script: locking_script
+        )
+      )
+
+      output_spec = {
+        satoshis: 500,
+        locking_script: locking_script.to_hex,
+        basket: 'my tokens',
+        output_description: 'basket output'
+      }
+
+      fake_tx.outputs.first.instance_variable_set(:@_spec, output_spec)
+
+      expect do
+        wallet.send(:store_tracked_outputs, txid, fake_tx, [output_spec])
+      end.not_to raise_error
+    end
+  end
+end

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/utxo_pool_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/utxo_pool_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+
+RSpec.describe 'BSV::Wallet::UTXOPool interface' do
+  # Use a fresh includer for each interface test
+  let(:includer_class) do
+    Class.new { include BSV::Wallet::UTXOPool }
+  end
+
+  let(:instance) { includer_class.new }
+
+  describe 'MAX_RETRIES constant' do
+    it 'equals 3' do
+      expect(BSV::Wallet::UTXOPool::MAX_RETRIES).to eq(3)
+    end
+  end
+
+  describe 'default #acquire' do
+    it 'raises NotImplementedError' do
+      expect { instance.acquire }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe 'default #release' do
+    it 'raises NotImplementedError' do
+      expect { instance.release('txid.0') }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe 'default #status' do
+    it 'raises NotImplementedError' do
+      expect { instance.status }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe 'default #shutdown' do
+    it 'raises NotImplementedError' do
+      expect { instance.shutdown }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe 'BSV::Wallet::PoolDepletedError' do
+    it 'is a subclass of WalletError' do
+      expect(BSV::Wallet::PoolDepletedError.ancestors).to include(BSV::Wallet::WalletError)
+    end
+
+    it 'includes the pool name in the message' do
+      error = BSV::Wallet::PoolDepletedError.new('my-pool')
+      expect(error.message).to include('my-pool')
+    end
+
+    it 'can be rescued as a WalletError' do
+      expect do
+        raise BSV::Wallet::PoolDepletedError, 'test-pool'
+      end.to raise_error(BSV::Wallet::WalletError)
+    end
+  end
+end

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/validators_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/validators_spec.rb
@@ -243,8 +243,12 @@ RSpec.describe BSV::Wallet::Validators do
         expect { described_class.validate_basket!("pool:#{'a' * 300}") }.to raise_error(BSV::Wallet::InvalidParameterError)
       end
 
-      it 'normalises case (Pool:DOOM becomes pool:doom via strip/downcase)' do
-        expect { described_class.validate_basket!('Pool:DOOM') }.not_to raise_error
+      it 'rejects non-normalised input (Pool:DOOM must be pool:doom)' do
+        expect { described_class.validate_basket!('Pool:DOOM') }.to raise_error(BSV::Wallet::InvalidParameterError)
+      end
+
+      it 'accepts already-normalised input' do
+        expect { described_class.validate_basket!('pool:test123') }.not_to raise_error
       end
 
       it 'rejects consecutive spaces in the content portion' do

--- a/gem/bsv-wallet/spec/bsv/wallet_interface/validators_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet_interface/validators_spec.rb
@@ -213,6 +213,56 @@ RSpec.describe BSV::Wallet::Validators do
     it 'rejects uppercase letters' do
       expect { described_class.validate_basket!('My Tokens') }.to raise_error(BSV::Wallet::InvalidParameterError)
     end
+
+    context 'with a structured zone (BRC-122) basket name' do
+      it 'accepts pool:doom' do
+        expect { described_class.validate_basket!('pool:doom') }.not_to raise_error
+      end
+
+      it 'accepts pool:12345' do
+        expect { described_class.validate_basket!('pool:12345') }.not_to raise_error
+      end
+
+      it 'accepts a structured basket with spaces in content' do
+        expect { described_class.validate_basket!('app:my tokens') }.not_to raise_error
+      end
+
+      it 'rejects trailing colon without content (pool:)' do
+        expect { described_class.validate_basket!('pool:') }.to raise_error(BSV::Wallet::InvalidParameterError)
+      end
+
+      it 'rejects leading colon (:orphan)' do
+        expect { described_class.validate_basket!(':orphan') }.to raise_error(BSV::Wallet::InvalidParameterError)
+      end
+
+      it 'rejects consecutive colons (pool::thing)' do
+        expect { described_class.validate_basket!('pool::thing') }.to raise_error(BSV::Wallet::InvalidParameterError)
+      end
+
+      it 'rejects structured names over 300 bytes' do
+        expect { described_class.validate_basket!("pool:#{'a' * 300}") }.to raise_error(BSV::Wallet::InvalidParameterError)
+      end
+
+      it 'normalises case (Pool:DOOM becomes pool:doom via strip/downcase)' do
+        expect { described_class.validate_basket!('Pool:DOOM') }.not_to raise_error
+      end
+
+      it 'rejects consecutive spaces in the content portion' do
+        expect { described_class.validate_basket!('pool:my  tokens') }.to raise_error(BSV::Wallet::InvalidParameterError)
+      end
+
+      it 'rejects structured basket with reserved prefix admin' do
+        expect { described_class.validate_basket!('admin:thing') }.to raise_error(BSV::Wallet::InvalidParameterError)
+      end
+
+      it 'accepts a single-character namespace and single-character content (a:b)' do
+        expect { described_class.validate_basket!('a:b') }.not_to raise_error
+      end
+
+      it 'rejects a numeric-only namespace prefix (9:thing)' do
+        expect { described_class.validate_basket!('9:thing') }.to raise_error(BSV::Wallet::InvalidParameterError)
+      end
+    end
   end
 
   describe '.validate_label!' do

--- a/gem/bsv-wallet/spec/support/shared_examples_for_storage_adapter.rb
+++ b/gem/bsv-wallet/spec/support/shared_examples_for_storage_adapter.rb
@@ -686,6 +686,70 @@ RSpec.shared_examples 'a storage adapter' do
     end
   end
 
+  describe '#update_output_basket' do
+    let(:outpoint) { 'basket.0' }
+
+    before do
+      store.store_output(
+        outpoint: outpoint,
+        satoshis: 5_000,
+        basket: 'old basket',
+        state: :spendable,
+        tags: %w[rare gold],
+        derivation_prefix: 'prefix123',
+        derivation_suffix: 'suffix456',
+        sender_identity_key: "02#{'ab' * 32}"
+      )
+    end
+
+    it 'changes the basket of an existing output' do
+      store.update_output_basket(outpoint, 'pool:doom')
+      results = store.find_outputs(basket: 'pool:doom', include_spent: true, limit: 1, offset: 0)
+      expect(results.length).to eq(1)
+      expect(results.first[:outpoint]).to eq(outpoint)
+    end
+
+    it 'returns the updated output hash' do
+      result = store.update_output_basket(outpoint, 'pool:doom')
+      expect(result).to be_a(Hash)
+      expect(result[:outpoint]).to eq(outpoint)
+      expect(result[:basket]).to eq('pool:doom')
+    end
+
+    it 'raises WalletError when outpoint not found' do
+      expect do
+        store.update_output_basket('nonexistent.99', 'pool:doom')
+      end.to raise_error(BSV::Wallet::WalletError)
+    end
+
+    it 'preserves satoshis, state, tags, and derivation fields' do
+      result = store.update_output_basket(outpoint, 'pool:doom')
+      expect(result[:satoshis]).to eq(5_000)
+      expect(result[:state].to_s).to eq('spendable')
+      expect(result[:tags]).to include('rare', 'gold')
+      expect(result[:derivation_prefix]).to eq('prefix123')
+      expect(result[:derivation_suffix]).to eq('suffix456')
+    end
+
+    it 'leaves a pending output still pending (basket change is metadata-only)' do
+      store.update_output_state(outpoint, :pending, pending_reference: 'ref-x')
+      result = store.update_output_basket(outpoint, 'pool:doom')
+      expect(result[:state].to_s).to eq('pending')
+    end
+
+    it 'output appears in new basket via find_spendable_outputs' do
+      store.update_output_basket(outpoint, 'pool:doom')
+      results = store.find_spendable_outputs(basket: 'pool:doom')
+      expect(results.map { |o| o[:outpoint] }).to include(outpoint)
+    end
+
+    it 'output disappears from old basket via find_spendable_outputs' do
+      store.update_output_basket(outpoint, 'pool:doom')
+      results = store.find_spendable_outputs(basket: 'old basket')
+      expect(results.map { |o| o[:outpoint] }).not_to include(outpoint)
+    end
+  end
+
   describe 'settings' do
     describe '#store_setting and #find_setting' do
       it 'persists a setting and retrieves it by key' do


### PR DESCRIPTION
## Summary

- Implement BRC-122 two-zone basket validation (flat zone unchanged, structured zone for colon-delimited namespaces like `pool:doom`)
- Add `UTXOPool` interface module + `LocalPool` concrete implementation with `acquire`/`release`/`status`/`shutdown`
- Add `ReplenishmentWorker` background thread with inlined BRC-29 derivation for pool output creation
- Add `update_output_basket` to StorageAdapter for metadata-only basket reassignment
- Fix `store_tracked_outputs` to persist derivation metadata for basket outputs
- Wire `utxo_pool` factory into `WalletClient`
- 84 new specs with regression coverage for all 9 bugs from the previous implementation attempt

## Round-1 bug regressions (all covered by specs)

1. Pool locks use `no_send: true` — exempt from 300s stale recovery
2. Basket validator accepts `pool:doom` via BRC-122 structured zone
3. Replenisher signalled at `<=` watermark (not `<`)
4. `store_tracked_outputs` persists derivation metadata
5. `create_action` called with explicit Hash literal
6. Split outputs include `output_description` (25 chars)
7. Split uses `auto_fund: true`
8. `pool.storage` exposed via `attr_reader`
9. Scavenge TOCTOU race documented (benign, self-corrects)

## Test plan

- [x] 1341 wallet specs pass (0 failures)
- [x] RuboCop clean on all changed files (79 files, 0 offences)
- [x] Concurrent acquire verified via thread barrier pattern
- [x] Pool-acquired outputs survive `release_stale_pending!`
- [x] All 15 acceptance criteria from HLR #474 verified

Closes #474

Generated with [Claude Code](https://claude.com/claude-code)
