### PR TITLE
feat(network): concrete protocol implementations — ARC, WoCREST, Chaintracks, Ordinals, TAALBinary (#525)

### DIFF
--- a/gem/bsv-sdk/lib/bsv/network/protocols.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols.rb
@@ -7,7 +7,11 @@ module BSV
     # Protocol implementations (e.g. ARC, WhatsOnChain adapters built on
     # the Protocol base class) will be autoloaded here in Phase B.
     module Protocols
-      # Protocol implementations will be autoloaded here in Phase B
+      autoload :ARC,         'bsv/network/protocols/arc'
+      autoload :Chaintracks, 'bsv/network/protocols/chaintracks'
+      autoload :Ordinals,    'bsv/network/protocols/ordinals'
+      autoload :TAALBinary,  'bsv/network/protocols/taal_binary'
+      autoload :WoCREST,     'bsv/network/protocols/woc_rest'
     end
   end
 end

--- a/gem/bsv-sdk/lib/bsv/network/protocols/arc.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/arc.rb
@@ -1,0 +1,283 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'securerandom'
+
+module BSV
+  module Network
+    module Protocols
+      # ARC protocol implementation for submitting transactions to the BSV network.
+      #
+      # Extends Protocol with five endpoints and two escape hatches for broadcast
+      # logic: EF format preference, rejection detection, and custom headers.
+      #
+      # The protocol returns Result objects (never raises). The facade layer
+      # (Phase D) is responsible for translating Results to BroadcastResponse /
+      # BroadcastError as needed by consumer code.
+      #
+      # == Example
+      #
+      #   arc = BSV::Network::Protocols::ARC.new(
+      #     base_url: 'https://arc.taal.com',
+      #     api_key: 'my-api-key'
+      #   )
+      #   result = arc.call(:broadcast, tx)
+      #   result.success? # => true
+      #   result.data[:txid] # => "abc123..."
+      class ARC < Protocol
+        # ARC response statuses that indicate a transaction was NOT accepted.
+        # Matches the TypeScript SDK's ARC broadcaster failure set.
+        REJECTED_STATUSES = %w[
+          REJECTED
+          DOUBLE_SPEND_ATTEMPTED
+          INVALID
+          MALFORMED
+          MINED_IN_STALE_BLOCK
+        ].freeze
+
+        # Substring marker for orphan detection in txStatus or extraInfo fields.
+        ORPHAN_MARKER = 'ORPHAN'
+
+        endpoint :broadcast,      :post, '/v1/tx',          response: :json
+        endpoint :broadcast_many, :post, '/v1/txs',         response: :json_array
+        endpoint :get_tx_status,  :get,  '/v1/tx/{txid}',   response: :json
+        endpoint :get_policy,     :get,  '/v1/policy',      response: :json
+        endpoint :health,         :get,  '/v1/health',      response: :json
+
+        # @param base_url      [String]      ARC base URL (may contain {network})
+        # @param api_key       [String, nil] optional bearer token
+        # @param network       [String, nil] network name for base URL interpolation
+        # @param deployment_id [String, nil] deployment identifier for the
+        #   XDeployment-ID header; defaults to a per-instance random hex value
+        # @param callback_url  [String, nil] optional X-CallbackUrl header value
+        # @param callback_token [String, nil] optional X-CallbackToken header value
+        # @param http_client   [#request, nil] injectable HTTP client for testing
+        def initialize(base_url:, api_key: nil, network: nil, deployment_id: nil,
+                       callback_url: nil, callback_token: nil, http_client: nil)
+          super(base_url: base_url, api_key: api_key, network: network, http_client: http_client)
+          @deployment_id  = deployment_id || "bsv-ruby-sdk-#{SecureRandom.hex(8)}"
+          @callback_url   = callback_url
+          @callback_token = callback_token
+        end
+
+        private
+
+        # Broadcast escape hatch: EF format preference, custom headers, rejection
+        # detection, and malformed 2xx detection.
+        #
+        # @param tx [Transaction] the transaction to broadcast
+        # @param wait_for [String, nil] ARC wait condition
+        # @param skip_fee_validation [Boolean, nil]
+        # @param skip_script_validation [Boolean, nil]
+        # @param skip_tx_validation [Boolean, nil]
+        # @param callback_url [String, nil] per-call callback URL override
+        # @param callback_token [String, nil] per-call callback token override
+        # @param callback_batch [Boolean, nil] when truthy, sends X-CallbackBatch header
+        # @return [Result::Success, Result::Error]
+        def call_broadcast(tx, wait_for: nil, skip_fee_validation: nil,
+                           skip_script_validation: nil, skip_tx_validation: nil,
+                           callback_url: nil, callback_token: nil, callback_batch: nil, **)
+          hex  = ef_hex_with_fallback(tx)
+          body = JSON.generate(rawTx: hex)
+
+          extra_headers = build_broadcast_headers(
+            wait_for: wait_for,
+            skip_fee_validation: skip_fee_validation,
+            skip_script_validation: skip_script_validation,
+            skip_tx_validation: skip_tx_validation,
+            callback_url: callback_url || @callback_url,
+            callback_token: callback_token || @callback_token,
+            callback_batch: callback_batch
+          )
+
+          response = post_with_headers('/v1/tx', body, extra_headers)
+          parse_single_broadcast_response(response)
+        end
+
+        # Broadcast-many escape hatch: batch broadcast with per-item rejection detection.
+        #
+        # @param txs [Array<Transaction>]
+        # @param wait_for [String, nil]
+        # @param skip_fee_validation [Boolean, nil]
+        # @param skip_script_validation [Boolean, nil]
+        # @param skip_tx_validation [Boolean, nil]
+        # @param callback_url [String, nil]
+        # @param callback_token [String, nil]
+        # @param callback_batch [Boolean, nil]
+        # @return [Result::Success, Result::Error]
+        def call_broadcast_many(txs, wait_for: nil, skip_fee_validation: nil,
+                                skip_script_validation: nil, skip_tx_validation: nil,
+                                callback_url: nil, callback_token: nil, callback_batch: nil, **)
+          return Result::Success.new(data: []) if txs.empty?
+
+          body = JSON.generate(txs.map { |tx| { rawTx: ef_hex_with_fallback(tx) } })
+
+          extra_headers = build_broadcast_headers(
+            wait_for: wait_for,
+            skip_fee_validation: skip_fee_validation,
+            skip_script_validation: skip_script_validation,
+            skip_tx_validation: skip_tx_validation,
+            callback_url: callback_url || @callback_url,
+            callback_token: callback_token || @callback_token,
+            callback_batch: callback_batch
+          )
+
+          response = post_with_headers('/v1/txs', body, extra_headers)
+          parse_batch_broadcast_response(response)
+        end
+
+        # Prefer Extended Format hex (BRC-30) so ARC can validate sighashes without
+        # fetching parent transactions. Falls back to plain raw-tx hex when any input
+        # lacks source_satoshis / source_locking_script.
+        def ef_hex_with_fallback(tx)
+          tx.to_ef_hex
+        rescue ArgumentError
+          tx.to_hex
+        end
+
+        # Build the hash of ARC-specific extra headers.
+        def build_broadcast_headers(wait_for:, skip_fee_validation:, skip_script_validation:,
+                                    skip_tx_validation:, callback_url:, callback_token:,
+                                    callback_batch:)
+          headers = { 'XDeployment-ID' => @deployment_id }
+          headers['X-WaitFor']              = wait_for                     if wait_for
+          headers['X-CallbackUrl']          = callback_url                 if callback_url
+          headers['X-CallbackToken']        = callback_token               if callback_token
+          headers['X-SkipFeeValidation']    = 'true'                       if skip_fee_validation
+          headers['X-SkipScriptValidation'] = 'true'                       if skip_script_validation
+          headers['X-SkipTxValidation']     = 'true'                       if skip_tx_validation
+          headers['X-CallbackBatch']        = 'true'                       if callback_batch
+          headers
+        end
+
+        # Perform a POST to the given path with a JSON body plus extra headers.
+        # Returns a Net::HTTPResponse-like object.
+        def post_with_headers(path, body, extra_headers)
+          uri     = URI("#{@base_url}#{path}")
+          request = build_request(:post, uri, body)
+          extra_headers.each { |k, v| request[k] = v }
+          execute(uri, request)
+        end
+
+        # Parse and validate a single-transaction ARC response.
+        def parse_single_broadcast_response(response)
+          code = response.code.to_i
+          body = safe_parse_json(response.body)
+
+          unless (200..299).cover?(code)
+            return Result::Error.new(
+              message: body['detail'] || body['title'] || "HTTP #{code}",
+              retryable: retryable_code?(code),
+              metadata: { arc_status: body['txStatus'], txid: body['txid'] }
+            )
+          end
+
+          if rejected_status?(body)
+            return Result::Error.new(
+              message: body['detail'] || body['title'] || body['txStatus'],
+              retryable: false,
+              metadata: { arc_status: body['txStatus'].to_s.upcase, txid: body['txid'] }
+            )
+          end
+
+          unless body['txid']
+            return Result::Error.new(
+              message: 'ARC returned a malformed 2xx response',
+              retryable: false,
+              metadata: {}
+            )
+          end
+
+          Result::Success.new(
+            data: {
+              txid: body['txid'],
+              tx_status: body['txStatus'],
+              extra_info: body['extraInfo']
+            },
+            metadata: { arc_status: body['txStatus'] }
+          )
+        end
+
+        # Parse and validate a batch ARC response. HTTP-level errors return a
+        # single Result::Error; per-item rejections are embedded in the data array.
+        def parse_batch_broadcast_response(response)
+          code = response.code.to_i
+          body = safe_parse_json(response.body)
+
+          unless (200..299).cover?(code)
+            return Result::Error.new(
+              message: body.is_a?(Hash) ? (body['detail'] || body['title'] || "HTTP #{code}") : "HTTP #{code}",
+              retryable: retryable_code?(code),
+              metadata: {}
+            )
+          end
+
+          unless body.is_a?(Array)
+            return Result::Error.new(
+              message: 'ARC returned a malformed batch response',
+              retryable: false,
+              metadata: {}
+            )
+          end
+
+          items = body.map { |item| build_item_result(item) }
+          Result::Success.new(data: items, metadata: {})
+        end
+
+        # Build a per-item result for a batch response entry.
+        def build_item_result(item)
+          if rejected_status?(item)
+            Result::Error.new(
+              message: item['detail'] || item['title'] || item['txStatus'],
+              retryable: false,
+              metadata: { arc_status: item['txStatus'].to_s.upcase, txid: item['txid'] }
+            )
+          elsif !item['txid']
+            Result::Error.new(
+              message: 'ARC returned a malformed 2xx response',
+              retryable: false,
+              metadata: {}
+            )
+          else
+            Result::Success.new(
+              data: {
+                txid: item['txid'],
+                tx_status: item['txStatus'],
+                extra_info: item['extraInfo']
+              },
+              metadata: { arc_status: item['txStatus'] }
+            )
+          end
+        end
+
+        # Determine whether a status code indicates a retryable failure.
+        def retryable_code?(code)
+          code == 429 || (500..599).cover?(code)
+        end
+
+        # Determine whether an ARC response body represents a rejected transaction.
+        # Case-insensitive match — the TypeScript reference SDK explicitly uppercases
+        # both fields before membership / substring checks. ARC has a documented
+        # history of emitting values outside its own OpenAPI enum, so case
+        # normalisation is the defensive choice.
+        def rejected_status?(body)
+          tx_status = body['txStatus'].to_s.upcase
+          return true if REJECTED_STATUSES.include?(tx_status)
+          return true if tx_status.include?(ORPHAN_MARKER)
+
+          extra_info = body['extraInfo'].to_s.upcase
+          return true if extra_info.include?(ORPHAN_MARKER)
+
+          false
+        end
+
+        # Parse JSON, returning a hash with a 'detail' key on parse failure.
+        def safe_parse_json(raw)
+          JSON.parse(raw.to_s)
+        rescue JSON::ParserError
+          { 'detail' => raw.to_s }
+        end
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/network/protocols/arc.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/arc.rb
@@ -164,6 +164,14 @@ module BSV
           code = response.code.to_i
           body = safe_parse_json(response.body)
 
+          unless body.is_a?(Hash)
+            return Result::Error.new(
+              message: "HTTP #{code}",
+              retryable: retryable_code?(code),
+              metadata: {}
+            )
+          end
+
           unless (200..299).cover?(code)
             return Result::Error.new(
               message: body['detail'] || body['title'] || "HTTP #{code}",
@@ -226,6 +234,14 @@ module BSV
 
         # Build a per-item result for a batch response entry.
         def build_item_result(item)
+          unless item.is_a?(Hash)
+            return Result::Error.new(
+              message: 'malformed batch item',
+              retryable: false,
+              metadata: {}
+            )
+          end
+
           if rejected_status?(item)
             Result::Error.new(
               message: item['detail'] || item['title'] || item['txStatus'],

--- a/gem/bsv-sdk/lib/bsv/network/protocols/chaintracks.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/chaintracks.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module BSV
+  module Network
+    module Protocols
+      # Chaintracks protocol adapter for the GorillaPool Chaintracks service.
+      #
+      # Provides block header lookup and current chain tip height via the
+      # GorillaPool Chaintracks v2 REST API.
+      #
+      # == Usage
+      #
+      #   ct = BSV::Network::Protocols::Chaintracks.new(
+      #     base_url: 'https://arcade.gorillapool.io'
+      #   )
+      #   result = ct.call(:get_block_header, height: 800_000)
+      #   result.data  # => { 'hash' => '...', 'height' => 800000, ... }
+      #
+      #   result = ct.call(:current_height)
+      #   result.data  # => 800000
+      class Chaintracks < BSV::Network::Protocol
+        endpoint :get_block_header, :get, '/chaintracks/v2/header/height/{height}', response: :json
+        endpoint :current_height,   :get, '/chaintracks/v2/tip',
+                 response: ->(body) { JSON.parse(body)['height'] }
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/network/protocols/chaintracks.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/chaintracks.rb
@@ -1,27 +1,39 @@
 # frozen_string_literal: true
 
+require 'json'
+
 module BSV
   module Network
     module Protocols
-      # Chaintracks protocol adapter for the GorillaPool Chaintracks service.
+      # Chaintracks implements the GorillaPool Chaintracks API as a Protocol subclass.
       #
       # Provides block header lookup and current chain tip height via the
-      # GorillaPool Chaintracks v2 REST API.
+      # GorillaPool Chaintracks v2 REST API. Pure DSL — no escape hatches needed.
+      #
+      # Chaintracks does not use a +{network}+ placeholder in the URL. Mainnet
+      # and testnet are served from separate base URLs; the default points to
+      # the mainnet ARCADE domain.
       #
       # == Usage
       #
-      #   ct = BSV::Network::Protocols::Chaintracks.new(
-      #     base_url: 'https://arcade.gorillapool.io'
-      #   )
-      #   result = ct.call(:get_block_header, height: 800_000)
-      #   result.data  # => { 'hash' => '...', 'height' => 800000, ... }
-      #
+      #   ct = BSV::Network::Protocols::Chaintracks.new
       #   result = ct.call(:current_height)
       #   result.data  # => 800000
-      class Chaintracks < BSV::Network::Protocol
+      #
+      #   result = ct.call(:get_block_header, 800_000)
+      #   result.data  # => { 'hash' => '...', 'height' => 800000, 'merkleRoot' => '...' }
+      class Chaintracks < Protocol
+        BASE_URL = 'https://arcade.gorillapool.io'
+
         endpoint :get_block_header, :get, '/chaintracks/v2/header/height/{height}', response: :json
         endpoint :current_height,   :get, '/chaintracks/v2/tip',
                  response: ->(body) { JSON.parse(body)['height'] }
+
+        # @param api_key     [String, nil] optional Bearer API key
+        # @param http_client [Object, nil] injectable HTTP client for testing
+        def initialize(api_key: nil, http_client: nil)
+          super(base_url: BASE_URL, api_key: api_key, http_client: http_client)
+        end
       end
     end
   end

--- a/gem/bsv-sdk/lib/bsv/network/protocols/ordinals.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/ordinals.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module BSV
+  module Network
+    module Protocols
+      # Ordinals protocol adapter for the GorillaPool Ordinals service.
+      #
+      # Provides raw transaction hex lookup and Merkle path (proof) retrieval
+      # via the GorillaPool Ordinals REST API.
+      #
+      # == Usage
+      #
+      #   ord = BSV::Network::Protocols::Ordinals.new(
+      #     base_url: 'https://ordinals.gorillapool.io'
+      #   )
+      #   result = ord.call(:get_tx, txid: 'abc123...')
+      #   result.data  # => "01000000..."  (raw hex string)
+      #
+      #   result = ord.call(:get_merkle_path, txid: 'abc123...')
+      #   result.data  # => { 'index' => 0, 'path' => [...] }
+      class Ordinals < BSV::Network::Protocol
+        endpoint :get_tx,          :get, '/api/tx/{txid}/hex'
+        endpoint :get_merkle_path, :get, '/api/tx/{txid}/proof', response: :json
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/network/protocols/ordinals.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/ordinals.rb
@@ -3,24 +3,30 @@
 module BSV
   module Network
     module Protocols
-      # Ordinals protocol adapter for the GorillaPool Ordinals service.
+      # Ordinals implements the GorillaPool Ordinals API as a Protocol subclass.
       #
       # Provides raw transaction hex lookup and Merkle path (proof) retrieval
-      # via the GorillaPool Ordinals REST API.
+      # via the GorillaPool Ordinals REST API. Pure DSL — no escape hatches needed.
       #
       # == Usage
       #
-      #   ord = BSV::Network::Protocols::Ordinals.new(
-      #     base_url: 'https://ordinals.gorillapool.io'
-      #   )
-      #   result = ord.call(:get_tx, txid: 'abc123...')
+      #   ord = BSV::Network::Protocols::Ordinals.new
+      #   result = ord.call(:get_tx, 'abc123...')
       #   result.data  # => "01000000..."  (raw hex string)
       #
-      #   result = ord.call(:get_merkle_path, txid: 'abc123...')
+      #   result = ord.call(:get_merkle_path, 'abc123...')
       #   result.data  # => { 'index' => 0, 'path' => [...] }
-      class Ordinals < BSV::Network::Protocol
+      class Ordinals < Protocol
+        BASE_URL = 'https://ordinals.gorillapool.io'
+
         endpoint :get_tx,          :get, '/api/tx/{txid}/hex'
         endpoint :get_merkle_path, :get, '/api/tx/{txid}/proof', response: :json
+
+        # @param api_key     [String, nil] optional Bearer API key
+        # @param http_client [Object, nil] injectable HTTP client for testing
+        def initialize(api_key: nil, http_client: nil)
+          super(base_url: BASE_URL, api_key: api_key, http_client: http_client)
+        end
       end
     end
   end

--- a/gem/bsv-sdk/lib/bsv/network/protocols/taal_binary.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/taal_binary.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module BSV
+  module Network
+    module Protocols
+      # TAALBinary implements the TAAL broadcast API using raw binary transaction
+      # submission over HTTP.
+      #
+      # TAAL quirks handled here:
+      # - Content-Type is +application/octet-stream+ (not JSON)
+      # - Authorization header uses the API key directly with no "Bearer" prefix
+      # - A response containing +txn-already-known+ in the error field is treated
+      #   as success (the transaction is already in the mempool — idempotent)
+      #
+      # == Example
+      #
+      #   protocol = BSV::Network::Protocols::TAALBinary.new(
+      #     base_url: 'https://api.taal.com',
+      #     api_key: 'mainnet_your_key_here'
+      #   )
+      #   result = protocol.call(:broadcast, tx)
+      #   puts result.data[:txid] if result.success?
+      class TAALBinary < BSV::Network::Protocol
+        endpoint :broadcast, :post, '/api/v1/broadcast', response: :json
+
+        private
+
+        # Escape hatch for broadcast: sends raw binary transaction bytes with
+        # TAAL-specific headers and applies TAAL-specific response quirk handling.
+        #
+        # @param tx [#to_binary, String] transaction object or raw binary string
+        # @return [Result::Success, Result::Error]
+        def call_broadcast(tx)
+          body = tx.respond_to?(:to_binary) ? tx.to_binary : tx
+
+          uri     = URI("#{@base_url}/api/v1/broadcast")
+          request = Net::HTTP::Post.new(uri)
+          request['Content-Type']  = 'application/octet-stream'
+          request['Authorization'] = @api_key if @api_key
+
+          request.body = body
+
+          response = execute(uri, request)
+          parse_broadcast_response(response)
+        end
+
+        # Maps the HTTP response from TAAL broadcast to a Result, applying the
+        # +txn-already-known+ idempotency quirk.
+        #
+        # @param response [Net::HTTPResponse]
+        # @return [Result::Success, Result::Error]
+        def parse_broadcast_response(response)
+          code = response.code.to_i
+          body = parse_json_body(response.body)
+
+          return Result::Success.new(data: { txid: body['txid'] }) if already_known?(body)
+
+          retryable = code == 429 || (500..599).cover?(code)
+
+          if (200..299).cover?(code)
+            Result::Success.new(data: { txid: body['txid'] })
+          else
+            message = (body.is_a?(Hash) && body['error']) || "HTTP #{code}"
+            Result::Error.new(message: message, retryable: retryable)
+          end
+        end
+
+        # Returns true when the response body indicates the transaction is already
+        # known to the network — TAAL treats this as a non-error.
+        #
+        # @param body [Hash, nil]
+        # @return [Boolean]
+        def already_known?(body)
+          body.is_a?(Hash) &&
+            body['error'].is_a?(String) &&
+            body['error'].include?('txn-already-known')
+        end
+
+        # Parses a JSON response body, returning nil on failure.
+        #
+        # @param raw [String, nil]
+        # @return [Hash, Array, nil]
+        def parse_json_body(raw)
+          return nil if raw.nil? || raw.empty?
+
+          JSON.parse(raw)
+        rescue JSON::ParserError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/network/protocols/taal_binary.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/taal_binary.rb
@@ -76,16 +76,20 @@ module BSV
             body['error'].include?('txn-already-known')
         end
 
-        # Parses a JSON response body, returning nil on failure.
+        # Parses a JSON response body, returning an empty Hash on failure or nil input.
+        #
+        # Always returns a Hash so callers can safely index the result without
+        # a nil-guard.
         #
         # @param raw [String, nil]
-        # @return [Hash, Array, nil]
+        # @return [Hash]
         def parse_json_body(raw)
-          return nil if raw.nil? || raw.empty?
+          return {} if raw.nil? || raw.empty?
 
-          JSON.parse(raw)
+          parsed = JSON.parse(raw)
+          parsed.is_a?(Hash) ? parsed : {}
         rescue JSON::ParserError
-          nil
+          {}
         end
       end
     end

--- a/gem/bsv-sdk/lib/bsv/network/protocols/woc_rest.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/woc_rest.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module BSV
+  module Network
+    module Protocols
+      # WoCREST implements the WhatsOnChain REST API as a Protocol subclass.
+      #
+      # Provides 12 endpoints covering chain info, block headers, transactions,
+      # UTXOs, scripts, broadcast, and health. Three escape hatches handle
+      # WoC-specific body formats and field remapping.
+      #
+      # == Network resolution
+      #
+      # WoC uses +main+ and +test+ in its URL paths. The constructor accepts
+      # symbolic aliases (:mainnet, :testnet, :stn) and resolves them to the
+      # correct string.
+      #
+      # == Usage
+      #
+      #   woc = BSV::Network::Protocols::WoCREST.new(network: :main)
+      #   result = woc.call(:get_tx, 'abc123...')
+      #   puts result.data if result.success?
+      class WoCREST < Protocol
+        BASE_URL = 'https://api.whatsonchain.com/v1/bsv/{network}'
+
+        NETWORKS = {
+          'main' => 'main',
+          'test' => 'test',
+          'stn' => 'stn',
+          main: 'main',
+          test: 'test',
+          stn: 'stn',
+          mainnet: 'main',
+          testnet: 'test'
+        }.freeze
+
+        # Chain
+        endpoint :current_height,   :get, '/chain/info',
+                 response: ->(body) { JSON.parse(body)['blocks'] }
+        endpoint :get_block_header, :get, '/block/{height}/header', response: :json
+
+        # Transaction
+        endpoint :get_tx,           :get,  '/tx/{txid}/hex'
+        endpoint :get_merkle_path,  :get,  '/tx/{txid}/proof/tsc', response: :json
+        endpoint :broadcast,        :post, '/tx/raw'
+        endpoint :get_tx_status,    :post, '/txs/status', response: :json
+
+        # UTXO / spent status
+        endpoint :get_utxos,        :get,  '/address/{address}/confirmed/unspent',
+                 response: :json_array
+        endpoint :is_utxo,          :get,  '/tx/{txid}/{vout}/spent', response: :json
+        endpoint :valid_root,       :get,  '/block/{height}/header', response: :json
+
+        # Script
+        endpoint :get_script_unspent, :get, '/script/{script_hash}/confirmed/unspent',
+                 response: :json_array
+
+        # Address balance
+        endpoint :get_balance,      :get,  '/address/{address}/confirmed/balance',
+                 response: :json
+
+        # Health
+        endpoint :health,           :get,  '/health'
+
+        attr_reader :network_name
+
+        # @param network  [Symbol, String] :main, :mainnet, :test, :testnet, :stn
+        # @param api_key  [String, nil]    optional Bearer API key
+        # @param http_client [Object, nil] injectable HTTP client for testing
+        def initialize(network: :main, api_key: nil, http_client: nil)
+          @network_name = resolve_network(network)
+          super(
+            base_url: BASE_URL,
+            api_key: api_key,
+            network: @network_name,
+            http_client: http_client
+          )
+        end
+
+        private
+
+        # Resolves network aliases to the WoC URL segment string.
+        #
+        # @param network [Symbol, String]
+        # @return [String] 'main', 'test', or 'stn'
+        # @raise [ArgumentError] when the network value is not recognised
+        def resolve_network(network)
+          NETWORKS.fetch(network) do
+            raise ArgumentError, "unknown network: #{network.inspect}"
+          end
+        end
+
+        # Fetches confirmed UTXOs for an address and remaps the +value+ field
+        # to +satoshis+ to match the SDK's UTXO convention.
+        #
+        # WoC returns entries with +{ tx_hash, tx_pos, value, height }+;
+        # callers and facades expect +satoshis+ in place of +value+.
+        #
+        # @param address [String] BSV address
+        # @return [Result::Success, Result::Error, Result::NotFound]
+        def call_get_utxos(address)
+          result = default_call(:get_utxos, address)
+          return result unless result.success?
+
+          remapped = result.data.map do |entry|
+            {
+              'tx_hash' => entry['tx_hash'],
+              'tx_pos' => entry['tx_pos'],
+              'satoshis' => entry['value'],
+              'height' => entry['height']
+            }
+          end
+
+          Result::Success.new(data: remapped)
+        end
+
+        # Checks whether a specific output is unspent by querying the WoC
+        # spent-status endpoint.
+        #
+        # WoC returns a JSON object indicating whether the output has been spent.
+        # The +script_hash:+ keyword is accepted for future fallback support
+        # (Phase E) but not used in this implementation.
+        #
+        # @param txid        [String]  transaction ID
+        # @param vout        [Integer] output index
+        # @param script_hash [String, nil] ignored in Phase B
+        # @return [Result::Success<Boolean>, Result::Error, Result::NotFound]
+        def call_is_utxo(txid, vout, script_hash: nil) # rubocop:disable Lint/UnusedMethodArgument
+          result = default_call(:is_utxo, txid, vout)
+          return result unless result.success?
+
+          # WoC returns { "spent": true/false, ... } — unspent means NOT spent
+          spent = result.data['spent']
+          Result::Success.new(data: !spent)
+        end
+
+        # Broadcasts a raw transaction to WhatsOnChain.
+        #
+        # WoC expects the body as +{ txhex: "..." }+ (JSON). On success it
+        # returns the txid as a plain-text string (not JSON). The response is
+        # stripped and wrapped in a Hash for caller convenience.
+        #
+        # @param tx [#to_hex, String] transaction object or raw hex string
+        # @return [Result::Success<{ txid: String }>, Result::Error]
+        def call_broadcast(tx)
+          hex  = tx.respond_to?(:to_hex) ? tx.to_hex : tx.to_s
+          body = JSON.generate(txhex: hex)
+
+          result = default_call(:broadcast, body: body)
+          return result unless result.success?
+
+          # WoC returns plain-text txid — result.data is the raw body string
+          Result::Success.new(data: { 'txid' => result.data.strip })
+        end
+
+        # Verifies that a merkle root matches the one recorded for a given
+        # block height. Uses the get_block_header endpoint internally.
+        #
+        # Comparison is case-insensitive to tolerate mixed-case hex from
+        # different providers.
+        #
+        # @param root   [String]  expected merkle root as hex
+        # @param height [Integer] block height
+        # @return [Result::Success<Boolean>, Result::Error, Result::NotFound]
+        def call_valid_root(root, height)
+          result = default_call(:valid_root, height)
+          return result unless result.success?
+
+          actual = result.data['merkleroot']
+          Result::Success.new(data: actual.to_s.downcase == root.to_s.downcase)
+        end
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/network/protocols/woc_rest.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/woc_rest.rb
@@ -106,10 +106,10 @@ module BSV
 
           remapped = result.data.map do |entry|
             {
-              'tx_hash' => entry['tx_hash'],
-              'tx_pos' => entry['tx_pos'],
-              'satoshis' => entry['value'],
-              'height' => entry['height']
+              tx_hash: entry['tx_hash'],
+              tx_pos: entry['tx_pos'],
+              satoshis: entry['value'],
+              height: entry['height']
             }
           end
 
@@ -132,6 +132,10 @@ module BSV
           return result unless result.success?
 
           # WoC returns { "spent": true/false, ... } — unspent means NOT spent
+          unless result.data.is_a?(Hash) && result.data.key?('spent')
+            return Result::Error.new(message: 'missing spent field in response', retryable: false)
+          end
+
           spent = result.data['spent']
           Result::Success.new(data: !spent)
         end
@@ -152,7 +156,7 @@ module BSV
           return result unless result.success?
 
           # WoC returns plain-text txid — result.data is the raw body string
-          Result::Success.new(data: { 'txid' => result.data.strip })
+          Result::Success.new(data: { txid: result.data.strip })
         end
 
         # Verifies that a merkle root matches the one recorded for a given

--- a/gem/bsv-sdk/spec/bsv/network/protocols/all_protocols_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/all_protocols_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/DescribeClass
+require 'spec_helper'
+
+RSpec.describe 'BSV::Network::Protocols integration' do
+  # Verify all 5 protocol classes load correctly via autoload.
+  describe 'autoloads' do
+    it 'loads ARC' do
+      expect(BSV::Network::Protocols::ARC).to be < BSV::Network::Protocol
+    end
+
+    it 'loads WoCREST' do
+      expect(BSV::Network::Protocols::WoCREST).to be < BSV::Network::Protocol
+    end
+
+    it 'loads Chaintracks' do
+      expect(BSV::Network::Protocols::Chaintracks).to be < BSV::Network::Protocol
+    end
+
+    it 'loads Ordinals' do
+      expect(BSV::Network::Protocols::Ordinals).to be < BSV::Network::Protocol
+    end
+
+    it 'loads TAALBinary' do
+      expect(BSV::Network::Protocols::TAALBinary).to be < BSV::Network::Protocol
+    end
+  end
+
+  # Verify command counts and no intra-protocol collisions.
+  describe 'command sets' do
+    describe 'ARC' do
+      subject(:commands) { BSV::Network::Protocols::ARC.commands }
+
+      it 'has 5 commands' do
+        expect(commands.size).to eq(5)
+      end
+
+      it 'includes the expected commands' do
+        expect(commands).to include(:broadcast, :broadcast_many, :get_tx_status, :get_policy, :health)
+      end
+
+      it 'has no duplicate command names' do
+        expect(commands.size).to eq(commands.to_a.uniq.size)
+      end
+    end
+
+    describe 'WoCREST' do
+      subject(:commands) { BSV::Network::Protocols::WoCREST.commands }
+
+      it 'has 12 commands' do
+        expect(commands.size).to eq(12)
+      end
+
+      it 'includes the expected commands' do
+        expect(commands).to include(
+          :current_height, :get_block_header, :get_tx, :get_merkle_path,
+          :broadcast, :get_tx_status, :get_utxos, :is_utxo,
+          :valid_root, :get_script_unspent, :get_balance, :health
+        )
+      end
+
+      it 'has no duplicate command names' do
+        expect(commands.size).to eq(commands.to_a.uniq.size)
+      end
+    end
+
+    describe 'Chaintracks' do
+      subject(:commands) { BSV::Network::Protocols::Chaintracks.commands }
+
+      it 'has 2 commands' do
+        expect(commands.size).to eq(2)
+      end
+
+      it 'includes the expected commands' do
+        expect(commands).to include(:get_block_header, :current_height)
+      end
+
+      it 'has no duplicate command names' do
+        expect(commands.size).to eq(commands.to_a.uniq.size)
+      end
+    end
+
+    describe 'Ordinals' do
+      subject(:commands) { BSV::Network::Protocols::Ordinals.commands }
+
+      it 'has 2 commands' do
+        expect(commands.size).to eq(2)
+      end
+
+      it 'includes the expected commands' do
+        expect(commands).to include(:get_tx, :get_merkle_path)
+      end
+
+      it 'has no duplicate command names' do
+        expect(commands.size).to eq(commands.to_a.uniq.size)
+      end
+    end
+
+    describe 'TAALBinary' do
+      subject(:commands) { BSV::Network::Protocols::TAALBinary.commands }
+
+      it 'has 1 command' do
+        expect(commands.size).to eq(1)
+      end
+
+      it 'includes the expected commands' do
+        expect(commands).to include(:broadcast)
+      end
+
+      it 'has no duplicate command names' do
+        expect(commands.size).to eq(commands.to_a.uniq.size)
+      end
+    end
+  end
+
+  # Verify that protocols sharing a command name are distinct classes.
+  describe 'shared command names across protocols' do
+    it ':broadcast is declared by ARC, WoCREST, and TAALBinary as distinct classes' do
+      classes = [
+        BSV::Network::Protocols::ARC,
+        BSV::Network::Protocols::WoCREST,
+        BSV::Network::Protocols::TAALBinary
+      ]
+      expect(classes.all? { |klass| klass.commands.include?(:broadcast) }).to be(true)
+      expect(classes.uniq.size).to eq(3)
+    end
+
+    it ':current_height is declared by WoCREST and Chaintracks as distinct classes' do
+      classes = [
+        BSV::Network::Protocols::WoCREST,
+        BSV::Network::Protocols::Chaintracks
+      ]
+      expect(classes.all? { |klass| klass.commands.include?(:current_height) }).to be(true)
+      expect(classes.uniq.size).to eq(2)
+    end
+
+    it ':get_block_header is declared by WoCREST and Chaintracks as distinct classes' do
+      classes = [
+        BSV::Network::Protocols::WoCREST,
+        BSV::Network::Protocols::Chaintracks
+      ]
+      expect(classes.all? { |klass| klass.commands.include?(:get_block_header) }).to be(true)
+      expect(classes.uniq.size).to eq(2)
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/gem/bsv-sdk/spec/bsv/network/protocols/arc_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/arc_spec.rb
@@ -1,0 +1,422 @@
+# frozen_string_literal: true
+
+RSpec.describe BSV::Network::Protocols::ARC do
+  subject(:arc) do
+    described_class.new(
+      base_url: 'https://arc.example.com',
+      api_key: 'test-key',
+      deployment_id: 'test-deployment',
+      http_client: http_client
+    )
+  end
+
+  # rubocop:disable RSpec/VerifiedDoubles
+  let(:http_client) { double('HttpClient') } # rubocop:disable RSpec/VerifiedDoubles
+
+  def stub_response(code, body)
+    response = double('Net::HTTPResponse', code: code.to_s, body: body)
+    allow(http_client).to receive(:request).and_return(response)
+    response
+  end
+  # rubocop:enable RSpec/VerifiedDoubles
+
+  def stub_json_response(code, data)
+    stub_response(code, JSON.generate(data))
+  end
+
+  def make_tx(ef_hex: nil, hex: 'deadbeef')
+    tx = instance_double(BSV::Transaction::Transaction)
+    if ef_hex
+      allow(tx).to receive(:to_ef_hex).and_return(ef_hex)
+    else
+      allow(tx).to receive(:to_ef_hex).and_raise(ArgumentError, 'source data missing')
+    end
+    allow(tx).to receive(:to_hex).and_return(hex)
+    tx
+  end
+
+  describe '.commands' do
+    it 'declares the expected 5 endpoints' do
+      expect(described_class.commands).to eq(
+        Set.new(%i[broadcast broadcast_many get_tx_status get_policy health])
+      )
+    end
+  end
+
+  describe '#call(:broadcast)' do
+    context 'when EF format is available' do
+      let(:tx) { make_tx(ef_hex: 'efhex123') }
+
+      before do
+        stub_json_response(200, { 'txid' => 'abc123', 'txStatus' => 'RECEIVED' })
+      end
+
+      it 'sends EF hex in the request body' do
+        arc.call(:broadcast, tx)
+        expect(http_client).to have_received(:request) do |_uri, req|
+          body = JSON.parse(req.body)
+          expect(body['rawTx']).to eq('efhex123')
+        end
+      end
+
+      it 'returns Result::Success' do
+        result = arc.call(:broadcast, tx)
+        expect(result).to be_a(BSV::Network::Result::Success)
+        expect(result.data[:txid]).to eq('abc123')
+      end
+
+      it 'includes arc_status in metadata' do
+        result = arc.call(:broadcast, tx)
+        expect(result.metadata[:arc_status]).to eq('RECEIVED')
+      end
+    end
+
+    context 'when EF format raises ArgumentError (fallback to raw hex)' do
+      let(:tx) { make_tx(ef_hex: nil, hex: 'rawhex456') }
+
+      before do
+        stub_json_response(200, { 'txid' => 'def456', 'txStatus' => 'RECEIVED' })
+      end
+
+      it 'falls back to raw hex' do
+        arc.call(:broadcast, tx)
+        expect(http_client).to have_received(:request) do |_uri, req|
+          body = JSON.parse(req.body)
+          expect(body['rawTx']).to eq('rawhex456')
+        end
+      end
+
+      it 'returns Result::Success' do
+        result = arc.call(:broadcast, tx)
+        expect(result).to be_a(BSV::Network::Result::Success)
+        expect(result.data[:txid]).to eq('def456')
+      end
+    end
+
+    context 'when ARC returns a rejected status' do
+      let(:tx) { make_tx(ef_hex: 'efhex') }
+
+      described_class::REJECTED_STATUSES.each do |status|
+        it "returns Result::Error for #{status}" do
+          stub_json_response(200, { 'txid' => 'abc', 'txStatus' => status })
+          result = arc.call(:broadcast, tx)
+          expect(result).to be_a(BSV::Network::Result::Error)
+          expect(result.metadata[:arc_status]).to eq(status)
+        end
+      end
+
+      it 'is case-insensitive for rejected statuses' do
+        stub_json_response(200, { 'txid' => 'abc', 'txStatus' => 'rejected' })
+        result = arc.call(:broadcast, tx)
+        expect(result).to be_a(BSV::Network::Result::Error)
+        expect(result.metadata[:arc_status]).to eq('REJECTED')
+      end
+    end
+
+    context 'when txStatus contains ORPHAN substring' do
+      let(:tx) { make_tx(ef_hex: 'efhex') }
+
+      it 'detects ORPHAN in txStatus' do
+        stub_json_response(200, { 'txid' => 'abc', 'txStatus' => 'ORPHAN' })
+        result = arc.call(:broadcast, tx)
+        expect(result).to be_a(BSV::Network::Result::Error)
+      end
+
+      it 'detects ORPHAN substring in txStatus' do
+        stub_json_response(200, { 'txid' => 'abc', 'txStatus' => 'SEEN_IN_ORPHAN_MEMPOOL' })
+        result = arc.call(:broadcast, tx)
+        expect(result).to be_a(BSV::Network::Result::Error)
+      end
+
+      it 'detects ORPHAN in extraInfo' do
+        stub_json_response(200, { 'txid' => 'abc', 'txStatus' => 'RECEIVED', 'extraInfo' => 'orphan detected' })
+        result = arc.call(:broadcast, tx)
+        expect(result).to be_a(BSV::Network::Result::Error)
+      end
+
+      it 'is case-insensitive for ORPHAN detection in extraInfo' do
+        stub_json_response(200, { 'txid' => 'abc', 'txStatus' => 'RECEIVED', 'extraInfo' => 'ORPHAN_MEMPOOL' })
+        result = arc.call(:broadcast, tx)
+        expect(result).to be_a(BSV::Network::Result::Error)
+      end
+    end
+
+    context 'when ARC returns malformed 2xx (no txid)' do
+      let(:tx) { make_tx(ef_hex: 'efhex') }
+
+      it 'returns Result::Error for missing txid' do
+        stub_json_response(200, { 'txStatus' => 'RECEIVED' })
+        result = arc.call(:broadcast, tx)
+        expect(result).to be_a(BSV::Network::Result::Error)
+        expect(result.message).to include('malformed')
+      end
+
+      it 'returns Result::Error for null txid' do
+        stub_json_response(200, { 'txid' => nil, 'txStatus' => 'RECEIVED' })
+        result = arc.call(:broadcast, tx)
+        expect(result).to be_a(BSV::Network::Result::Error)
+      end
+
+      it 'returns Result::Error for non-JSON body' do
+        stub_response(200, 'not json at all')
+        result = arc.call(:broadcast, tx)
+        expect(result).to be_a(BSV::Network::Result::Error)
+      end
+    end
+
+    context 'when ARC returns non-2xx status' do
+      let(:tx) { make_tx(ef_hex: 'efhex') }
+
+      it 'returns Result::Error for 400' do
+        stub_json_response(400, { 'detail' => 'bad request' })
+        result = arc.call(:broadcast, tx)
+        expect(result).to be_a(BSV::Network::Result::Error)
+        expect(result.retryable?).to be(false)
+      end
+
+      it 'returns retryable Result::Error for 500' do
+        stub_json_response(500, { 'detail' => 'server error' })
+        result = arc.call(:broadcast, tx)
+        expect(result).to be_a(BSV::Network::Result::Error)
+        expect(result.retryable?).to be(true)
+      end
+
+      it 'returns retryable Result::Error for 429' do
+        stub_json_response(429, { 'detail' => 'rate limited' })
+        result = arc.call(:broadcast, tx)
+        expect(result).to be_a(BSV::Network::Result::Error)
+        expect(result.retryable?).to be(true)
+      end
+    end
+
+    context 'with custom headers' do
+      let(:tx) { make_tx(ef_hex: 'efhex') }
+
+      before { stub_json_response(200, { 'txid' => 'abc', 'txStatus' => 'RECEIVED' }) }
+
+      it 'sends XDeployment-ID header' do
+        arc.call(:broadcast, tx)
+        expect(http_client).to have_received(:request) do |_uri, req|
+          expect(req['XDeployment-ID']).to eq('test-deployment')
+        end
+      end
+
+      it 'sends X-WaitFor header when specified' do
+        arc.call(:broadcast, tx, wait_for: 'MINED')
+        expect(http_client).to have_received(:request) do |_uri, req|
+          expect(req['X-WaitFor']).to eq('MINED')
+        end
+      end
+
+      it 'does not send X-WaitFor when nil' do
+        arc.call(:broadcast, tx)
+        expect(http_client).to have_received(:request) do |_uri, req|
+          expect(req['X-WaitFor']).to be_nil
+        end
+      end
+
+      it 'sends X-SkipFeeValidation header when truthy' do
+        arc.call(:broadcast, tx, skip_fee_validation: true)
+        expect(http_client).to have_received(:request) do |_uri, req|
+          expect(req['X-SkipFeeValidation']).to eq('true')
+        end
+      end
+
+      it 'sends X-SkipScriptValidation header when truthy' do
+        arc.call(:broadcast, tx, skip_script_validation: true)
+        expect(http_client).to have_received(:request) do |_uri, req|
+          expect(req['X-SkipScriptValidation']).to eq('true')
+        end
+      end
+
+      it 'sends X-SkipTxValidation header when truthy' do
+        arc.call(:broadcast, tx, skip_tx_validation: true)
+        expect(http_client).to have_received(:request) do |_uri, req|
+          expect(req['X-SkipTxValidation']).to eq('true')
+        end
+      end
+    end
+
+    context 'with callback configuration' do
+      let(:arc_with_callbacks) do
+        described_class.new(
+          base_url: 'https://arc.example.com',
+          deployment_id: 'test-deployment',
+          callback_url: 'https://my-callback.example.com',
+          callback_token: 'cb-token',
+          http_client: http_client
+        )
+      end
+      let(:tx) { make_tx(ef_hex: 'efhex') }
+
+      before { stub_json_response(200, { 'txid' => 'abc', 'txStatus' => 'RECEIVED' }) }
+
+      it 'sends X-CallbackUrl from constructor' do
+        arc_with_callbacks.call(:broadcast, tx)
+        expect(http_client).to have_received(:request) do |_uri, req|
+          expect(req['X-CallbackUrl']).to eq('https://my-callback.example.com')
+        end
+      end
+
+      it 'sends X-CallbackToken from constructor' do
+        arc_with_callbacks.call(:broadcast, tx)
+        expect(http_client).to have_received(:request) do |_uri, req|
+          expect(req['X-CallbackToken']).to eq('cb-token')
+        end
+      end
+    end
+  end
+
+  describe '#call(:broadcast_many)' do
+    let(:tx_with_ef)     { make_tx(ef_hex: 'ef1', hex: 'raw1') }
+    let(:tx_without_ef)  { make_tx(ef_hex: nil, hex: 'raw2') }
+
+    context 'with an empty array' do
+      it 'returns Result::Success with empty data without making HTTP calls' do
+        allow(http_client).to receive(:request)
+        result = arc.call(:broadcast_many, [])
+        expect(result).to be_a(BSV::Network::Result::Success)
+        expect(result.data).to eq([])
+        expect(http_client).not_to have_received(:request)
+      end
+    end
+
+    context 'with mixed success and failure responses' do
+      before do
+        stub_json_response(200, [
+                             { 'txid' => 'tx1id', 'txStatus' => 'RECEIVED' },
+                             { 'txid' => 'tx2id', 'txStatus' => 'REJECTED' }
+                           ])
+      end
+
+      it 'returns Result::Success containing per-item results' do
+        result = arc.call(:broadcast_many, [tx_with_ef, tx_without_ef])
+        expect(result).to be_a(BSV::Network::Result::Success)
+        expect(result.data.length).to eq(2)
+      end
+
+      it 'maps successful items to Result::Success' do
+        result = arc.call(:broadcast_many, [tx_with_ef, tx_without_ef])
+        expect(result.data[0]).to be_a(BSV::Network::Result::Success)
+        expect(result.data[0].data[:txid]).to eq('tx1id')
+      end
+
+      it 'maps rejected items to Result::Error' do
+        result = arc.call(:broadcast_many, [tx_with_ef, tx_without_ef])
+        expect(result.data[1]).to be_a(BSV::Network::Result::Error)
+        expect(result.data[1].metadata[:arc_status]).to eq('REJECTED')
+      end
+    end
+
+    context 'when HTTP returns non-2xx' do
+      before { stub_json_response(500, { 'detail' => 'server error' }) }
+
+      it 'returns Result::Error for the whole batch' do
+        result = arc.call(:broadcast_many, [tx_with_ef])
+        expect(result).to be_a(BSV::Network::Result::Error)
+        expect(result.retryable?).to be(true)
+      end
+    end
+
+    context 'when response is not an array' do
+      before { stub_json_response(200, { 'detail' => 'unexpected' }) }
+
+      it 'returns Result::Error for malformed batch response' do
+        result = arc.call(:broadcast_many, [tx_with_ef])
+        expect(result).to be_a(BSV::Network::Result::Error)
+        expect(result.message).to include('malformed batch')
+      end
+    end
+
+    it 'uses EF hex for transactions that support it' do
+      stub_json_response(200, [{ 'txid' => 'abc', 'txStatus' => 'RECEIVED' }])
+      arc.call(:broadcast_many, [tx_with_ef])
+      expect(http_client).to have_received(:request) do |_uri, req|
+        body = JSON.parse(req.body)
+        expect(body[0]['rawTx']).to eq('ef1')
+      end
+    end
+
+    it 'falls back to raw hex for transactions without EF support' do
+      stub_json_response(200, [{ 'txid' => 'abc', 'txStatus' => 'RECEIVED' }])
+      arc.call(:broadcast_many, [tx_without_ef])
+      expect(http_client).to have_received(:request) do |_uri, req|
+        body = JSON.parse(req.body)
+        expect(body[0]['rawTx']).to eq('raw2')
+      end
+    end
+  end
+
+  describe '#call(:get_tx_status)' do
+    context 'when transaction exists' do
+      before { stub_json_response(200, { 'txid' => 'abc123', 'txStatus' => 'MINED' }) }
+
+      it 'returns Result::Success with parsed JSON data' do
+        result = arc.call(:get_tx_status, 'abc123')
+        expect(result).to be_a(BSV::Network::Result::Success)
+        expect(result.data['txid']).to eq('abc123')
+        expect(result.data['txStatus']).to eq('MINED')
+      end
+    end
+
+    context 'when transaction is not found' do
+      before { stub_response(404, 'Not found') }
+
+      it 'returns Result::NotFound' do
+        result = arc.call(:get_tx_status, 'unknowntxid')
+        expect(result).to be_a(BSV::Network::Result::NotFound)
+      end
+    end
+
+    context 'when server returns 500' do
+      before { stub_response(500, 'Internal server error') }
+
+      it 'returns retryable Result::Error' do
+        result = arc.call(:get_tx_status, 'abc123')
+        expect(result).to be_a(BSV::Network::Result::Error)
+        expect(result.retryable?).to be(true)
+      end
+    end
+  end
+
+  describe '#call(:get_policy)' do
+    before do
+      stub_json_response(200, {
+                           'policy' => { 'maxscriptsizepolicy' => 100_000, 'maxtxsizepolicy' => 10_000_000 }
+                         })
+    end
+
+    it 'returns Result::Success with parsed JSON policy data' do
+      result = arc.call(:get_policy)
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data['policy']).to be_a(Hash)
+    end
+  end
+
+  describe '#call(:health)' do
+    before { stub_json_response(200, { 'healthy' => true }) }
+
+    it 'returns Result::Success' do
+      result = arc.call(:health)
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data['healthy']).to be(true)
+    end
+  end
+
+  describe 'constructor' do
+    it 'assigns a random deployment_id when none is provided' do
+      arc1 = described_class.new(base_url: 'https://arc.example.com', http_client: http_client)
+      arc2 = described_class.new(base_url: 'https://arc.example.com', http_client: http_client)
+      expect(arc1.instance_variable_get(:@deployment_id)).not_to eq(arc2.instance_variable_get(:@deployment_id))
+    end
+
+    it 'uses the provided deployment_id' do
+      custom = described_class.new(
+        base_url: 'https://arc.example.com',
+        deployment_id: 'my-deployment',
+        http_client: http_client
+      )
+      expect(custom.instance_variable_get(:@deployment_id)).to eq('my-deployment')
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/network/protocols/arc_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/arc_spec.rb
@@ -162,6 +162,12 @@ RSpec.describe BSV::Network::Protocols::ARC do
         result = arc.call(:broadcast, tx)
         expect(result).to be_a(BSV::Network::Result::Error)
       end
+
+      it 'returns Result::Error when JSON parses to a non-Hash (e.g. Array)' do
+        stub_response(200, JSON.generate([{ 'txid' => 'abc' }]))
+        result = arc.call(:broadcast, tx)
+        expect(result).to be_a(BSV::Network::Result::Error)
+      end
     end
 
     context 'when ARC returns non-2xx status' do
@@ -325,6 +331,23 @@ RSpec.describe BSV::Network::Protocols::ARC do
         result = arc.call(:broadcast_many, [tx_with_ef])
         expect(result).to be_a(BSV::Network::Result::Error)
         expect(result.message).to include('malformed batch')
+      end
+    end
+
+    context 'when a batch item is not a Hash' do
+      before { stub_response(200, JSON.generate(['not-a-hash', { 'txid' => 'abc', 'txStatus' => 'RECEIVED' }])) }
+
+      it 'maps non-Hash items to Result::Error' do
+        result = arc.call(:broadcast_many, [tx_with_ef, tx_without_ef])
+        expect(result).to be_a(BSV::Network::Result::Success)
+        expect(result.data[0]).to be_a(BSV::Network::Result::Error)
+        expect(result.data[0].message).to include('malformed batch item')
+      end
+
+      it 'still maps valid Hash items to Result::Success' do
+        result = arc.call(:broadcast_many, [tx_with_ef, tx_without_ef])
+        expect(result.data[1]).to be_a(BSV::Network::Result::Success)
+        expect(result.data[1].data[:txid]).to eq('abc')
       end
     end
 

--- a/gem/bsv-sdk/spec/bsv/network/protocols/chaintracks_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/chaintracks_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'BSV::Network::Protocols::Chaintracks' do
+  let(:described_class) { BSV::Network::Protocols::Chaintracks }
+
+  let(:mock_http) do
+    Class.new do
+      attr_reader :last_uri, :last_request
+
+      def initialize(code, body)
+        @code = code
+        @body = body
+      end
+
+      def request(uri, req)
+        @last_uri     = uri
+        @last_request = req
+        Struct.new(:code, :body).new(@code.to_s, @body)
+      end
+    end
+  end
+
+  def make_instance(code, body, api_key: nil)
+    http = mock_http.new(code, body)
+    instance = described_class.new(
+      base_url: 'https://arcade.gorillapool.io',
+      api_key: api_key,
+      http_client: http
+    )
+    [instance, http]
+  end
+
+  describe '.commands' do
+    it 'returns the correct set of commands' do
+      expect(described_class.commands).to eq(Set[:get_block_header, :current_height])
+    end
+  end
+
+  describe ':get_block_header' do
+    let(:header_body) do
+      { 'hash' => 'abc123', 'height' => 800_000, 'merkleroot' => 'def456' }.to_json
+    end
+
+    it 'returns parsed JSON on success' do
+      instance, _http = make_instance(200, header_body)
+      result = instance.call(:get_block_header, height: 800_000)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq({ 'hash' => 'abc123', 'height' => 800_000, 'merkleroot' => 'def456' })
+    end
+
+    it 'builds the correct URL' do
+      instance, http = make_instance(200, header_body)
+      instance.call(:get_block_header, height: 800_000)
+
+      expect(http.last_uri.to_s).to eq('https://arcade.gorillapool.io/chaintracks/v2/header/height/800000')
+    end
+
+    it 'returns Result::NotFound on 404' do
+      instance, _http = make_instance(404, 'not found')
+      result = instance.call(:get_block_header, height: 9_999_999)
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+      expect(result.not_found?).to be(true)
+    end
+
+    it 'accepts height as a positional argument' do
+      instance, http = make_instance(200, header_body)
+      instance.call(:get_block_header, 800_000)
+
+      expect(http.last_uri.to_s).to eq('https://arcade.gorillapool.io/chaintracks/v2/header/height/800000')
+    end
+  end
+
+  describe ':current_height' do
+    let(:tip_body) { { 'height' => 825_000, 'hash' => 'tipblockhash' }.to_json }
+
+    it 'extracts the height integer from the tip JSON' do
+      instance, _http = make_instance(200, tip_body)
+      result = instance.call(:current_height)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq(825_000)
+    end
+
+    it 'returns an Integer, not a String or Hash' do
+      instance, _http = make_instance(200, tip_body)
+      result = instance.call(:current_height)
+
+      expect(result.data).to be_an(Integer)
+    end
+
+    it 'returns Result::NotFound on 404' do
+      instance, _http = make_instance(404, 'not found')
+      result = instance.call(:current_height)
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+
+    it 'returns Result::Error with retryable true on 5xx' do
+      instance, _http = make_instance(503, 'service unavailable')
+      result = instance.call(:current_height)
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+  end
+
+  describe 'authentication' do
+    let(:tip_body) { { 'height' => 800_000 }.to_json }
+
+    it 'sends Authorization: Bearer header when api_key is set' do
+      instance, http = make_instance(200, tip_body, api_key: 'my-api-key')
+      instance.call(:current_height)
+
+      expect(http.last_request['Authorization']).to eq('Bearer my-api-key')
+    end
+
+    it 'omits Authorization header when api_key is nil' do
+      instance, http = make_instance(200, tip_body)
+      instance.call(:current_height)
+
+      expect(http.last_request['Authorization']).to be_nil
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/network/protocols/chaintracks_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/chaintracks_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'BSV::Network::Protocols::Chaintracks' do
-  let(:described_class) { BSV::Network::Protocols::Chaintracks }
-
+RSpec.describe BSV::Network::Protocols::Chaintracks do
   let(:mock_http) do
     Class.new do
       attr_reader :last_uri, :last_request
@@ -24,11 +22,7 @@ RSpec.describe 'BSV::Network::Protocols::Chaintracks' do
 
   def make_instance(code, body, api_key: nil)
     http = mock_http.new(code, body)
-    instance = described_class.new(
-      base_url: 'https://arcade.gorillapool.io',
-      api_key: api_key,
-      http_client: http
-    )
+    instance = described_class.new(api_key: api_key, http_client: http)
     [instance, http]
   end
 

--- a/gem/bsv-sdk/spec/bsv/network/protocols/ordinals_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/ordinals_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'BSV::Network::Protocols::Ordinals' do
+  let(:described_class) { BSV::Network::Protocols::Ordinals }
+  let(:txid) { 'deadbeefcafe0123456789abcdef0123456789abcdef0123456789abcdef0123' }
+
+  let(:mock_http) do
+    Class.new do
+      attr_reader :last_uri, :last_request
+
+      def initialize(code, body)
+        @code = code
+        @body = body
+      end
+
+      def request(uri, req)
+        @last_uri     = uri
+        @last_request = req
+        Struct.new(:code, :body).new(@code.to_s, @body)
+      end
+    end
+  end
+
+  def make_instance(code, body, api_key: nil)
+    http = mock_http.new(code, body)
+    instance = described_class.new(
+      base_url: 'https://ordinals.gorillapool.io',
+      api_key: api_key,
+      http_client: http
+    )
+    [instance, http]
+  end
+
+  describe '.commands' do
+    it 'returns the correct set of commands' do
+      expect(described_class.commands).to eq(Set[:get_tx, :get_merkle_path])
+    end
+  end
+
+  describe ':get_tx' do
+    let(:hex_body) { '01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff' }
+
+    it 'returns raw hex string on success' do
+      instance, _http = make_instance(200, hex_body)
+      result = instance.call(:get_tx, txid: txid)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq(hex_body)
+    end
+
+    it 'returns a String, not a parsed object' do
+      instance, _http = make_instance(200, hex_body)
+      result = instance.call(:get_tx, txid: txid)
+
+      expect(result.data).to be_a(String)
+    end
+
+    it 'builds the correct URL' do
+      instance, http = make_instance(200, hex_body)
+      instance.call(:get_tx, txid: txid)
+
+      expect(http.last_uri.to_s).to eq("https://ordinals.gorillapool.io/api/tx/#{txid}/hex")
+    end
+
+    it 'returns Result::NotFound on 404' do
+      instance, _http = make_instance(404, 'not found')
+      result = instance.call(:get_tx, txid: txid)
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+      expect(result.not_found?).to be(true)
+    end
+
+    it 'accepts txid as a positional argument' do
+      instance, http = make_instance(200, hex_body)
+      instance.call(:get_tx, txid)
+
+      expect(http.last_uri.to_s).to eq("https://ordinals.gorillapool.io/api/tx/#{txid}/hex")
+    end
+  end
+
+  describe ':get_merkle_path' do
+    let(:proof_body) do
+      { 'index' => 42, 'txOrId' => txid, 'path' => [%w[abc R], %w[def L]] }.to_json
+    end
+
+    it 'returns parsed JSON on success' do
+      instance, _http = make_instance(200, proof_body)
+      result = instance.call(:get_merkle_path, txid: txid)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to be_a(Hash)
+      expect(result.data['index']).to eq(42)
+    end
+
+    it 'builds the correct URL' do
+      instance, http = make_instance(200, proof_body)
+      instance.call(:get_merkle_path, txid: txid)
+
+      expect(http.last_uri.to_s).to eq("https://ordinals.gorillapool.io/api/tx/#{txid}/proof")
+    end
+
+    it 'returns Result::NotFound on 404' do
+      instance, _http = make_instance(404, 'not found')
+      result = instance.call(:get_merkle_path, txid: txid)
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+
+    it 'returns Result::Error with retryable true on 5xx' do
+      instance, _http = make_instance(500, 'internal server error')
+      result = instance.call(:get_merkle_path, txid: txid)
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+  end
+
+  describe 'authentication' do
+    let(:hex_body) { '01000000' }
+
+    it 'sends Authorization: Bearer header when api_key is set' do
+      instance, http = make_instance(200, hex_body, api_key: 'secret-key')
+      instance.call(:get_tx, txid: txid)
+
+      expect(http.last_request['Authorization']).to eq('Bearer secret-key')
+    end
+
+    it 'omits Authorization header when api_key is nil' do
+      instance, http = make_instance(200, hex_body)
+      instance.call(:get_tx, txid: txid)
+
+      expect(http.last_request['Authorization']).to be_nil
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/network/protocols/ordinals_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/ordinals_spec.rb
@@ -2,8 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'BSV::Network::Protocols::Ordinals' do
-  let(:described_class) { BSV::Network::Protocols::Ordinals }
+RSpec.describe BSV::Network::Protocols::Ordinals do
   let(:txid) { 'deadbeefcafe0123456789abcdef0123456789abcdef0123456789abcdef0123' }
 
   let(:mock_http) do
@@ -25,11 +24,7 @@ RSpec.describe 'BSV::Network::Protocols::Ordinals' do
 
   def make_instance(code, body, api_key: nil)
     http = mock_http.new(code, body)
-    instance = described_class.new(
-      base_url: 'https://ordinals.gorillapool.io',
-      api_key: api_key,
-      http_client: http
-    )
+    instance = described_class.new(api_key: api_key, http_client: http)
     [instance, http]
   end
 

--- a/gem/bsv-sdk/spec/bsv/network/protocols/taal_binary_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/taal_binary_spec.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'BSV::Network::Protocols::TAALBinary' do
+  let(:described_class) { BSV::Network::Protocols::TAALBinary }
+
+  let(:mock_http) do
+    Class.new do
+      attr_reader :last_uri, :last_request
+
+      def initialize(code, body)
+        @code = code
+        @body = body
+      end
+
+      def request(uri, req)
+        @last_uri     = uri
+        @last_request = req
+        Struct.new(:code, :body).new(@code.to_s, @body)
+      end
+    end
+  end
+
+  def make_instance(code, body, api_key: 'mainnet_test_key')
+    http     = mock_http.new(code, body)
+    instance = described_class.new(
+      base_url: 'https://api.taal.com',
+      api_key: api_key,
+      http_client: http
+    )
+    [instance, http]
+  end
+
+  describe '.commands' do
+    it 'returns Set[:broadcast]' do
+      expect(described_class.commands).to eq(Set[:broadcast])
+    end
+  end
+
+  describe ':broadcast — success' do
+    let(:success_body) { { 'txid' => 'deadbeef' * 8 }.to_json }
+
+    it 'returns Result::Success with txid on 200' do
+      instance, _http = make_instance(200, success_body)
+      result = instance.call(:broadcast, "\x01\x00")
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data[:txid]).to eq('deadbeef' * 8)
+    end
+
+    it 'sends raw binary body as-is when given a String' do
+      instance, http = make_instance(200, success_body)
+      instance.call(:broadcast, "\xde\xad\xbe\xef")
+
+      expect(http.last_request.body).to eq("\xde\xad\xbe\xef")
+    end
+
+    it 'calls #to_binary on a transaction object' do
+      tx = double('tx') # rubocop:disable RSpec/VerifiedDoubles
+      allow(tx).to receive(:respond_to?).with(:to_binary).and_return(true)
+      allow(tx).to receive(:to_binary).and_return("\xca\xfe")
+
+      instance, http = make_instance(200, success_body)
+      instance.call(:broadcast, tx)
+
+      expect(http.last_request.body).to eq("\xca\xfe")
+    end
+  end
+
+  describe ':broadcast — Content-Type header' do
+    let(:success_body) { { 'txid' => 'abc123' }.to_json }
+
+    it 'sets Content-Type to application/octet-stream' do
+      instance, http = make_instance(200, success_body)
+      instance.call(:broadcast, "\x00")
+
+      expect(http.last_request.content_type).to eq('application/octet-stream')
+    end
+  end
+
+  describe ':broadcast — Authorization header' do
+    let(:success_body) { { 'txid' => 'abc123' }.to_json }
+
+    it 'sends the API key directly with no Bearer prefix' do
+      instance, http = make_instance(200, success_body, api_key: 'mainnet_secret')
+      instance.call(:broadcast, "\x00")
+
+      expect(http.last_request['Authorization']).to eq('mainnet_secret')
+    end
+
+    it 'does not include "Bearer" in the header' do
+      instance, http = make_instance(200, success_body, api_key: 'mykey')
+      instance.call(:broadcast, "\x00")
+
+      expect(http.last_request['Authorization']).not_to include('Bearer')
+    end
+
+    it 'omits Authorization header when api_key is nil' do
+      instance, http = make_instance(200, success_body, api_key: nil)
+      instance.call(:broadcast, "\x00")
+
+      expect(http.last_request['Authorization']).to be_nil
+    end
+  end
+
+  describe ':broadcast — txn-already-known quirk' do
+    it 'treats txn-already-known error as Result::Success' do
+      body = { 'txid' => 'abc123', 'error' => 'txn-already-known' }.to_json
+      instance, _http = make_instance(400, body)
+      result = instance.call(:broadcast, "\x00")
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data[:txid]).to eq('abc123')
+    end
+
+    it 'treats txn-already-known in a 409 response as success' do
+      body = { 'txid' => 'def456', 'error' => 'txn-already-known' }.to_json
+      instance, _http = make_instance(409, body)
+      result = instance.call(:broadcast, "\x00")
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+    end
+
+    it 'treats txn-already-known even when embedded in a longer error string' do
+      body = { 'txid' => 'def456', 'error' => 'error: txn-already-known in mempool' }.to_json
+      instance, _http = make_instance(400, body)
+      result = instance.call(:broadcast, "\x00")
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+    end
+  end
+
+  describe ':broadcast — error responses' do
+    it 'returns Result::Error with the error field as message on 4xx' do
+      body = { 'error' => 'txn-invalid-script' }.to_json
+      instance, _http = make_instance(400, body)
+      result = instance.call(:broadcast, "\x00")
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.message).to eq('txn-invalid-script')
+    end
+
+    it 'falls back to HTTP status message when no error field' do
+      instance, _http = make_instance(400, '{}')
+      result = instance.call(:broadcast, "\x00")
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.message).to eq('HTTP 400')
+    end
+
+    it 'returns retryable: false for 4xx errors' do
+      body = { 'error' => 'bad input' }.to_json
+      instance, _http = make_instance(400, body)
+      result = instance.call(:broadcast, "\x00")
+
+      expect(result.retryable?).to be(false)
+    end
+
+    it 'returns retryable: true for 429 responses' do
+      instance, _http = make_instance(429, '{"error":"rate limited"}')
+      result = instance.call(:broadcast, "\x00")
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+
+    it 'returns retryable: true for 5xx responses' do
+      instance, _http = make_instance(500, '{"error":"internal error"}')
+      result = instance.call(:broadcast, "\x00")
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+  end
+
+  describe ':broadcast — URL' do
+    let(:success_body) { { 'txid' => 'abc123' }.to_json }
+
+    it 'posts to /api/v1/broadcast' do
+      instance, http = make_instance(200, success_body)
+      instance.call(:broadcast, "\x00")
+
+      expect(http.last_uri.to_s).to eq('https://api.taal.com/api/v1/broadcast')
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/network/protocols/taal_binary_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/taal_binary_spec.rb
@@ -49,6 +49,30 @@ RSpec.describe 'BSV::Network::Protocols::TAALBinary' do
       expect(result.data[:txid]).to eq('deadbeef' * 8)
     end
 
+    it 'returns Result::Success with nil txid when body is nil' do
+      instance, _http = make_instance(200, nil)
+      result = instance.call(:broadcast, "\x01\x00")
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data[:txid]).to be_nil
+    end
+
+    it 'returns Result::Success with nil txid when body is empty' do
+      instance, _http = make_instance(200, '')
+      result = instance.call(:broadcast, "\x01\x00")
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data[:txid]).to be_nil
+    end
+
+    it 'returns Result::Success with nil txid when body is non-JSON' do
+      instance, _http = make_instance(200, 'OK')
+      result = instance.call(:broadcast, "\x01\x00")
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data[:txid]).to be_nil
+    end
+
     it 'sends raw binary body as-is when given a String' do
       instance, http = make_instance(200, success_body)
       instance.call(:broadcast, "\xde\xad\xbe\xef")

--- a/gem/bsv-sdk/spec/bsv/network/protocols/woc_rest_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/woc_rest_spec.rb
@@ -1,0 +1,691 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe BSV::Network::Protocols::WoCREST do # rubocop:disable RSpec/SpecFilePathFormat
+  subject(:woc) { described_class.new(network: :main, http_client: http) }
+
+  # Minimal fake HTTP client — configurable per example or using the shared
+  # queue-style helper below.
+  let(:http) { FakeHttp.new(200, '{}') }
+
+  # Simple fake HTTP client that returns a canned response.
+  # Stores the last URI and request for assertion.
+  let(:fake_http_class) do
+    Class.new do
+      attr_reader :last_uri, :last_request
+
+      def initialize(code, body)
+        @code = code.to_s
+        @body = body
+      end
+
+      def request(uri, req)
+        @last_uri     = uri
+        @last_request = req
+        Struct.new(:code, :body).new(@code, @body)
+      end
+    end
+  end
+
+  # Convenience helper — creates a FakeHttp instance with given code and body.
+  def fake(code, body)
+    fake_http_class.new(code, body)
+  end
+
+  # Use FakeHttp as a named alias for the anonymous class.
+  before { stub_const('FakeHttp', fake_http_class) }
+
+  # ---------------------------------------------------------------------------
+  # Constructor / network resolution
+  # ---------------------------------------------------------------------------
+
+  describe '#initialize — network resolution' do
+    it 'resolves :main to "main" in the base URL' do
+      protocol = described_class.new(network: :main, http_client: fake(200, ''))
+      expect(protocol.base_url).to eq('https://api.whatsonchain.com/v1/bsv/main')
+    end
+
+    it 'resolves :mainnet to "main"' do
+      protocol = described_class.new(network: :mainnet, http_client: fake(200, ''))
+      expect(protocol.base_url).to include('/main')
+    end
+
+    it 'resolves :test to "test"' do
+      protocol = described_class.new(network: :test, http_client: fake(200, ''))
+      expect(protocol.base_url).to include('/test')
+    end
+
+    it 'resolves :testnet to "test"' do
+      protocol = described_class.new(network: :testnet, http_client: fake(200, ''))
+      expect(protocol.base_url).to include('/test')
+    end
+
+    it 'resolves :stn to "stn"' do
+      protocol = described_class.new(network: :stn, http_client: fake(200, ''))
+      expect(protocol.base_url).to include('/stn')
+    end
+
+    it 'resolves string "main"' do
+      protocol = described_class.new(network: 'main', http_client: fake(200, ''))
+      expect(protocol.base_url).to include('/main')
+    end
+
+    it 'exposes network_name' do
+      protocol = described_class.new(network: :mainnet, http_client: fake(200, ''))
+      expect(protocol.network_name).to eq('main')
+    end
+
+    it 'raises ArgumentError for an unknown network' do
+      expect { described_class.new(network: :unknown) }
+        .to raise_error(ArgumentError, /unknown network/)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Declared commands
+  # ---------------------------------------------------------------------------
+
+  describe '.commands' do
+    it 'declares all 12 expected commands' do
+      expected = %i[
+        current_height get_block_header
+        get_tx get_merkle_path broadcast get_tx_status
+        get_utxos is_utxo valid_root
+        get_script_unspent get_balance health
+      ]
+      expected.each do |cmd|
+        expect(described_class.commands).to include(cmd),
+                                            "expected commands to include :#{cmd}"
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # current_height — lambda extracts blocks from chain info JSON
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:current_height)' do
+    it 'extracts the blocks field from chain info JSON' do
+      body = '{"chain":"main","blocks":812345,"bestblockhash":"abcd"}'
+      http_client = fake(200, body)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:current_height)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq(812_345)
+    end
+
+    it 'sends GET to /chain/info' do
+      body = '{"blocks":800000}'
+      http_client = fake(200, body)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:current_height)
+
+      expect(http_client.last_uri.path).to end_with('/chain/info')
+    end
+
+    it 'returns Result::Error on 500' do
+      http_client = fake(500, 'server error')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:current_height)
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+
+    it 'returns Result::Error on 429 (rate limited)' do
+      http_client = fake(429, 'rate limited')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:current_height)
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_block_header
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_block_header)' do
+    let(:header_json) do
+      {
+        'hash' => 'abc123',
+        'height' => 800_000,
+        'merkleroot' => 'deadbeef00000000' * 4
+      }.to_json
+    end
+
+    it 'returns JSON header for a given height' do
+      http_client = fake(200, header_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_block_header, 800_000)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data['height']).to eq(800_000)
+    end
+
+    it 'sends GET to /block/{height}/header' do
+      http_client = fake(200, header_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_block_header, 800_000)
+
+      expect(http_client.last_uri.path).to end_with('/block/800000/header')
+    end
+
+    it 'returns Result::NotFound for an unknown height' do
+      http_client = fake(404, 'not found')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_block_header, 99_999_999)
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_tx — returns raw hex
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_tx)' do
+    it 'returns raw hex body on success' do
+      hex = "01000000#{'00' * 100}"
+      http_client = fake(200, hex)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_tx, 'abc123' * 10)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq(hex)
+    end
+
+    it 'sends GET to /tx/{txid}/hex' do
+      http_client = fake(200, '01000000')
+      protocol = described_class.new(network: :main, http_client: http_client)
+      txid = 'a' * 64
+
+      protocol.call(:get_tx, txid)
+
+      expect(http_client.last_uri.path).to end_with("/tx/#{txid}/hex")
+    end
+
+    it 'returns Result::NotFound for unknown txid' do
+      http_client = fake(404, 'not found')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_tx, 'unknown_txid')
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_merkle_path
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_merkle_path)' do
+    let(:proof_json) do
+      { 'index' => 3, 'txOrId' => 'abc123', 'target' => 'deadbeef' }.to_json
+    end
+
+    it 'returns parsed JSON proof' do
+      http_client = fake(200, proof_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_merkle_path, 'abc123')
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to be_a(Hash)
+      expect(result.data['index']).to eq(3)
+    end
+
+    it 'sends GET to /tx/{txid}/proof/tsc' do
+      http_client = fake(200, proof_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+      txid = 'b' * 64
+
+      protocol.call(:get_merkle_path, txid)
+
+      expect(http_client.last_uri.path).to end_with("/tx/#{txid}/proof/tsc")
+    end
+
+    it 'returns Result::NotFound when proof does not exist' do
+      http_client = fake(404, 'not found')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_merkle_path, 'unconfirmed_txid')
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+
+    it 'returns Result::Error(retryable: true) on 500' do
+      http_client = fake(500, 'internal error')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_merkle_path, 'abc')
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_utxos — value → satoshis remapping (escape hatch)
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_utxos)' do
+    let(:woc_response) do
+      [
+        { 'tx_hash' => 'abc', 'tx_pos' => 0, 'value' => 50_000, 'height' => 800_000 },
+        { 'tx_hash' => 'def', 'tx_pos' => 1, 'value' => 100_000, 'height' => 800_001 }
+      ].to_json
+    end
+
+    it 'remaps value to satoshis in the result' do
+      http_client = fake(200, woc_response)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_utxos, '1AddressBSV')
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data[0]['satoshis']).to eq(50_000)
+      expect(result.data[1]['satoshis']).to eq(100_000)
+    end
+
+    it 'does not include a value key in remapped entries' do
+      http_client = fake(200, woc_response)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_utxos, '1AddressBSV')
+
+      expect(result.data[0]).not_to have_key('value')
+    end
+
+    it 'preserves tx_hash, tx_pos, and height fields' do
+      http_client = fake(200, woc_response)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_utxos, '1AddressBSV')
+
+      entry = result.data[0]
+      expect(entry['tx_hash']).to eq('abc')
+      expect(entry['tx_pos']).to eq(0)
+      expect(entry['height']).to eq(800_000)
+    end
+
+    it 'returns an empty array when the address has no UTXOs' do
+      http_client = fake(200, '[]')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_utxos, '1EmptyAddress')
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq([])
+    end
+
+    it 'sends GET to the confirmed/unspent path' do
+      http_client = fake(200, '[]')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_utxos, '1CheckPath')
+
+      expect(http_client.last_uri.path).to end_with('/address/1CheckPath/confirmed/unspent')
+    end
+
+    it 'returns Result::NotFound on 404' do
+      http_client = fake(404, 'not found')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_utxos, '1UnknownAddress')
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+
+    it 'returns Result::Error(retryable: true) on 500' do
+      http_client = fake(500, 'server error')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_utxos, '1Addr')
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # is_utxo — spent status (escape hatch)
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:is_utxo)' do
+    it 'returns true when the output is unspent' do
+      http_client = fake(200, '{"spent":false}')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:is_utxo, 'abc123', 0)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to be(true)
+    end
+
+    it 'returns false when the output is spent' do
+      http_client = fake(200, '{"spent":true}')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:is_utxo, 'abc123', 1)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to be(false)
+    end
+
+    it 'sends GET to /tx/{txid}/{vout}/spent' do
+      http_client = fake(200, '{"spent":false}')
+      protocol = described_class.new(network: :main, http_client: http_client)
+      txid = 'c' * 64
+
+      protocol.call(:is_utxo, txid, 2)
+
+      expect(http_client.last_uri.path).to end_with("/tx/#{txid}/2/spent")
+    end
+
+    it 'accepts script_hash: keyword without error' do
+      http_client = fake(200, '{"spent":false}')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      expect { protocol.call(:is_utxo, 'abc', 0, script_hash: 'deadbeef') }.not_to raise_error
+    end
+
+    it 'returns Result::NotFound when the txid is unknown' do
+      http_client = fake(404, 'not found')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:is_utxo, 'unknown', 0)
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+
+    it 'returns Result::Error(retryable: true) on 500' do
+      http_client = fake(500, 'error')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:is_utxo, 'abc', 0)
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # broadcast — plain text txid response (escape hatch)
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:broadcast)' do
+    let(:raw_txid) { 'a' * 64 }
+
+    it 'returns a hash with the txid on success' do
+      http_client = fake(200, raw_txid)
+      protocol = described_class.new(network: :main, http_client: http_client)
+      tx = double('tx', to_hex: '01000000') # rubocop:disable RSpec/VerifiedDoubles
+
+      result = protocol.call(:broadcast, tx)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data['txid']).to eq(raw_txid)
+    end
+
+    it 'strips whitespace from the txid response' do
+      http_client = fake(200, "#{raw_txid}\n")
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:broadcast, '01000000')
+
+      expect(result.data['txid']).to eq(raw_txid)
+    end
+
+    it 'uses txhex as the body field name' do
+      http_client = fake(200, raw_txid)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:broadcast, '01000000')
+
+      body = JSON.parse(http_client.last_request.body)
+      expect(body).to have_key('txhex')
+      expect(body).not_to have_key('rawTx')
+    end
+
+    it 'calls to_hex on a transaction object' do
+      http_client = fake(200, raw_txid)
+      protocol = described_class.new(network: :main, http_client: http_client)
+      tx = double('tx', to_hex: 'deadbeef') # rubocop:disable RSpec/VerifiedDoubles
+
+      protocol.call(:broadcast, tx)
+
+      body = JSON.parse(http_client.last_request.body)
+      expect(body['txhex']).to eq('deadbeef')
+    end
+
+    it 'uses the string directly when tx does not respond to to_hex' do
+      http_client = fake(200, raw_txid)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:broadcast, 'cafebabe')
+
+      body = JSON.parse(http_client.last_request.body)
+      expect(body['txhex']).to eq('cafebabe')
+    end
+
+    it 'sends POST to /tx/raw' do
+      http_client = fake(200, raw_txid)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:broadcast, '01000000')
+
+      expect(http_client.last_uri.path).to end_with('/tx/raw')
+      expect(http_client.last_request).to be_a(Net::HTTP::Post)
+    end
+
+    it 'returns Result::Error on 400' do
+      http_client = fake(400, 'bad request')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:broadcast, '01000000')
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(false)
+    end
+
+    it 'returns Result::Error(retryable: true) on 500' do
+      http_client = fake(500, 'server error')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:broadcast, '01000000')
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # valid_root — merkle root comparison (escape hatch)
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:valid_root)' do
+    let(:merkle_root) { 'abcdef1234567890' * 4 }
+    let(:header_json) { { 'height' => 800_000, 'merkleroot' => merkle_root }.to_json }
+
+    it 'returns true when the root matches' do
+      http_client = fake(200, header_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:valid_root, merkle_root, 800_000)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to be(true)
+    end
+
+    it 'returns false when the root does not match' do
+      http_client = fake(200, header_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:valid_root, 'wrong_root', 800_000)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to be(false)
+    end
+
+    it 'is case-insensitive in comparison' do
+      upper_root = merkle_root.upcase
+      http_client = fake(200, { 'merkleroot' => merkle_root.downcase }.to_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:valid_root, upper_root, 800_000)
+
+      expect(result.data).to be(true)
+    end
+
+    it 'returns Result::NotFound when the block height is unknown' do
+      http_client = fake(404, 'not found')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:valid_root, merkle_root, 99_999_999)
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+
+    it 'returns Result::Error on 500' do
+      http_client = fake(500, 'error')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:valid_root, merkle_root, 800_000)
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_script_unspent
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_script_unspent)' do
+    let(:script_hash) { 'f' * 64 }
+    let(:utxo_array)  { [{ 'tx_hash' => 'aaa', 'tx_pos' => 0, 'value' => 5000, 'height' => 1 }].to_json }
+
+    it 'returns a JSON array on success' do
+      http_client = fake(200, utxo_array)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_script_unspent, script_hash)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to be_an(Array)
+      expect(result.data.length).to eq(1)
+    end
+
+    it 'sends GET to /script/{script_hash}/confirmed/unspent' do
+      http_client = fake(200, '[]')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_script_unspent, script_hash)
+
+      expect(http_client.last_uri.path).to end_with("/script/#{script_hash}/confirmed/unspent")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_balance
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_balance)' do
+    it 'returns parsed JSON balance object' do
+      body = '{"confirmed":50000,"unconfirmed":0}'
+      http_client = fake(200, body)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_balance, '1AddressBSV')
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data['confirmed']).to eq(50_000)
+    end
+
+    it 'sends GET to /address/{address}/confirmed/balance' do
+      http_client = fake(200, '{"confirmed":0}')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_balance, '1TestAddr')
+
+      expect(http_client.last_uri.path).to end_with('/address/1TestAddr/confirmed/balance')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # health
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:health)' do
+    it 'returns raw body string on success' do
+      http_client = fake(200, 'Whats On Chain')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:health)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq('Whats On Chain')
+    end
+
+    it 'sends GET to /health' do
+      http_client = fake(200, 'ok')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:health)
+
+      expect(http_client.last_uri.path).to end_with('/health')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_tx_status
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_tx_status)' do
+    it 'sends POST to /txs/status' do
+      body = '[{"txid":"abc","status":"mined"}]'
+      http_client = fake(200, body)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_tx_status, body: '[{"txid":"abc"}]')
+
+      expect(http_client.last_uri.path).to end_with('/txs/status')
+      expect(http_client.last_request).to be_a(Net::HTTP::Post)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # API key auth
+  # ---------------------------------------------------------------------------
+
+  describe 'API key authentication' do
+    it 'sends Bearer auth header when api_key is provided' do
+      http_client = fake(200, '{"blocks":800000}')
+      protocol = described_class.new(network: :main, api_key: 'my-woc-key', http_client: http_client)
+
+      protocol.call(:current_height)
+
+      expect(http_client.last_request['Authorization']).to eq('Bearer my-woc-key')
+    end
+
+    it 'omits Authorization header when api_key is not provided' do
+      http_client = fake(200, '{"blocks":800000}')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:current_height)
+
+      expect(http_client.last_request['Authorization']).to be_nil
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/network/protocols/woc_rest_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/woc_rest_spec.rb
@@ -295,8 +295,8 @@ RSpec.describe BSV::Network::Protocols::WoCREST do # rubocop:disable RSpec/SpecF
       result = protocol.call(:get_utxos, '1AddressBSV')
 
       expect(result).to be_a(BSV::Network::Result::Success)
-      expect(result.data[0]['satoshis']).to eq(50_000)
-      expect(result.data[1]['satoshis']).to eq(100_000)
+      expect(result.data[0][:satoshis]).to eq(50_000)
+      expect(result.data[1][:satoshis]).to eq(100_000)
     end
 
     it 'does not include a value key in remapped entries' do
@@ -305,19 +305,20 @@ RSpec.describe BSV::Network::Protocols::WoCREST do # rubocop:disable RSpec/SpecF
 
       result = protocol.call(:get_utxos, '1AddressBSV')
 
+      expect(result.data[0]).not_to have_key(:value)
       expect(result.data[0]).not_to have_key('value')
     end
 
-    it 'preserves tx_hash, tx_pos, and height fields' do
+    it 'preserves tx_hash, tx_pos, and height fields as symbol keys' do
       http_client = fake(200, woc_response)
       protocol = described_class.new(network: :main, http_client: http_client)
 
       result = protocol.call(:get_utxos, '1AddressBSV')
 
       entry = result.data[0]
-      expect(entry['tx_hash']).to eq('abc')
-      expect(entry['tx_pos']).to eq(0)
-      expect(entry['height']).to eq(800_000)
+      expect(entry[:tx_hash]).to eq('abc')
+      expect(entry[:tx_pos]).to eq(0)
+      expect(entry[:height]).to eq(800_000)
     end
 
     it 'returns an empty array when the address has no UTXOs' do
@@ -419,6 +420,26 @@ RSpec.describe BSV::Network::Protocols::WoCREST do # rubocop:disable RSpec/SpecF
       expect(result).to be_a(BSV::Network::Result::Error)
       expect(result.retryable?).to be(true)
     end
+
+    it 'returns Result::Error when the spent field is absent from the response' do
+      http_client = fake(200, '{"something_else":true}')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:is_utxo, 'abc123', 0)
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.message).to include('missing spent field')
+    end
+
+    it 'returns Result::Error when the response body is not a Hash' do
+      http_client = fake(200, '"just a string"')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:is_utxo, 'abc123', 0)
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.message).to include('missing spent field')
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -436,7 +457,7 @@ RSpec.describe BSV::Network::Protocols::WoCREST do # rubocop:disable RSpec/SpecF
       result = protocol.call(:broadcast, tx)
 
       expect(result).to be_a(BSV::Network::Result::Success)
-      expect(result.data['txid']).to eq(raw_txid)
+      expect(result.data[:txid]).to eq(raw_txid)
     end
 
     it 'strips whitespace from the txid response' do
@@ -445,7 +466,7 @@ RSpec.describe BSV::Network::Protocols::WoCREST do # rubocop:disable RSpec/SpecF
 
       result = protocol.call(:broadcast, '01000000')
 
-      expect(result.data['txid']).to eq(raw_txid)
+      expect(result.data[:txid]).to eq(raw_txid)
     end
 
     it 'uses txhex as the body field name' do


### PR DESCRIPTION
## Summary
- Implement `Protocols::ARC` -- 5 endpoints with broadcast escape hatches (EF format, rejection detection, custom headers)
- Implement `Protocols::WoCREST` -- 12 endpoints with escape hatches for UTXO remapping, broadcast format, and root verification
- Implement `Protocols::Chaintracks` -- 2 endpoints, pure DSL
- Implement `Protocols::Ordinals` -- 2 endpoints, pure DSL
- Implement `Protocols::TAALBinary` -- 1 endpoint with binary format escape hatch
- Integration spec verifying all 5 protocols load, command counts, and no collisions

## Test plan
- [x] All SDK specs pass (3,751 examples, 0 failures)
- [x] RuboCop clean (402 files, no offences)
- [x] All acceptance criteria from #525 verified

Closes #525
