### PR TITLE
feat(network): WhatsOnChain and ARC provider implementations (#496)

### DIFF
--- a/gem/bsv-sdk/lib/bsv/network.rb
+++ b/gem/bsv-sdk/lib/bsv/network.rb
@@ -3,6 +3,7 @@
 module BSV
   module Network
     autoload :Command,            'bsv/network/command'
+    autoload :Commands,           'bsv/network/commands'
     autoload :BroadcastError,     'bsv/network/broadcast_error'
     autoload :BroadcastResponse,  'bsv/network/broadcast_response'
     autoload :ChainProviderError, 'bsv/network/chain_provider_error'
@@ -13,5 +14,6 @@ module BSV
     autoload :Registry,           'bsv/network/registry'
     autoload :Specifier,          'bsv/network/specifier'
     autoload :WhatsOnChain,       'bsv/network/whats_on_chain'
+    autoload :Providers,          'bsv/network/providers'
   end
 end

--- a/gem/bsv-sdk/lib/bsv/network.rb
+++ b/gem/bsv-sdk/lib/bsv/network.rb
@@ -3,7 +3,6 @@
 module BSV
   module Network
     autoload :Command,            'bsv/network/command'
-    autoload :Commands,           'bsv/network/commands'
     autoload :BroadcastError,     'bsv/network/broadcast_error'
     autoload :BroadcastResponse,  'bsv/network/broadcast_response'
     autoload :ChainProviderError, 'bsv/network/chain_provider_error'
@@ -15,5 +14,46 @@ module BSV
     autoload :Specifier,          'bsv/network/specifier'
     autoload :WhatsOnChain,       'bsv/network/whats_on_chain'
     autoload :Providers,          'bsv/network/providers'
+
+    # Eagerly register all 11 standard commands so they are available
+    # as soon as BSV::Network is loaded, before any provider is instantiated.
+    require 'bsv/network/commands'
+
+    # Returns all registered network commands.
+    #
+    # @return [Hash{Symbol => Command}]
+    def self.commands
+      Command.all
+    end
+
+    # Returns a pre-configured Registry with both standard providers registered.
+    #
+    # WoC handles chain-data commands; ARC handles broadcast commands.
+    # Options allow the registry to be tailored without subclassing.
+    #
+    # @param network [Symbol] :main or :test — passed to WhatsOnChain
+    # @param arc_url [String] ARC base URL (defaults to GorillaPool ARCADE)
+    # @param woc_api_key [String, nil] optional WhatsOnChain API key
+    # @param arc_api_key [String, nil] optional ARC bearer token
+    # @return [Registry]
+    def self.default_registry(network: :main, arc_url: BSV::MAINNET_URL,
+                              woc_api_key: nil, arc_api_key: nil)
+      woc = Providers::WhatsOnChain.new(network: network, api_key: woc_api_key)
+      arc = Providers::ARC.new(url: arc_url, api_key: arc_api_key)
+
+      Registry.new
+              .register(woc)
+              .register(arc)
+    end
+
+    # Returns a capability matrix for a default registry instance.
+    #
+    # Delegates to {Registry#capability_matrix} on a fresh default registry.
+    # Useful for introspection and tooling.
+    #
+    # @return [Hash{Provider => Array<Symbol>}]
+    def self.capability_matrix
+      default_registry.capability_matrix
+    end
   end
 end

--- a/gem/bsv-sdk/lib/bsv/network/commands.rb
+++ b/gem/bsv-sdk/lib/bsv/network/commands.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module BSV
+  module Network
+    # Registers all standard BSV network commands.
+    #
+    # Commands are registered eagerly when this file is required. Each command
+    # describes a discrete network operation: its accepted parameters (as
+    # documentation metadata) and the shape of its return value.
+    #
+    # Providers implement these commands via +call_<name>+ instance methods.
+    # See {BSV::Network::Provider} for the dispatch mechanism.
+
+    Command.define(
+      :broadcast,
+      params: { tx: 'Transaction' },
+      returns: '{ txid: String, status: String, extra_info: Hash }',
+      description: 'Submit a single transaction to the network via ARC'
+    )
+
+    Command.define(
+      :broadcast_many,
+      params: { txs: 'Array<Transaction>' },
+      returns: 'Array<{ txid: String, status: String } | Error>',
+      description: 'Submit multiple transactions to the network via ARC in a single request'
+    )
+
+    Command.define(
+      :get_tx,
+      params: { txid: 'String' },
+      returns: 'String (raw hex)',
+      description: 'Fetch a raw transaction by its TXID'
+    )
+
+    Command.define(
+      :get_tx_status,
+      params: { txid: 'String' },
+      returns: '{ txid: String, tx_status: String, block_hash: String, block_height: Integer }',
+      description: 'Fetch the ARC broadcast status of a transaction'
+    )
+
+    Command.define(
+      :get_utxos,
+      params: { address: 'String' },
+      returns: 'Array<{ tx_hash: String, tx_pos: Integer, satoshis: Integer, height: Integer }>',
+      description: 'Fetch all unspent outputs for a given address'
+    )
+
+    Command.define(
+      :is_utxo,
+      params: { txid: 'String', vout: 'Integer', script_hash: 'String (optional)' },
+      returns: 'Boolean',
+      description: 'Check whether a given outpoint is unspent. ' \
+                   'Provide script_hash: for a single HTTP call; ' \
+                   'omit it to trigger a two-call fallback (fetch tx, compute hash, then check).'
+    )
+
+    Command.define(
+      :get_merkle_path,
+      params: { txid: 'String' },
+      returns: 'Hash (TSC proof components: { index:, tx_or_id:, target:, nodes: })',
+      description: 'Fetch the TSC Merkle proof for a confirmed transaction. ' \
+                   'Returns raw proof components — the caller must supply block_height ' \
+                   'when converting to a MerklePath object.'
+    )
+
+    Command.define(
+      :valid_root,
+      params: { root: 'String', height: 'Integer' },
+      returns: 'Boolean',
+      description: 'Verify that a Merkle root matches the block header at a given height'
+    )
+
+    Command.define(
+      :current_height,
+      params: {},
+      returns: 'Integer',
+      description: 'Return the current best-chain block height'
+    )
+
+    Command.define(
+      :get_script_unspent,
+      params: { script_hash: 'String' },
+      returns: 'Array<{ tx_hash: String, tx_pos: Integer, satoshis: Integer, height: Integer }>',
+      description: 'Fetch all unspent outputs for a given script hash (SHA-256 of locking script)'
+    )
+
+    Command.define(
+      :get_policy,
+      params: {},
+      returns: '{ policy: Hash }',
+      description: 'Fetch the current ARC miner policy (fee rates, script limits, etc.)'
+    )
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/network/provider.rb
+++ b/gem/bsv-sdk/lib/bsv/network/provider.rb
@@ -69,11 +69,16 @@ module BSV
 
       # Dispatch a command to the corresponding +call_<name>+ method.
       #
+      # Both positional and keyword arguments are forwarded so command
+      # implementations can use keyword-only options (e.g. +wait_for:+,
+      # +skip_fee_validation:+) without wrapper shims.
+      #
       # @param command_name [Symbol, String] the command to invoke
-      # @param args [Array] arguments forwarded to the handler method
+      # @param args [Array] positional arguments forwarded to the handler method
+      # @param kwargs [Hash] keyword arguments forwarded to the handler method
       # @return [Result::Success, Result::Error, Result::NotFound]
       # @raise [ArgumentError] when the command is not in {.capabilities}
-      def call(command_name, *args)
+      def call(command_name, *args, **kwargs)
         sym = command_name.to_sym
         unless self.class.capabilities.include?(sym)
           raise ArgumentError,
@@ -81,7 +86,11 @@ module BSV
                 "Provided: #{self.class.capabilities.to_a.sort.inspect}"
         end
 
-        send(:"call_#{sym}", *args)
+        if kwargs.empty?
+          send(:"call_#{sym}", *args)
+        else
+          send(:"call_#{sym}", *args, **kwargs)
+        end
       end
 
       private

--- a/gem/bsv-sdk/lib/bsv/network/providers.rb
+++ b/gem/bsv-sdk/lib/bsv/network/providers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module BSV
+  module Network
+    # Namespace for concrete {Provider} implementations.
+    #
+    # Each provider is registered here via +autoload+ so it is loaded on first
+    # reference without eagerly requiring all implementations at boot.
+    #
+    # @example Access a provider class
+    #   BSV::Network::Providers::WhatsOnChain
+    #   BSV::Network::Providers::ARC
+    module Providers
+      autoload :WhatsOnChain, 'bsv/network/providers/whats_on_chain'
+      autoload :ARC,          'bsv/network/providers/arc'
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/network/providers/arc.rb
+++ b/gem/bsv-sdk/lib/bsv/network/providers/arc.rb
@@ -1,0 +1,258 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+require 'uri'
+require 'securerandom'
+
+module BSV
+  module Network
+    module Providers
+      # ARC provider implementing broadcast, broadcast_many, get_tx_status, and get_policy
+      # using the Result-based return convention from {BSV::Network::Provider}.
+      #
+      # This is distinct from {BSV::Network::ARC}, which raises exceptions. This provider
+      # returns {BSV::Network::Result} objects so it can be composed with the Registry.
+      #
+      # @example
+      #   provider = BSV::Network::Providers::ARC.new(api_key: 'my-key')
+      #   result = provider.call(:broadcast, tx)
+      #   result.success? # => true
+      #   result.data     # => { txid: '...', status: '...', extra_info: nil }
+      class ARC < BSV::Network::Provider
+        provides :broadcast, :broadcast_many, :get_tx_status, :get_policy
+
+        # ARC response statuses that indicate the transaction was NOT accepted.
+        # Matches the behaviour of {BSV::Network::ARC::REJECTED_STATUSES}.
+        REJECTED_STATUSES = %w[
+          REJECTED
+          DOUBLE_SPEND_ATTEMPTED
+          INVALID
+          MALFORMED
+          MINED_IN_STALE_BLOCK
+        ].freeze
+
+        # Substring matched case-insensitively against txStatus and extraInfo.
+        ORPHAN_MARKER = 'ORPHAN'
+
+        # @param url [String] ARC base URL (without trailing slash);
+        #   defaults to {BSV::MAINNET_URL} (GorillaPool ARCADE endpoint)
+        # @param api_key [String, nil] optional bearer token for Authorization header
+        # @param deployment_id [String, nil] optional deployment identifier for
+        #   the +XDeployment-ID+ header; defaults to a per-instance random value
+        # @param callback_url [String, nil] optional +X-CallbackUrl+ for ARC status callbacks
+        # @param callback_token [String, nil] optional +X-CallbackToken+ for callback auth
+        # @param http_client [#request, nil] injectable HTTP client for testing
+        def initialize(url: BSV::MAINNET_URL, api_key: nil, deployment_id: nil,
+                       callback_url: nil, callback_token: nil, http_client: nil)
+          super(http_client: http_client)
+          @url = url.chomp('/')
+          @api_key = api_key
+          @deployment_id = deployment_id || "bsv-ruby-sdk-#{SecureRandom.hex(8)}"
+          @callback_url = callback_url
+          @callback_token = callback_token
+        end
+
+        private
+
+        # Submit a single transaction to ARC.
+        #
+        # Prefers Extended Format (BRC-30) hex when available; falls back to plain hex.
+        #
+        # @param tx [Transaction] the transaction to broadcast
+        # @param wait_for [String, nil] ARC wait condition
+        # @param skip_fee_validation [Boolean, nil] send +X-SkipFeeValidation: true+ header
+        # @param skip_script_validation [Boolean, nil] send +X-SkipScriptValidation: true+ header
+        # @return [Result::Success, Result::Error]
+        def call_broadcast(tx, wait_for: nil, skip_fee_validation: nil, skip_script_validation: nil)
+          uri = URI("#{@url}/v1/tx")
+          request = build_post_request(uri, wait_for: wait_for,
+                                            skip_fee_validation: skip_fee_validation,
+                                            skip_script_validation: skip_script_validation)
+          request.body = JSON.generate(rawTx: raw_tx_hex(tx))
+
+          response = execute(uri, request)
+          parse_single_broadcast_response(response)
+        end
+
+        # Submit multiple transactions to ARC in a single batch request.
+        #
+        # Returns a success wrapping an array; each element is either
+        # +{ txid:, status: }+ or a nested +Result::Error+ for rejected items.
+        #
+        # @param txs [Array<Transaction>] transactions to broadcast
+        # @param wait_for [String, nil] ARC wait condition
+        # @param skip_fee_validation [Boolean, nil] send +X-SkipFeeValidation: true+ header
+        # @param skip_script_validation [Boolean, nil] send +X-SkipScriptValidation: true+ header
+        # @return [Result::Success, Result::Error]
+        def call_broadcast_many(txs, wait_for: nil, skip_fee_validation: nil, skip_script_validation: nil)
+          return success([]) if txs.empty?
+
+          uri = URI("#{@url}/v1/txs")
+          request = build_post_request(uri, wait_for: wait_for,
+                                            skip_fee_validation: skip_fee_validation,
+                                            skip_script_validation: skip_script_validation)
+          request.body = JSON.generate(txs.map { |tx| { rawTx: raw_tx_hex(tx) } })
+
+          response = execute(uri, request)
+          parse_batch_response(response)
+        end
+
+        # Query the ARC broadcast status of a previously submitted transaction.
+        #
+        # @param txid [String] the transaction identifier
+        # @return [Result::Success, Result::NotFound, Result::Error]
+        def call_get_tx_status(txid)
+          uri = URI("#{@url}/v1/tx/#{txid}")
+          request = Net::HTTP::Get.new(uri)
+          request['XDeployment-ID'] = @deployment_id
+          apply_auth_header(request)
+
+          response = execute(uri, request)
+          code = response.code.to_i
+
+          return not_found if code == 404
+
+          body = parse_json(response.body)
+
+          unless (200..299).cover?(code)
+            msg = body['detail'] || body['title'] || "HTTP #{code}"
+            return error(msg, retryable: retryable_code?(code))
+          end
+
+          success(
+            txid: body['txid'],
+            tx_status: body['txStatus'],
+            block_hash: body['blockHash'],
+            block_height: body['blockHeight']
+          )
+        end
+
+        # Fetch the current ARC miner policy (fee rates, script limits, etc.).
+        #
+        # @return [Result::Success, Result::Error]
+        def call_get_policy
+          uri = URI("#{@url}/v1/policy")
+          request = Net::HTTP::Get.new(uri)
+          request['XDeployment-ID'] = @deployment_id
+          apply_auth_header(request)
+
+          response = execute(uri, request)
+          code = response.code.to_i
+          body = parse_json(response.body)
+
+          unless (200..299).cover?(code)
+            msg = body['detail'] || body['title'] || "HTTP #{code}"
+            return error(msg, retryable: retryable_code?(code))
+          end
+
+          success(policy: body['policy'])
+        end
+
+        # Prefer Extended Format (BRC-30) hex so ARC can validate sighashes without
+        # fetching parent transactions. Falls back to plain raw-tx hex when any input
+        # lacks source_satoshis / source_locking_script.
+        def raw_tx_hex(tx)
+          tx.to_ef_hex
+        rescue ArgumentError
+          tx.to_hex
+        end
+
+        def build_post_request(uri, wait_for: nil, skip_fee_validation: nil, skip_script_validation: nil)
+          request = Net::HTTP::Post.new(uri)
+          request['Content-Type'] = 'application/json'
+          request['XDeployment-ID'] = @deployment_id
+          request['X-WaitFor'] = wait_for if wait_for
+          request['X-CallbackUrl'] = @callback_url if @callback_url
+          request['X-CallbackToken'] = @callback_token if @callback_token
+          request['X-SkipFeeValidation'] = 'true' if skip_fee_validation
+          request['X-SkipScriptValidation'] = 'true' if skip_script_validation
+          apply_auth_header(request)
+          request
+        end
+
+        def apply_auth_header(request)
+          request['Authorization'] = "Bearer #{@api_key}" if @api_key
+        end
+
+        def execute(uri, request)
+          if @http_client
+            @http_client.request(uri, request)
+          else
+            Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+              http.request(request)
+            end
+          end
+        end
+
+        def parse_single_broadcast_response(response)
+          code = response.code.to_i
+          body = parse_json(response.body)
+
+          unless (200..299).cover?(code)
+            msg = body['detail'] || body['title'] || "HTTP #{code}"
+            return error(msg, retryable: retryable_code?(code))
+          end
+
+          if rejected_status?(body)
+            msg = body['detail'] || body['title'] || body['txStatus']
+            return error(msg, retryable: false)
+          end
+
+          return error('ARC returned a malformed 2xx response', retryable: false) unless body['txid']
+
+          success(
+            txid: body['txid'],
+            status: body['txStatus'],
+            extra_info: body['extraInfo']
+          )
+        end
+
+        def parse_batch_response(response)
+          code = response.code.to_i
+          body = parse_json(response.body)
+
+          unless (200..299).cover?(code)
+            msg = body['detail'] || body['title'] || "HTTP #{code}"
+            return error(msg, retryable: retryable_code?(code))
+          end
+
+          return error('ARC returned a malformed batch response', retryable: false) unless body.is_a?(Array)
+
+          items = body.map { |item| build_batch_item(item) }
+          success(items)
+        end
+
+        def build_batch_item(item)
+          if rejected_status?(item)
+            msg = item['detail'] || item['title'] || item['txStatus']
+            error(msg, retryable: false)
+          elsif !item['txid']
+            error('ARC returned a malformed 2xx response', retryable: false)
+          else
+            { txid: item['txid'], status: item['txStatus'] }
+          end
+        end
+
+        def rejected_status?(body)
+          tx_status = body['txStatus'].to_s.upcase
+          return true if REJECTED_STATUSES.include?(tx_status)
+          return true if tx_status.include?(ORPHAN_MARKER)
+
+          extra_info = body['extraInfo'].to_s.upcase
+          extra_info.include?(ORPHAN_MARKER)
+        end
+
+        def parse_json(raw)
+          JSON.parse(raw)
+        rescue JSON::ParserError
+          { 'detail' => raw }
+        end
+
+        def retryable_code?(code)
+          code == 429 || code >= 500
+        end
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/network/providers/whats_on_chain.rb
+++ b/gem/bsv-sdk/lib/bsv/network/providers/whats_on_chain.rb
@@ -2,6 +2,7 @@
 
 require 'net/http'
 require 'json'
+require 'openssl'
 require 'uri'
 
 module BSV
@@ -17,7 +18,8 @@ module BSV
       #   result = provider.call(:get_tx, 'abc123...')
       #   result.data if result.success?
       class WhatsOnChain < Provider
-        provides :get_tx, :get_utxos, :current_height, :valid_root
+        provides :get_tx, :get_utxos, :current_height, :valid_root,
+                 :is_utxo, :get_merkle_path, :get_script_unspent
 
         BASE_URL = 'https://api.whatsonchain.com'
 
@@ -109,7 +111,111 @@ module BSV
           success(merkle_root.downcase == root.downcase)
         end
 
+        # Check whether a given outpoint is currently unspent.
+        #
+        # If +script_hash:+ is provided the check requires a single HTTP call.
+        # If omitted, the transaction is fetched first, the locking script at
+        # +vout+ is extracted, its SHA-256 hash is computed, and then the
+        # unspent endpoint is queried — two HTTP calls total.
+        #
+        # @param txid [String] transaction ID (hex)
+        # @param vout [Integer] output index
+        # @param script_hash [String, nil] SHA-256 of locking script (LE hex), optional
+        # @return [Result::Success<Boolean>, Result::NotFound, Result::Error]
+        def call_is_utxo(txid, vout, script_hash: nil)
+          if script_hash.nil?
+            result = compute_script_hash(txid, vout)
+            return result unless result.is_a?(String)
+
+            script_hash = result
+          end
+
+          check_utxo_in_unspent(txid, vout, script_hash)
+        end
+
+        # Fetch the TSC Merkle proof for a confirmed transaction.
+        #
+        # Returns raw proof components — caller must supply the block height
+        # when converting to a {BSV::Transaction::MerklePath} object.
+        #
+        # @param txid [String] transaction ID (hex)
+        # @return [Result::Success<Hash>, Result::NotFound, Result::Error]
+        def call_get_merkle_path(txid)
+          response = get("/v1/bsv/#{@network}/tx/#{txid}/proof/tsc")
+          return response if response.is_a?(Result::Error) || response.is_a?(Result::NotFound)
+
+          body = parse_json(response.body)
+          return body if body.is_a?(Result::Error)
+
+          # WoC returns null for unconfirmed transactions
+          return not_found if body.nil?
+
+          # WoC returns an array; take the first element (canonical proof)
+          proof = body.is_a?(Array) ? body.first : body
+          return not_found if proof.nil?
+
+          success(
+            index: proof['index'],
+            tx_or_id: proof['txOrId'],
+            target: proof['target'],
+            nodes: proof['nodes']
+          )
+        end
+
+        # Fetch all unspent outputs for a given script hash.
+        #
+        # @param script_hash [String] SHA-256 of locking script (LE hex)
+        # @return [Result::Success<Array>, Result::Error]
+        def call_get_script_unspent(script_hash)
+          response = get("/v1/bsv/#{@network}/script/#{script_hash}/unspent", not_found_returns_empty: true)
+          return response if response.is_a?(Result::Success) || response.is_a?(Result::Error)
+
+          body = parse_json(response.body)
+          return body if body.is_a?(Result::Error)
+
+          utxos = body.map do |entry|
+            {
+              tx_hash: entry['tx_hash'],
+              tx_pos: entry['tx_pos'],
+              satoshis: entry['value'],
+              height: entry['height']
+            }
+          end
+
+          success(utxos)
+        end
+
         private
+
+        # Fetch a transaction, extract the output at +vout+, and compute its script hash.
+        #
+        # @return [String] the script hash on success, or a {Result} on failure
+        def compute_script_hash(txid, vout)
+          result = call_get_tx(txid)
+          return result unless result.success?
+
+          tx = BSV::Transaction::Transaction.from_hex(result.data)
+          output = tx.outputs[vout]
+          return error("vout #{vout} out of range (tx has #{tx.outputs.length} outputs)", retryable: false) if output.nil?
+
+          script_bytes = output.locking_script.to_binary
+          digest = OpenSSL::Digest::SHA256.digest(script_bytes)
+          # Script hash is SHA-256 of the script in little-endian (reversed byte order)
+          digest.reverse.unpack1('H*')
+        rescue StandardError => e
+          error("failed to parse transaction: #{e.message}", retryable: false)
+        end
+
+        # Query the script unspent endpoint and check for the given outpoint.
+        #
+        # @return [Result::Success<Boolean>, Result::Error]
+        def check_utxo_in_unspent(txid, vout, script_hash)
+          result = call_get_script_unspent(script_hash)
+          return result unless result.success?
+
+          found = result.data.any? { |u| u[:tx_hash] == txid && u[:tx_pos] == vout }
+          success(found)
+        end
 
         # Perform a GET request to the given path.
         #

--- a/gem/bsv-sdk/lib/bsv/network/providers/whats_on_chain.rb
+++ b/gem/bsv-sdk/lib/bsv/network/providers/whats_on_chain.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+require 'uri'
+
+module BSV
+  module Network
+    module Providers
+      # WhatsOnChain provider implementing core BSV network commands.
+      #
+      # Implements {BSV::Network::Provider} for the WhatsOnChain API, covering
+      # transaction lookup, UTXO fetching, chain height, and Merkle root validation.
+      #
+      # @example
+      #   provider = BSV::Network::Providers::WhatsOnChain.new(network: :main)
+      #   result = provider.call(:get_tx, 'abc123...')
+      #   result.data if result.success?
+      class WhatsOnChain < Provider
+        provides :get_tx, :get_utxos, :current_height, :valid_root
+
+        BASE_URL = 'https://api.whatsonchain.com'
+
+        NETWORKS = {
+          main: 'main',
+          mainnet: 'main',
+          test: 'test',
+          testnet: 'test',
+          stn: 'stn'
+        }.freeze
+
+        # @param network [Symbol] :main, :mainnet, :test, :testnet, or :stn
+        # @param api_key [String, nil] optional WoC API key sent in Authorization header
+        # @param http_client [#request, nil] injectable HTTP client for testing
+        def initialize(network: :main, api_key: nil, http_client: nil)
+          super(http_client: http_client)
+          @network = NETWORKS.fetch(network) { raise ArgumentError, "unknown network: #{network}" }
+          @api_key = api_key
+        end
+
+        # Fetch a raw transaction by TXID.
+        #
+        # @param txid [String] transaction ID (hex)
+        # @return [Result::Success<String>, Result::NotFound, Result::Error]
+        def call_get_tx(txid)
+          response = get("/v1/bsv/#{@network}/tx/#{txid}/hex")
+          return response if response.is_a?(Result::Error) || response.is_a?(Result::NotFound)
+
+          success(response.body.strip)
+        end
+
+        # Fetch all unspent outputs for an address.
+        #
+        # @param address [String] BSV address
+        # @return [Result::Success<Array>, Result::Error]
+        def call_get_utxos(address)
+          response = get("/v1/bsv/#{@network}/address/#{address}/unspent", not_found_returns_empty: true)
+          return response if response.is_a?(Result::Success) || response.is_a?(Result::Error)
+
+          body = parse_json(response.body)
+          return body if body.is_a?(Result::Error)
+
+          utxos = body.map do |entry|
+            {
+              tx_hash: entry['tx_hash'],
+              tx_pos: entry['tx_pos'],
+              satoshis: entry['value'],
+              height: entry['height']
+            }
+          end
+
+          success(utxos)
+        end
+
+        # Return the current best-chain block height.
+        #
+        # @return [Result::Success<Integer>, Result::Error]
+        def call_current_height
+          response = get("/v1/bsv/#{@network}/chain/info", not_found_returns_empty: false)
+          return response if response.is_a?(Result::Error)
+
+          body = parse_json(response.body)
+          return body if body.is_a?(Result::Error)
+
+          height = body['blocks']
+          return error('chain/info response missing "blocks" field', retryable: false) if height.nil?
+
+          success(height)
+        end
+
+        # Verify that a Merkle root matches the block header at a given height.
+        #
+        # Performs a case-insensitive comparison against the merkleroot field
+        # returned by the WoC block header endpoint.
+        #
+        # @param root [String] Merkle root as a hex string
+        # @param height [Integer] block height
+        # @return [Result::Success<Boolean>, Result::NotFound, Result::Error]
+        def call_valid_root(root, height)
+          response = get("/v1/bsv/#{@network}/block/#{height}/header")
+          return response if response.is_a?(Result::Error) || response.is_a?(Result::NotFound)
+
+          body = parse_json(response.body)
+          return body if body.is_a?(Result::Error)
+
+          merkle_root = body['merkleroot']
+          return error('block header response missing "merkleroot" field', retryable: false) if merkle_root.nil?
+
+          success(merkle_root.downcase == root.downcase)
+        end
+
+        private
+
+        # Perform a GET request to the given path.
+        #
+        # @param path [String] API path (including leading slash)
+        # @param not_found_returns_empty [Boolean, nil]
+        #   - true  → 404 returns success([])
+        #   - false → 404 returns error
+        #   - nil   → 404 returns not_found (default)
+        # @return [Net::HTTPResponse, Result::Success, Result::NotFound, Result::Error]
+        def get(path, not_found_returns_empty: nil)
+          uri = URI("#{BASE_URL}#{path}")
+          request = Net::HTTP::Get.new(uri)
+          request['Authorization'] = @api_key if @api_key
+
+          response = execute(uri, request)
+          code = response.code.to_i
+
+          case code
+          when 200..299
+            response
+          when 404
+            handle_not_found(not_found_returns_empty)
+          when 429, 500..599
+            error("HTTP #{code}: #{response.body&.strip}", retryable: true)
+          else
+            error("HTTP #{code}: #{response.body&.strip}", retryable: false)
+          end
+        end
+
+        def handle_not_found(not_found_returns_empty)
+          case not_found_returns_empty
+          when true
+            success([])
+          when false
+            error('HTTP 404: not found', retryable: false)
+          else
+            not_found
+          end
+        end
+
+        def execute(uri, request)
+          if @http_client
+            @http_client.request(uri, request)
+          else
+            Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+              http.request(request)
+            end
+          end
+        end
+
+        def parse_json(body)
+          JSON.parse(body)
+        rescue JSON::ParserError => e
+          error("JSON parse error: #{e.message}", retryable: false)
+        end
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/network/command_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/command_spec.rb
@@ -2,7 +2,11 @@
 
 RSpec.describe BSV::Network::Command do
   before { described_class.reset! }
-  after  { described_class.reset!; load 'bsv/network/commands.rb' }
+
+  after do
+    described_class.reset!
+    load 'bsv/network/commands.rb'
+  end
 
   let(:name)        { :broadcast }
   let(:params)      { { tx: 'Transaction' } }

--- a/gem/bsv-sdk/spec/bsv/network/command_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/command_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe BSV::Network::Command do
   before { described_class.reset! }
-  after  { described_class.reset! }
+  after  { described_class.reset!; load 'bsv/network/commands.rb' }
 
   let(:name)        { :broadcast }
   let(:params)      { { tx: 'Transaction' } }

--- a/gem/bsv-sdk/spec/bsv/network/commands_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/commands_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+# Eagerly load Commands so the registry is populated before each example.
+require 'bsv/network/commands'
+
+ALL_COMMAND_NAMES = %i[
+  broadcast
+  broadcast_many
+  get_tx
+  get_tx_status
+  get_utxos
+  is_utxo
+  get_merkle_path
+  valid_root
+  current_height
+  get_script_unspent
+  get_policy
+].freeze
+
+RSpec.describe 'BSV::Network::Commands' do
+  # Use a real but isolated registry by NOT calling reset! — Commands are
+  # registered at load time (module-eval), so they are already present.
+  # We must NOT reset! between examples or the define calls won't rerun.
+
+  describe 'command registration' do
+    it 'registers exactly 11 commands' do
+      count = ALL_COMMAND_NAMES.count { |name| BSV::Network::Command.find(name) }
+      expect(count).to eq(11)
+    end
+
+    ALL_COMMAND_NAMES.each do |name|
+      it "registers :#{name}" do
+        expect(BSV::Network::Command.find(name)).to be_a(BSV::Network::Command)
+      end
+    end
+  end
+
+  describe 'command metadata' do
+    subject(:cmd) { BSV::Network::Command.find(command_name) }
+
+    context ':broadcast' do
+      let(:command_name) { :broadcast }
+
+      it { is_expected.not_to be_nil }
+      it('has a description') { expect(cmd.description).not_to be_empty }
+      it('includes tx param') { expect(cmd.params).to have_key(:tx) }
+      it('returns shape includes txid') { expect(cmd.returns).to include('txid') }
+    end
+
+    context ':broadcast_many' do
+      let(:command_name) { :broadcast_many }
+
+      it { is_expected.not_to be_nil }
+      it('has a description') { expect(cmd.description).not_to be_empty }
+      it('includes txs param') { expect(cmd.params).to have_key(:txs) }
+    end
+
+    context ':get_tx' do
+      let(:command_name) { :get_tx }
+
+      it { is_expected.not_to be_nil }
+      it('includes txid param') { expect(cmd.params).to have_key(:txid) }
+      it('returns raw hex') { expect(cmd.returns).to include('hex') }
+    end
+
+    context ':get_tx_status' do
+      let(:command_name) { :get_tx_status }
+
+      it { is_expected.not_to be_nil }
+      it('includes txid param') { expect(cmd.params).to have_key(:txid) }
+      it('returns includes tx_status') { expect(cmd.returns).to include('tx_status') }
+    end
+
+    context ':get_utxos' do
+      let(:command_name) { :get_utxos }
+
+      it { is_expected.not_to be_nil }
+      it('includes address param') { expect(cmd.params).to have_key(:address) }
+      it('returns an array') { expect(cmd.returns).to include('Array') }
+    end
+
+    context ':is_utxo' do
+      let(:command_name) { :is_utxo }
+
+      it { is_expected.not_to be_nil }
+      it('includes txid param') { expect(cmd.params).to have_key(:txid) }
+      it('includes vout param') { expect(cmd.params).to have_key(:vout) }
+      it('includes optional script_hash param') { expect(cmd.params).to have_key(:script_hash) }
+      it('marks script_hash as optional') { expect(cmd.params[:script_hash]).to include('optional') }
+      it('returns Boolean') { expect(cmd.returns).to eq('Boolean') }
+    end
+
+    context ':get_merkle_path' do
+      let(:command_name) { :get_merkle_path }
+
+      it { is_expected.not_to be_nil }
+      it('includes txid param') { expect(cmd.params).to have_key(:txid) }
+      it('returns TSC proof components') { expect(cmd.returns).to include('TSC') }
+      it('mentions index in return description') { expect(cmd.returns).to include('index') }
+    end
+
+    context ':valid_root' do
+      let(:command_name) { :valid_root }
+
+      it { is_expected.not_to be_nil }
+      it('includes root param') { expect(cmd.params).to have_key(:root) }
+      it('includes height param') { expect(cmd.params).to have_key(:height) }
+      it('returns Boolean') { expect(cmd.returns).to eq('Boolean') }
+    end
+
+    context ':current_height' do
+      let(:command_name) { :current_height }
+
+      it { is_expected.not_to be_nil }
+      it('accepts no params') { expect(cmd.params).to be_empty }
+      it('returns Integer') { expect(cmd.returns).to eq('Integer') }
+    end
+
+    context ':get_script_unspent' do
+      let(:command_name) { :get_script_unspent }
+
+      it { is_expected.not_to be_nil }
+      it('includes script_hash param') { expect(cmd.params).to have_key(:script_hash) }
+      it('returns an array') { expect(cmd.returns).to include('Array') }
+    end
+
+    context ':get_policy' do
+      let(:command_name) { :get_policy }
+
+      it { is_expected.not_to be_nil }
+      it('accepts no params') { expect(cmd.params).to be_empty }
+      it('returns policy hash') { expect(cmd.returns).to include('policy') }
+    end
+  end
+
+  describe 'idempotent loading' do
+    it 'does not raise when the file is required a second time' do
+      expect { require 'bsv/network/commands' }.not_to raise_error
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/network/providers/arc_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/providers/arc_spec.rb
@@ -1,0 +1,628 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe BSV::Network::Providers::ARC do
+  # Minimal HTTP client stub — stores the last request and returns a configurable response.
+  let(:mock_http) do
+    Class.new do
+      attr_reader :last_uri, :last_request
+
+      def initialize(code, body)
+        @code = code
+        @body = body
+      end
+
+      def request(uri, req)
+        @last_uri = uri
+        @last_request = req
+        Struct.new(:code, :body).new(@code.to_s, @body)
+      end
+    end
+  end
+
+  # Transaction double with EF hex support.
+  let(:tx) do
+    instance_double(
+      BSV::Transaction::Transaction,
+      to_ef_hex: '010000000000ef0000',
+      to_hex: '01000000'
+    )
+  end
+
+  # Transaction double that cannot produce EF form.
+  let(:tx_no_source) do
+    dbl = instance_double(BSV::Transaction::Transaction, to_hex: '01000000')
+    allow(dbl).to receive(:to_ef_hex).and_raise(ArgumentError, 'inputs must have source_satoshis for EF')
+    dbl
+  end
+
+  let(:tx2) do
+    instance_double(
+      BSV::Transaction::Transaction,
+      to_ef_hex: '020000000000ef0000',
+      to_hex: '02000000'
+    )
+  end
+
+  let(:success_body) do
+    {
+      'txid' => 'abc123',
+      'txStatus' => 'SEEN_ON_NETWORK',
+      'title' => 'Added to mempool',
+      'extraInfo' => '',
+      'blockHash' => '',
+      'blockHeight' => 0,
+      'timestamp' => '2025-01-01T00:00:00Z'
+    }.to_json
+  end
+
+  def new_arc(**opts)
+    http = opts.delete(:http_client)
+    described_class.new(url: 'https://arc.example.com', http_client: http, **opts)
+  end
+
+  # ---------------------------------------------------------------------------
+  # :broadcast
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:broadcast)' do
+    it 'returns a success result with txid, status, and extra_info' do
+      http = mock_http.new(200, success_body)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:broadcast, tx)
+
+      expect(result).to be_success
+      expect(result.data[:txid]).to eq('abc123')
+      expect(result.data[:status]).to eq('SEEN_ON_NETWORK')
+      expect(result.data[:extra_info]).to eq('')
+    end
+
+    it 'sends JSON body with Extended Format hex' do
+      http = mock_http.new(200, success_body)
+      arc = new_arc(http_client: http)
+
+      arc.call(:broadcast, tx)
+
+      expect(http.last_request['Content-Type']).to eq('application/json')
+      body = JSON.parse(http.last_request.body)
+      expect(body).to eq('rawTx' => '010000000000ef0000')
+    end
+
+    it 'falls back to plain hex when EF encoding is unavailable' do
+      http = mock_http.new(200, success_body)
+      arc = new_arc(http_client: http)
+
+      arc.call(:broadcast, tx_no_source)
+
+      body = JSON.parse(http.last_request.body)
+      expect(body).to eq('rawTx' => '01000000')
+    end
+
+    it 'posts to /v1/tx' do
+      http = mock_http.new(200, success_body)
+      arc = new_arc(http_client: http)
+
+      arc.call(:broadcast, tx)
+
+      expect(http.last_uri.to_s).to eq('https://arc.example.com/v1/tx')
+    end
+
+    it 'sets the XDeployment-ID header with a default random value' do
+      http = mock_http.new(200, success_body)
+      arc = new_arc(http_client: http)
+
+      arc.call(:broadcast, tx)
+
+      expect(http.last_request['XDeployment-ID']).to start_with('bsv-ruby-sdk-')
+    end
+
+    it 'uses an explicit deployment_id when configured' do
+      http = mock_http.new(200, success_body)
+      arc = new_arc(deployment_id: 'my-deployment', http_client: http)
+
+      arc.call(:broadcast, tx)
+
+      expect(http.last_request['XDeployment-ID']).to eq('my-deployment')
+    end
+
+    it 'sets X-WaitFor header when wait_for: is provided' do
+      http = mock_http.new(200, success_body)
+      arc = new_arc(http_client: http)
+
+      arc.call(:broadcast, tx, wait_for: 'SEEN_ON_NETWORK')
+
+      expect(http.last_request['X-WaitFor']).to eq('SEEN_ON_NETWORK')
+    end
+
+    it 'sets X-SkipFeeValidation header when skip_fee_validation: true' do
+      http = mock_http.new(200, success_body)
+      arc = new_arc(http_client: http)
+
+      arc.call(:broadcast, tx, skip_fee_validation: true)
+
+      expect(http.last_request['X-SkipFeeValidation']).to eq('true')
+    end
+
+    it 'sets X-SkipScriptValidation header when skip_script_validation: true' do
+      http = mock_http.new(200, success_body)
+      arc = new_arc(http_client: http)
+
+      arc.call(:broadcast, tx, skip_script_validation: true)
+
+      expect(http.last_request['X-SkipScriptValidation']).to eq('true')
+    end
+
+    it 'omits skip-validation headers when not set' do
+      http = mock_http.new(200, success_body)
+      arc = new_arc(http_client: http)
+
+      arc.call(:broadcast, tx)
+
+      expect(http.last_request['X-SkipFeeValidation']).to be_nil
+      expect(http.last_request['X-SkipScriptValidation']).to be_nil
+    end
+
+    it 'returns a non-retryable error when txStatus is REJECTED' do
+      body = { 'txid' => 'abc123', 'txStatus' => 'REJECTED', 'title' => 'Transaction rejected' }.to_json
+      http = mock_http.new(200, body)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:broadcast, tx)
+
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+      expect(result.message).to eq('Transaction rejected')
+    end
+
+    it 'returns a non-retryable error when txStatus is DOUBLE_SPEND_ATTEMPTED' do
+      body = { 'txid' => 'abc123', 'txStatus' => 'DOUBLE_SPEND_ATTEMPTED', 'title' => 'Double spend' }.to_json
+      http = mock_http.new(200, body)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:broadcast, tx)
+
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+    end
+
+    %w[INVALID MALFORMED MINED_IN_STALE_BLOCK].each do |status|
+      it "returns a non-retryable error when txStatus is #{status}" do
+        body = { 'txid' => 'abc123', 'txStatus' => status, 'title' => status }.to_json
+        http = mock_http.new(200, body)
+        arc = new_arc(http_client: http)
+
+        result = arc.call(:broadcast, tx)
+
+        expect(result).to be_error
+        expect(result.retryable?).to be false
+      end
+    end
+
+    it 'returns a non-retryable error when txStatus contains ORPHAN' do
+      body = { 'txid' => 'abc123', 'txStatus' => 'ORPHAN_MISSING_PARENT', 'title' => 'Orphan' }.to_json
+      http = mock_http.new(200, body)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:broadcast, tx)
+
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+    end
+
+    it 'returns a non-retryable error when extraInfo contains orphan marker' do
+      body = { 'txid' => 'abc123', 'txStatus' => 'SEEN_ON_NETWORK', 'extraInfo' => 'transaction is an ORPHAN' }.to_json
+      http = mock_http.new(200, body)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:broadcast, tx)
+
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+    end
+
+    it 'returns a retryable error on HTTP 500' do
+      body = { 'title' => 'Internal error', 'detail' => 'server fault' }.to_json
+      http = mock_http.new(500, body)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:broadcast, tx)
+
+      expect(result).to be_error
+      expect(result.retryable?).to be true
+      expect(result.message).to eq('server fault')
+    end
+
+    it 'returns a retryable error on HTTP 429' do
+      body = { 'detail' => 'rate limited' }.to_json
+      http = mock_http.new(429, body)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:broadcast, tx)
+
+      expect(result).to be_error
+      expect(result.retryable?).to be true
+    end
+
+    it 'returns a non-retryable error on HTTP 400' do
+      body = { 'detail' => 'malformed tx' }.to_json
+      http = mock_http.new(400, body)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:broadcast, tx)
+
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+      expect(result.message).to eq('malformed tx')
+    end
+
+    it 'returns a non-retryable error for 2xx response missing txid' do
+      body = { 'txStatus' => 'SEEN_ON_NETWORK' }.to_json
+      http = mock_http.new(200, body)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:broadcast, tx)
+
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+      expect(result.message).to match(/malformed/)
+    end
+
+    it 'returns a non-retryable error for non-JSON 2xx response' do
+      http = mock_http.new(200, 'plain text from proxy')
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:broadcast, tx)
+
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # :broadcast_many
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:broadcast_many)' do
+    let(:batch_success) do
+      [JSON.parse(success_body), JSON.parse(success_body).merge('txid' => 'def456')].to_json
+    end
+
+    it 'returns success wrapping an array of results' do
+      http = mock_http.new(200, batch_success)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:broadcast_many, [tx, tx2])
+
+      expect(result).to be_success
+      expect(result.data.length).to eq(2)
+      expect(result.data[0][:txid]).to eq('abc123')
+      expect(result.data[1][:txid]).to eq('def456')
+    end
+
+    it 'posts to /v1/txs with a JSON array body' do
+      http = mock_http.new(200, batch_success)
+      arc = new_arc(http_client: http)
+
+      arc.call(:broadcast_many, [tx, tx2])
+
+      expect(http.last_uri.to_s).to eq('https://arc.example.com/v1/txs')
+      body = JSON.parse(http.last_request.body)
+      expect(body).to eq([{ 'rawTx' => '010000000000ef0000' }, { 'rawTx' => '020000000000ef0000' }])
+    end
+
+    it 'returns success([]) without an HTTP request when given an empty array' do
+      http = mock_http.new(200, '[]')
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:broadcast_many, [])
+
+      expect(result).to be_success
+      expect(result.data).to eq([])
+      expect(http.last_request).to be_nil
+    end
+
+    it 'returns a mixed array when some transactions are rejected' do
+      rejected = {
+        'txid' => 'def456',
+        'txStatus' => 'REJECTED',
+        'title' => 'Transaction rejected',
+        'detail' => 'inputs already spent'
+      }
+      batch = [JSON.parse(success_body), rejected].to_json
+      http = mock_http.new(200, batch)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:broadcast_many, [tx, tx2])
+
+      expect(result).to be_success
+      items = result.data
+      expect(items[0][:txid]).to eq('abc123')
+      expect(items[1]).to be_a(BSV::Network::Result::Error)
+      expect(items[1].message).to eq('inputs already spent')
+      expect(items[1].retryable?).to be false
+    end
+
+    it 'returns error items for batch entries missing txid' do
+      body = [{ 'txStatus' => 'SEEN_ON_NETWORK' }].to_json
+      http = mock_http.new(200, body)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:broadcast_many, [tx])
+
+      expect(result).to be_success
+      expect(result.data[0]).to be_a(BSV::Network::Result::Error)
+      expect(result.data[0].message).to match(/malformed/)
+    end
+
+    it 'uses EF hex for each transaction when available' do
+      http = mock_http.new(200, [JSON.parse(success_body)].to_json)
+      arc = new_arc(http_client: http)
+
+      arc.call(:broadcast_many, [tx])
+
+      body = JSON.parse(http.last_request.body)
+      expect(body[0]['rawTx']).to eq('010000000000ef0000')
+    end
+
+    it 'falls back to plain hex per transaction when EF is unavailable' do
+      batch = [JSON.parse(success_body), JSON.parse(success_body).merge('txid' => 'def456')].to_json
+      http = mock_http.new(200, batch)
+      arc = new_arc(http_client: http)
+
+      arc.call(:broadcast_many, [tx_no_source, tx2])
+
+      body = JSON.parse(http.last_request.body)
+      expect(body[0]['rawTx']).to eq('01000000')
+      expect(body[1]['rawTx']).to eq('020000000000ef0000')
+    end
+
+    it 'returns a retryable error on HTTP 500' do
+      body = { 'detail' => 'server fault' }.to_json
+      http = mock_http.new(500, body)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:broadcast_many, [tx])
+
+      expect(result).to be_error
+      expect(result.retryable?).to be true
+    end
+
+    it 'returns a non-retryable error when ARC returns a non-array 2xx body' do
+      http = mock_http.new(200, success_body)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:broadcast_many, [tx])
+
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+      expect(result.message).to match(/malformed batch/)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # :get_tx_status
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_tx_status)' do
+    it 'returns success with txid, tx_status, block_hash, block_height' do
+      body = {
+        'txid' => 'abc123',
+        'txStatus' => 'MINED',
+        'blockHash' => '000000abc',
+        'blockHeight' => 800_000
+      }.to_json
+      http = mock_http.new(200, body)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:get_tx_status, 'abc123')
+
+      expect(result).to be_success
+      expect(result.data[:txid]).to eq('abc123')
+      expect(result.data[:tx_status]).to eq('MINED')
+      expect(result.data[:block_hash]).to eq('000000abc')
+      expect(result.data[:block_height]).to eq(800_000)
+    end
+
+    it 'sends GET to /v1/tx/{txid}' do
+      body = { 'txid' => 'abc123', 'txStatus' => 'SEEN_ON_NETWORK' }.to_json
+      http = mock_http.new(200, body)
+      arc = new_arc(http_client: http)
+
+      arc.call(:get_tx_status, 'abc123')
+
+      expect(http.last_uri.to_s).to eq('https://arc.example.com/v1/tx/abc123')
+      expect(http.last_request).to be_a(Net::HTTP::Get)
+    end
+
+    it 'returns not_found on HTTP 404' do
+      http = mock_http.new(404, { 'detail' => 'not found' }.to_json)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:get_tx_status, 'unknown')
+
+      expect(result).to be_not_found
+    end
+
+    it 'returns a retryable error on HTTP 500' do
+      body = { 'detail' => 'server error' }.to_json
+      http = mock_http.new(500, body)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:get_tx_status, 'abc123')
+
+      expect(result).to be_error
+      expect(result.retryable?).to be true
+    end
+
+    it 'returns a non-retryable error on HTTP 400' do
+      body = { 'detail' => 'bad request' }.to_json
+      http = mock_http.new(400, body)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:get_tx_status, 'abc123')
+
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # :get_policy
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_policy)' do
+    let(:policy_body) do
+      {
+        'policy' => {
+          'miningFee' => { 'bytes' => 1000, 'satoshis' => 1 },
+          'maxScriptSizePolicy' => 100_000
+        }
+      }.to_json
+    end
+
+    it 'returns success wrapping the policy hash' do
+      http = mock_http.new(200, policy_body)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:get_policy)
+
+      expect(result).to be_success
+      expect(result.data[:policy]).to be_a(Hash)
+      expect(result.data[:policy]['miningFee']).to eq('bytes' => 1000, 'satoshis' => 1)
+    end
+
+    it 'sends GET to /v1/policy' do
+      http = mock_http.new(200, policy_body)
+      arc = new_arc(http_client: http)
+
+      arc.call(:get_policy)
+
+      expect(http.last_uri.to_s).to eq('https://arc.example.com/v1/policy')
+      expect(http.last_request).to be_a(Net::HTTP::Get)
+    end
+
+    it 'returns a retryable error on HTTP 500' do
+      http = mock_http.new(500, { 'detail' => 'server error' }.to_json)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:get_policy)
+
+      expect(result).to be_error
+      expect(result.retryable?).to be true
+    end
+
+    it 'returns a non-retryable error on HTTP 400' do
+      http = mock_http.new(400, { 'detail' => 'bad request' }.to_json)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:get_policy)
+
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+    end
+
+    it 'tolerates non-standard policy shapes from ARC implementations' do
+      body = { 'policy' => { 'custom_field' => 42 } }.to_json
+      http = mock_http.new(200, body)
+      arc = new_arc(http_client: http)
+
+      result = arc.call(:get_policy)
+
+      expect(result).to be_success
+      expect(result.data[:policy]).to eq('custom_field' => 42)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Authentication and header wiring
+  # ---------------------------------------------------------------------------
+
+  describe 'authentication and headers' do
+    it 'sets Authorization header when api_key is provided' do
+      http = mock_http.new(200, success_body)
+      arc = new_arc(api_key: 'my-key', http_client: http)
+
+      arc.call(:broadcast, tx)
+
+      expect(http.last_request['Authorization']).to eq('Bearer my-key')
+    end
+
+    it 'omits Authorization header when api_key is nil' do
+      http = mock_http.new(200, success_body)
+      arc = new_arc(http_client: http)
+
+      arc.call(:broadcast, tx)
+
+      expect(http.last_request['Authorization']).to be_nil
+    end
+
+    it 'sets X-CallbackUrl and X-CallbackToken when configured' do
+      http = mock_http.new(200, success_body)
+      arc = new_arc(
+        callback_url: 'https://example.com/cb',
+        callback_token: 'secret',
+        http_client: http
+      )
+
+      arc.call(:broadcast, tx)
+
+      expect(http.last_request['X-CallbackUrl']).to eq('https://example.com/cb')
+      expect(http.last_request['X-CallbackToken']).to eq('secret')
+    end
+
+    it 'omits callback headers when not configured' do
+      http = mock_http.new(200, success_body)
+      arc = new_arc(http_client: http)
+
+      arc.call(:broadcast, tx)
+
+      expect(http.last_request['X-CallbackUrl']).to be_nil
+      expect(http.last_request['X-CallbackToken']).to be_nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # URL configuration
+  # ---------------------------------------------------------------------------
+
+  describe 'URL configuration' do
+    it 'uses BSV::MAINNET_URL as the default base URL' do
+      arc = described_class.new
+      expect(arc.instance_variable_get(:@url)).to eq(BSV::MAINNET_URL.chomp('/'))
+    end
+
+    it 'accepts a custom base URL' do
+      http = mock_http.new(200, success_body)
+      arc = described_class.new(url: 'https://custom-arc.example.com', http_client: http)
+
+      arc.call(:broadcast, tx)
+
+      expect(http.last_uri.host).to eq('custom-arc.example.com')
+    end
+
+    it 'strips trailing slash from the base URL' do
+      http = mock_http.new(200, success_body)
+      arc = described_class.new(url: 'https://arc.example.com/', http_client: http)
+
+      arc.call(:broadcast, tx)
+
+      expect(http.last_uri.to_s).to eq('https://arc.example.com/v1/tx')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Capabilities
+  # ---------------------------------------------------------------------------
+
+  describe '.capabilities' do
+    it 'declares all four required commands' do
+      expect(described_class.capabilities).to include(:broadcast, :broadcast_many, :get_tx_status, :get_policy)
+    end
+
+    it 'inherits from BSV::Network::Provider' do
+      expect(described_class.superclass).to eq(BSV::Network::Provider)
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/network/providers/integration_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/providers/integration_spec.rb
@@ -1,0 +1,361 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'BSV::Network integration — Registry + Provider composition' do
+  # ---------------------------------------------------------------------------
+  # Shared HTTP stub helpers
+  # ---------------------------------------------------------------------------
+
+  def make_http(code, body)
+    Class.new do
+      define_method(:request) { |_uri, _req| Struct.new(:code, :body).new(code.to_s, body) }
+    end.new
+  end
+
+  # Minimal HTTP client that records calls and dispatches based on path prefix.
+  def routing_http(routes)
+    Class.new do
+      define_method(:request) do |uri, _req|
+        path = uri.path
+        entry = routes.find { |prefix, _| path.include?(prefix) }
+        code, body = entry ? entry[1] : [404, 'not found']
+        Struct.new(:code, :body).new(code.to_s, body)
+      end
+    end.new
+  end
+
+  # ---------------------------------------------------------------------------
+  # Provider construction helpers
+  # ---------------------------------------------------------------------------
+
+  def woc(http_client: nil)
+    BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_client)
+  end
+
+  def arc(http_client: nil)
+    BSV::Network::Providers::ARC.new(url: 'https://arc.example.com', http_client: http_client)
+  end
+
+  # ---------------------------------------------------------------------------
+  # 1. Default registry construction
+  # ---------------------------------------------------------------------------
+
+  describe 'BSV::Network.default_registry' do
+    subject(:registry) { BSV::Network.default_registry }
+
+    it 'returns a Registry instance' do
+      expect(registry).to be_a(BSV::Network::Registry)
+    end
+
+    it 'has both providers registered' do
+      providers = registry.registered_providers
+      expect(providers.any?(BSV::Network::Providers::WhatsOnChain)).to be true
+      expect(providers.any?(BSV::Network::Providers::ARC)).to be true
+    end
+
+    it 'accepts network: keyword' do
+      reg = BSV::Network.default_registry(network: :test)
+      expect(reg).to be_a(BSV::Network::Registry)
+    end
+
+    it 'accepts arc_url: keyword' do
+      reg = BSV::Network.default_registry(arc_url: 'https://custom.arc.example.com')
+      expect(reg).to be_a(BSV::Network::Registry)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 2. Command routing: WoC handles chain-data, ARC handles broadcast
+  # ---------------------------------------------------------------------------
+
+  describe 'command routing' do
+    let(:woc_http) { make_http(200, '"deadbeef"') }
+    let(:arc_http) do
+      make_http(200, JSON.generate(
+                       'txid' => 'abc123',
+                       'txStatus' => 'SEEN_ON_NETWORK',
+                       'extraInfo' => nil
+                     ))
+    end
+
+    let(:registry) do
+      BSV::Network::Registry.new
+                            .register(woc(http_client: woc_http))
+                            .register(arc(http_client: arc_http))
+    end
+
+    it 'routes :get_tx to WoC (not ARC)' do
+      pairs = registry.providers_for(:get_tx)
+      expect(pairs.map(&:first)).to all(be_a(BSV::Network::Providers::WhatsOnChain))
+    end
+
+    it 'routes :broadcast to ARC (not WoC)' do
+      pairs = registry.providers_for(:broadcast)
+      expect(pairs.map(&:first)).to all(be_a(BSV::Network::Providers::ARC))
+    end
+
+    it 'routes :get_utxos, :valid_root, :current_height, :get_merkle_path, :is_utxo, :get_script_unspent to WoC' do
+      woc_commands = %i[get_utxos valid_root current_height get_merkle_path is_utxo get_script_unspent]
+      woc_commands.each do |cmd|
+        pairs = registry.providers_for(cmd)
+        expect(pairs).not_to be_empty, "expected #{cmd} to have a provider"
+        expect(pairs.map(&:first)).to all(be_a(BSV::Network::Providers::WhatsOnChain)),
+                                      "expected #{cmd} to route to WoC"
+      end
+    end
+
+    it 'routes :broadcast_many, :get_tx_status, :get_policy to ARC' do
+      arc_commands = %i[broadcast_many get_tx_status get_policy]
+      arc_commands.each do |cmd|
+        pairs = registry.providers_for(cmd)
+        expect(pairs).not_to be_empty, "expected #{cmd} to have a provider"
+        expect(pairs.map(&:first)).to all(be_a(BSV::Network::Providers::ARC)),
+                                      "expected #{cmd} to route to ARC"
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 3. Capability matrix shows all 11 commands
+  # ---------------------------------------------------------------------------
+
+  describe 'capability matrix' do
+    let(:registry) do
+      BSV::Network::Registry.new
+                            .register(woc)
+                            .register(arc)
+    end
+
+    it 'lists all 11 commands across both providers' do
+      matrix = registry.capability_matrix
+      all_cmds = matrix.values.flatten.uniq
+      expect(all_cmds.length).to eq(11)
+    end
+
+    it 'assigns WoC commands only to the WoC provider' do
+      matrix = registry.capability_matrix
+      woc_entry = matrix.find { |p, _| p.is_a?(BSV::Network::Providers::WhatsOnChain) }
+      expect(woc_entry).not_to be_nil
+      expect(woc_entry[1]).to include(:get_tx, :get_utxos, :valid_root, :current_height,
+                                      :get_merkle_path, :is_utxo, :get_script_unspent)
+    end
+
+    it 'assigns ARC commands only to the ARC provider' do
+      matrix = registry.capability_matrix
+      arc_entry = matrix.find { |p, _| p.is_a?(BSV::Network::Providers::ARC) }
+      expect(arc_entry).not_to be_nil
+      expect(arc_entry[1]).to include(:broadcast, :broadcast_many, :get_tx_status, :get_policy)
+    end
+
+    it 'BSV::Network.capability_matrix returns the same structure' do
+      matrix = BSV::Network.capability_matrix
+      all_cmds = matrix.values.flatten.uniq
+      expect(all_cmds.length).to eq(11)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 4. BSV::Network.commands convenience method
+  # ---------------------------------------------------------------------------
+
+  describe 'BSV::Network.commands' do
+    # command_spec.rb resets Command registry between examples; clear and reload
+    # so these tests are not order-dependent.
+    before do
+      BSV::Network::Command.reset!
+      load "#{Bundler.root}/gem/bsv-sdk/lib/bsv/network/commands.rb"
+    end
+
+    it 'returns a hash of all 11 registered commands' do
+      cmds = BSV::Network.commands
+      expect(cmds).to be_a(Hash)
+      expect(cmds.length).to eq(11)
+    end
+
+    it 'keys are Symbols matching command names' do
+      expect(BSV::Network.commands.keys).to include(:broadcast, :get_tx, :get_policy)
+    end
+
+    it 'values are Command instances' do
+      expect(BSV::Network.commands.values).to all(be_a(BSV::Network::Command))
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 5. WoC-only registry: :broadcast raises NoProviderError
+  # ---------------------------------------------------------------------------
+
+  describe 'WoC-only registry' do
+    let(:registry) { BSV::Network::Registry.new.register(woc) }
+
+    it 'raises NoProviderError for :broadcast' do
+      expect { registry.call(:broadcast, double) }
+        .to raise_error(BSV::Network::Registry::NoProviderError)
+    end
+
+    it 'raises NoProviderError for :get_policy' do
+      expect { registry.call(:get_policy) }
+        .to raise_error(BSV::Network::Registry::NoProviderError)
+    end
+
+    it 'can still route :get_tx' do
+      pairs = registry.providers_for(:get_tx)
+      expect(pairs).not_to be_empty
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 6. Failover: WoC retryable error -> next provider tried
+  # ---------------------------------------------------------------------------
+
+  describe 'failover on retryable error' do
+    let(:failing_woc) do
+      bsv_woc_class = Class.new(BSV::Network::Provider) do
+        provides :get_tx
+
+        def call_get_tx(_txid)
+          error('timeout', retryable: true)
+        end
+      end
+      bsv_woc_class.new
+    end
+
+    let(:fallback_http) { make_http(200, 'fallback_hex') }
+    let(:fallback_woc)  { woc(http_client: fallback_http) }
+
+    let(:registry) do
+      BSV::Network::Registry.new
+                            .register(failing_woc, priority: 1)
+                            .register(fallback_woc, priority: 2)
+    end
+
+    it 'falls over to the next WoC provider on retryable error' do
+      result = registry.call(:get_tx, 'somtxid')
+      expect(result).to be_success
+      expect(result.data).to eq('fallback_hex')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 7. ARC non-retryable error: does not fall through
+  # ---------------------------------------------------------------------------
+
+  describe 'non-retryable ARC error stops immediately' do
+    let(:rejected_body) do
+      JSON.generate('txid' => 'abc', 'txStatus' => 'REJECTED', 'detail' => 'bad tx', 'extraInfo' => nil)
+    end
+    let(:arc_http) { make_http(200, rejected_body) }
+    let(:good_arc_http) { make_http(200, JSON.generate('txid' => 'good', 'txStatus' => 'SEEN_ON_NETWORK', 'extraInfo' => nil)) }
+
+    let(:tx) { instance_double(BSV::Transaction::Transaction, to_ef_hex: '00', to_hex: '00') }
+
+    let(:registry) do
+      BSV::Network::Registry.new
+                            .register(arc(http_client: arc_http), priority: 1)
+                            .register(arc(http_client: good_arc_http), priority: 2)
+    end
+
+    it 'returns a non-retryable error and does not try the second ARC provider' do
+      result = registry.call(:broadcast, tx)
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 8. End-to-end: registry.call(:get_tx) dispatches to WoC with HTTP stub
+  # ---------------------------------------------------------------------------
+
+  describe 'end-to-end dispatch — :get_tx via WoC' do
+    let(:hex) { 'deadbeef01020304' }
+    let(:woc_http) { make_http(200, hex) } # WoC returns the raw hex string (not JSON-encoded)
+
+    let(:registry) do
+      BSV::Network::Registry.new
+                            .register(woc(http_client: woc_http))
+                            .register(arc)
+    end
+
+    it 'returns Success with the raw hex' do
+      result = registry.call(:get_tx, 'abc123')
+      expect(result).to be_success
+      expect(result.data).to eq(hex)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 9. End-to-end: registry.call(:broadcast) dispatches to ARC with HTTP stub
+  # ---------------------------------------------------------------------------
+
+  describe 'end-to-end dispatch — :broadcast via ARC' do
+    let(:txid) { 'feedcafe01' }
+    let(:arc_body) do
+      JSON.generate('txid' => txid, 'txStatus' => 'SEEN_ON_NETWORK', 'extraInfo' => nil)
+    end
+    let(:arc_http) { make_http(200, arc_body) }
+
+    let(:tx) do
+      instance_double(BSV::Transaction::Transaction, to_ef_hex: 'efhex', to_hex: 'rawhex')
+    end
+
+    let(:registry) do
+      BSV::Network::Registry.new
+                            .register(woc)
+                            .register(arc(http_client: arc_http))
+    end
+
+    it 'returns Success with txid and status' do
+      result = registry.call(:broadcast, tx)
+      expect(result).to be_success
+      expect(result.data[:txid]).to eq(txid)
+      expect(result.data[:status]).to eq('SEEN_ON_NETWORK')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 10. Specifier filtering: ARC registered except: [:get_policy]
+  # ---------------------------------------------------------------------------
+
+  describe 'specifier filtering — except:' do
+    let(:registry) do
+      BSV::Network::Registry.new
+                            .register(woc)
+                            .register(arc, except: [:get_policy])
+    end
+
+    it 'routes :broadcast normally' do
+      pairs = registry.providers_for(:broadcast)
+      expect(pairs).not_to be_empty
+    end
+
+    it 'raises NoProviderError for :get_policy' do
+      expect { registry.call(:get_policy) }
+        .to raise_error(BSV::Network::Registry::NoProviderError)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 11. No interference with legacy BSV::Network::ARC / BSV::Network::WhatsOnChain
+  # ---------------------------------------------------------------------------
+
+  describe 'legacy namespace coexistence' do
+    it 'BSV::Network::ARC (legacy) is still accessible' do
+      expect(BSV::Network::ARC).to be_a(Class)
+    end
+
+    it 'BSV::Network::WhatsOnChain (legacy) is still accessible' do
+      expect(BSV::Network::WhatsOnChain).to be_a(Class)
+    end
+
+    it 'BSV::Network::Providers::ARC is a different class from BSV::Network::ARC' do
+      expect(BSV::Network::Providers::ARC).not_to eq(BSV::Network::ARC)
+    end
+
+    it 'BSV::Network::Providers::WhatsOnChain is a different class from BSV::Network::WhatsOnChain' do
+      expect(BSV::Network::Providers::WhatsOnChain).not_to eq(BSV::Network::WhatsOnChain)
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/gem/bsv-sdk/spec/bsv/network/providers/whats_on_chain_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/providers/whats_on_chain_spec.rb
@@ -346,4 +346,325 @@ RSpec.describe 'BSV::Network::Providers::WhatsOnChain' do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # .capabilities (extended)
+  # ---------------------------------------------------------------------------
+
+  describe '.capabilities (extended)' do
+    it 'includes the three advanced commands' do
+      caps = BSV::Network::Providers::WhatsOnChain.capabilities
+      expect(caps).to include(:is_utxo, :get_merkle_path, :get_script_unspent)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # :get_script_unspent
+  # ---------------------------------------------------------------------------
+
+  describe '#call_get_script_unspent' do
+    let(:script_hash) { 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890' }
+    let(:unspent_body) do
+      [
+        { 'tx_hash' => 'aabb11', 'tx_pos' => 0, 'value' => 10_000, 'height' => 800_000 },
+        { 'tx_hash' => 'ccdd22', 'tx_pos' => 2, 'value' => 5_000,  'height' => 800_001 }
+      ].to_json
+    end
+
+    it 'returns success with array of UTXO hashes on 200' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, unspent_body))
+      result = p.call(:get_script_unspent, script_hash)
+      expect(result).to be_success
+      expect(result.data.length).to eq(2)
+    end
+
+    it 'maps fields correctly including value -> satoshis' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, unspent_body))
+      result = p.call(:get_script_unspent, script_hash)
+      first = result.data.first
+      expect(first[:tx_hash]).to eq('aabb11')
+      expect(first[:tx_pos]).to eq(0)
+      expect(first[:satoshis]).to eq(10_000)
+      expect(first[:height]).to eq(800_000)
+    end
+
+    it 'returns success with empty array when result is empty' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, '[]'))
+      result = p.call(:get_script_unspent, script_hash)
+      expect(result).to be_success
+      expect(result.data).to eq([])
+    end
+
+    it 'returns success with empty array on 404' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(404, ''))
+      result = p.call(:get_script_unspent, script_hash)
+      expect(result).to be_success
+      expect(result.data).to eq([])
+    end
+
+    it 'sends GET to the correct URL' do
+      http = http_stub(200, unspent_body)
+      BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http)
+                                           .call(:get_script_unspent, script_hash)
+      expect(http.last_uri.to_s).to eq("https://api.whatsonchain.com/v1/bsv/main/script/#{script_hash}/unspent")
+    end
+
+    it 'returns non-retryable error on malformed JSON' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, 'not-json'))
+      result = p.call(:get_script_unspent, script_hash)
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+    end
+
+    it_behaves_like 'retryable on 429', :get_script_unspent, 'deadbeef'
+    it_behaves_like 'retryable on 500', :get_script_unspent, 'deadbeef'
+  end
+
+  # ---------------------------------------------------------------------------
+  # :is_utxo
+  # ---------------------------------------------------------------------------
+
+  describe '#call_is_utxo' do
+    let(:txid) { 'f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16' }
+    let(:vout) { 0 }
+    let(:script_hash) { 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890' }
+    let(:unspent_body_with_match) do
+      [{ 'tx_hash' => txid, 'tx_pos' => vout, 'value' => 5_000, 'height' => 800_000 }].to_json
+    end
+    let(:unspent_body_without_match) do
+      [{ 'tx_hash' => 'othertx', 'tx_pos' => 0, 'value' => 1_000, 'height' => 800_000 }].to_json
+    end
+
+    context 'with script_hash: provided (single-call path)' do
+      it 'returns success(true) when outpoint is in unspent set' do
+        p = BSV::Network::Providers::WhatsOnChain.new(network: :main,
+                                                      http_client: http_stub(200, unspent_body_with_match))
+        result = p.call(:is_utxo, txid, vout, script_hash: script_hash)
+        expect(result).to be_success
+        expect(result.data).to be true
+      end
+
+      it 'returns success(false) when outpoint is not in unspent set (spent)' do
+        p = BSV::Network::Providers::WhatsOnChain.new(network: :main,
+                                                      http_client: http_stub(200, unspent_body_without_match))
+        result = p.call(:is_utxo, txid, vout, script_hash: script_hash)
+        expect(result).to be_success
+        expect(result.data).to be false
+      end
+
+      it 'returns success(false) when unspent set is empty' do
+        p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, '[]'))
+        result = p.call(:is_utxo, txid, vout, script_hash: script_hash)
+        expect(result).to be_success
+        expect(result.data).to be false
+      end
+
+      it 'returns success(false) when outpoint tx_pos does not match' do
+        body = [{ 'tx_hash' => txid, 'tx_pos' => 1, 'value' => 1_000, 'height' => 0 }].to_json
+        p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, body))
+        result = p.call(:is_utxo, txid, vout, script_hash: script_hash)
+        expect(result).to be_success
+        expect(result.data).to be false
+      end
+
+      it 'returns retryable error on HTTP 429' do
+        p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(429, 'Rate limited'))
+        result = p.call(:is_utxo, txid, vout, script_hash: script_hash)
+        expect(result).to be_error
+        expect(result.retryable?).to be true
+      end
+
+      it 'returns retryable error on HTTP 500' do
+        p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(500, 'Server error'))
+        result = p.call(:is_utxo, txid, vout, script_hash: script_hash)
+        expect(result).to be_error
+        expect(result.retryable?).to be true
+      end
+    end
+
+    context 'without script_hash: (two-call fallback)' do
+      # Minimal valid P2PKH transaction serialised in raw hex.
+      # Built to exercise the fallback path: get_tx -> parse -> compute hash -> get_script_unspent.
+      let(:real_txid) { 'f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16' }
+
+      # Build a minimal raw transaction with a single P2PKH output so we can
+      # compute the expected script hash without pulling in the full SDK stack here.
+      let(:locking_script_hex) do
+        # OP_DUP OP_HASH160 <20-byte hash> OP_EQUALVERIFY OP_CHECKSIG
+        "76a914#{'aa' * 20}88ac"
+      end
+
+      let(:raw_tx_hex) do
+        # version (4 LE) | input count (varint) | ... | output count | value (8 LE) | script len | script | locktime
+        version = '01000000'
+        # one input: prev hash (32), prev index (4), script len (0), sequence (4)
+        inputs = "01#{'00' * 32}ffffffff00ffffffff"
+        # one output: value (8 LE) = 5000 sat, script
+        script_bytes = [locking_script_hex].pack('H*')
+        value_le = [5000].pack('Q<').unpack1('H*')
+        script_len = [script_bytes.bytesize].pack('C').unpack1('H*')
+        outputs = "01#{value_le}#{script_len}#{locking_script_hex}"
+        locktime = '00000000'
+        version + inputs + outputs + locktime
+      end
+
+      let(:expected_script_hash) do
+        script_bytes = [locking_script_hex].pack('H*')
+        digest = OpenSSL::Digest::SHA256.digest(script_bytes)
+        digest.reverse.unpack1('H*')
+      end
+
+      it 'makes two HTTP calls: one for tx hex, one for script unspent' do
+        call_count = 0
+        responses = [
+          Struct.new(:code, :body).new('200', raw_tx_hex),
+          Struct.new(:code, :body).new('200', unspent_body_with_match)
+        ]
+
+        multi_http = Class.new do
+          define_method(:request) do |_uri, _req|
+            call_count += 1
+            responses[call_count - 1]
+          end
+        end.new
+
+        p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: multi_http)
+        result = p.call(:is_utxo, real_txid, vout)
+        expect(result).to be_success
+        expect(call_count).to eq(2)
+      end
+
+      it 'returns success(true) when outpoint is found in unspent set' do
+        call_count = 0
+        responses = [
+          Struct.new(:code, :body).new('200', raw_tx_hex),
+          Struct.new(:code, :body).new('200', unspent_body_with_match)
+        ]
+
+        multi_http = Class.new do
+          define_method(:request) do |_uri, _req|
+            call_count += 1
+            responses[call_count - 1]
+          end
+        end.new
+
+        p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: multi_http)
+        result = p.call(:is_utxo, real_txid, vout)
+        expect(result).to be_success
+        expect(result.data).to be true
+      end
+
+      it 'returns success(false) when outpoint is not in unspent set' do
+        call_count = 0
+        responses = [
+          Struct.new(:code, :body).new('200', raw_tx_hex),
+          Struct.new(:code, :body).new('200', '[]')
+        ]
+
+        multi_http = Class.new do
+          define_method(:request) do |_uri, _req|
+            call_count += 1
+            responses[call_count - 1]
+          end
+        end.new
+
+        p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: multi_http)
+        result = p.call(:is_utxo, real_txid, vout)
+        expect(result).to be_success
+        expect(result.data).to be false
+      end
+
+      it 'returns not_found when the tx itself is not found (404 on hex fetch)' do
+        p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(404, 'Not found'))
+        result = p.call(:is_utxo, real_txid, vout)
+        expect(result).to be_not_found
+      end
+
+      it 'returns non-retryable error when vout is beyond output count' do
+        call_count = 0
+        responses = [
+          Struct.new(:code, :body).new('200', raw_tx_hex),
+          Struct.new(:code, :body).new('200', '[]')
+        ]
+
+        multi_http = Class.new do
+          define_method(:request) do |_uri, _req|
+            call_count += 1
+            responses[call_count - 1]
+          end
+        end.new
+
+        p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: multi_http)
+        result = p.call(:is_utxo, real_txid, 99)
+        expect(result).to be_error
+        expect(result.retryable?).to be false
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # :get_merkle_path
+  # ---------------------------------------------------------------------------
+
+  describe '#call_get_merkle_path' do
+    let(:txid) { 'f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16' }
+    let(:tsc_body) do
+      [{
+        'index' => 3,
+        'txOrId' => txid,
+        'target' => 'blockhashdeadbeef',
+        'nodes' => %w[node1 node2 node3]
+      }].to_json
+    end
+
+    it 'returns success with normalised TSC proof hash on 200' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, tsc_body))
+      result = p.call(:get_merkle_path, txid)
+      expect(result).to be_success
+      expect(result.data[:index]).to eq(3)
+      expect(result.data[:tx_or_id]).to eq(txid)
+      expect(result.data[:target]).to eq('blockhashdeadbeef')
+      expect(result.data[:nodes]).to eq(%w[node1 node2 node3])
+    end
+
+    it 'takes the first element when WoC returns multiple proofs in the array' do
+      body = [
+        { 'index' => 1, 'txOrId' => txid, 'target' => 'first',  'nodes' => [] },
+        { 'index' => 2, 'txOrId' => txid, 'target' => 'second', 'nodes' => [] }
+      ].to_json
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, body))
+      result = p.call(:get_merkle_path, txid)
+      expect(result).to be_success
+      expect(result.data[:target]).to eq('first')
+    end
+
+    it 'returns not_found when WoC returns null (unconfirmed transaction)' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, 'null'))
+      result = p.call(:get_merkle_path, txid)
+      expect(result).to be_not_found
+    end
+
+    it 'returns not_found on HTTP 404' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(404, 'Not found'))
+      result = p.call(:get_merkle_path, txid)
+      expect(result).to be_not_found
+    end
+
+    it 'sends GET to the correct URL' do
+      http = http_stub(200, tsc_body)
+      BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http)
+                                           .call(:get_merkle_path, txid)
+      expect(http.last_uri.to_s).to eq("https://api.whatsonchain.com/v1/bsv/main/tx/#{txid}/proof/tsc")
+    end
+
+    it 'returns non-retryable error on malformed JSON' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, 'bad json'))
+      result = p.call(:get_merkle_path, txid)
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+    end
+
+    it_behaves_like 'retryable on 429', :get_merkle_path, 'txid'
+    it_behaves_like 'retryable on 500', :get_merkle_path, 'txid'
+  end
 end

--- a/gem/bsv-sdk/spec/bsv/network/providers/whats_on_chain_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/providers/whats_on_chain_spec.rb
@@ -1,0 +1,349 @@
+# frozen_string_literal: true
+
+RSpec.describe 'BSV::Network::Providers::WhatsOnChain' do
+  require 'spec_helper'
+
+  subject(:provider) { BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: mock_http) }
+
+  # Minimal mock HTTP client — stores the last request for inspection.
+  let(:mock_http_class) do
+    Class.new do
+      attr_reader :last_uri, :last_request
+
+      def initialize(code, body)
+        @code = code
+        @body = body
+      end
+
+      def request(uri, req)
+        @last_uri = uri
+        @last_request = req
+        Struct.new(:code, :body).new(@code.to_s, @body)
+      end
+    end
+  end
+
+  let(:mock_http) { mock_http_class.new(200, '{}') }
+
+  def http_stub(code, body)
+    mock_http_class.new(code, body)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Shared examples
+  # ---------------------------------------------------------------------------
+
+  shared_examples 'retryable on 429' do |command, *args|
+    it 'returns retryable error on HTTP 429' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(429, 'Rate limited'))
+      result = p.call(command, *args)
+      expect(result).to be_error
+      expect(result.retryable?).to be true
+    end
+  end
+
+  shared_examples 'retryable on 500' do |command, *args|
+    it 'returns retryable error on HTTP 500' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(500, 'Server error'))
+      result = p.call(command, *args)
+      expect(result).to be_error
+      expect(result.retryable?).to be true
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Capabilities
+  # ---------------------------------------------------------------------------
+
+  describe '.capabilities' do
+    it 'includes the four core commands' do
+      expect(BSV::Network::Providers::WhatsOnChain.capabilities).to include(:get_tx, :get_utxos, :current_height, :valid_root)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Constructor
+  # ---------------------------------------------------------------------------
+
+  describe '#initialize' do
+    it 'accepts :main network' do
+      expect { BSV::Network::Providers::WhatsOnChain.new(network: :main) }.not_to raise_error
+    end
+
+    it 'accepts :mainnet as an alias for :main' do
+      expect { BSV::Network::Providers::WhatsOnChain.new(network: :mainnet) }.not_to raise_error
+    end
+
+    it 'accepts :test network' do
+      expect { BSV::Network::Providers::WhatsOnChain.new(network: :test) }.not_to raise_error
+    end
+
+    it 'accepts :testnet as an alias for :test' do
+      expect { BSV::Network::Providers::WhatsOnChain.new(network: :testnet) }.not_to raise_error
+    end
+
+    it 'accepts :stn network' do
+      expect { BSV::Network::Providers::WhatsOnChain.new(network: :stn) }.not_to raise_error
+    end
+
+    it 'raises ArgumentError for unknown network' do
+      expect { BSV::Network::Providers::WhatsOnChain.new(network: :regtest) }.to raise_error(ArgumentError, /unknown network/)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # API key header
+  # ---------------------------------------------------------------------------
+
+  describe 'API key header' do
+    let(:txid) { 'abc123' }
+
+    it 'sends Authorization header when api_key is provided' do
+      http = http_stub(200, 'deadbeef')
+      BSV::Network::Providers::WhatsOnChain.new(network: :main, api_key: 'my-key', http_client: http)
+                                           .call(:get_tx, txid)
+      expect(http.last_request['Authorization']).to eq('my-key')
+    end
+
+    it 'omits Authorization header when api_key is nil' do
+      http = http_stub(200, 'deadbeef')
+      BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http)
+                                           .call(:get_tx, txid)
+      expect(http.last_request['Authorization']).to be_nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # :get_tx
+  # ---------------------------------------------------------------------------
+
+  describe '#call_get_tx' do
+    let(:txid) { 'f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16' }
+    let(:hex_body) { 'deadbeef01020304' }
+
+    it 'returns success with raw hex string on 200' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, hex_body))
+      result = p.call(:get_tx, txid)
+      expect(result).to be_success
+      expect(result.data).to eq(hex_body)
+    end
+
+    it 'strips whitespace from the hex response' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, "#{hex_body}\n"))
+      result = p.call(:get_tx, txid)
+      expect(result.data).to eq(hex_body)
+    end
+
+    it 'returns not_found on HTTP 404' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(404, 'Not found'))
+      result = p.call(:get_tx, txid)
+      expect(result).to be_not_found
+    end
+
+    it 'sends GET to the correct mainnet URL' do
+      http = http_stub(200, hex_body)
+      BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http).call(:get_tx, txid)
+      expect(http.last_uri.to_s).to eq("https://api.whatsonchain.com/v1/bsv/main/tx/#{txid}/hex")
+    end
+
+    it 'sends GET to the correct testnet URL when network is :test' do
+      http = http_stub(200, hex_body)
+      BSV::Network::Providers::WhatsOnChain.new(network: :test, http_client: http).call(:get_tx, txid)
+      expect(http.last_uri.to_s).to include('/v1/bsv/test/')
+    end
+
+    it_behaves_like 'retryable on 429', :get_tx, 'abc123'
+    it_behaves_like 'retryable on 500', :get_tx, 'abc123'
+
+    it 'returns non-retryable error on HTTP 400' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(400, 'Bad request'))
+      result = p.call(:get_tx, txid)
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # :get_utxos
+  # ---------------------------------------------------------------------------
+
+  describe '#call_get_utxos' do
+    let(:address) { '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa' }
+    let(:utxo_body) do
+      [
+        { 'tx_hash' => 'aabb11', 'tx_pos' => 0, 'value' => 50_000, 'height' => 800_000 },
+        { 'tx_hash' => 'ccdd22', 'tx_pos' => 1, 'value' => 25_000, 'height' => 0 }
+      ].to_json
+    end
+
+    it 'returns success with array of UTXO hashes on 200' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, utxo_body))
+      result = p.call(:get_utxos, address)
+      expect(result).to be_success
+      expect(result.data.length).to eq(2)
+    end
+
+    it 'maps WoC "value" field to :satoshis' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, utxo_body))
+      result = p.call(:get_utxos, address)
+      first = result.data.first
+      expect(first[:tx_hash]).to eq('aabb11')
+      expect(first[:tx_pos]).to eq(0)
+      expect(first[:satoshis]).to eq(50_000)
+      expect(first[:height]).to eq(800_000)
+    end
+
+    it 'returns success with empty array on 404' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(404, ''))
+      result = p.call(:get_utxos, address)
+      expect(result).to be_success
+      expect(result.data).to eq([])
+    end
+
+    it 'returns success with empty array when response body is "[]"' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, '[]'))
+      result = p.call(:get_utxos, address)
+      expect(result).to be_success
+      expect(result.data).to eq([])
+    end
+
+    it 'sends GET to the correct URL' do
+      http = http_stub(200, utxo_body)
+      BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http).call(:get_utxos, address)
+      expect(http.last_uri.to_s).to eq("https://api.whatsonchain.com/v1/bsv/main/address/#{address}/unspent")
+    end
+
+    it 'returns non-retryable error on malformed JSON' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, 'not-json'))
+      result = p.call(:get_utxos, address)
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+    end
+
+    it_behaves_like 'retryable on 429', :get_utxos, '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'
+    it_behaves_like 'retryable on 500', :get_utxos, '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'
+  end
+
+  # ---------------------------------------------------------------------------
+  # :current_height
+  # ---------------------------------------------------------------------------
+
+  describe '#call_current_height' do
+    let(:chain_info_body) { '{"blocks":850123,"headers":850123,"bestblockhash":"abc"}' }
+
+    it 'returns success with integer block height on 200' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, chain_info_body))
+      result = p.call(:current_height)
+      expect(result).to be_success
+      expect(result.data).to eq(850_123)
+    end
+
+    it 'sends GET to the correct URL' do
+      http = http_stub(200, chain_info_body)
+      BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http).call(:current_height)
+      expect(http.last_uri.to_s).to eq('https://api.whatsonchain.com/v1/bsv/main/chain/info')
+    end
+
+    it 'returns non-retryable error when "blocks" field is missing' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, '{"headers":100}'))
+      result = p.call(:current_height)
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+    end
+
+    it 'returns non-retryable error on malformed JSON' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, 'bad json'))
+      result = p.call(:current_height)
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+    end
+
+    it_behaves_like 'retryable on 429', :current_height
+    it_behaves_like 'retryable on 500', :current_height
+  end
+
+  # ---------------------------------------------------------------------------
+  # :valid_root
+  # ---------------------------------------------------------------------------
+
+  describe '#call_valid_root' do
+    let(:height) { 800_000 }
+    let(:merkle_root) { 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890' }
+    let(:header_body) { { 'merkleroot' => merkle_root, 'hash' => 'blockhashabc' }.to_json }
+
+    it 'returns success(true) when merkle roots match' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, header_body))
+      result = p.call(:valid_root, merkle_root, height)
+      expect(result).to be_success
+      expect(result.data).to be true
+    end
+
+    it 'returns success(false) when merkle roots do not match' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, header_body))
+      result = p.call(:valid_root, 'aaaa0000', height)
+      expect(result).to be_success
+      expect(result.data).to be false
+    end
+
+    it 'performs case-insensitive comparison' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, header_body))
+      result = p.call(:valid_root, merkle_root.upcase, height)
+      expect(result).to be_success
+      expect(result.data).to be true
+    end
+
+    it 'returns not_found on HTTP 404' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(404, ''))
+      result = p.call(:valid_root, merkle_root, height)
+      expect(result).to be_not_found
+    end
+
+    it 'handles block height 0 (genesis)' do
+      genesis_root = '4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b'
+      body = { 'merkleroot' => genesis_root }.to_json
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, body))
+      result = p.call(:valid_root, genesis_root, 0)
+      expect(result).to be_success
+      expect(result.data).to be true
+    end
+
+    it 'sends GET to the correct URL including block height' do
+      http = http_stub(200, header_body)
+      BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http).call(:valid_root, merkle_root, height)
+      expect(http.last_uri.to_s).to eq("https://api.whatsonchain.com/v1/bsv/main/block/#{height}/header")
+    end
+
+    it 'returns non-retryable error when "merkleroot" field is missing' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, '{"hash":"abc"}'))
+      result = p.call(:valid_root, merkle_root, height)
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+    end
+
+    it 'returns non-retryable error on malformed JSON' do
+      p = BSV::Network::Providers::WhatsOnChain.new(network: :main, http_client: http_stub(200, 'bad json'))
+      result = p.call(:valid_root, merkle_root, height)
+      expect(result).to be_error
+      expect(result.retryable?).to be false
+    end
+
+    it_behaves_like 'retryable on 429', :valid_root, 'root', 100
+    it_behaves_like 'retryable on 500', :valid_root, 'root', 100
+  end
+
+  # ---------------------------------------------------------------------------
+  # Network URL selection
+  # ---------------------------------------------------------------------------
+
+  describe 'network URL selection' do
+    let(:txid) { 'abc123' }
+
+    { main: 'main', mainnet: 'main', test: 'test', testnet: 'test', stn: 'stn' }.each do |sym, segment|
+      it "maps :#{sym} to '#{segment}' in URL" do
+        http = http_stub(200, 'hex')
+        BSV::Network::Providers::WhatsOnChain.new(network: sym, http_client: http).call(:get_tx, txid)
+        expect(http.last_uri.to_s).to include("/v1/bsv/#{segment}/")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Define all 11 network commands (broadcast, get_tx, is_utxo, get_merkle_path, etc.)
- Implement `BSV::Network::Providers::WhatsOnChain` -- 7 commands including new `:is_utxo` and `:get_merkle_path` capabilities
- Implement `BSV::Network::Providers::ARC` -- 4 commands (broadcast, broadcast_many, get_tx_status, get_policy)
- Add `BSV::Network.default_registry` factory for pre-configured provider composition
- Add `BSV::Network.commands` and `BSV::Network.capability_matrix` introspection
- Integration specs verifying end-to-end dispatch, failover, and provider routing

## Design Decisions

- **`:is_utxo`** uses `script_hash:` parameter with two-call fallback (WoC lacks a direct outpoint-spent endpoint)
- **`:get_script_unspent`** renamed from `:get_script_history` (WoC only has `/script/{hash}/unspent`)
- **`:get_merkle_path`** returns raw TSC proof components -- caller handles height lookup

## Test plan
- [x] All SDK specs pass (3803 examples, 0 failures)
- [x] RuboCop clean (403 files, 0 offences)
- [x] All acceptance criteria from #496 verified

Closes #496

## Sub-issues
- #508 -- Command definitions and Providers module (d403593)
- #509 -- WhatsOnChain core commands (ce76f66)
- #510 -- WhatsOnChain advanced commands (77b8af5)
- #511 -- ARC provider (20feea3)
- #512 -- Integration and wiring (0ab06d7)
