### PR TITLE
feat(network): Provider as configuration container with block DSL (#526)

### DIFF
--- a/gem/bsv-sdk/lib/bsv/network.rb
+++ b/gem/bsv-sdk/lib/bsv/network.rb
@@ -5,6 +5,7 @@ module BSV
     autoload :Result,             'bsv/network/result'
     autoload :Protocol,           'bsv/network/protocol'
     autoload :Protocols,          'bsv/network/protocols'
+    autoload :Provider,           'bsv/network/provider'
     autoload :BroadcastError,     'bsv/network/broadcast_error'
     autoload :BroadcastResponse,  'bsv/network/broadcast_response'
     autoload :ChainProviderError, 'bsv/network/chain_provider_error'

--- a/gem/bsv-sdk/lib/bsv/network/protocols/chaintracks.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/chaintracks.rb
@@ -29,10 +29,11 @@ module BSV
         endpoint :current_height,   :get, '/chaintracks/v2/tip',
                  response: ->(body) { JSON.parse(body)['height'] }
 
+        # @param base_url    [String, nil] override the default base URL
         # @param api_key     [String, nil] optional Bearer API key
         # @param http_client [Object, nil] injectable HTTP client for testing
-        def initialize(api_key: nil, http_client: nil)
-          super(base_url: BASE_URL, api_key: api_key, http_client: http_client)
+        def initialize(base_url: nil, api_key: nil, http_client: nil)
+          super(base_url: base_url || BASE_URL, api_key: api_key, http_client: http_client)
         end
       end
     end

--- a/gem/bsv-sdk/lib/bsv/network/protocols/ordinals.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/ordinals.rb
@@ -22,10 +22,11 @@ module BSV
         endpoint :get_tx,          :get, '/api/tx/{txid}/hex'
         endpoint :get_merkle_path, :get, '/api/tx/{txid}/proof', response: :json
 
+        # @param base_url    [String, nil] override the default base URL
         # @param api_key     [String, nil] optional Bearer API key
         # @param http_client [Object, nil] injectable HTTP client for testing
-        def initialize(api_key: nil, http_client: nil)
-          super(base_url: BASE_URL, api_key: api_key, http_client: http_client)
+        def initialize(base_url: nil, api_key: nil, http_client: nil)
+          super(base_url: base_url || BASE_URL, api_key: api_key, http_client: http_client)
         end
       end
     end

--- a/gem/bsv-sdk/lib/bsv/network/protocols/woc_rest.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/woc_rest.rb
@@ -66,13 +66,15 @@ module BSV
 
         attr_reader :network_name
 
+        # @param base_url    [String, nil] override the default base URL; may contain
+        #   +{network}+ which will be interpolated with the resolved network name
         # @param network  [Symbol, String] :main, :mainnet, :test, :testnet, :stn
         # @param api_key  [String, nil]    optional Bearer API key
         # @param http_client [Object, nil] injectable HTTP client for testing
-        def initialize(network: :main, api_key: nil, http_client: nil)
+        def initialize(base_url: nil, network: :main, api_key: nil, http_client: nil)
           @network_name = resolve_network(network)
           super(
-            base_url: BASE_URL,
+            base_url: base_url || BASE_URL,
             api_key: api_key,
             network: @network_name,
             http_client: http_client

--- a/gem/bsv-sdk/lib/bsv/network/provider.rb
+++ b/gem/bsv-sdk/lib/bsv/network/provider.rb
@@ -69,6 +69,41 @@ module BSV
         Set.new(@command_index.keys)
       end
 
+      # Returns the protocol instance that serves a given command, or nil if no
+      # registered protocol handles it.
+      #
+      # @param command_name [Symbol, String]
+      # @return [Protocol, nil]
+      def protocol_for(command_name)
+        @command_index[command_name.to_sym]
+      end
+
+      # Returns a hash mapping each protocol instance to the sorted list of
+      # commands it actually serves within this provider (respecting
+      # first-registered-wins — a protocol that lost a command to an earlier
+      # registration is not listed for that command).
+      #
+      # Protocols that serve no commands in this provider are omitted.
+      #
+      # @return [Hash{Protocol => Array<Symbol>}]
+      def capability_matrix
+        matrix = {}
+        @protocols.each do |proto|
+          served = proto.class.commands.select { |cmd| @command_index[cmd] == proto }
+          matrix[proto] = served.sort unless served.empty?
+        end
+        matrix
+      end
+
+      # Returns a human-readable representation of the provider.
+      #
+      # @return [String]
+      def to_s
+        protocol_summary = @protocols.map { |p| p.class.name.split('::').last }.join(', ')
+        "#<#{self.class} name=#{@name.inspect} protocols=[#{protocol_summary}]>"
+      end
+      alias inspect to_s
+
       # Dispatches a command to the first-registered protocol that serves it.
       #
       # @param command_name [Symbol, String] command to invoke

--- a/gem/bsv-sdk/lib/bsv/network/provider.rb
+++ b/gem/bsv-sdk/lib/bsv/network/provider.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module BSV
+  module Network
+    # Provider is a named configuration container that hosts one or more Protocol
+    # instances and dispatches commands to the appropriate protocol.
+    #
+    # Protocols are registered via a block DSL or by calling +#protocol+ directly
+    # after construction. For each command symbol, the first-registered protocol
+    # that serves it wins (first-registered-wins, no warning on duplicates).
+    #
+    # == Example
+    #
+    #   gorillapool = BSV::Network::Provider.new('GorillaPool') do |p|
+    #     p.protocol Protocols::ARC,         base_url: 'https://arcade.gorillapool.io'
+    #     p.protocol Protocols::Chaintracks, base_url: 'https://arcade.gorillapool.io'
+    #     p.protocol Protocols::Ordinals,    base_url: 'https://ordinals.gorillapool.io'
+    #   end
+    #
+    #   result = gorillapool.call(:broadcast, tx)
+    #   result.success?  # => true
+    class Provider
+      attr_reader :name
+
+      # @param name  [String] human-readable provider name (e.g. 'GorillaPool')
+      # @param block [Proc]   optional configuration block — yields +self+
+      def initialize(name, &block)
+        @name           = name
+        @protocols      = []
+        @command_index  = {}
+        block&.call(self)
+      end
+
+      # Registers a protocol class with the provider.
+      #
+      # The class is instantiated with the supplied +kwargs+. Its commands are
+      # indexed: each command not yet in the index is mapped to this instance.
+      # Commands already in the index are left unchanged (first-registered wins).
+      #
+      # The provider remains mutable — +protocol+ may be called after block
+      # execution.
+      #
+      # @param klass  [Class]  a Protocol subclass
+      # @param kwargs [Hash]   keyword arguments forwarded to +klass.new+
+      # @return [Protocol] the newly created protocol instance
+      def protocol(klass, **kwargs)
+        instance = klass.new(**kwargs)
+        @protocols << instance
+        klass.commands.each do |cmd|
+          @command_index[cmd] ||= instance
+        end
+        instance
+      end
+
+      # Returns a frozen copy of the registered protocol instances, in
+      # registration order.
+      #
+      # @return [Array<Protocol>]
+      def protocols
+        @protocols.dup.freeze
+      end
+
+      # Returns the set of all command symbols available on this provider.
+      #
+      # @return [Set<Symbol>]
+      def commands
+        Set.new(@command_index.keys)
+      end
+
+      # Dispatches a command to the first-registered protocol that serves it.
+      #
+      # @param command_name [Symbol, String] command to invoke
+      # @param args   [Array]  positional arguments forwarded to the protocol
+      # @param kwargs [Hash]   keyword arguments forwarded to the protocol
+      # @return [Result::Success, Result::Error, Result::NotFound]
+      # @raise [ArgumentError] when no registered protocol serves the command
+      def call(command_name, *args, **kwargs)
+        sym      = command_name.to_sym
+        instance = @command_index[sym]
+        raise ArgumentError, "#{@name} does not provide command :#{sym}" unless instance
+
+        instance.call(sym, *args, **kwargs)
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/network/protocols/chaintracks_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/chaintracks_spec.rb
@@ -102,6 +102,29 @@ RSpec.describe BSV::Network::Protocols::Chaintracks do
     end
   end
 
+  describe 'base_url override' do
+    let(:tip_body) { { 'height' => 800_000 }.to_json }
+
+    it 'uses BASE_URL when base_url: is omitted' do
+      http = mock_http.new(200, tip_body)
+      instance = described_class.new(http_client: http)
+      expect(instance.base_url).to eq(described_class::BASE_URL)
+    end
+
+    it 'overrides the base URL when base_url: is provided' do
+      http = mock_http.new(200, tip_body)
+      instance = described_class.new(base_url: 'https://my.chaintracks.example', http_client: http)
+      expect(instance.base_url).to eq('https://my.chaintracks.example')
+    end
+
+    it 'uses the overridden base URL when building request URLs' do
+      http = mock_http.new(200, tip_body)
+      instance = described_class.new(base_url: 'https://my.chaintracks.example', http_client: http)
+      instance.call(:current_height)
+      expect(http.last_uri.to_s).to start_with('https://my.chaintracks.example')
+    end
+  end
+
   describe 'authentication' do
     let(:tip_body) { { 'height' => 800_000 }.to_json }
 

--- a/gem/bsv-sdk/spec/bsv/network/protocols/ordinals_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/ordinals_spec.rb
@@ -112,6 +112,29 @@ RSpec.describe BSV::Network::Protocols::Ordinals do
     end
   end
 
+  describe 'base_url override' do
+    let(:hex_body) { '01000000' }
+
+    it 'uses BASE_URL when base_url: is omitted' do
+      http = mock_http.new(200, hex_body)
+      instance = described_class.new(http_client: http)
+      expect(instance.base_url).to eq(described_class::BASE_URL)
+    end
+
+    it 'overrides the base URL when base_url: is provided' do
+      http = mock_http.new(200, hex_body)
+      instance = described_class.new(base_url: 'https://my.ordinals.example', http_client: http)
+      expect(instance.base_url).to eq('https://my.ordinals.example')
+    end
+
+    it 'uses the overridden base URL when building request URLs' do
+      http = mock_http.new(200, hex_body)
+      instance = described_class.new(base_url: 'https://my.ordinals.example', http_client: http)
+      instance.call(:get_tx, txid)
+      expect(http.last_uri.to_s).to start_with('https://my.ordinals.example')
+    end
+  end
+
   describe 'authentication' do
     let(:hex_body) { '01000000' }
 

--- a/gem/bsv-sdk/spec/bsv/network/protocols/woc_rest_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/woc_rest_spec.rb
@@ -83,6 +83,31 @@ RSpec.describe BSV::Network::Protocols::WoCREST do # rubocop:disable RSpec/SpecF
   end
 
   # ---------------------------------------------------------------------------
+  # base_url override
+  # ---------------------------------------------------------------------------
+
+  describe '#initialize — base_url override' do
+    it 'uses the default BASE_URL when base_url: is omitted' do
+      protocol = described_class.new(network: :main, http_client: fake(200, ''))
+      expect(protocol.base_url).to eq('https://api.whatsonchain.com/v1/bsv/main')
+    end
+
+    it 'uses a fully-qualified override when base_url: is provided without {network}' do
+      protocol = described_class.new(base_url: 'https://my.woc.example', network: :main, http_client: fake(200, ''))
+      expect(protocol.base_url).to eq('https://my.woc.example')
+    end
+
+    it 'still interpolates {network} in an overridden URL template' do
+      protocol = described_class.new(
+        base_url: 'https://staging.woc.example/v2/bsv/{network}',
+        network: :test,
+        http_client: fake(200, '')
+      )
+      expect(protocol.base_url).to eq('https://staging.woc.example/v2/bsv/test')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Declared commands
   # ---------------------------------------------------------------------------
 

--- a/gem/bsv-sdk/spec/bsv/network/provider_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/provider_spec.rb
@@ -1,0 +1,249 @@
+# frozen_string_literal: true
+
+RSpec.describe 'BSV::Network::Provider' do
+  subject(:provider) { BSV::Network::Provider }
+
+  let(:http_client) { double('http_client') } # rubocop:disable RSpec/VerifiedDoubles
+
+  let(:arc_class)        { BSV::Network::Protocols::ARC }
+  let(:woc_class)        { BSV::Network::Protocols::WoCREST }
+  let(:chaintracks_class) { BSV::Network::Protocols::Chaintracks }
+  let(:ordinals_class) { BSV::Network::Protocols::Ordinals }
+
+  # ── Constructor ──────────────────────────────────────────────────────────────
+
+  describe '.new' do
+    it 'stores the provider name' do
+      p = provider.new('GorillaPool')
+      expect(p.name).to eq('GorillaPool')
+    end
+
+    it 'creates a provider with no protocols when no block is given' do
+      p = provider.new('Empty')
+      expect(p.protocols).to be_empty
+    end
+
+    it 'creates a provider with empty commands when no block is given' do
+      p = provider.new('Empty')
+      expect(p.commands).to be_empty
+    end
+
+    it 'yields self to the block for DSL calls' do
+      yielded = nil
+      p = provider.new('Test') { |pr| yielded = pr }
+      expect(yielded).to be(p)
+    end
+  end
+
+  # ── Block DSL ─────────────────────────────────────────────────────────────────
+
+  describe '#protocol' do
+    it 'registers a protocol instance in the block' do
+      p = provider.new('GorillaPool') do |pr|
+        pr.protocol arc_class, base_url: 'https://arcade.gorillapool.io', http_client: http_client
+      end
+      expect(p.protocols.length).to eq(1)
+      expect(p.protocols.first).to be_a(arc_class)
+    end
+
+    it 'returns the created protocol instance' do
+      instance = nil
+      provider.new('Test') do |pr|
+        instance = pr.protocol arc_class, base_url: 'https://example.com', http_client: http_client
+      end
+      expect(instance).to be_a(arc_class)
+    end
+
+    it 'registers multiple protocols' do
+      p = provider.new('Multi') do |pr|
+        pr.protocol arc_class, base_url: 'https://arc.example.com', http_client: http_client
+        pr.protocol chaintracks_class,  base_url: 'https://ct.example.com',     http_client: http_client
+        pr.protocol ordinals_class,     base_url: 'https://ord.example.com',    http_client: http_client
+      end
+      expect(p.protocols.length).to eq(3)
+    end
+
+    it 'is callable after block execution (provider remains mutable)' do
+      p = provider.new('Growing')
+      expect(p.protocols).to be_empty
+
+      p.protocol arc_class, base_url: 'https://arc.example.com', http_client: http_client
+      expect(p.protocols.length).to eq(1)
+    end
+
+    it 'accepts extra kwargs like deployment_id for ARC' do
+      p = provider.new('ARC') do |pr|
+        pr.protocol arc_class,
+                    base_url: 'https://arc.example.com',
+                    deployment_id: 'my-deployment',
+                    http_client: http_client
+      end
+      expect(p.protocols.first).to be_a(arc_class)
+    end
+  end
+
+  # ── #protocols reader ─────────────────────────────────────────────────────────
+
+  describe '#protocols' do
+    it 'returns a frozen copy (not the internal array)' do
+      p = provider.new('Test') do |pr|
+        pr.protocol chaintracks_class, base_url: 'https://ct.example.com', http_client: http_client
+      end
+      copy = p.protocols
+      expect(copy).to be_frozen
+      expect { copy << 'anything' }.to raise_error(FrozenError)
+    end
+
+    it 'preserves registration order' do
+      p = provider.new('Ordered') do |pr|
+        pr.protocol chaintracks_class, base_url: 'https://ct.example.com',  http_client: http_client
+        pr.protocol ordinals_class,    base_url: 'https://ord.example.com', http_client: http_client
+      end
+      expect(p.protocols.map(&:class)).to eq([chaintracks_class, ordinals_class])
+    end
+  end
+
+  # ── #commands ────────────────────────────────────────────────────────────────
+
+  describe '#commands' do
+    it 'returns a Set' do
+      p = provider.new('Test')
+      expect(p.commands).to be_a(Set)
+    end
+
+    it 'returns empty Set when no protocols are registered' do
+      p = provider.new('Empty')
+      expect(p.commands).to be_empty
+    end
+
+    it 'returns the union of all protocol commands' do
+      p = provider.new('Union') do |pr|
+        pr.protocol chaintracks_class, base_url: 'https://ct.example.com',  http_client: http_client
+        pr.protocol ordinals_class,    base_url: 'https://ord.example.com', http_client: http_client
+      end
+      expected = chaintracks_class.commands | ordinals_class.commands
+      expect(p.commands).to eq(expected)
+    end
+
+    it 'includes commands from all protocols (ARC + WoCREST)' do
+      p = provider.new('Full') do |pr|
+        pr.protocol arc_class, base_url: 'https://arc.example.com', http_client: http_client
+        pr.protocol woc_class, http_client: http_client
+      end
+      expect(p.commands).to include(:broadcast, :get_tx, :current_height, :health)
+    end
+  end
+
+  # ── #call dispatch ────────────────────────────────────────────────────────────
+
+  describe '#call' do
+    let(:mock_response) do
+      resp = double('response') # rubocop:disable RSpec/VerifiedDoubles
+      allow(resp).to receive_messages(code: '200', body: '{"txid":"abc123","txStatus":"MINED"}')
+      resp
+    end
+
+    it 'dispatches to the correct protocol' do
+      allow(http_client).to receive(:request).and_return(mock_response)
+
+      p = provider.new('Dispatch') do |pr|
+        pr.protocol arc_class, base_url: 'https://arc.example.com', http_client: http_client
+      end
+
+      # ARC broadcast uses the escape hatch call_broadcast — pass a minimal tx double
+      tx = double('tx') # rubocop:disable RSpec/VerifiedDoubles
+      allow(tx).to receive(:to_ef_hex).and_return('deadbeef')
+
+      result = p.call(:broadcast, tx)
+      expect(result).to be_success
+    end
+
+    it 'raises ArgumentError for an unknown command' do
+      p = provider.new('Limited') do |pr|
+        pr.protocol chaintracks_class, base_url: 'https://ct.example.com', http_client: http_client
+      end
+      expect { p.call(:nonexistent_command) }.to raise_error(ArgumentError, /does not provide command :nonexistent_command/)
+    end
+
+    it 'raises ArgumentError on an empty provider' do
+      p = provider.new('Empty')
+      expect { p.call(:broadcast) }.to raise_error(ArgumentError, /does not provide command :broadcast/)
+    end
+
+    it 'error message includes provider name' do
+      p = provider.new('MyProvider')
+      expect { p.call(:missing) }.to raise_error(ArgumentError, /MyProvider/)
+    end
+  end
+
+  # ── First-registered wins ─────────────────────────────────────────────────────
+
+  describe 'first-registered-wins for duplicate commands' do
+    let(:ct_response) do
+      resp = double('response') # rubocop:disable RSpec/VerifiedDoubles
+      allow(resp).to receive_messages(code: '200', body: '{"height":1000}')
+      resp
+    end
+
+    let(:woc_response) do
+      resp = double('response') # rubocop:disable RSpec/VerifiedDoubles
+      allow(resp).to receive_messages(code: '200', body: '{"blocks":900}')
+      resp
+    end
+
+    let(:ct_client)  { double('ct_http_client') } # rubocop:disable RSpec/VerifiedDoubles
+    let(:woc_client) { double('woc_http_client') } # rubocop:disable RSpec/VerifiedDoubles
+
+    it 'dispatches :current_height to the first-registered protocol (Chaintracks)' do
+      allow(ct_client).to receive(:request).and_return(ct_response)
+
+      p = provider.new('Competing') do |pr|
+        pr.protocol chaintracks_class, base_url: 'https://ct.example.com', http_client: ct_client
+        pr.protocol woc_class, http_client: woc_client
+      end
+
+      result = p.call(:current_height)
+      expect(result).to be_success
+      # Chaintracks returns the height integer directly; WoCREST would return 900
+      expect(result.data).to eq(1000)
+    end
+
+    it 'dispatches :current_height to WoCREST when registered first' do
+      allow(woc_client).to receive(:request).and_return(woc_response)
+
+      p = provider.new('Reversed') do |pr|
+        pr.protocol woc_class,          http_client: woc_client
+        pr.protocol chaintracks_class,  base_url: 'https://ct.example.com', http_client: ct_client
+      end
+
+      result = p.call(:current_height)
+      expect(result).to be_success
+      expect(result.data).to eq(900)
+    end
+
+    it 'stores both protocol instances when the same class is registered twice' do
+      p = provider.new('Duplicate') do |pr|
+        pr.protocol chaintracks_class, base_url: 'https://ct1.example.com', http_client: http_client
+        pr.protocol chaintracks_class, base_url: 'https://ct2.example.com', http_client: http_client
+      end
+      expect(p.protocols.length).to eq(2)
+    end
+
+    it 'first instance wins in the index when same class registered twice' do
+      allow(http_client).to receive(:request).and_return(ct_response)
+
+      p = provider.new('Duplicate') do |pr|
+        pr.protocol chaintracks_class, base_url: 'https://ct1.example.com', http_client: http_client
+        pr.protocol chaintracks_class, base_url: 'https://ct2.example.com', http_client: http_client
+      end
+
+      # Both Chaintracks instances have the same commands; first wins in index.
+      # The first has base_url ct1.example.com.
+      first_instance = p.protocols.first
+      expect(first_instance.base_url).to eq('https://ct1.example.com')
+      # Verify dispatch hits the first instance
+      result = p.call(:current_height)
+      expect(result).to be_success
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/network/provider_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/provider_spec.rb
@@ -246,4 +246,131 @@ RSpec.describe 'BSV::Network::Provider' do
       expect(result).to be_success
     end
   end
+
+  # ── #protocol_for ─────────────────────────────────────────────────────────────
+
+  describe '#protocol_for' do
+    it 'returns the protocol instance serving the given command' do
+      p = provider.new('Test') do |pr|
+        pr.protocol arc_class, base_url: 'https://arc.example.com', http_client: http_client
+      end
+      result = p.protocol_for(:broadcast)
+      expect(result).to be_a(arc_class)
+    end
+
+    it 'accepts a string command name' do
+      p = provider.new('Test') do |pr|
+        pr.protocol chaintracks_class, base_url: 'https://ct.example.com', http_client: http_client
+      end
+      expect(p.protocol_for('current_height')).to be_a(chaintracks_class)
+    end
+
+    it 'returns nil for an unknown command' do
+      p = provider.new('Test') do |pr|
+        pr.protocol chaintracks_class, base_url: 'https://ct.example.com', http_client: http_client
+      end
+      expect(p.protocol_for(:nonexistent)).to be_nil
+    end
+
+    it 'returns nil on an empty provider' do
+      p = provider.new('Empty')
+      expect(p.protocol_for(:broadcast)).to be_nil
+    end
+
+    it 'returns the first-registered protocol when commands overlap' do
+      p = provider.new('Overlap') do |pr|
+        pr.protocol chaintracks_class, base_url: 'https://ct.example.com', http_client: http_client
+        pr.protocol woc_class, http_client: http_client
+      end
+      # :current_height is served by both; first-registered (Chaintracks) wins
+      expect(p.protocol_for(:current_height)).to be_a(chaintracks_class)
+    end
+  end
+
+  # ── #capability_matrix ────────────────────────────────────────────────────────
+
+  describe '#capability_matrix' do
+    it 'returns an empty hash when no protocols are registered' do
+      p = provider.new('Empty')
+      expect(p.capability_matrix).to eq({})
+    end
+
+    it 'maps each protocol instance to its served commands' do
+      p = provider.new('Single') do |pr|
+        pr.protocol chaintracks_class, base_url: 'https://ct.example.com', http_client: http_client
+      end
+      matrix = p.capability_matrix
+      expect(matrix.keys.first).to be_a(chaintracks_class)
+      expect(matrix.values.first).to eq(chaintracks_class.commands.sort)
+    end
+
+    it 'lists commands as a sorted array' do
+      p = provider.new('Sorted') do |pr|
+        pr.protocol chaintracks_class, base_url: 'https://ct.example.com', http_client: http_client
+      end
+      commands = p.capability_matrix.values.first
+      expect(commands).to eq(commands.sort)
+    end
+
+    it 'respects first-registered-wins — second protocol loses overlapping commands' do
+      p = provider.new('Overlap') do |pr|
+        pr.protocol chaintracks_class, base_url: 'https://ct.example.com', http_client: http_client
+        pr.protocol woc_class,                                              http_client: http_client
+      end
+      matrix = p.capability_matrix
+
+      ct_instance  = p.protocols[0]
+      woc_instance = p.protocols[1]
+
+      overlap = chaintracks_class.commands & woc_class.commands
+
+      # Chaintracks owns all its commands (including the overlapping ones)
+      expect(matrix[ct_instance]).to include(*overlap.to_a)
+      # WoCREST does not list the overlapping commands
+      expect(matrix[woc_instance]).not_to include(*overlap.to_a)
+    end
+
+    it 'omits a protocol instance that serves no commands in this provider' do
+      p = provider.new('Shadowed') do |pr|
+        pr.protocol chaintracks_class, base_url: 'https://ct1.example.com', http_client: http_client
+        pr.protocol chaintracks_class, base_url: 'https://ct2.example.com', http_client: http_client
+      end
+      matrix = p.capability_matrix
+      # Second Chaintracks instance had all its commands taken by the first
+      second_instance = p.protocols[1]
+      expect(matrix).not_to have_key(second_instance)
+    end
+  end
+
+  # ── #to_s / #inspect ──────────────────────────────────────────────────────────
+
+  describe '#to_s' do
+    it 'includes the provider name' do
+      p = provider.new('GorillaPool')
+      expect(p.to_s).to include('GorillaPool')
+    end
+
+    it 'includes protocol class names' do
+      p = provider.new('Test') do |pr|
+        pr.protocol arc_class,         base_url: 'https://arc.example.com', http_client: http_client
+        pr.protocol chaintracks_class, base_url: 'https://ct.example.com',  http_client: http_client
+      end
+      expect(p.to_s).to include('ARC')
+      expect(p.to_s).to include('Chaintracks')
+    end
+
+    it 'shows an empty protocols list when no protocols are registered' do
+      p = provider.new('Empty')
+      expect(p.to_s).to include('protocols=[]')
+    end
+  end
+
+  describe '#inspect' do
+    it 'returns the same string as #to_s' do
+      p = provider.new('GorillaPool') do |pr|
+        pr.protocol arc_class, base_url: 'https://arc.example.com', http_client: http_client
+      end
+      expect(p.inspect).to eq(p.to_s)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add `base_url:` override to Chaintracks, Ordinals, and WoCREST protocol constructors (#540)
- Implement `BSV::Network::Provider` as named configuration container with block DSL (#541)
- Provider `protocol(klass, **kwargs)` DSL instantiates and registers protocols
- `commands` returns Set union, `call` dispatches via O(1) command index
- First-registered protocol wins for duplicate commands
- Introspection: `protocol_for`, `capability_matrix`, `to_s`/`inspect` (#542)

## Acceptance Criteria Verification

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `Provider.new(name) { \|p\| p.protocol(...) }` block DSL works | PASS |
| 2 | `provider.commands` returns union of all protocol commands | PASS |
| 3 | `provider.call(:command, *args)` delegates to correct protocol | PASS |
| 4 | Registry accepts new Provider shape | DEFERRED (Phase D/E) |
| 5 | Specifier still works with new Providers | DEFERRED (Phase D/E) |
| 6 | Multiple protocols, same command -> first-registered wins | PASS |
| 7 | Failover between providers still works | DEFERRED (Phase D/E) |
| 8 | `capability_matrix` shows Provider -> Protocol -> Command relationships | PASS |
| 9 | Full RSpec coverage | PASS |

Items 4, 5, 7 are Registry/Specifier concerns belonging to later phases.

## Test plan
- [x] All SDK specs pass (3,805 examples, 0 failures)
- [x] All wallet specs pass (1,342 examples, 0 failures)
- [x] RuboCop clean (404 files, no offences)
- [x] All Provider-scoped acceptance criteria from #526 verified

Closes #526

Generated with [Claude Code](https://claude.com/claude-code)
