### PR TITLE
feat(network): Command/Provider/Registry core framework (#495)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -250,8 +250,10 @@ RSpec/DescribeClass:
     - 'gem/bsv-sdk/spec/conformance/**/*'
     - 'gem/bsv-wallet/spec/bsv/wallet_interface/**/*'
     - 'gem/bsv-sdk/spec/bsv/registry/**/*'
+    - 'gem/bsv-sdk/spec/bsv/network/provider_spec.rb'
 
 # Vector specs define constants at spec scope for shared test infrastructure.
+# Provider spec defines top-level test subclasses to avoid RSpec/LeakyConstantDeclaration.
 Lint/ConstantDefinitionInBlock:
   Exclude:
     - 'gem/bsv-sdk/spec/bsv/script/interpreter/script_vectors_spec.rb'
@@ -259,6 +261,11 @@ Lint/ConstantDefinitionInBlock:
 RSpec/LeakyConstantDeclaration:
   Exclude:
     - 'gem/bsv-sdk/spec/bsv/script/interpreter/script_vectors_spec.rb'
+
+# Spec files that define multiple top-level test helper classes.
+Style/OneClassPerFile:
+  Exclude:
+    - 'gem/bsv-sdk/spec/bsv/network/provider_spec.rb'
 
 # Dynamic test generation produces describe blocks populated at runtime.
 RSpec/EmptyExampleGroup:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -157,6 +157,7 @@ Layout/LineLength:
 RSpec/ContextWording:
   Exclude:
     - 'gem/bsv-sdk/spec/bsv/primitives/**/*'
+    - 'gem/bsv-sdk/spec/bsv/network/**/*'
 
 # Specs for low-level modules legitimately need multiple assertions
 # per example and longer examples for thorough test coverage.
@@ -185,6 +186,7 @@ RSpec/MultipleMemoizedHelpers:
     - 'gem/bsv-sdk/spec/bsv/primitives/**/*'
     - 'gem/bsv-sdk/spec/bsv/script/**/*'
     - 'gem/bsv-sdk/spec/bsv/transaction/**/*'
+    - 'gem/bsv-sdk/spec/bsv/network/**/*'
     - 'gem/bsv-sdk/spec/bsv/auth/**/*'
     - 'gem/bsv-sdk/spec/bsv/overlay/**/*'
     - 'gem/bsv-sdk/spec/bsv/identity/**/*'

--- a/gem/bsv-sdk/lib/bsv/network.rb
+++ b/gem/bsv-sdk/lib/bsv/network.rb
@@ -8,6 +8,7 @@ module BSV
     autoload :ChainProviderError, 'bsv/network/chain_provider_error'
     autoload :UTXO,               'bsv/network/utxo'
     autoload :ARC,                'bsv/network/arc'
+    autoload :Provider,           'bsv/network/provider'
     autoload :Result,             'bsv/network/result'
     autoload :Specifier,          'bsv/network/specifier'
     autoload :WhatsOnChain,       'bsv/network/whats_on_chain'

--- a/gem/bsv-sdk/lib/bsv/network.rb
+++ b/gem/bsv-sdk/lib/bsv/network.rb
@@ -10,6 +10,7 @@ module BSV
     autoload :ARC,                'bsv/network/arc'
     autoload :Provider,           'bsv/network/provider'
     autoload :Result,             'bsv/network/result'
+    autoload :Registry,           'bsv/network/registry'
     autoload :Specifier,          'bsv/network/specifier'
     autoload :WhatsOnChain,       'bsv/network/whats_on_chain'
   end

--- a/gem/bsv-sdk/lib/bsv/network.rb
+++ b/gem/bsv-sdk/lib/bsv/network.rb
@@ -2,11 +2,14 @@
 
 module BSV
   module Network
+    autoload :Command,            'bsv/network/command'
     autoload :BroadcastError,     'bsv/network/broadcast_error'
     autoload :BroadcastResponse,  'bsv/network/broadcast_response'
     autoload :ChainProviderError, 'bsv/network/chain_provider_error'
     autoload :UTXO,               'bsv/network/utxo'
     autoload :ARC,                'bsv/network/arc'
+    autoload :Result,             'bsv/network/result'
+    autoload :Specifier,          'bsv/network/specifier'
     autoload :WhatsOnChain,       'bsv/network/whats_on_chain'
   end
 end

--- a/gem/bsv-sdk/lib/bsv/network/command.rb
+++ b/gem/bsv-sdk/lib/bsv/network/command.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module BSV
+  module Network
+    # A value object representing a declared network operation.
+    #
+    # Commands are registered at class level via {Command.define} and retrieved
+    # via {Command.find} or {Command.all}. The registry is thread-safe.
+    #
+    # @example Define a command
+    #   BSV::Network::Command.define(
+    #     :broadcast,
+    #     params: { tx: 'Transaction' },
+    #     returns: 'Result::Success<BroadcastResponse>',
+    #     description: 'Submit a transaction to the network'
+    #   )
+    class Command
+      @commands = {}
+      @mutex = Mutex.new
+
+      attr_reader :name, :params, :returns, :description
+
+      # Define and register a new command.
+      #
+      # @param name [Symbol, String] the command identifier; coerced to Symbol
+      # @param params [Object] opaque metadata describing accepted parameters
+      # @param returns [Object] opaque metadata describing the return value
+      # @param description [String] human-readable description of the command
+      # @return [Command] the newly registered (frozen) command
+      # @raise [ArgumentError] if a command with the same name is already registered
+      def self.define(name, params:, returns:, description:)
+        sym = name.to_sym
+
+        @mutex.synchronize do
+          raise ArgumentError, "command :#{sym} already defined" if @commands.key?(sym)
+
+          command = new(sym, params: params, returns: returns, description: description)
+          @commands[sym] = command
+          command
+        end
+      end
+
+      # Returns a frozen copy of all registered commands.
+      #
+      # @return [Hash{Symbol => Command}]
+      def self.all
+        @mutex.synchronize { @commands.dup.freeze }
+      end
+
+      # Find a registered command by name.
+      #
+      # @param name [Symbol, String] the command identifier; coerced to Symbol
+      # @return [Command, nil] the command, or nil if not found
+      def self.find(name)
+        @mutex.synchronize { @commands[name.to_sym] }
+      end
+
+      # Clear all registered commands.
+      #
+      # Intended for use in tests only.
+      def self.reset!
+        @mutex.synchronize { @commands.clear }
+      end
+
+      private_class_method :new
+
+      def initialize(name, params:, returns:, description:)
+        @name = name
+        @params = params
+        @returns = returns
+        @description = description
+        freeze
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/network/provider.rb
+++ b/gem/bsv-sdk/lib/bsv/network/provider.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module BSV
+  module Network
+    # Abstract base class for network endpoint implementations.
+    #
+    # Subclasses declare supported commands via the +provides+ class macro and
+    # implement each command as a +call_<name>+ instance method. The base class
+    # handles dispatch, capability validation, and result construction.
+    #
+    # == Example
+    #
+    #   class MyProvider < BSV::Network::Provider
+    #     provides :get_tx, :broadcast
+    #
+    #     def call_get_tx(txid)
+    #       # ... fetch transaction ...
+    #       success(tx)
+    #     end
+    #
+    #     def call_broadcast(tx)
+    #       # ... submit to network ...
+    #       error('rejected', retryable: false)
+    #     end
+    #   end
+    #
+    # == Inheritance
+    #
+    # Capabilities are inherited. If a parent class provides +:get_tx+ and a
+    # child class provides +:broadcast+, the child's +capabilities+ includes
+    # both symbols.
+    #
+    # == HTTP client injection
+    #
+    # Pass +http_client:+ to the constructor for testability. Subclasses access
+    # it via +@http_client+. The client must respond to +#request(uri, request)+.
+    class Provider
+      # Returns the set of command names this class (and its ancestors) support.
+      #
+      # @return [Set<Symbol>] frozen set of supported command names
+      def self.capabilities
+        if superclass.respond_to?(:capabilities)
+          superclass.capabilities | own_capabilities
+        else
+          own_capabilities
+        end.freeze
+      end
+
+      # Declare one or more commands this provider supports.
+      #
+      # May be called multiple times; declarations accumulate (union semantics).
+      # String arguments are coerced to Symbols.
+      #
+      # @param command_names [Array<Symbol, String>] supported command names
+      def self.provides(*command_names)
+        command_names.each do |name|
+          own_capabilities << name.to_sym
+        end
+      end
+
+      # @param http_client [#request, nil] injectable HTTP client for testing
+      # @param options [Hash] arbitrary options forwarded to subclass
+      def initialize(http_client: nil, **options)
+        @http_client = http_client
+        @options = options
+      end
+
+      # Dispatch a command to the corresponding +call_<name>+ method.
+      #
+      # @param command_name [Symbol, String] the command to invoke
+      # @param args [Array] arguments forwarded to the handler method
+      # @return [Result::Success, Result::Error, Result::NotFound]
+      # @raise [ArgumentError] when the command is not in {.capabilities}
+      def call(command_name, *args)
+        sym = command_name.to_sym
+        unless self.class.capabilities.include?(sym)
+          raise ArgumentError,
+                "#{self.class} does not provide command :#{sym}. " \
+                "Provided: #{self.class.capabilities.to_a.sort.inspect}"
+        end
+
+        send(:"call_#{sym}", *args)
+      end
+
+      private
+
+      # Returns a {Result::Success} carrying the given data.
+      #
+      # @param data [Object] the successful result value
+      # @return [Result::Success]
+      def success(data)
+        Result::Success.new(data: data)
+      end
+
+      # Returns a {Result::Error} with a message and optional retryable flag.
+      #
+      # @param message [String] human-readable error description
+      # @param retryable [Boolean] whether another provider may succeed (default: false)
+      # @return [Result::Error]
+      def error(message, retryable: false)
+        Result::Error.new(message, retryable: retryable)
+      end
+
+      # Returns a {Result::NotFound} indicating the resource does not exist.
+      #
+      # @return [Result::NotFound]
+      def not_found
+        Result::NotFound.new
+      end
+
+      # Lazy-initialised per-class capability Set (not shared with ancestors).
+      def self.own_capabilities
+        @own_capabilities ||= Set.new
+      end
+      private_class_method :own_capabilities
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/network/registry.rb
+++ b/gem/bsv-sdk/lib/bsv/network/registry.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+module BSV
+  module Network
+    # Runtime composition layer for network providers.
+    #
+    # The Registry holds a prioritised list of {Provider} instances, each paired
+    # with a {Specifier} that controls which commands that provider handles. When
+    # a command is dispatched via {#call}, the registry tries each eligible
+    # provider in priority order and applies failover semantics based on the
+    # {Result} type returned.
+    #
+    # == Registration
+    #
+    #   registry = BSV::Network::Registry.new
+    #   registry.register(primary_provider, priority: 1)
+    #   registry.register(fallback_provider, priority: 10, only: [:broadcast])
+    #
+    # == Dispatch semantics
+    #
+    # Providers are tried in ascending priority order (lower number = higher
+    # precedence). Within the same priority, registration order (FIFO) is used.
+    #
+    # - {Result::Success}  — returned immediately; no further providers tried
+    # - {Result::NotFound} — returned immediately; no further providers tried
+    # - {Result::Error} with +retryable: true+  — next provider is tried
+    # - {Result::Error} with +retryable: false+ — returned immediately
+    # - All providers exhausted with retryable errors — last error returned
+    # - No providers for command — raises {NoProviderError}
+    #
+    # == Exception wrapping
+    #
+    # If a provider raises a Ruby exception (rather than returning a Result),
+    # the registry wraps it in a retryable {Result::Error} and tries the next
+    # provider.
+    class Registry
+      # Raised when {#call} is invoked but no providers are registered for the
+      # given command (either the registry is empty, or all specifiers exclude it).
+      class NoProviderError < ArgumentError; end
+
+      # @return [Array<Provider>] all registered provider instances (in insertion order, deduplicated by entry)
+      def registered_providers
+        @entries.map { |entry| entry[:provider] }
+      end
+
+      def initialize
+        @entries = []
+        @insertion_counter = 0
+      end
+
+      # Register a provider with optional routing control and priority.
+      #
+      # The same provider instance may be registered multiple times with
+      # different specifiers — each registration is independent.
+      #
+      # @param provider [Provider] the provider to register
+      # @param priority [Integer] lower numbers are tried first (default: 0)
+      # @param only [Array<Symbol>, nil] allowlist passed to {Specifier}
+      # @param except [Array<Symbol>, nil] blocklist passed to {Specifier}
+      # @param filter [#call, nil] callable passed to {Specifier}
+      # @return [self]
+      def register(provider, priority: 0, only: nil, except: nil, filter: nil)
+        specifier = Specifier.new(only: only, except: except, filter: filter)
+        @entries << {
+          provider: provider,
+          specifier: specifier,
+          priority: priority,
+          order: @insertion_counter
+        }
+        @insertion_counter += 1
+        self
+      end
+
+      # Dispatch a command to eligible providers, applying failover semantics.
+      #
+      # @param command_name [Symbol, String] the command to invoke
+      # @param args [Array] arguments forwarded to the provider
+      # @return [Result::Success, Result::Error, Result::NotFound]
+      # @raise [NoProviderError] if no providers are registered for the command
+      def call(command_name, *args)
+        sym = command_name.to_sym
+        candidates = providers_for(sym)
+
+        raise NoProviderError, "no providers registered for command :#{sym}" if candidates.empty?
+
+        last_error = nil
+
+        candidates.map(&:first).each do |provider|
+          result = safe_call(provider, sym, *args)
+
+          return result if result.success?
+          return result if result.not_found?
+          return result if result.error? && !result.retryable?
+
+          # Retryable error — record it and continue to next provider
+          last_error = result
+        end
+
+        last_error
+      end
+
+      # Returns eligible providers for the given command, in priority order.
+      #
+      # A provider is eligible if:
+      # 1. It declares the command in its capabilities
+      # 2. Its specifier allows the command
+      #
+      # @param command_name [Symbol, String] the command to query
+      # @return [Array<Array(Provider, Specifier)>] ordered list of [provider, specifier] pairs
+      def providers_for(command_name)
+        sym = command_name.to_sym
+
+        eligible = @entries.select do |entry|
+          entry[:provider].class.capabilities.include?(sym) &&
+            entry[:specifier].allows?(sym)
+        end
+
+        sorted = eligible.sort_by { |entry| [entry[:priority], entry[:order]] }
+        sorted.map { |entry| [entry[:provider], entry[:specifier]] }
+      end
+
+      # Returns a hash mapping each registered provider to the command names
+      # it can handle, filtered by its specifier.
+      #
+      # When the same provider is registered multiple times (with different
+      # specifiers), each registration appears as a separate entry with the
+      # union of commands from all registrations attributed to the same object.
+      # In practice the hash key is the provider object, so multiple
+      # registrations of the same object are merged.
+      #
+      # @return [Hash{Provider => Array<Symbol>}] capability matrix
+      def capability_matrix
+        matrix = {}
+
+        @entries.each do |entry|
+          provider  = entry[:provider]
+          specifier = entry[:specifier]
+
+          commands = provider.class.capabilities.select { |cmd| specifier.allows?(cmd) }.sort
+
+          existing = matrix[provider] || []
+          matrix[provider] = (existing + commands).uniq.sort
+        end
+
+        matrix
+      end
+
+      private
+
+      # Calls provider#call, wrapping any raised exception as a retryable error.
+      #
+      # @return [Result::Success, Result::Error, Result::NotFound]
+      def safe_call(provider, command_name, *args)
+        provider.call(command_name, *args)
+      rescue StandardError => e
+        Result::Error.new(e.message, retryable: true)
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/network/result.rb
+++ b/gem/bsv-sdk/lib/bsv/network/result.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module BSV
+  module Network
+    # Result module provides immutable value objects for network operation outcomes.
+    #
+    # Three distinct result types are provided:
+    #   - Result::Success  — operation completed; carries optional data
+    #   - Result::Error    — operation failed; carries message and retryable flag
+    #   - Result::NotFound — resource does not exist; distinct from a transport error
+    #
+    # All types are frozen after initialisation and support value equality.
+    module Result
+      # Shared predicate defaults for result types.
+      #
+      # Each class overrides the one predicate that applies to it; the module
+      # supplies the false defaults so callers can always call all three methods
+      # on any result without a NoMethodError.
+      module Predicates
+        def success?
+          false
+        end
+
+        def error?
+          false
+        end
+
+        def not_found?
+          false
+        end
+      end
+
+      # Represents a successful operation outcome.
+      class Success
+        include Predicates
+
+        attr_reader :data
+
+        def initialize(data: nil)
+          @data = data
+          freeze
+        end
+
+        def success?
+          true
+        end
+
+        def ==(other)
+          other.is_a?(Success) && other.data == data
+        end
+
+        alias eql? ==
+
+        def hash
+          [self.class, data].hash
+        end
+      end
+
+      # Represents a failed operation outcome.
+      class Error
+        include Predicates
+
+        attr_reader :message, :retryable
+
+        def initialize(message, retryable: false)
+          @message = message
+          @retryable = retryable
+          freeze
+        end
+
+        def error?
+          true
+        end
+
+        def retryable?
+          !!retryable
+        end
+
+        def ==(other)
+          other.is_a?(Error) && other.message == message && other.retryable == retryable
+        end
+
+        alias eql? ==
+
+        def hash
+          [self.class, message, retryable].hash
+        end
+      end
+
+      # Represents a "resource not found" outcome — distinct from a transport error.
+      class NotFound
+        include Predicates
+
+        def initialize
+          freeze
+        end
+
+        def not_found?
+          true
+        end
+
+        def ==(other)
+          other.is_a?(NotFound)
+        end
+
+        alias eql? ==
+
+        def hash
+          self.class.hash
+        end
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/network/specifier.rb
+++ b/gem/bsv-sdk/lib/bsv/network/specifier.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module BSV
+  module Network
+    # Controls which commands a provider handles within a registry registration.
+    #
+    # At most one of +only:+, +except:+, or +filter:+ may be provided.
+    # Providing more than one raises +ArgumentError+ at construction.
+    #
+    # @example Allow everything (default)
+    #   Specifier.new.allows?(:broadcast)  # => true
+    #
+    # @example Allowlist
+    #   Specifier.new(only: [:broadcast]).allows?(:broadcast)  # => true
+    #   Specifier.new(only: [:broadcast]).allows?(:get_tx)     # => false
+    #
+    # @example Blocklist
+    #   Specifier.new(except: [:broadcast]).allows?(:broadcast) # => false
+    #   Specifier.new(except: [:broadcast]).allows?(:get_tx)    # => true
+    #
+    # @example Custom predicate
+    #   s = Specifier.new(filter: ->(cmd) { cmd.to_s.start_with?('get_') })
+    #   s.allows?(:get_tx)    # => true
+    #   s.allows?(:broadcast) # => false
+    class Specifier
+      # @param only   [Array<Symbol, String>, nil] allowlist of command names
+      # @param except [Array<Symbol, String>, nil] blocklist of command names
+      # @param filter [#call, nil] callable predicate; receives a Symbol command name
+      def initialize(only: nil, except: nil, filter: nil)
+        provided = [only, except, filter].count { |v| !v.nil? }
+        raise ArgumentError, 'at most one of only:, except:, or filter: may be provided' if provided > 1
+
+        @only   = coerce_symbols(only)
+        @except = coerce_symbols(except)
+        @filter = filter
+      end
+
+      # Returns true if the given command is permitted by this specifier.
+      #
+      # @param command_name [Symbol, String] the command to test
+      # @return [Boolean]
+      def allows?(command_name)
+        name = command_name.to_sym
+
+        return @filter.call(name) ? true : false if @filter
+        return @only.include?(name)               if @only
+        return !@except.include?(name)            if @except
+
+        true
+      end
+
+      private
+
+      def coerce_symbols(value)
+        return nil if value.nil?
+
+        value.map(&:to_sym)
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/network/command_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/command_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe BSV::Network::Command do
+  before { described_class.reset! }
+  after  { described_class.reset! }
+
+  let(:name)        { :broadcast }
+  let(:params)      { { tx: 'Transaction' } }
+  let(:returns)     { 'Result::Success' }
+  let(:description) { 'Submit a transaction to the network' }
+
+  def define_broadcast
+    described_class.define(name, params: params, returns: returns, description: description)
+  end
+
+  describe '.define' do
+    it 'registers and returns a Command instance' do
+      cmd = define_broadcast
+      expect(cmd).to be_a(described_class)
+    end
+
+    it 'coerces a String name to Symbol' do
+      cmd = described_class.define('get_tx', params: {}, returns: nil, description: 'Get tx')
+      expect(cmd.name).to eq(:get_tx)
+    end
+
+    it 'raises ArgumentError on duplicate name' do
+      define_broadcast
+      expect { define_broadcast }.to raise_error(ArgumentError, /command :broadcast already defined/)
+    end
+
+    it 'freezes the returned command' do
+      cmd = define_broadcast
+      expect(cmd).to be_frozen
+    end
+  end
+
+  describe '.find' do
+    it 'returns the command when found' do
+      define_broadcast
+      expect(described_class.find(:broadcast)).to be_a(described_class)
+    end
+
+    it 'returns nil for an unknown command' do
+      expect(described_class.find(:nonexistent)).to be_nil
+    end
+
+    it 'coerces a String name to Symbol for lookup' do
+      define_broadcast
+      expect(described_class.find('broadcast')).not_to be_nil
+    end
+  end
+
+  describe '.all' do
+    it 'returns an empty hash when no commands are registered' do
+      expect(described_class.all).to eq({})
+    end
+
+    it 'returns all registered commands keyed by Symbol name' do
+      define_broadcast
+      described_class.define(:get_tx, params: {}, returns: nil, description: 'Get tx')
+      all = described_class.all
+      expect(all.keys).to contain_exactly(:broadcast, :get_tx)
+    end
+
+    it 'returns a frozen hash' do
+      define_broadcast
+      expect(described_class.all).to be_frozen
+    end
+
+    it 'returns a copy — mutations do not affect the registry' do
+      define_broadcast
+      copy = described_class.all
+      expect { copy[:extra] = :value }.to raise_error(FrozenError)
+    end
+  end
+
+  describe '.reset!' do
+    it 'clears all registered commands' do
+      define_broadcast
+      described_class.reset!
+      expect(described_class.all).to be_empty
+    end
+  end
+
+  describe 'instance attributes' do
+    subject(:cmd) { define_broadcast }
+
+    it 'exposes #name as a Symbol' do
+      expect(cmd.name).to eq(:broadcast)
+    end
+
+    it 'exposes #params' do
+      expect(cmd.params).to eq(params)
+    end
+
+    it 'exposes #returns' do
+      expect(cmd.returns).to eq(returns)
+    end
+
+    it 'exposes #description' do
+      expect(cmd.description).to eq(description)
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/network/provider_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/provider_spec.rb
@@ -1,0 +1,228 @@
+# frozen_string_literal: true
+
+# Test subclasses — defined outside the RSpec.describe block to avoid
+# Lint/ConstantDefinitionInBlock and RSpec/LeakyConstantDeclaration offences.
+
+class ProviderTestBase < BSV::Network::Provider
+  provides :get_tx, :broadcast
+
+  def call_get_tx(txid)
+    success(txid)
+  end
+
+  def call_broadcast(_tx)
+    error('rejected', retryable: false)
+  end
+end
+
+class ProviderTestChild < ProviderTestBase
+  provides :query_status
+
+  def call_query_status(txid)
+    success("status:#{txid}")
+  end
+end
+
+class ProviderTestEmpty < BSV::Network::Provider; end
+
+class ProviderTestIncomplete < BSV::Network::Provider
+  provides :get_tx
+  # call_get_tx intentionally omitted
+end
+
+RSpec.describe 'BSV::Network::Provider' do
+  describe '.capabilities' do
+    it 'returns the declared command names as Symbols' do
+      expect(ProviderTestBase.capabilities).to include(:get_tx, :broadcast)
+    end
+
+    it 'returns a frozen set' do
+      expect(ProviderTestBase.capabilities).to be_frozen
+    end
+
+    it 'is empty when no commands have been declared' do
+      expect(ProviderTestEmpty.capabilities).to be_empty
+    end
+
+    it 'inherits parent capabilities in a child class' do
+      expect(ProviderTestChild.capabilities).to include(:get_tx, :broadcast, :query_status)
+    end
+
+    it 'does not pollute the parent capabilities with child additions' do
+      expect(ProviderTestBase.capabilities).not_to include(:query_status)
+    end
+  end
+
+  describe '.provides' do
+    it 'coerces String arguments to Symbols' do
+      klass = Class.new(BSV::Network::Provider) { provides 'some_command' }
+      expect(klass.capabilities).to include(:some_command)
+    end
+
+    it 'is idempotent when the same name is declared multiple times' do
+      klass = Class.new(BSV::Network::Provider) do
+        provides :duplicate
+        provides :duplicate
+      end
+      expect(klass.capabilities.count { |c| c == :duplicate }).to eq(1)
+    end
+
+    it 'accumulates across multiple provides calls' do
+      klass = Class.new(BSV::Network::Provider) do
+        provides :alpha
+        provides :beta
+      end
+      expect(klass.capabilities).to include(:alpha, :beta)
+    end
+  end
+
+  describe '#call' do
+    let(:provider) { ProviderTestBase.new }
+
+    it 'dispatches :get_tx to call_get_tx and returns a Result::Success' do
+      result = provider.call(:get_tx, 'abc123')
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq('abc123')
+    end
+
+    it 'dispatches :broadcast to call_broadcast and returns a Result::Error' do
+      result = provider.call(:broadcast, nil)
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.message).to eq('rejected')
+      expect(result.retryable?).to be false
+    end
+
+    it 'accepts a String command name (coerced to Symbol)' do
+      result = provider.call('get_tx', 'xyz')
+      expect(result.success?).to be true
+    end
+
+    it 'raises ArgumentError for an unsupported command' do
+      expect { provider.call(:unsupported) }.to raise_error(
+        ArgumentError, /does not provide command :unsupported/
+      )
+    end
+
+    it 'raises ArgumentError mentioning which commands are available' do
+      expect { provider.call(:nonexistent) }.to raise_error(
+        ArgumentError, /Provided:/
+      )
+    end
+
+    it 'raises NoMethodError naturally when call_<name> is not implemented' do
+      incomplete = ProviderTestIncomplete.new
+      expect { incomplete.call(:get_tx) }.to raise_error(NoMethodError)
+    end
+
+    context 'with a child provider' do
+      let(:child) { ProviderTestChild.new }
+
+      it 'dispatches inherited commands' do
+        result = child.call(:get_tx, 'parent_cmd')
+        expect(result.success?).to be true
+        expect(result.data).to eq('parent_cmd')
+      end
+
+      it 'dispatches child-specific commands' do
+        result = child.call(:query_status, 'tx42')
+        expect(result.success?).to be true
+        expect(result.data).to eq('status:tx42')
+      end
+    end
+  end
+
+  describe 'result helper methods' do
+    it 'success() returns a Result::Success with the given data' do
+      klass = Class.new(BSV::Network::Provider) do
+        provides :fetch
+        def call_fetch(val)
+          success(val)
+        end
+      end
+      result = klass.new.call(:fetch, 'payload')
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq('payload')
+    end
+
+    it 'error() returns a Result::Error with retryable: true' do
+      klass = Class.new(BSV::Network::Provider) do
+        provides :failing
+        def call_failing
+          error('oops', retryable: true)
+        end
+      end
+      result = klass.new.call(:failing)
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.message).to eq('oops')
+      expect(result.retryable?).to be true
+    end
+
+    it 'error() defaults retryable to false' do
+      klass = Class.new(BSV::Network::Provider) do
+        provides :failing
+        def call_failing
+          error('oops')
+        end
+      end
+      result = klass.new.call(:failing)
+      expect(result.retryable?).to be false
+    end
+
+    it 'not_found() returns a Result::NotFound' do
+      klass = Class.new(BSV::Network::Provider) do
+        provides :missing
+        def call_missing
+          not_found
+        end
+      end
+      result = klass.new.call(:missing)
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+      expect(result.not_found?).to be true
+    end
+  end
+
+  describe 'constructor' do
+    it 'stores an injectable http_client accessible to subclass' do
+      klass = Class.new(BSV::Network::Provider) do
+        provides :ping
+        def call_ping
+          success(@http_client)
+        end
+      end
+      sentinel = Object.new
+      result = klass.new(http_client: sentinel).call(:ping)
+      expect(result.data).to equal(sentinel)
+    end
+
+    it 'defaults http_client to nil when not supplied' do
+      klass = Class.new(BSV::Network::Provider) do
+        provides :ping
+        def call_ping
+          success(@http_client)
+        end
+      end
+      expect(klass.new.call(:ping).data).to be_nil
+    end
+
+    it 'stores arbitrary options for subclass use' do
+      klass = Class.new(BSV::Network::Provider) do
+        provides :ping
+        def call_ping
+          success(@options)
+        end
+      end
+      result = klass.new(url: 'https://example.com', api_key: 'secret').call(:ping)
+      expect(result.data).to eq(url: 'https://example.com', api_key: 'secret')
+    end
+
+    it 'stores an empty options hash when no options supplied' do
+      klass = Class.new(BSV::Network::Provider) do
+        provides :ping
+        def call_ping
+          success(@options)
+        end
+      end
+      expect(klass.new.call(:ping).data).to eq({})
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/network/registry_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/registry_spec.rb
@@ -1,0 +1,460 @@
+# frozen_string_literal: true
+
+RSpec.describe 'BSV::Network::Registry' do
+  subject(:registry) { BSV::Network::Registry.new }
+
+  # ---------------------------------------------------------------------------
+  # Test provider subclasses
+  # ---------------------------------------------------------------------------
+
+  let(:provider_class) do
+    Class.new(BSV::Network::Provider) do
+      provides :get_tx, :broadcast
+
+      def call_get_tx(txid)
+        success(txid)
+      end
+
+      def call_broadcast(_tx)
+        success('ok')
+      end
+    end
+  end
+
+  let(:failing_provider_class) do
+    Class.new(BSV::Network::Provider) do
+      provides :get_tx, :broadcast
+
+      def call_get_tx(_txid)
+        error('timeout', retryable: true)
+      end
+
+      def call_broadcast(_tx)
+        error('timeout', retryable: true)
+      end
+    end
+  end
+
+  let(:fatal_provider_class) do
+    Class.new(BSV::Network::Provider) do
+      provides :get_tx, :broadcast
+
+      def call_get_tx(_txid)
+        error('auth failure', retryable: false)
+      end
+
+      def call_broadcast(_tx)
+        error('auth failure', retryable: false)
+      end
+    end
+  end
+
+  let(:not_found_provider_class) do
+    Class.new(BSV::Network::Provider) do
+      provides :get_tx
+
+      def call_get_tx(_txid)
+        not_found
+      end
+    end
+  end
+
+  let(:broadcast_only_class) do
+    Class.new(BSV::Network::Provider) do
+      provides :broadcast
+
+      def call_broadcast(_tx)
+        success('broadcast ok')
+      end
+    end
+  end
+
+  let(:exploding_provider_class) do
+    Class.new(BSV::Network::Provider) do
+      provides :get_tx
+
+      def call_get_tx(_txid)
+        raise 'unexpected boom'
+      end
+    end
+  end
+
+  let(:provider)            { provider_class.new }
+  let(:failing_provider)    { failing_provider_class.new }
+  let(:fatal_provider)      { fatal_provider_class.new }
+  let(:not_found_provider)  { not_found_provider_class.new }
+  let(:broadcast_provider)  { broadcast_only_class.new }
+  let(:exploding_provider)  { exploding_provider_class.new }
+
+  # ---------------------------------------------------------------------------
+  # #register
+  # ---------------------------------------------------------------------------
+
+  describe '#register' do
+    it 'returns self for chaining' do
+      expect(registry.register(provider)).to be(registry)
+    end
+
+    it 'adds the provider to registered_providers' do
+      registry.register(provider)
+      expect(registry.registered_providers).to include(provider)
+    end
+
+    it 'allows the same provider to be registered multiple times' do
+      registry.register(provider, only: [:get_tx])
+      registry.register(provider, only: [:broadcast])
+      expect(registry.registered_providers.count(provider)).to eq(2)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #call — basic dispatch
+  # ---------------------------------------------------------------------------
+
+  describe '#call' do
+    context 'with one provider supporting the command' do
+      before { registry.register(provider) }
+
+      it 'returns Success from the provider' do
+        result = registry.call(:get_tx, 'abc123')
+        expect(result).to be_a(BSV::Network::Result::Success)
+        expect(result.data).to eq('abc123')
+      end
+    end
+
+    context 'when the provider does not support the command' do
+      before { registry.register(broadcast_provider) }
+
+      it 'raises NoProviderError' do
+        expect { registry.call(:get_tx, 'abc') }
+          .to raise_error(BSV::Network::Registry::NoProviderError)
+      end
+    end
+
+    context 'with an empty registry' do
+      it 'raises NoProviderError' do
+        expect { registry.call(:get_tx, 'abc') }
+          .to raise_error(BSV::Network::Registry::NoProviderError)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #call — failover semantics
+  # ---------------------------------------------------------------------------
+
+  describe '#call failover' do
+    context 'first provider retryable error, second returns success' do
+      before do
+        registry.register(failing_provider, priority: 1)
+        registry.register(provider, priority: 2)
+      end
+
+      it 'falls over to the second provider and returns Success' do
+        result = registry.call(:get_tx, 'txid')
+        expect(result).to be_a(BSV::Network::Result::Success)
+        expect(result.data).to eq('txid')
+      end
+    end
+
+    context 'first provider returns non-retryable error' do
+      before do
+        registry.register(fatal_provider, priority: 1)
+        registry.register(provider, priority: 2)
+      end
+
+      it 'returns the error immediately without trying the second provider' do
+        result = registry.call(:get_tx, 'txid')
+        expect(result).to be_a(BSV::Network::Result::Error)
+        expect(result.retryable?).to be false
+        expect(result.message).to eq('auth failure')
+      end
+    end
+
+    context 'first provider returns NotFound' do
+      before do
+        registry.register(not_found_provider, priority: 1)
+        registry.register(provider, priority: 2)
+      end
+
+      it 'returns NotFound immediately without trying the second provider' do
+        result = registry.call(:get_tx, 'txid')
+        expect(result).to be_a(BSV::Network::Result::NotFound)
+      end
+    end
+
+    context 'all providers fail with retryable errors' do
+      let(:failing2) { failing_provider_class.new }
+
+      before do
+        registry.register(failing_provider, priority: 1)
+        registry.register(failing2, priority: 2)
+      end
+
+      it 'returns the last retryable error' do
+        result = registry.call(:get_tx, 'txid')
+        expect(result).to be_a(BSV::Network::Result::Error)
+        expect(result.retryable?).to be true
+        expect(result.message).to eq('timeout')
+      end
+    end
+
+    context 'single provider with retryable error and no fallback' do
+      before { registry.register(failing_provider) }
+
+      it 'returns the retryable error (no fallback available)' do
+        result = registry.call(:get_tx, 'txid')
+        expect(result).to be_a(BSV::Network::Result::Error)
+        expect(result.retryable?).to be true
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #call — exception wrapping
+  # ---------------------------------------------------------------------------
+
+  describe '#call exception wrapping' do
+    context 'when the provider raises a StandardError' do
+      before do
+        registry.register(exploding_provider, priority: 1)
+        registry.register(provider, priority: 2)
+      end
+
+      it 'wraps the exception as a retryable error and falls over to the next provider' do
+        result = registry.call(:get_tx, 'txid')
+        expect(result).to be_a(BSV::Network::Result::Success)
+      end
+    end
+
+    context 'when the only provider raises and no fallback' do
+      before { registry.register(exploding_provider) }
+
+      it 'returns a retryable Result::Error wrapping the exception message' do
+        result = registry.call(:get_tx, 'txid')
+        expect(result).to be_a(BSV::Network::Result::Error)
+        expect(result.retryable?).to be true
+        expect(result.message).to eq('unexpected boom')
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Priority ordering
+  # ---------------------------------------------------------------------------
+
+  describe 'priority ordering' do
+    let(:call_order) { [] }
+
+    let(:recording_class) do
+      log = call_order
+      Class.new(BSV::Network::Provider) do
+        provides :get_tx
+
+        define_method(:call_get_tx) do |_txid|
+          log << self
+          error('retryable', retryable: true)
+        end
+      end
+    end
+
+    it 'tries lower priority number first' do
+      p1 = recording_class.new
+      p10 = recording_class.new
+
+      registry.register(p10, priority: 10)
+      registry.register(p1, priority: 1)
+
+      registry.call(:get_tx, 'x')
+
+      expect(call_order).to eq([p1, p10])
+    end
+
+    it 'uses registration order (FIFO) to break ties within same priority' do
+      pa = recording_class.new
+      pb = recording_class.new
+      pc = recording_class.new
+
+      registry.register(pa, priority: 5)
+      registry.register(pb, priority: 5)
+      registry.register(pc, priority: 5)
+
+      registry.call(:get_tx, 'x')
+
+      expect(call_order).to eq([pa, pb, pc])
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Specifier integration
+  # ---------------------------------------------------------------------------
+
+  describe 'specifier filtering' do
+    context 'with only: [:broadcast]' do
+      before { registry.register(provider, only: [:broadcast]) }
+
+      it 'allows the provider for :broadcast' do
+        result = registry.call(:broadcast, 'tx')
+        expect(result).to be_a(BSV::Network::Result::Success)
+      end
+
+      it 'raises NoProviderError for :get_tx' do
+        expect { registry.call(:get_tx, 'id') }
+          .to raise_error(BSV::Network::Registry::NoProviderError)
+      end
+    end
+
+    context 'with except: [:get_tx]' do
+      before { registry.register(provider, except: [:get_tx]) }
+
+      it 'allows the provider for :broadcast' do
+        result = registry.call(:broadcast, 'tx')
+        expect(result).to be_a(BSV::Network::Result::Success)
+      end
+
+      it 'raises NoProviderError for :get_tx' do
+        expect { registry.call(:get_tx, 'id') }
+          .to raise_error(BSV::Network::Registry::NoProviderError)
+      end
+    end
+
+    context 'with filter:' do
+      before do
+        registry.register(provider, filter: ->(cmd) { cmd == :broadcast })
+      end
+
+      it 'allows commands passing the filter' do
+        result = registry.call(:broadcast, 'tx')
+        expect(result).to be_a(BSV::Network::Result::Success)
+      end
+
+      it 'raises NoProviderError for commands blocked by the filter' do
+        expect { registry.call(:get_tx, 'id') }
+          .to raise_error(BSV::Network::Registry::NoProviderError)
+      end
+    end
+
+    context 'with only: []' do
+      before { registry.register(provider, only: []) }
+
+      it 'makes the provider invisible for all commands' do
+        expect { registry.call(:get_tx, 'id') }
+          .to raise_error(BSV::Network::Registry::NoProviderError)
+        expect { registry.call(:broadcast, 'tx') }
+          .to raise_error(BSV::Network::Registry::NoProviderError)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Same provider registered with different specifiers
+  # ---------------------------------------------------------------------------
+
+  describe 'same provider registered twice with different specifiers' do
+    before do
+      registry.register(provider, only: [:get_tx], priority: 1)
+      registry.register(provider, only: [:broadcast], priority: 2)
+    end
+
+    it 'handles :get_tx via the first registration' do
+      result = registry.call(:get_tx, 'id')
+      expect(result).to be_a(BSV::Network::Result::Success)
+    end
+
+    it 'handles :broadcast via the second registration' do
+      result = registry.call(:broadcast, 'tx')
+      expect(result).to be_a(BSV::Network::Result::Success)
+    end
+
+    it 'reports two entries in registered_providers' do
+      expect(registry.registered_providers.count(provider)).to eq(2)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #providers_for
+  # ---------------------------------------------------------------------------
+
+  describe '#providers_for' do
+    it 'returns an empty array when no providers match' do
+      registry.register(broadcast_provider)
+      expect(registry.providers_for(:get_tx)).to be_empty
+    end
+
+    it 'returns [provider, specifier] pairs in priority order' do
+      p1 = provider_class.new
+      p2 = provider_class.new
+
+      registry.register(p2, priority: 10)
+      registry.register(p1, priority: 1)
+
+      pairs = registry.providers_for(:get_tx)
+      expect(pairs.map(&:first)).to eq([p1, p2])
+    end
+
+    it 'includes the specifier as the second element of each pair' do
+      registry.register(provider)
+      pairs = registry.providers_for(:get_tx)
+      expect(pairs.first.last).to be_a(BSV::Network::Specifier)
+    end
+
+    it 'excludes providers whose specifier does not allow the command' do
+      registry.register(provider, only: [:broadcast])
+      expect(registry.providers_for(:get_tx)).to be_empty
+    end
+
+    it 'returns both entries when the same provider is registered twice with different specifiers' do
+      registry.register(provider, only: [:get_tx])
+      registry.register(provider, only: [:get_tx])
+      pairs = registry.providers_for(:get_tx)
+      expect(pairs.size).to eq(2)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #capability_matrix
+  # ---------------------------------------------------------------------------
+
+  describe '#capability_matrix' do
+    it 'returns an empty hash for an empty registry' do
+      expect(registry.capability_matrix).to eq({})
+    end
+
+    it 'maps providers to their specifier-filtered command names' do
+      registry.register(provider)
+      matrix = registry.capability_matrix
+      expect(matrix[provider]).to match_array(%i[get_tx broadcast])
+    end
+
+    it 'respects specifier filtering in the matrix' do
+      registry.register(provider, only: [:broadcast])
+      matrix = registry.capability_matrix
+      expect(matrix[provider]).to eq([:broadcast])
+    end
+
+    it 'excludes commands blocked by the specifier' do
+      registry.register(provider, except: [:broadcast])
+      matrix = registry.capability_matrix
+      expect(matrix[provider]).not_to include(:broadcast)
+      expect(matrix[provider]).to include(:get_tx)
+    end
+
+    it 'reflects only: [] as no capabilities' do
+      registry.register(provider, only: [])
+      matrix = registry.capability_matrix
+      expect(matrix[provider]).to be_empty
+    end
+
+    it 'includes multiple providers as separate keys' do
+      p1 = provider_class.new
+      p2 = broadcast_only_class.new
+
+      registry.register(p1)
+      registry.register(p2)
+
+      matrix = registry.capability_matrix
+      expect(matrix.keys).to include(p1, p2)
+      expect(matrix[p2]).to eq([:broadcast])
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/network/result_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/result_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/MultipleMemoizedHelpers
+RSpec.describe 'BSV::Network::Result' do
+  let(:success) { BSV::Network::Result::Success.new(data: 'payload') }
+  let(:success_nil) { BSV::Network::Result::Success.new(data: nil) }
+  let(:error_retryable) { BSV::Network::Result::Error.new('timeout', retryable: true) }
+  let(:error_not_retryable) { BSV::Network::Result::Error.new('bad request', retryable: false) }
+  let(:error_nil_retryable) { BSV::Network::Result::Error.new('unknown', retryable: nil) }
+  let(:not_found) { BSV::Network::Result::NotFound.new }
+
+  describe 'BSV::Network::Result::Success' do
+    it 'reports success? as true' do
+      expect(success.success?).to be true
+    end
+
+    it 'reports error? as false' do
+      expect(success.error?).to be false
+    end
+
+    it 'reports not_found? as false' do
+      expect(success.not_found?).to be false
+    end
+
+    it 'exposes the data attribute' do
+      expect(success.data).to eq('payload')
+    end
+
+    it 'accepts nil data' do
+      expect(success_nil.data).to be_nil
+      expect(success_nil.success?).to be true
+    end
+
+    it 'is frozen after initialisation' do
+      expect(success).to be_frozen
+    end
+
+    it 'is equal to another Success with the same data' do
+      expect(BSV::Network::Result::Success.new(data: 'payload')).to eq(success)
+    end
+
+    it 'is not equal to a Success with different data' do
+      expect(BSV::Network::Result::Success.new(data: 'other')).not_to eq(success)
+    end
+
+    it 'is not equal to a NotFound' do
+      expect(success_nil).not_to eq(not_found)
+    end
+  end
+
+  describe 'BSV::Network::Result::Error' do
+    it 'reports error? as true' do
+      expect(error_retryable.error?).to be true
+    end
+
+    it 'reports success? as false' do
+      expect(error_retryable.success?).to be false
+    end
+
+    it 'reports not_found? as false' do
+      expect(error_retryable.not_found?).to be false
+    end
+
+    it 'exposes the message attribute' do
+      expect(error_retryable.message).to eq('timeout')
+    end
+
+    it 'exposes the retryable attribute' do
+      expect(error_retryable.retryable).to be true
+    end
+
+    it 'reports retryable? as true when retryable is true' do
+      expect(error_retryable.retryable?).to be true
+    end
+
+    it 'reports retryable? as false when retryable is false' do
+      expect(error_not_retryable.retryable?).to be false
+    end
+
+    it 'reports retryable? as false when retryable is nil' do
+      expect(error_nil_retryable.retryable?).to be false
+    end
+
+    it 'defaults retryable to false when not supplied' do
+      err = BSV::Network::Result::Error.new('oops')
+      expect(err.retryable?).to be false
+    end
+
+    it 'is frozen after initialisation' do
+      expect(error_retryable).to be_frozen
+    end
+
+    it 'is equal to another Error with the same message and retryable flag' do
+      expect(BSV::Network::Result::Error.new('timeout', retryable: true)).to eq(error_retryable)
+    end
+
+    it 'is not equal to an Error with a different message' do
+      expect(BSV::Network::Result::Error.new('different', retryable: true)).not_to eq(error_retryable)
+    end
+
+    it 'is not equal to an Error with a different retryable flag' do
+      expect(BSV::Network::Result::Error.new('timeout', retryable: false)).not_to eq(error_retryable)
+    end
+
+    it 'is not equal to a Success' do
+      expect(error_retryable).not_to eq(success)
+    end
+  end
+
+  describe 'BSV::Network::Result::NotFound' do
+    it 'reports not_found? as true' do
+      expect(not_found.not_found?).to be true
+    end
+
+    it 'reports success? as false' do
+      expect(not_found.success?).to be false
+    end
+
+    it 'reports error? as false' do
+      expect(not_found.error?).to be false
+    end
+
+    it 'is frozen after initialisation' do
+      expect(not_found).to be_frozen
+    end
+
+    it 'is equal to another NotFound' do
+      expect(BSV::Network::Result::NotFound.new).to eq(not_found)
+    end
+
+    it 'is not equal to a Success with nil data' do
+      expect(not_found).not_to eq(success_nil)
+    end
+
+    it 'is not equal to an Error' do
+      expect(not_found).not_to eq(error_not_retryable)
+    end
+  end
+end
+# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/gem/bsv-sdk/spec/bsv/network/result_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/result_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe 'BSV::Network::Result' do
   let(:success) { BSV::Network::Result::Success.new(data: 'payload') }
   let(:success_nil) { BSV::Network::Result::Success.new(data: nil) }
@@ -137,4 +136,3 @@ RSpec.describe 'BSV::Network::Result' do
     end
   end
 end
-# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/gem/bsv-sdk/spec/bsv/network/specifier_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/specifier_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe BSV::Network::Specifier do
+  describe '#initialize' do
+    it 'raises ArgumentError when only: and except: are both provided' do
+      expect { described_class.new(only: [:broadcast], except: [:get_tx]) }
+        .to raise_error(ArgumentError, /at most one/)
+    end
+
+    it 'raises ArgumentError when only: and filter: are both provided' do
+      expect { described_class.new(only: [:broadcast], filter: ->(_cmd) { true }) }
+        .to raise_error(ArgumentError, /at most one/)
+    end
+
+    it 'raises ArgumentError when except: and filter: are both provided' do
+      expect { described_class.new(except: [:broadcast], filter: ->(_cmd) { true }) }
+        .to raise_error(ArgumentError, /at most one/)
+    end
+
+    it 'raises ArgumentError when all three options are provided' do
+      expect { described_class.new(only: [:broadcast], except: [:get_tx], filter: ->(_cmd) { true }) }
+        .to raise_error(ArgumentError, /at most one/)
+    end
+  end
+
+  describe '#allows?' do
+    context 'with no options (default)' do
+      subject(:specifier) { described_class.new }
+
+      it 'allows any command' do
+        expect(specifier.allows?(:broadcast)).to be true
+        expect(specifier.allows?(:get_tx)).to be true
+        expect(specifier.allows?(:anything)).to be true
+      end
+    end
+
+    context 'with only:' do
+      subject(:specifier) { described_class.new(only: [:broadcast]) }
+
+      it 'allows listed commands' do
+        expect(specifier.allows?(:broadcast)).to be true
+      end
+
+      it 'rejects unlisted commands' do
+        expect(specifier.allows?(:get_tx)).to be false
+      end
+    end
+
+    context 'with only: []' do
+      subject(:specifier) { described_class.new(only: []) }
+
+      it 'allows nothing' do
+        expect(specifier.allows?(:broadcast)).to be false
+        expect(specifier.allows?(:get_tx)).to be false
+      end
+    end
+
+    context 'with except:' do
+      subject(:specifier) { described_class.new(except: [:broadcast]) }
+
+      it 'rejects listed commands' do
+        expect(specifier.allows?(:broadcast)).to be false
+      end
+
+      it 'allows unlisted commands' do
+        expect(specifier.allows?(:get_tx)).to be true
+      end
+    end
+
+    context 'with except: []' do
+      subject(:specifier) { described_class.new(except: []) }
+
+      it 'allows everything' do
+        expect(specifier.allows?(:broadcast)).to be true
+        expect(specifier.allows?(:get_tx)).to be true
+      end
+    end
+
+    context 'with filter:' do
+      subject(:specifier) { described_class.new(filter: ->(cmd) { cmd.to_s.start_with?('get_') }) }
+
+      it 'allows commands where the predicate returns truthy' do
+        expect(specifier.allows?(:get_tx)).to be true
+      end
+
+      it 'rejects commands where the predicate returns falsy' do
+        expect(specifier.allows?(:broadcast)).to be false
+      end
+    end
+
+    context 'with String values in only:' do
+      subject(:specifier) { described_class.new(only: %w[broadcast get_tx]) }
+
+      it 'coerces strings to symbols and allows them' do
+        expect(specifier.allows?(:broadcast)).to be true
+        expect(specifier.allows?(:get_tx)).to be true
+      end
+
+      it 'rejects unlisted commands' do
+        expect(specifier.allows?(:other)).to be false
+      end
+    end
+
+    context 'with String values in except:' do
+      subject(:specifier) { described_class.new(except: %w[broadcast]) }
+
+      it 'coerces strings to symbols and rejects them' do
+        expect(specifier.allows?(:broadcast)).to be false
+      end
+
+      it 'allows commands not in the list' do
+        expect(specifier.allows?(:get_tx)).to be true
+      end
+    end
+
+    context 'with filter: that raises' do
+      subject(:specifier) { described_class.new(filter: ->(_cmd) { raise 'filter error' }) }
+
+      it 'propagates the exception' do
+        expect { specifier.allows?(:broadcast) }.to raise_error(RuntimeError, 'filter error')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Implement `BSV::Network::Result` value types (Success, Error, NotFound) for normalised dispatch results
- Implement `BSV::Network::Command` for static declaration of network operations
- Implement `BSV::Network::Specifier` for routing control (only/except/filter)
- Implement `BSV::Network::Provider` base class with `provides` macro and `call_<name>` dispatch
- Implement `BSV::Network::Registry` with provider registration, priority-ordered failover dispatch, and introspection

## Test plan
- [x] All SDK specs pass (3,599 examples, 0 failures)
- [x] RuboCop clean (395 files, no offences)
- [x] All acceptance criteria from #495 verified
- [x] No existing tests broken (purely additive)

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)