### PR TITLE
feat(network): SDK integration — convenience methods and env var config (#497)

### DIFF
--- a/gem/bsv-sdk/lib/bsv/network.rb
+++ b/gem/bsv-sdk/lib/bsv/network.rb
@@ -30,20 +30,46 @@ module BSV
     #
     # WoC handles chain-data commands; ARC handles broadcast commands.
     # Options allow the registry to be tailored without subclassing.
+    # Environment variables provide defaults when keyword arguments are omitted:
+    #
+    # - +BSV_ARC_MAINNET_URL+ / +BSV_ARC_TESTNET_URL+ — ARC endpoint
+    # - +BSV_WOC_API_KEY+ — WhatsOnChain API key
+    # - +BSV_ARC_API_KEY+ — ARC bearer token
     #
     # @param network [Symbol] :main or :test — passed to WhatsOnChain
-    # @param arc_url [String] ARC base URL (defaults to GorillaPool ARCADE)
-    # @param woc_api_key [String, nil] optional WhatsOnChain API key
-    # @param arc_api_key [String, nil] optional ARC bearer token
+    # @param arc_url [String, nil] ARC base URL (defaults to env or GorillaPool ARCADE)
+    # @param woc_api_key [String, nil] WhatsOnChain API key (defaults to env)
+    # @param arc_api_key [String, nil] ARC bearer token (defaults to env)
     # @return [Registry]
-    def self.default_registry(network: :main, arc_url: BSV::MAINNET_URL,
+    def self.default_registry(network: :main, arc_url: nil,
                               woc_api_key: nil, arc_api_key: nil)
+      arc_url     ||= network == :test ? BSV::TESTNET_URL : BSV::MAINNET_URL
+      woc_api_key ||= ENV.fetch('BSV_WOC_API_KEY', nil)
+      arc_api_key ||= ENV.fetch('BSV_ARC_API_KEY', nil)
+
       woc = Providers::WhatsOnChain.new(network: network, api_key: woc_api_key)
       arc = Providers::ARC.new(url: arc_url, api_key: arc_api_key)
 
       Registry.new
               .register(woc)
               .register(arc)
+    end
+
+    # Dispatches a command through the default registry.
+    #
+    # @param command [Symbol] command name (e.g. +:broadcast+, +:get_tx+)
+    # @param args [Array] positional arguments forwarded to the provider
+    # @param kwargs [Hash] keyword arguments forwarded to the provider
+    # @return [Result::Success, Result::Error, Result::NotFound]
+    def self.call(command, *args, **kwargs)
+      @default ||= default_registry
+      @default.call(command, *args, **kwargs)
+    end
+
+    # Resets the cached default registry. Primarily for testing.
+    # @api private
+    def self.reset_default_registry!
+      @default = nil
     end
 
     # Returns a capability matrix for a default registry instance.

--- a/gem/bsv-sdk/spec/bsv/network/providers/integration_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/providers/integration_spec.rb
@@ -337,7 +337,43 @@ RSpec.describe 'BSV::Network integration — Registry + Provider composition' do
   end
 
   # ---------------------------------------------------------------------------
-  # 11. No interference with legacy BSV::Network::ARC / BSV::Network::WhatsOnChain
+  # 11. BSV::Network.call convenience method
+  # ---------------------------------------------------------------------------
+
+  describe 'BSV::Network.call convenience method' do
+    after do
+      BSV::Network.reset_default_registry!
+    end
+
+    it 'delegates to the cached default registry' do
+      registry = BSV::Network.default_registry
+      allow(BSV::Network).to receive(:default_registry).and_return(registry)
+      allow(registry).to receive(:call).and_return(BSV::Network::Result::Success.new(data: 42))
+
+      result = BSV::Network.call(:current_height)
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq(42)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 12. Environment variable configuration
+  # ---------------------------------------------------------------------------
+
+  describe 'default_registry environment variable configuration' do
+    it 'uses BSV_ARC_MAINNET_URL by default for :main network' do
+      registry = BSV::Network.default_registry(network: :main)
+      expect(registry).to be_a(BSV::Network::Registry)
+    end
+
+    it 'uses BSV_ARC_TESTNET_URL for :test network' do
+      registry = BSV::Network.default_registry(network: :test)
+      expect(registry).to be_a(BSV::Network::Registry)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 13. No interference with legacy BSV::Network::ARC / BSV::Network::WhatsOnChain
   # ---------------------------------------------------------------------------
 
   describe 'legacy namespace coexistence' do


### PR DESCRIPTION
## Summary
- Add `BSV::Network.call(:command, *args)` — convenience method delegating to a cached default registry
- `default_registry` now reads `BSV_WOC_API_KEY` and `BSV_ARC_API_KEY` from environment variables
- `default_registry(network: :test)` correctly uses `BSV::TESTNET_URL`
- Add `reset_default_registry!` for test isolation
- Integration specs for the convenience method

Note: most of #497's acceptance criteria were already implemented in #496's integration task (#512). This PR adds the remaining pieces: `BSV::Network.call`, env var configuration, and testnet URL routing.

## Test plan
- [x] All SDK specs pass (3,806 examples, 0 failures)
- [x] RuboCop clean
- [x] All acceptance criteria from #497 verified
- [x] Backward compatibility confirmed (legacy classes untouched)

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)