### PR TITLE
feat(network): Protocol base class with endpoint DSL (#524)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -190,6 +190,7 @@ RSpec/MultipleMemoizedHelpers:
     - 'gem/bsv-sdk/spec/bsv/identity/**/*'
     - 'gem/bsv-sdk/spec/bsv/registry/**/*'
     - 'gem/bsv-sdk/spec/bsv/mcp/**/*'
+    - 'gem/bsv-sdk/spec/bsv/network/**/*'
     - 'gem/bsv-sdk/spec/conformance/**/*'
     - 'gem/bsv-wallet/spec/bsv/wallet_interface/**/*'
     - 'gem/bsv-wallet-postgres/spec/bsv/wallet_postgres/**/*'

--- a/gem/bsv-sdk/lib/bsv/network.rb
+++ b/gem/bsv-sdk/lib/bsv/network.rb
@@ -3,6 +3,7 @@
 module BSV
   module Network
     autoload :Result,             'bsv/network/result'
+    autoload :Protocol,           'bsv/network/protocol'
     autoload :BroadcastError,     'bsv/network/broadcast_error'
     autoload :BroadcastResponse,  'bsv/network/broadcast_response'
     autoload :ChainProviderError, 'bsv/network/chain_provider_error'

--- a/gem/bsv-sdk/lib/bsv/network.rb
+++ b/gem/bsv-sdk/lib/bsv/network.rb
@@ -4,6 +4,7 @@ module BSV
   module Network
     autoload :Result,             'bsv/network/result'
     autoload :Protocol,           'bsv/network/protocol'
+    autoload :Protocols,          'bsv/network/protocols'
     autoload :BroadcastError,     'bsv/network/broadcast_error'
     autoload :BroadcastResponse,  'bsv/network/broadcast_response'
     autoload :ChainProviderError, 'bsv/network/chain_provider_error'

--- a/gem/bsv-sdk/lib/bsv/network.rb
+++ b/gem/bsv-sdk/lib/bsv/network.rb
@@ -2,6 +2,7 @@
 
 module BSV
   module Network
+    autoload :Result,             'bsv/network/result'
     autoload :BroadcastError,     'bsv/network/broadcast_error'
     autoload :BroadcastResponse,  'bsv/network/broadcast_response'
     autoload :ChainProviderError, 'bsv/network/chain_provider_error'

--- a/gem/bsv-sdk/lib/bsv/network/protocol.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocol.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module BSV
+  module Network
+    # Protocol is the base class for all BSV network protocol definitions.
+    #
+    # Subclasses declare their commands via the +endpoint+ DSL macro. Each
+    # endpoint maps a command name (Symbol) to an HTTP method, a path template,
+    # and a response handler. The +subscription+ macro is a placeholder for future
+    # WebSocket support.
+    #
+    # Subclass isolation is enforced via an +inherited+ hook — each subclass
+    # receives its own empty +@endpoints+ and +@subscriptions+ hashes. Adding
+    # endpoints to a subclass never affects the parent.
+    #
+    # HTTP dispatch is not yet implemented (Task 3). Calling +call+ raises
+    # +NotImplementedError+.
+    #
+    # == Example
+    #
+    #   class MyProtocol < BSV::Network::Protocol
+    #     endpoint :get_tx, :get, '/v1/tx/{txid}'
+    #     endpoint :broadcast, :post, '/v1/tx', response: :json
+    #   end
+    #
+    #   p = MyProtocol.new(base_url: 'https://api.example.com', network: 'main')
+    #   p.commands #=> #<Set: {:get_tx, :broadcast}>
+    class Protocol
+      class << self
+        # Registers an endpoint definition for this protocol class.
+        #
+        # @param command_name [Symbol] the command name (e.g. +:broadcast+)
+        # @param http_method  [Symbol] +:get+ or +:post+
+        # @param path_template [String] path with +{param}+ placeholders
+        # @param response [Symbol, #call] response handler — +:raw+, +:json+,
+        #   +:json_array+, or a callable (lambda/proc)
+        def endpoint(command_name, http_method, path_template, response: :raw)
+          @endpoints[command_name] = {
+            method: http_method,
+            path: path_template,
+            response: response
+          }
+        end
+
+        # Registers a subscription definition. Placeholder for Phase C WebSocket
+        # support. Stored but not callable at runtime.
+        #
+        # @param event_name [Symbol] the event name
+        # @param path       [String] WebSocket path
+        # @param opts       [Hash]   additional options (reserved)
+        def subscription(event_name, path, **opts)
+          @subscriptions[event_name] = { path: path }.merge(opts)
+        end
+
+        # Returns a +Set+ of command names declared on this protocol class.
+        #
+        # @return [Set<Symbol>]
+        def commands
+          Set.new(@endpoints.keys)
+        end
+
+        # Returns a frozen copy of the endpoints hash for introspection.
+        #
+        # @return [Hash]
+        def endpoints
+          @endpoints.dup.freeze
+        end
+
+        # Returns a frozen copy of the subscriptions hash for introspection.
+        #
+        # @return [Hash]
+        def subscriptions
+          @subscriptions.dup.freeze
+        end
+
+        # Give each subclass its own isolated +@endpoints+ and +@subscriptions+
+        # hashes. Deep-copies the parent's endpoints so that existing declarations
+        # are inherited but mutations on the subclass do not affect the parent.
+        def inherited(subclass)
+          super
+          # Deep copy: each endpoint value is a plain hash of scalar values,
+          # so a one-level transform_values dup is sufficient.
+          parent_endpoints = @endpoints.each_with_object({}) do |(k, v), h|
+            h[k] = v.dup
+          end
+          subclass.instance_variable_set(:@endpoints,     parent_endpoints)
+          subclass.instance_variable_set(:@subscriptions, {})
+        end
+      end
+
+      # Initialise the class-level hashes on Protocol itself so that the
+      # inherited hook works correctly for direct subclasses.
+      @endpoints     = {}
+      @subscriptions = {}
+
+      attr_reader :base_url, :api_key, :network, :http_client
+
+      # @param base_url    [String] base URL, may contain +{network}+ placeholder
+      # @param api_key     [String, nil] API key for authenticated requests
+      # @param network     [String, Symbol, nil] network name (e.g. 'main', 'test')
+      # @param http_client [Object, nil] injectable HTTP client (used in Task 3)
+      def initialize(base_url:, api_key: nil, network: nil, http_client: nil)
+        @api_key     = api_key
+        @network     = network
+        @http_client = http_client
+        @base_url    = build_base_url(base_url, network)
+      end
+
+      # Dispatches a command. HTTP dispatch is not yet implemented (Task 3).
+      #
+      # @raise [NotImplementedError]
+      def call(_command_name, *_args, **_kwargs)
+        raise NotImplementedError, 'HTTP dispatch not yet implemented (Task 3)'
+      end
+
+      private
+
+      # Resolves the final base URL by interpolating +{network}+ and stripping
+      # any trailing slash.
+      #
+      # @param url     [String]
+      # @param network [String, Symbol, nil]
+      # @return [String]
+      # @raise [ArgumentError] when +{network}+ placeholder is present but
+      #   +network+ was not provided
+      def build_base_url(url, network)
+        if url.include?('{network}')
+          raise ArgumentError, 'base_url contains {network} placeholder but no network: was provided' if network.nil?
+
+          url = url.gsub('{network}', network.to_s)
+        end
+
+        url.chomp('/')
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/network/protocol.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocol.rb
@@ -18,8 +18,10 @@ module BSV
     # receives its own empty +@endpoints+ and +@subscriptions+ hashes. Adding
     # endpoints to a subclass never affects the parent.
     #
-    # HTTP dispatch is not yet implemented (Task 3). Calling +call+ raises
-    # +NotImplementedError+.
+    # HTTP dispatch routes through +call+: if a +call_<name>+ escape hatch
+    # method exists on the instance, it is called; otherwise +default_call+
+    # interpolates the URL template, makes the HTTP request, and maps the
+    # response to a +Result+.
     #
     # == Example
     #
@@ -29,7 +31,7 @@ module BSV
     #   end
     #
     #   p = MyProtocol.new(base_url: 'https://api.example.com', network: 'main')
-    #   p.commands #=> #<Set: {:get_tx, :broadcast}>
+    #   MyProtocol.commands #=> #<Set: {:get_tx, :broadcast}>
     class Protocol
       class << self
         # Registers an endpoint definition for this protocol class.
@@ -214,7 +216,7 @@ module BSV
             else
               raise ArgumentError, "missing path parameter: #{name}"
             end
-          result = result.sub("{#{name}}", value.to_s)
+          result = result.sub("{#{name}}") { value.to_s }
         end
         result
       end
@@ -234,7 +236,10 @@ module BSV
           end
 
         request['Authorization'] = "Bearer #{@api_key}" if @api_key
-        request.body = body if body && request.respond_to?(:body=)
+        if body && request.respond_to?(:body=)
+          request.body = body
+          request.content_type = 'application/json' unless request.content_type
+        end
         request
       end
 
@@ -279,22 +284,29 @@ module BSV
 
       # Applies the response handler to a raw body string.
       #
-      # @param body    [String]
+      # @param body    [String, nil]
       # @param handler [Symbol, #call]
       # @return [Object, Result::Error]
       def apply_handler(body, handler)
+        return body if body.nil?
+
         case handler
         when :raw
           body
-        when :json, :json_array
-          begin
-            JSON.parse(body)
-          rescue JSON::ParserError => e
-            Result::Error.new(message: "JSON parse error: #{e.message}", retryable: false)
-          end
+        when :json
+          JSON.parse(body)
+        when :json_array
+          parsed = JSON.parse(body)
+          raise TypeError, "expected Array, got #{parsed.class}" unless parsed.is_a?(Array)
+
+          parsed
         else
-          handler.call(body) if handler.respond_to?(:call)
+          raise ArgumentError, "unsupported response handler: #{handler.inspect}" unless handler.respond_to?(:call)
+
+          handler.call(body)
         end
+      rescue JSON::ParserError, TypeError => e
+        Result::Error.new(message: "JSON/response error: #{e.message}", retryable: false)
       end
     end
   end

--- a/gem/bsv-sdk/lib/bsv/network/protocol.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocol.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require 'set'
+require 'net/http'
+require 'json'
+require 'uri'
 
 module BSV
   module Network
@@ -108,11 +111,60 @@ module BSV
         @base_url    = build_base_url(base_url, network)
       end
 
-      # Dispatches a command. HTTP dispatch is not yet implemented (Task 3).
+      # Dispatches a command by name.
       #
-      # @raise [NotImplementedError]
-      def call(_command_name, *_args, **_kwargs)
-        raise NotImplementedError, 'HTTP dispatch not yet implemented (Task 3)'
+      # If a method named +call_<command_name>+ exists on the instance it is
+      # used as an escape hatch — that method receives +args+ and +kwargs+
+      # and MUST return a +Result+. Otherwise +default_call+ is invoked.
+      #
+      # Subscriptions are not callable; calling one raises +NotImplementedError+.
+      #
+      # @param command_name [Symbol, String] command to invoke
+      # @param args   [Array]  positional arguments forwarded to path interpolation
+      # @param kwargs [Hash]   keyword arguments forwarded to path interpolation
+      # @return [Result::Success, Result::Error, Result::NotFound]
+      # @raise [ArgumentError] when command_name is not registered
+      def call(command_name, *args, **kwargs)
+        name = command_name.to_sym
+
+        if self.class.subscriptions.key?(name)
+          raise NotImplementedError,
+                "#{name} is a subscription — WebSocket dispatch is not yet implemented"
+        end
+
+        escape = :"call_#{name}"
+        return send(escape, *args, **kwargs) if respond_to?(escape, true)
+
+        default_call(name, *args, **kwargs)
+      end
+
+      # Dispatches a command directly via HTTP, bypassing any escape hatch.
+      #
+      # Path placeholders (+{param}+) are filled from +kwargs+ first; any
+      # remaining placeholders are filled positionally from +args+. Named
+      # kwargs take precedence over positional args for the same placeholder.
+      #
+      # POST body is taken from +kwargs.delete(:body)+ (removed before path
+      # interpolation).
+      #
+      # @param command_name [Symbol] registered command name
+      # @param args   [Array]  positional path parameters
+      # @param kwargs [Hash]   named path parameters (and optional +:body+)
+      # @return [Result::Success, Result::Error, Result::NotFound]
+      # @raise [ArgumentError] when command_name is not registered or a
+      #   required path parameter is missing
+      def default_call(command_name, *args, **kwargs)
+        name = command_name.to_sym
+        defn = self.class.endpoints[name]
+        raise ArgumentError, "unknown command: #{name}" unless defn
+
+        body       = kwargs.delete(:body)
+        path       = interpolate_path(defn[:path], args, kwargs)
+        uri        = URI("#{@base_url}#{path}")
+        request    = build_request(defn[:method], uri, body)
+        response   = execute(uri, request)
+
+        map_response(response, defn[:response])
       end
 
       private
@@ -133,6 +185,116 @@ module BSV
         end
 
         url.chomp('/')
+      end
+
+      # Interpolates +{placeholder}+ tokens in a path template.
+      #
+      # Named kwargs are matched first (removing matched keys from the hash).
+      # Remaining positional args fill placeholders in template order.
+      #
+      # @param template [String]  path template with +{name}+ tokens
+      # @param args     [Array]   positional substitution values
+      # @param kwargs   [Hash]    named substitution values (modified in place)
+      # @return [String]
+      # @raise [ArgumentError] when a placeholder cannot be filled
+      def interpolate_path(template, args, kwargs)
+        pos_args  = args.dup
+        remaining = kwargs.dup
+
+        # Extract ordered placeholder names from the template
+        names = template.scan(/\{(\w+)\}/).flatten.map(&:to_sym)
+
+        result = template.dup
+        names.each do |name|
+          value =
+            if remaining.key?(name)
+              remaining.delete(name)
+            elsif !pos_args.empty?
+              pos_args.shift
+            else
+              raise ArgumentError, "missing path parameter: #{name}"
+            end
+          result = result.sub("{#{name}}", value.to_s)
+        end
+        result
+      end
+
+      # Builds a Net::HTTP request for the given method, URI, and optional body.
+      #
+      # @param http_method [Symbol] +:get+ or +:post+
+      # @param uri   [URI]
+      # @param body  [String, nil] raw body for POST requests
+      # @return [Net::HTTPRequest]
+      def build_request(http_method, uri, body)
+        request =
+          case http_method
+          when :get  then Net::HTTP::Get.new(uri)
+          when :post then Net::HTTP::Post.new(uri)
+          else raise ArgumentError, "unsupported HTTP method: #{http_method}"
+          end
+
+        request['Authorization'] = "Bearer #{@api_key}" if @api_key
+        request.body = body if body && request.respond_to?(:body=)
+        request
+      end
+
+      # Executes the request via the injectable client or +Net::HTTP.start+.
+      #
+      # @param uri     [URI]
+      # @param request [Net::HTTPRequest]
+      # @return [Net::HTTPResponse]
+      def execute(uri, request)
+        if @http_client
+          @http_client.request(uri, request)
+        else
+          Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+            http.request(request)
+          end
+        end
+      end
+
+      # Maps an HTTP response to a Result type, applying the response handler
+      # on 2xx bodies.
+      #
+      # @param response [Net::HTTPResponse]
+      # @param handler  [Symbol, #call]
+      # @return [Result::Success, Result::Error, Result::NotFound]
+      def map_response(response, handler)
+        code = response.code.to_i
+
+        case code
+        when 200..299
+          data = apply_handler(response.body, handler)
+          return data if data.is_a?(Result::Error)
+
+          Result::Success.new(data: data)
+        when 404
+          Result::NotFound.new
+        when 429, 500..599
+          Result::Error.new(message: response.body, retryable: true)
+        else
+          Result::Error.new(message: response.body, retryable: false)
+        end
+      end
+
+      # Applies the response handler to a raw body string.
+      #
+      # @param body    [String]
+      # @param handler [Symbol, #call]
+      # @return [Object, Result::Error]
+      def apply_handler(body, handler)
+        case handler
+        when :raw
+          body
+        when :json, :json_array
+          begin
+            JSON.parse(body)
+          rescue JSON::ParserError => e
+            Result::Error.new(message: "JSON parse error: #{e.message}", retryable: false)
+          end
+        else
+          handler.call(body) if handler.respond_to?(:call)
+        end
       end
     end
   end

--- a/gem/bsv-sdk/lib/bsv/network/protocols.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module BSV
+  module Network
+    # Protocols is a namespace module for concrete Protocol subclasses.
+    #
+    # Protocol implementations (e.g. ARC, WhatsOnChain adapters built on
+    # the Protocol base class) will be autoloaded here in Phase B.
+    module Protocols
+      # Protocol implementations will be autoloaded here in Phase B
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/network/result.rb
+++ b/gem/bsv-sdk/lib/bsv/network/result.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+module BSV
+  module Network
+    # Result module provides three immutable value types for Protocol dispatch outcomes.
+    #
+    # All three types share a Predicates mixin with default false implementations.
+    # Each type overrides only the predicate that returns true for that type.
+    module Result
+      # Mixin providing default false implementations for all query predicates.
+      module Predicates
+        def success?
+          false
+        end
+
+        def error?
+          false
+        end
+
+        def not_found?
+          false
+        end
+      end
+
+      # Represents a successful outcome. Carries the response payload in +data+
+      # and optional protocol-specific extras in +metadata+.
+      class Success
+        include Predicates
+
+        attr_reader :data, :metadata
+
+        def initialize(data:, metadata: {})
+          @data = data
+          @metadata = metadata.freeze
+          freeze
+        end
+
+        def success?
+          true
+        end
+
+        def ==(other)
+          other.is_a?(Success) && data == other.data && metadata == other.metadata
+        end
+
+        alias eql? ==
+
+        def hash
+          [self.class, data, metadata].hash
+        end
+      end
+
+      # Represents a failed outcome. Carries a human-readable +message+, a boolean
+      # +retryable+ flag indicating whether the caller should retry, and optional
+      # +metadata+ for structured protocol-specific details (e.g. +arc_status+).
+      class Error
+        include Predicates
+
+        attr_reader :message, :retryable, :metadata
+
+        def initialize(message:, retryable: false, metadata: {})
+          @message = message
+          @retryable = retryable
+          @metadata = metadata.freeze
+          freeze
+        end
+
+        def error?
+          true
+        end
+
+        def retryable?
+          @retryable
+        end
+
+        def ==(other)
+          other.is_a?(Error) &&
+            message == other.message &&
+            retryable == other.retryable &&
+            metadata == other.metadata
+        end
+
+        alias eql? ==
+
+        def hash
+          [self.class, message, retryable, metadata].hash
+        end
+      end
+
+      # Represents a resource-not-found outcome. Carries an optional human-readable
+      # +message+ and optional +metadata+.
+      class NotFound
+        include Predicates
+
+        attr_reader :message, :metadata
+
+        def initialize(message: nil, metadata: {})
+          @message = message
+          @metadata = metadata.freeze
+          freeze
+        end
+
+        def not_found?
+          true
+        end
+
+        def ==(other)
+          other.is_a?(NotFound) && message == other.message && metadata == other.metadata
+        end
+
+        alias eql? ==
+
+        def hash
+          [self.class, message, metadata].hash
+        end
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/network/protocol_integration_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocol_integration_spec.rb
@@ -1,0 +1,278 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/DescribeClass
+
+# rubocop:disable Style/OneClassPerFile
+
+# Minimal fake response — mimics Net::HTTPResponse interface.
+IntegrationFakeResponse = Struct.new(:code, :body)
+
+# Injectable HTTP client that records the last call and returns a canned response.
+class IntegrationFakeHttpClient
+  attr_reader :last_uri, :last_request
+
+  def initialize(response)
+    @response = response
+  end
+
+  def request(uri, req)
+    @last_uri     = uri
+    @last_request = req
+    @response
+  end
+end
+
+# A concrete Protocol subclass used throughout the integration spec.
+#
+# Endpoints:
+#   :get_item        GET  /items/{id}          — raw response
+#   :create_item     POST /items               — raw response
+#   :get_info        GET  /info                — JSON response
+#   :get_count       GET  /count               — lambda response (body.to_i)
+#   :on_item_change  subscription placeholder
+#
+# Escape hatch:
+#   call_transform_item calls default_call(:get_item, ...) then wraps the data.
+class TestIntegrationProtocol < BSV::Network::Protocol
+  endpoint :get_item, :get, '/items/{id}'
+  endpoint :create_item, :post, '/items'
+  endpoint :get_info,   :get,  '/info',  response: :json
+  endpoint :get_count,  :get,  '/count', response: lambda(&:to_i)
+
+  subscription :on_item_change, '/ws/items'
+
+  # Escape hatch: delegates to the default GET path then augments the result.
+  def call_transform_item(*args, **kwargs)
+    result = default_call(:get_item, *args, **kwargs)
+    return result unless result.success?
+
+    BSV::Network::Result::Success.new(data: result.data.upcase, metadata: { transformed: true })
+  end
+end
+
+# rubocop:enable Style/OneClassPerFile
+
+RSpec.describe 'BSV::Network::Protocol — integration' do
+  let(:ok_response)       { IntegrationFakeResponse.new('200', 'item_body') }
+  let(:created_response)  { IntegrationFakeResponse.new('201', 'created') }
+  let(:json_response)     { IntegrationFakeResponse.new('200', '{"version":"1.0"}') }
+  let(:count_response)    { IntegrationFakeResponse.new('200', '42') }
+  let(:not_found_resp)    { IntegrationFakeResponse.new('404', 'not found') }
+  let(:server_error_resp) { IntegrationFakeResponse.new('500', 'internal error') }
+  let(:auth_error_resp)   { IntegrationFakeResponse.new('401', 'unauthorised') }
+
+  def make_client(response, api_key: nil)
+    http = IntegrationFakeHttpClient.new(response)
+    instance = TestIntegrationProtocol.new(
+      base_url: 'https://api.example.com',
+      api_key: api_key,
+      http_client: http
+    )
+    [instance, http]
+  end
+
+  # ---------------------------------------------------------------------------
+  # Autoload resolution
+  # ---------------------------------------------------------------------------
+
+  describe 'autoload resolution' do
+    it 'BSV::Network::Result is accessible without explicit require' do
+      expect(BSV::Network::Result).to be_a(Module)
+    end
+
+    it 'BSV::Network::Protocol is accessible without explicit require' do
+      expect(BSV::Network::Protocol).to be_a(Class)
+    end
+
+    it 'BSV::Network::Protocols is accessible without explicit require' do
+      expect(BSV::Network::Protocols).to be_a(Module)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # GET endpoint — full round-trip
+  # ---------------------------------------------------------------------------
+
+  describe 'GET endpoint round-trip' do
+    it 'call(:get_item, id) issues GET to /items/{id} and returns Success' do
+      instance, http = make_client(ok_response)
+      result = instance.call(:get_item, 'abc')
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq('item_body')
+      expect(http.last_uri.to_s).to eq('https://api.example.com/items/abc')
+    end
+
+    it 'uses an HTTP GET request' do
+      instance, http = make_client(ok_response)
+      instance.call(:get_item, 'abc')
+      expect(http.last_request).to be_a(Net::HTTP::Get)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # POST endpoint — full round-trip
+  # ---------------------------------------------------------------------------
+
+  describe 'POST endpoint round-trip' do
+    it 'call(:create_item, body:) issues POST and returns Success' do
+      instance, http = make_client(created_response)
+      result = instance.call(:create_item, body: '{"name":"test"}')
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq('created')
+      expect(http.last_request).to be_a(Net::HTTP::Post)
+      expect(http.last_request.body).to eq('{"name":"test"}')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # JSON response handler
+  # ---------------------------------------------------------------------------
+
+  describe 'JSON response handler' do
+    it 'call(:get_info) parses JSON body into a Hash' do
+      instance, _http = make_client(json_response)
+      result = instance.call(:get_info)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq({ 'version' => '1.0' })
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Lambda response handler
+  # ---------------------------------------------------------------------------
+
+  describe 'lambda response handler' do
+    it 'call(:get_count) applies the lambda to the body' do
+      instance, _http = make_client(count_response)
+      result = instance.call(:get_count)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq(42)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Escape hatch
+  # ---------------------------------------------------------------------------
+
+  describe 'escape hatch with default_call' do
+    it 'call(:transform_item, id) delegates to default_call then post-processes' do
+      instance, http = make_client(ok_response)
+      result = instance.call(:transform_item, 'abc')
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq('ITEM_BODY')
+      expect(result.metadata).to eq({ transformed: true })
+      # The underlying HTTP call still targets the correct URL
+      expect(http.last_uri.to_s).to eq('https://api.example.com/items/abc')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Subscription — NotImplementedError
+  # ---------------------------------------------------------------------------
+
+  describe 'subscription call' do
+    it 'call(:on_item_change) raises NotImplementedError' do
+      instance, _http = make_client(ok_response)
+      expect { instance.call(:on_item_change) }
+        .to raise_error(NotImplementedError, /subscription/)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Unknown command
+  # ---------------------------------------------------------------------------
+
+  describe 'unknown command' do
+    it 'call(:unknown) raises ArgumentError' do
+      instance, _http = make_client(ok_response)
+      expect { instance.call(:unknown) }
+        .to raise_error(ArgumentError)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # HTTP error status codes
+  # ---------------------------------------------------------------------------
+
+  describe 'HTTP 404' do
+    it 'returns Result::NotFound' do
+      instance, _http = make_client(not_found_resp)
+      expect(instance.call(:get_item, 'missing')).to be_a(BSV::Network::Result::NotFound)
+    end
+  end
+
+  describe 'HTTP 500' do
+    it 'returns Result::Error with retryable: true' do
+      instance, _http = make_client(server_error_resp)
+      result = instance.call(:get_item, 'id')
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+  end
+
+  describe 'HTTP 401' do
+    it 'returns Result::Error with retryable: false' do
+      instance, _http = make_client(auth_error_resp)
+      result = instance.call(:get_item, 'id')
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(false)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # API key in Authorization header
+  # ---------------------------------------------------------------------------
+
+  describe 'Authorization header' do
+    it 'includes Bearer token when api_key is set' do
+      instance, http = make_client(ok_response, api_key: 'my-api-key')
+      instance.call(:get_item, 'id')
+      expect(http.last_request['Authorization']).to eq('Bearer my-api-key')
+    end
+
+    it 'omits Authorization header when api_key is nil' do
+      instance, http = make_client(ok_response)
+      instance.call(:get_item, 'id')
+      expect(http.last_request['Authorization']).to be_nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # .commands
+  # ---------------------------------------------------------------------------
+
+  describe '.commands' do
+    it 'returns a Set of all endpoint command names' do
+      expected = Set[:get_item, :create_item, :get_info, :get_count]
+      expect(TestIntegrationProtocol.commands).to eq(expected)
+    end
+
+    it 'does not include subscription names' do
+      expect(TestIntegrationProtocol.commands).not_to include(:on_item_change)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Subclass isolation
+  # ---------------------------------------------------------------------------
+
+  describe 'subclass isolation' do
+    let(:sibling_protocol) do
+      Class.new(BSV::Network::Protocol) do
+        endpoint :sibling_only, :get, '/sibling'
+      end
+    end
+
+    it 'two protocol classes do not share endpoints' do
+      expect(TestIntegrationProtocol.commands).not_to include(:sibling_only)
+      expect(sibling_protocol.commands).not_to include(:get_item)
+    end
+  end
+end
+
+# rubocop:enable RSpec/DescribeClass

--- a/gem/bsv-sdk/spec/bsv/network/protocol_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocol_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+RSpec.describe 'BSV::Network::Protocol' do
+  let(:base_protocol) do
+    Class.new(BSV::Network::Protocol) do
+      endpoint :get_tx,    :get,  '/v1/tx/{txid}'
+      endpoint :broadcast, :post, '/v1/tx', response: :json
+    end
+  end
+
+  describe 'endpoint DSL' do
+    it 'registers endpoints on the class' do
+      eps = base_protocol.endpoints
+      expect(eps[:get_tx]).to eq({ method: :get, path: '/v1/tx/{txid}', response: :raw })
+      expect(eps[:broadcast]).to eq({ method: :post, path: '/v1/tx', response: :json })
+    end
+
+    it 'returns a frozen copy from .endpoints' do
+      expect(base_protocol.endpoints).to be_frozen
+    end
+  end
+
+  describe '.commands' do
+    it 'returns a Set of declared command names' do
+      expect(base_protocol.commands).to be_a(Set)
+      expect(base_protocol.commands).to eq(Set[:get_tx, :broadcast])
+    end
+
+    it 'returns an empty Set when no endpoints are declared' do
+      empty = Class.new(BSV::Network::Protocol)
+      expect(empty.commands).to be_empty
+    end
+  end
+
+  describe 'subclass isolation' do
+    let(:child_protocol) do
+      Class.new(base_protocol) do
+        endpoint :health, :get, '/v1/health'
+      end
+    end
+
+    it 'inherits parent endpoints' do
+      expect(child_protocol.commands).to include(:get_tx, :broadcast)
+    end
+
+    it 'includes its own additional endpoints' do
+      expect(child_protocol.commands).to include(:health)
+    end
+
+    it 'does not add child endpoints to the parent' do
+      child_protocol # trigger class creation
+      expect(base_protocol.commands).not_to include(:health)
+    end
+
+    it 'allows the child to override a parent endpoint' do
+      override = Class.new(base_protocol) do
+        endpoint :get_tx, :post, '/v2/tx/{txid}', response: :json
+      end
+      expect(override.endpoints[:get_tx]).to eq({ method: :post, path: '/v2/tx/{txid}', response: :json })
+      expect(base_protocol.endpoints[:get_tx]).to eq({ method: :get, path: '/v1/tx/{txid}', response: :raw })
+    end
+
+    it 'sibling subclasses do not share endpoints' do
+      sibling_a = Class.new(base_protocol) do
+        endpoint :only_in_a, :get, '/only-a'
+      end
+      sibling_b = Class.new(base_protocol) do
+        endpoint :only_in_b, :get, '/only-b'
+      end
+      expect(sibling_a.commands).not_to include(:only_in_b)
+      expect(sibling_b.commands).not_to include(:only_in_a)
+    end
+  end
+
+  describe 'subscription DSL' do
+    let(:sub_protocol) do
+      Class.new(BSV::Network::Protocol) do
+        subscription :on_tx, '/ws/tx', event: 'tx'
+      end
+    end
+
+    it 'stores the subscription definition without error' do
+      expect(sub_protocol.subscriptions[:on_tx]).to eq({ path: '/ws/tx', event: 'tx' })
+    end
+
+    it 'returns a frozen copy from .subscriptions' do
+      expect(sub_protocol.subscriptions).to be_frozen
+    end
+
+    it 'subscription does not appear in commands' do
+      expect(sub_protocol.commands).not_to include(:on_tx)
+    end
+  end
+
+  describe '#initialize' do
+    let(:klass) { Class.new(BSV::Network::Protocol) }
+
+    it 'stores base_url, api_key, network, and http_client' do
+      client = Object.new
+      p = klass.new(base_url: 'https://example.com', api_key: 'key123', network: 'main', http_client: client)
+      expect(p.base_url).to eq('https://example.com')
+      expect(p.api_key).to eq('key123')
+      expect(p.network).to eq('main')
+      expect(p.http_client).to be(client)
+    end
+
+    it 'interpolates {network} in base_url' do
+      p = klass.new(base_url: 'https://api.example.com/v1/bsv/{network}', network: 'main')
+      expect(p.base_url).to eq('https://api.example.com/v1/bsv/main')
+    end
+
+    it 'accepts a Symbol for network and converts it to string in the URL' do
+      p = klass.new(base_url: 'https://api.example.com/{network}', network: :test)
+      expect(p.base_url).to eq('https://api.example.com/test')
+    end
+
+    it 'strips trailing slash from base_url' do
+      p = klass.new(base_url: 'https://example.com/')
+      expect(p.base_url).to eq('https://example.com')
+    end
+
+    it 'strips trailing slash after network interpolation' do
+      p = klass.new(base_url: 'https://example.com/{network}/', network: 'main')
+      expect(p.base_url).to eq('https://example.com/main')
+    end
+
+    it 'raises ArgumentError when {network} is present but network: is not provided' do
+      expect do
+        klass.new(base_url: 'https://api.example.com/v1/bsv/{network}')
+      end.to raise_error(ArgumentError, /network/)
+    end
+
+    it 'allows nil api_key and http_client' do
+      p = klass.new(base_url: 'https://example.com')
+      expect(p.api_key).to be_nil
+      expect(p.http_client).to be_nil
+    end
+  end
+
+  describe '#call' do
+    let(:instance) { Class.new(BSV::Network::Protocol).new(base_url: 'https://example.com') }
+
+    it 'raises NotImplementedError (HTTP dispatch is Task 3)' do
+      expect { instance.call(:get_tx, 'abc123') }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/network/protocol_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocol_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe 'BSV::Network::Protocol' do
     it 'JSON parse failure returns Result::Error' do
       result = make_instance(bad_json_response).default_call(:get_info)
       expect(result).to be_a(BSV::Network::Result::Error)
-      expect(result.message).to match(/JSON parse error/)
+      expect(result.message).to match(%r{JSON/response error})
       expect(result.retryable?).to be(false)
     end
   end

--- a/gem/bsv-sdk/spec/bsv/network/protocol_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocol_spec.rb
@@ -1,11 +1,56 @@
 # frozen_string_literal: true
 
+# Minimal fake response used in place of Net::HTTPResponse.
+ProtocolSpecFakeResponse = Struct.new(:code, :body)
+
+# Fake injectable HTTP client — records the last request, returns a canned response.
+class ProtocolSpecFakeHttpClient
+  attr_reader :last_uri, :last_request
+
+  def initialize(response)
+    @response = response
+  end
+
+  def request(uri, req)
+    @last_uri     = uri
+    @last_request = req
+    @response
+  end
+end
+
 RSpec.describe 'BSV::Network::Protocol' do
   let(:base_protocol) do
     Class.new(BSV::Network::Protocol) do
       endpoint :get_tx,    :get,  '/v1/tx/{txid}'
       endpoint :broadcast, :post, '/v1/tx', response: :json
     end
+  end
+
+  let(:test_protocol_class) do
+    Class.new(BSV::Network::Protocol) do
+      endpoint :get_tx,    :get,  '/v1/tx/{txid}'
+      endpoint :get_out,   :get,  '/v1/tx/{txid}/out/{vout}/hex'
+      endpoint :broadcast, :post, '/v1/tx',    response: :json
+      endpoint :get_info,  :get,  '/v1/info',  response: :json
+      endpoint :get_raw,   :get,  '/v1/raw',   response: :raw
+      endpoint :get_list,  :get,  '/v1/list',  response: :json_array
+      endpoint :custom,    :get,  '/v1/custom', response: ->(body) { body.upcase } # rubocop:disable Style/SymbolProc
+      subscription :on_tx, '/ws/tx'
+    end
+  end
+
+  let(:ok_response)        { ProtocolSpecFakeResponse.new('200', 'raw_body') }
+  let(:json_response)      { ProtocolSpecFakeResponse.new('200', '{"txid":"abc"}') }
+  let(:array_response)     { ProtocolSpecFakeResponse.new('200', '[{"txid":"abc"}]') }
+  let(:not_found_response) { ProtocolSpecFakeResponse.new('404', 'not found') }
+  let(:too_many_response)  { ProtocolSpecFakeResponse.new('429', 'rate limited') }
+  let(:server_error_resp)  { ProtocolSpecFakeResponse.new('500', 'server error') }
+  let(:bad_request_resp)   { ProtocolSpecFakeResponse.new('400', 'bad request') }
+  let(:bad_json_response)  { ProtocolSpecFakeResponse.new('200', 'not-json{') }
+
+  def make_instance(response, api_key: nil)
+    http = ProtocolSpecFakeHttpClient.new(response)
+    test_protocol_class.new(base_url: 'https://api.example.com', api_key: api_key, http_client: http)
   end
 
   describe 'endpoint DSL' do
@@ -137,11 +182,222 @@ RSpec.describe 'BSV::Network::Protocol' do
     end
   end
 
-  describe '#call' do
-    let(:instance) { Class.new(BSV::Network::Protocol).new(base_url: 'https://example.com') }
+  # ---------------------------------------------------------------------------
+  # HTTP dispatch (Task 3)
+  # ---------------------------------------------------------------------------
 
-    it 'raises NotImplementedError (HTTP dispatch is Task 3)' do
-      expect { instance.call(:get_tx, 'abc123') }.to raise_error(NotImplementedError)
+  describe '#call — escape hatch dispatch' do
+    it 'delegates to call_<name> when defined' do
+      klass = Class.new(test_protocol_class) do
+        def call_broadcast(*_args, **_kwargs)
+          BSV::Network::Result::Success.new(data: 'escape_hatch')
+        end
+      end
+      http     = ProtocolSpecFakeHttpClient.new(ok_response)
+      instance = klass.new(base_url: 'https://api.example.com', http_client: http)
+      result   = instance.call(:broadcast)
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq('escape_hatch')
+    end
+
+    it 'forwards args and kwargs to the escape hatch' do
+      received = {}
+      klass = Class.new(test_protocol_class) do
+        define_method(:call_get_tx) do |*args, **kwargs|
+          received[:args]   = args
+          received[:kwargs] = kwargs
+          BSV::Network::Result::Success.new(data: nil)
+        end
+      end
+      http     = ProtocolSpecFakeHttpClient.new(ok_response)
+      instance = klass.new(base_url: 'https://api.example.com', http_client: http)
+      instance.call(:get_tx, 'abc123', extra: 'val')
+      expect(received[:args]).to eq(['abc123'])
+      expect(received[:kwargs]).to eq({ extra: 'val' })
+    end
+
+    it 'accepts escape hatch command as String' do
+      klass = Class.new(test_protocol_class) do
+        def call_get_tx(*_args, **_kwargs)
+          BSV::Network::Result::Success.new(data: 'string_command')
+        end
+      end
+      http     = ProtocolSpecFakeHttpClient.new(ok_response)
+      instance = klass.new(base_url: 'https://api.example.com', http_client: http)
+      expect(instance.call('get_tx', 'abc').data).to eq('string_command')
+    end
+
+    it 'raises NotImplementedError for subscription calls' do
+      expect { make_instance(ok_response).call(:on_tx) }
+        .to raise_error(NotImplementedError, /subscription/)
+    end
+  end
+
+  describe '#call — falls through to HTTP' do
+    it 'calls default_call when no escape hatch is defined' do
+      result = make_instance(ok_response).call(:get_raw)
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq('raw_body')
+    end
+
+    it 'raises ArgumentError for unknown command' do
+      expect { make_instance(ok_response).call(:nonexistent) }
+        .to raise_error(ArgumentError, /unknown command/)
+    end
+  end
+
+  describe '#default_call — URL interpolation' do
+    it 'interpolates a single positional arg' do
+      http     = ProtocolSpecFakeHttpClient.new(ok_response)
+      instance = test_protocol_class.new(base_url: 'https://api.example.com', http_client: http)
+      instance.default_call(:get_tx, 'abc123')
+      expect(http.last_uri.to_s).to eq('https://api.example.com/v1/tx/abc123')
+    end
+
+    it 'interpolates multiple positional args in template order' do
+      http     = ProtocolSpecFakeHttpClient.new(ok_response)
+      instance = test_protocol_class.new(base_url: 'https://api.example.com', http_client: http)
+      instance.default_call(:get_out, 'abc123', 0)
+      expect(http.last_uri.to_s).to eq('https://api.example.com/v1/tx/abc123/out/0/hex')
+    end
+
+    it 'interpolates named kwargs' do
+      http     = ProtocolSpecFakeHttpClient.new(ok_response)
+      instance = test_protocol_class.new(base_url: 'https://api.example.com', http_client: http)
+      instance.default_call(:get_tx, txid: 'xyz789')
+      expect(http.last_uri.to_s).to eq('https://api.example.com/v1/tx/xyz789')
+    end
+
+    it 'named kwargs take precedence over positional args' do
+      http     = ProtocolSpecFakeHttpClient.new(ok_response)
+      instance = test_protocol_class.new(base_url: 'https://api.example.com', http_client: http)
+      instance.default_call(:get_tx, 'positional', txid: 'named')
+      expect(http.last_uri.to_s).to eq('https://api.example.com/v1/tx/named')
+    end
+
+    it 'raises ArgumentError when a required placeholder is missing' do
+      expect { make_instance(ok_response).default_call(:get_tx) }
+        .to raise_error(ArgumentError, /missing path parameter/)
+    end
+
+    it 'raises ArgumentError for unknown command' do
+      expect { make_instance(ok_response).default_call(:no_such_cmd) }
+        .to raise_error(ArgumentError, /unknown command/)
+    end
+
+    it 'bypasses any escape hatch method' do
+      klass = Class.new(test_protocol_class) do
+        def call_get_raw(*_args, **_kwargs)
+          BSV::Network::Result::Success.new(data: 'escape')
+        end
+      end
+      http     = ProtocolSpecFakeHttpClient.new(ok_response)
+      instance = klass.new(base_url: 'https://api.example.com', http_client: http)
+      expect(instance.default_call(:get_raw).data).to eq('raw_body')
+    end
+  end
+
+  describe '#default_call — response handlers' do
+    it ':raw returns body as a String' do
+      result = make_instance(ok_response).default_call(:get_raw)
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq('raw_body')
+    end
+
+    it ':json parses body to Hash' do
+      result = make_instance(json_response).default_call(:get_info)
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq({ 'txid' => 'abc' })
+    end
+
+    it ':json_array parses body to Array' do
+      result = make_instance(array_response).default_call(:get_list)
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to be_an(Array)
+      expect(result.data.first).to eq({ 'txid' => 'abc' })
+    end
+
+    it 'custom lambda is called with body' do
+      result = make_instance(ok_response).default_call(:custom)
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq('RAW_BODY')
+    end
+
+    it 'JSON parse failure returns Result::Error' do
+      result = make_instance(bad_json_response).default_call(:get_info)
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.message).to match(/JSON parse error/)
+      expect(result.retryable?).to be(false)
+    end
+  end
+
+  describe '#default_call — HTTP status mapping' do
+    it '2xx returns Result::Success' do
+      expect(make_instance(ok_response).default_call(:get_raw))
+        .to be_a(BSV::Network::Result::Success)
+    end
+
+    it '404 returns Result::NotFound' do
+      expect(make_instance(not_found_response).default_call(:get_raw))
+        .to be_a(BSV::Network::Result::NotFound)
+    end
+
+    it '429 returns Result::Error with retryable: true' do
+      result = make_instance(too_many_response).default_call(:get_raw)
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+
+    it '5xx returns Result::Error with retryable: true' do
+      result = make_instance(server_error_resp).default_call(:get_raw)
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+
+    it 'other 4xx returns Result::Error with retryable: false' do
+      result = make_instance(bad_request_resp).default_call(:get_raw)
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(false)
+    end
+
+    it 'Error message contains response body' do
+      expect(make_instance(bad_request_resp).default_call(:get_raw).message).to eq('bad request')
+    end
+  end
+
+  describe '#default_call — POST with body' do
+    it 'sends body: kwarg as request body' do
+      http     = ProtocolSpecFakeHttpClient.new(json_response)
+      instance = test_protocol_class.new(base_url: 'https://api.example.com', http_client: http)
+      instance.default_call(:broadcast, body: '{"rawTx":"deadbeef"}')
+      expect(http.last_request.body).to eq('{"rawTx":"deadbeef"}')
+    end
+
+    it 'does not include body: in path interpolation' do
+      http     = ProtocolSpecFakeHttpClient.new(json_response)
+      instance = test_protocol_class.new(base_url: 'https://api.example.com', http_client: http)
+      instance.default_call(:broadcast, body: 'data')
+      expect(http.last_uri.to_s).to eq('https://api.example.com/v1/tx')
+    end
+  end
+
+  describe '#default_call — Authorization header' do
+    it 'sends Authorization: Bearer header when api_key is set' do
+      http     = ProtocolSpecFakeHttpClient.new(ok_response)
+      instance = test_protocol_class.new(
+        base_url: 'https://api.example.com',
+        api_key: 'secret-key',
+        http_client: http
+      )
+      instance.default_call(:get_raw)
+      expect(http.last_request['Authorization']).to eq('Bearer secret-key')
+    end
+
+    it 'omits Authorization header when api_key is nil' do
+      http     = ProtocolSpecFakeHttpClient.new(ok_response)
+      instance = test_protocol_class.new(base_url: 'https://api.example.com', http_client: http)
+      instance.default_call(:get_raw)
+      expect(http.last_request['Authorization']).to be_nil
     end
   end
 end

--- a/gem/bsv-sdk/spec/bsv/network/result_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/result_spec.rb
@@ -1,0 +1,241 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe BSV::Network::Result do
+  describe BSV::Network::Result::Success do
+    it 'stores data' do
+      result = described_class.new(data: 'payload')
+      expect(result.data).to eq('payload')
+    end
+
+    it 'defaults metadata to empty hash' do
+      result = described_class.new(data: nil)
+      expect(result.metadata).to eq({})
+    end
+
+    it 'stores explicit metadata' do
+      result = described_class.new(data: 'x', metadata: { code: 200 })
+      expect(result.metadata).to eq({ code: 200 })
+    end
+
+    it 'accepts nil data' do
+      result = described_class.new(data: nil)
+      expect(result.data).to be_nil
+    end
+
+    it 'accepts String data' do
+      result = described_class.new(data: 'hello')
+      expect(result.data).to eq('hello')
+    end
+
+    it 'accepts Hash data' do
+      result = described_class.new(data: { txid: 'abc' })
+      expect(result.data).to eq({ txid: 'abc' })
+    end
+
+    it 'accepts Array data' do
+      result = described_class.new(data: [1, 2, 3])
+      expect(result.data).to eq([1, 2, 3])
+    end
+
+    it 'is frozen after construction' do
+      result = described_class.new(data: 'x')
+      expect(result).to be_frozen
+    end
+
+    it 'returns true for success?' do
+      expect(described_class.new(data: nil).success?).to be true
+    end
+
+    it 'returns false for error?' do
+      expect(described_class.new(data: nil).error?).to be false
+    end
+
+    it 'returns false for not_found?' do
+      expect(described_class.new(data: nil).not_found?).to be false
+    end
+
+    describe 'equality' do
+      it 'equals another Success with same data and metadata' do
+        a = described_class.new(data: 'x', metadata: { k: 1 })
+        b = described_class.new(data: 'x', metadata: { k: 1 })
+        expect(a).to eq(b)
+      end
+
+      it 'does not equal a Success with different data' do
+        a = described_class.new(data: 'x')
+        b = described_class.new(data: 'y')
+        expect(a).not_to eq(b)
+      end
+
+      it 'does not equal a Success with different metadata' do
+        a = described_class.new(data: 'x', metadata: { k: 1 })
+        b = described_class.new(data: 'x', metadata: { k: 2 })
+        expect(a).not_to eq(b)
+      end
+
+      it 'produces the same hash for equal instances' do
+        a = described_class.new(data: 'x')
+        b = described_class.new(data: 'x')
+        expect(a.hash).to eq(b.hash)
+      end
+    end
+  end
+
+  describe BSV::Network::Result::Error do
+    it 'stores message' do
+      result = described_class.new(message: 'something failed')
+      expect(result.message).to eq('something failed')
+    end
+
+    it 'defaults retryable to false' do
+      result = described_class.new(message: 'oops')
+      expect(result.retryable).to be false
+    end
+
+    it 'defaults metadata to empty hash' do
+      result = described_class.new(message: 'oops')
+      expect(result.metadata).to eq({})
+    end
+
+    it 'stores explicit retryable flag' do
+      result = described_class.new(message: 'rate limited', retryable: true)
+      expect(result.retryable).to be true
+    end
+
+    it 'stores explicit metadata' do
+      result = described_class.new(message: 'rejected', metadata: { arc_status: 'MINED' })
+      expect(result.metadata).to eq({ arc_status: 'MINED' })
+    end
+
+    it 'is frozen after construction' do
+      result = described_class.new(message: 'fail')
+      expect(result).to be_frozen
+    end
+
+    it 'returns false for success?' do
+      expect(described_class.new(message: 'fail').success?).to be false
+    end
+
+    it 'returns true for error?' do
+      expect(described_class.new(message: 'fail').error?).to be true
+    end
+
+    it 'returns false for not_found?' do
+      expect(described_class.new(message: 'fail').not_found?).to be false
+    end
+
+    describe '#retryable?' do
+      it 'returns false when retryable is false' do
+        result = described_class.new(message: 'fail', retryable: false)
+        expect(result.retryable?).to be false
+      end
+
+      it 'returns true when retryable is true' do
+        result = described_class.new(message: 'rate limited', retryable: true)
+        expect(result.retryable?).to be true
+      end
+    end
+
+    describe 'equality' do
+      it 'equals another Error with same attributes' do
+        a = described_class.new(message: 'fail', retryable: true, metadata: { code: 429 })
+        b = described_class.new(message: 'fail', retryable: true, metadata: { code: 429 })
+        expect(a).to eq(b)
+      end
+
+      it 'does not equal an Error with different message' do
+        a = described_class.new(message: 'fail')
+        b = described_class.new(message: 'other')
+        expect(a).not_to eq(b)
+      end
+
+      it 'does not equal an Error with different retryable' do
+        a = described_class.new(message: 'fail', retryable: false)
+        b = described_class.new(message: 'fail', retryable: true)
+        expect(a).not_to eq(b)
+      end
+
+      it 'produces the same hash for equal instances' do
+        a = described_class.new(message: 'fail', retryable: true)
+        b = described_class.new(message: 'fail', retryable: true)
+        expect(a.hash).to eq(b.hash)
+      end
+    end
+  end
+
+  describe BSV::Network::Result::NotFound do
+    it 'works with no arguments' do
+      result = described_class.new
+      expect(result.message).to be_nil
+      expect(result.metadata).to eq({})
+    end
+
+    it 'accepts an optional message' do
+      result = described_class.new(message: 'transaction not found')
+      expect(result.message).to eq('transaction not found')
+    end
+
+    it 'defaults metadata to empty hash' do
+      result = described_class.new
+      expect(result.metadata).to eq({})
+    end
+
+    it 'stores explicit metadata' do
+      result = described_class.new(metadata: { txid: 'abc' })
+      expect(result.metadata).to eq({ txid: 'abc' })
+    end
+
+    it 'is frozen after construction' do
+      result = described_class.new
+      expect(result).to be_frozen
+    end
+
+    it 'returns false for success?' do
+      expect(described_class.new.success?).to be false
+    end
+
+    it 'returns false for error?' do
+      expect(described_class.new.error?).to be false
+    end
+
+    it 'returns true for not_found?' do
+      expect(described_class.new.not_found?).to be true
+    end
+
+    describe 'equality' do
+      it 'equals another NotFound with same attributes' do
+        a = described_class.new(message: 'gone', metadata: { code: 404 })
+        b = described_class.new(message: 'gone', metadata: { code: 404 })
+        expect(a).to eq(b)
+      end
+
+      it 'does not equal a NotFound with different message' do
+        a = described_class.new(message: 'gone')
+        b = described_class.new(message: nil)
+        expect(a).not_to eq(b)
+      end
+
+      it 'produces the same hash for equal instances' do
+        a = described_class.new(message: 'gone')
+        b = described_class.new(message: 'gone')
+        expect(a.hash).to eq(b.hash)
+      end
+    end
+  end
+
+  describe 'cross-type inequality' do
+    it 'Success does not equal Error' do
+      expect(BSV::Network::Result::Success.new(data: nil)).not_to eq(BSV::Network::Result::Error.new(message: 'fail'))
+    end
+
+    it 'Success does not equal NotFound' do
+      expect(BSV::Network::Result::Success.new(data: nil)).not_to eq(BSV::Network::Result::NotFound.new)
+    end
+
+    it 'Error does not equal NotFound' do
+      expect(BSV::Network::Result::Error.new(message: 'fail')).not_to eq(BSV::Network::Result::NotFound.new)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Implement `BSV::Network::Result` value types (Success, Error, NotFound) with metadata support
- Implement `BSV::Network::Protocol` base class with `endpoint` DSL macro
- Implement HTTP dispatch with URL interpolation, response handlers, and Result mapping
- Escape hatch support via `call_<name>` methods with `default_call` for raw HTTP
- `subscription` placeholder for future WebSocket support
- Integration spec covering full Protocol lifecycle
- `BSV::Network::Protocols` namespace module for Phase B

## Test plan
- [x] All SDK specs pass (3585 examples, 0 failures)
- [x] RuboCop clean (391 files, no offences)
- [x] All acceptance criteria from #524 verified

Closes #524
Closes #529
Closes #530
Closes #531
Closes #532

Generated with [Claude Code](https://claude.com/claude-code)
