### PR TITLE
feat(network): expand command vocabulary — 17 new endpoints (#528)

### DIFF
--- a/gem/bsv-sdk/lib/bsv/network/protocols/arc.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/arc.rb
@@ -126,6 +126,13 @@ module BSV
           parse_batch_broadcast_response(response)
         end
 
+        # Override to always include XDeployment-ID on every ARC request.
+        def build_request(http_method, uri, body)
+          request = super
+          request['XDeployment-ID'] = @deployment_id
+          request
+        end
+
         # Prefer Extended Format hex (BRC-30) so ARC can validate sighashes without
         # fetching parent transactions. Falls back to plain raw-tx hex when any input
         # lacks source_satoshis / source_locking_script.
@@ -274,7 +281,7 @@ module BSV
             return Result::Error.new(
               message: body['detail'] || body['title'] || body['txStatus'],
               retryable: false,
-              metadata: { arc_status: body['txStatus'].to_s.upcase, txid: body['txid'] }
+              metadata: { arc_status: body['txStatus'].to_s.upcase, txid: body['txid'], status_code: 200 }
             )
           end
 
@@ -282,7 +289,7 @@ module BSV
             return Result::Error.new(
               message: 'ARC returned a malformed 2xx response',
               retryable: false,
-              metadata: {}
+              metadata: { status_code: 200 }
             )
           end
 

--- a/gem/bsv-sdk/lib/bsv/network/protocols/woc_rest.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/woc_rest.rb
@@ -7,9 +7,9 @@ module BSV
     module Protocols
       # WoCREST implements the WhatsOnChain REST API as a Protocol subclass.
       #
-      # Provides 12 endpoints covering chain info, block headers, transactions,
-      # UTXOs, scripts, broadcast, and health. Three escape hatches handle
-      # WoC-specific body formats and field remapping.
+      # Provides 22 endpoints covering chain info, block headers, transactions,
+      # UTXOs, scripts, address queries, broadcast, and health. Four escape hatches
+      # handle WoC-specific body formats and field remapping.
       #
       # == Network resolution
       #
@@ -39,7 +39,9 @@ module BSV
         # Chain
         endpoint :current_height,   :get, '/chain/info',
                  response: ->(body) { JSON.parse(body)['blocks'] }
+        endpoint :get_chain_info,   :get, '/chain/info', response: :json
         endpoint :get_block_header, :get, '/block/{height}/header', response: :json
+        endpoint :get_block_headers, :get, '/block/headers', response: :json_array
 
         # Transaction
         endpoint :get_tx,           :get,  '/tx/{txid}/hex'
@@ -53,6 +55,7 @@ module BSV
         endpoint :get_utxos_all,    :get,  '/address/{address}/unspent',
                  response: :json_array
         endpoint :is_utxo,          :get,  '/tx/{txid}/{vout}/spent', response: :json
+        endpoint :is_utxo_bulk,     :post, '/utxos/spent', response: :json_array
         endpoint :valid_root,       :get,  '/block/{height}/header', response: :json
 
         # Script
@@ -60,11 +63,21 @@ module BSV
                  response: :json_array
 
         # Address balance
-        endpoint :get_balance,      :get,  '/address/{address}/confirmed/balance',
+        endpoint :get_balance, :get, '/address/{address}/confirmed/balance',
                  response: :json
+        endpoint :get_unconfirmed_balance, :get, '/address/{address}/unconfirmed/balance',
+                 response: :json
+        endpoint :get_history,           :get, '/address/{address}/confirmed/history',
+                 response: :json_array
+        endpoint :is_address_used,       :get, '/address/{address}/used', response: :json
+
+        # Exchange rate / fees / mempool
+        endpoint :get_exchange_rate,      :get, '/exchangerate',      response: :json
+        endpoint :get_fee_recommendation, :get, '/feerecommendation', response: :json
+        endpoint :get_mempool_info,       :get, '/mempool/info',      response: :json
 
         # Health
-        endpoint :health,           :get,  '/health'
+        endpoint :health, :get, '/health'
 
         attr_reader :network_name
 
@@ -161,6 +174,40 @@ module BSV
 
           spent = result.data['spent']
           Result::Success.new(data: !spent)
+        end
+
+        # Bulk-checks whether a set of outputs are unspent.
+        #
+        # WoC expects a JSON array of +{ txid, vout }+ objects. It returns an
+        # array of entries, each containing +txid+, +vout+, and +spent+ fields.
+        # Entries absent from the response (unknown outputs) are treated as spent.
+        #
+        # @param outpoints [Array<Hash>] array of +{ txid:, vout: }+ hashes
+        # @return [Result::Success<Hash{String => Boolean}>, Result::Error]
+        #   On success, data is a hash mapping +"txid.vout"+ keys to booleans
+        #   (+true+ = unspent, +false+ = spent).
+        def call_is_utxo_bulk(outpoints)
+          return Result::Success.new(data: {}) if outpoints.empty?
+
+          body = JSON.generate(outpoints.map { |op| { 'txid' => op[:txid].to_s, 'vout' => op[:vout].to_i } })
+          result = default_call(:is_utxo_bulk, body: body)
+          return result unless result.success?
+
+          # Build a lookup from the response — unknown outpoints default to spent
+          spent_map = {}
+          result.data.each do |entry|
+            next unless entry.is_a?(Hash) && entry.key?('txid') && entry.key?('vout')
+
+            key = "#{entry['txid']}.#{entry['vout']}"
+            spent_map[key] = entry['spent']
+          end
+
+          normalised = outpoints.each_with_object({}) do |op, h|
+            key = "#{op[:txid]}.#{op[:vout]}"
+            h[key] = spent_map.key?(key) ? !spent_map[key] : false
+          end
+
+          Result::Success.new(data: normalised)
         end
 
         # Broadcasts a raw transaction to WhatsOnChain.

--- a/gem/bsv-sdk/lib/bsv/network/protocols/woc_rest.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/woc_rest.rb
@@ -7,8 +7,8 @@ module BSV
     module Protocols
       # WoCREST implements the WhatsOnChain REST API as a Protocol subclass.
       #
-      # Provides 22 endpoints covering chain info, block headers, transactions,
-      # UTXOs, scripts, address queries, broadcast, and health. Four escape hatches
+      # Provides 30 endpoints covering chain info, block headers, transactions,
+      # UTXOs, scripts, address queries, broadcast, and health. Seven escape hatches
       # handle WoC-specific body formats and field remapping.
       #
       # == Network resolution
@@ -39,15 +39,20 @@ module BSV
         # Chain
         endpoint :current_height,   :get, '/chain/info',
                  response: ->(body) { JSON.parse(body)['blocks'] }
-        endpoint :get_chain_info,   :get, '/chain/info', response: :json
-        endpoint :get_block_header, :get, '/block/{height}/header', response: :json
+        endpoint :get_chain_info,    :get, '/chain/info', response: :json
+        endpoint :get_block_header,  :get, '/block/{height}/header', response: :json
         endpoint :get_block_headers, :get, '/block/headers', response: :json_array
 
         # Transaction
-        endpoint :get_tx,           :get,  '/tx/{txid}/hex'
-        endpoint :get_merkle_path,  :get,  '/tx/{txid}/proof/tsc', response: :json
-        endpoint :broadcast,        :post, '/tx/raw'
-        endpoint :get_tx_status,    :post, '/txs/status', response: :json
+        endpoint :get_tx,            :get,  '/tx/{txid}/hex'
+        endpoint :get_tx_details,    :get,  '/tx/hash/{txid}', response: :json
+        endpoint :get_output_script, :get,  '/tx/{txid}/out/{index}/hex'
+        endpoint :get_opreturn,      :get,  '/tx/{txid}/opreturn', response: :json
+        endpoint :get_merkle_path,   :get,  '/tx/{txid}/proof/tsc', response: :json
+        endpoint :broadcast,         :post, '/tx/raw'
+        endpoint :decode_tx,         :post, '/tx/decode', response: :json
+        endpoint :get_tx_status,     :post, '/txs/status', response: :json
+        endpoint :get_tx_hex_bulk,   :post, '/txs/hex', response: :json
 
         # UTXO / spent status
         endpoint :get_utxos,        :get,  '/address/{address}/confirmed/unspent',
@@ -59,17 +64,22 @@ module BSV
         endpoint :valid_root,       :get,  '/block/{height}/header', response: :json
 
         # Script
-        endpoint :get_script_unspent, :get, '/script/{script_hash}/confirmed/unspent',
+        endpoint :get_script_unspent,     :get,  '/script/{script_hash}/confirmed/unspent',
                  response: :json_array
+        endpoint :get_script_history,     :get,  '/script/{script_hash}/confirmed/history',
+                 response: :json_array
+        endpoint :get_script_all_unspent, :get,  '/script/{script_hash}/unspent/all',
+                 response: :json_array
+        endpoint :get_script_unspent_bulk, :post, '/scripts/confirmed/unspent', response: :json
 
-        # Address balance
-        endpoint :get_balance, :get, '/address/{address}/confirmed/balance',
+        # Address balance / history
+        endpoint :get_balance,             :get, '/address/{address}/confirmed/balance',
                  response: :json
         endpoint :get_unconfirmed_balance, :get, '/address/{address}/unconfirmed/balance',
                  response: :json
-        endpoint :get_history,           :get, '/address/{address}/confirmed/history',
+        endpoint :get_history,             :get, '/address/{address}/confirmed/history',
                  response: :json_array
-        endpoint :is_address_used,       :get, '/address/{address}/used', response: :json
+        endpoint :is_address_used,         :get, '/address/{address}/used', response: :json
 
         # Exchange rate / fees / mempool
         endpoint :get_exchange_rate,      :get, '/exchangerate',      response: :json
@@ -157,11 +167,11 @@ module BSV
         #
         # WoC returns a JSON object indicating whether the output has been spent.
         # The +script_hash:+ keyword is accepted for future fallback support
-        # (Phase E) but not used in this implementation.
+        # but not used in this implementation.
         #
         # @param txid        [String]  transaction ID
         # @param vout        [Integer] output index
-        # @param script_hash [String, nil] ignored in Phase B
+        # @param script_hash [String, nil] ignored
         # @return [Result::Success<Boolean>, Result::Error, Result::NotFound]
         def call_is_utxo(txid, vout, script_hash: nil) # rubocop:disable Lint/UnusedMethodArgument
           result = default_call(:is_utxo, txid, vout)
@@ -227,6 +237,40 @@ module BSV
 
           # WoC returns plain-text txid — result.data is the raw body string
           Result::Success.new(data: { txid: result.data.strip })
+        end
+
+        # Decodes a raw transaction hex by posting to the WoC decode endpoint.
+        #
+        # WoC expects the body as +{ txhex: "..." }+ (JSON) and returns a
+        # full decoded transaction object.
+        #
+        # @param txhex [String] raw transaction hex string
+        # @return [Result::Success<Hash>, Result::Error]
+        def call_decode_tx(txhex)
+          body = JSON.generate(txhex: txhex.to_s)
+          default_call(:decode_tx, body: body)
+        end
+
+        # Fetches raw hex for multiple transactions in a single request.
+        #
+        # WoC expects a bare JSON array of txid strings as the request body.
+        #
+        # @param txids [Array<String>] list of transaction IDs
+        # @return [Result::Success<Array>, Result::Error]
+        def call_get_tx_hex_bulk(txids)
+          body = JSON.generate(txids)
+          default_call(:get_tx_hex_bulk, body: body)
+        end
+
+        # Fetches confirmed UTXOs for multiple script hashes in a single request.
+        #
+        # WoC expects a bare JSON array of script hash strings as the request body.
+        #
+        # @param script_hashes [Array<String>] list of script hashes
+        # @return [Result::Success<Hash>, Result::Error]
+        def call_get_script_unspent_bulk(script_hashes)
+          body = JSON.generate(script_hashes)
+          default_call(:get_script_unspent_bulk, body: body)
         end
 
         # Verifies that a merkle root matches the one recorded for a given

--- a/gem/bsv-sdk/lib/bsv/network/protocols/woc_rest.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/woc_rest.rb
@@ -236,7 +236,7 @@ module BSV
           return result unless result.success?
 
           # WoC returns plain-text txid — result.data is the raw body string
-          Result::Success.new(data: { txid: result.data.strip })
+          Result::Success.new(data: { txid: result.data.to_s.strip })
         end
 
         # Decodes a raw transaction hex by posting to the WoC decode endpoint.

--- a/gem/bsv-sdk/spec/bsv/network/protocols/all_protocols_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/all_protocols_spec.rb
@@ -48,15 +48,21 @@ RSpec.describe 'BSV::Network::Protocols integration' do
     describe 'WoCREST' do
       subject(:commands) { BSV::Network::Protocols::WoCREST.commands }
 
-      it 'has 13 commands' do
-        expect(commands.size).to eq(13)
+      it 'has 30 commands' do
+        expect(commands.size).to eq(30)
       end
 
       it 'includes the expected commands' do
         expect(commands).to include(
-          :current_height, :get_block_header, :get_tx, :get_merkle_path,
-          :broadcast, :get_tx_status, :get_utxos, :is_utxo,
-          :valid_root, :get_script_unspent, :get_balance, :health
+          :current_height, :get_chain_info, :get_block_header, :get_block_headers,
+          :get_tx, :get_tx_details, :get_output_script, :get_opreturn,
+          :get_merkle_path, :broadcast, :decode_tx, :get_tx_status,
+          :get_tx_hex_bulk, :get_utxos, :get_utxos_all, :is_utxo,
+          :is_utxo_bulk, :valid_root, :get_script_unspent,
+          :get_script_history, :get_script_all_unspent, :get_script_unspent_bulk,
+          :get_balance, :get_unconfirmed_balance, :get_history,
+          :is_address_used, :get_exchange_rate, :get_fee_recommendation,
+          :get_mempool_info, :health
         )
       end
 

--- a/gem/bsv-sdk/spec/bsv/network/protocols/woc_rest_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/woc_rest_spec.rb
@@ -1104,6 +1104,365 @@ RSpec.describe BSV::Network::Protocols::WoCREST do # rubocop:disable RSpec/SpecF
   end
 
   # ---------------------------------------------------------------------------
+  # get_tx_details — full transaction JSON
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_tx_details)' do
+    let(:txid) { 'a' * 64 }
+    let(:tx_json) do
+      { 'txid' => txid, 'blockhash' => 'b' * 64, 'confirmations' => 6 }.to_json
+    end
+
+    it 'returns parsed JSON transaction detail on success' do
+      http_client = fake(200, tx_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_tx_details, txid)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data['txid']).to eq(txid)
+      expect(result.data['confirmations']).to eq(6)
+    end
+
+    it 'sends GET to /tx/hash/{txid}' do
+      http_client = fake(200, tx_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_tx_details, txid)
+
+      expect(http_client.last_uri.path).to end_with("/tx/hash/#{txid}")
+    end
+
+    it 'returns Result::NotFound for unknown txid' do
+      http_client = fake(404, 'not found')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_tx_details, 'unknown')
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+
+    it 'returns Result::Error(retryable: true) on 500' do
+      http_client = fake(500, 'server error')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_tx_details, txid)
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_output_script — single output script hex
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_output_script)' do
+    let(:txid)   { 'b' * 64 }
+    let(:script) { '76a914deadbeef88ac' }
+
+    it 'returns raw hex script on success' do
+      http_client = fake(200, script)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_output_script, txid, 0)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq(script)
+    end
+
+    it 'sends GET to /tx/{txid}/out/{index}/hex' do
+      http_client = fake(200, script)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_output_script, txid, 2)
+
+      expect(http_client.last_uri.path).to end_with("/tx/#{txid}/out/2/hex")
+    end
+
+    it 'returns Result::NotFound for unknown txid or index' do
+      http_client = fake(404, 'not found')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_output_script, 'unknown', 0)
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_opreturn — OP_RETURN data for a transaction
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_opreturn)' do
+    let(:txid)    { 'c' * 64 }
+    let(:op_json) { '{"data":"68656c6c6f","type":"OP_RETURN"}' }
+
+    it 'returns parsed JSON OP_RETURN data on success' do
+      http_client = fake(200, op_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_opreturn, txid)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data['data']).to eq('68656c6c6f')
+    end
+
+    it 'sends GET to /tx/{txid}/opreturn' do
+      http_client = fake(200, op_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_opreturn, txid)
+
+      expect(http_client.last_uri.path).to end_with("/tx/#{txid}/opreturn")
+    end
+
+    it 'returns Result::NotFound when no OP_RETURN output exists' do
+      http_client = fake(404, 'not found')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_opreturn, 'no_opreturn_txid')
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_tx_hex_bulk — bulk raw hex fetch (escape hatch)
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_tx_hex_bulk)' do
+    let(:txids)     { ['a' * 64, 'b' * 64] }
+    let(:bulk_json) { [{ 'txid' => 'a' * 64, 'hex' => '01000000' }].to_json }
+
+    it 'returns parsed JSON array on success' do
+      http_client = fake(200, bulk_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_tx_hex_bulk, txids)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to be_an(Array)
+    end
+
+    it 'sends POST to /txs/hex' do
+      http_client = fake(200, bulk_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_tx_hex_bulk, txids)
+
+      expect(http_client.last_uri.path).to end_with('/txs/hex')
+      expect(http_client.last_request).to be_a(Net::HTTP::Post)
+    end
+
+    it 'sends a bare JSON array of txid strings as the body' do
+      http_client = fake(200, bulk_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_tx_hex_bulk, txids)
+
+      body = JSON.parse(http_client.last_request.body)
+      expect(body).to be_an(Array)
+      expect(body).to eq(txids)
+    end
+
+    it 'returns Result::Error(retryable: true) on 500' do
+      http_client = fake(500, 'server error')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_tx_hex_bulk, txids)
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # decode_tx — decode raw transaction (escape hatch)
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:decode_tx)' do
+    let(:decoded_json) { '{"txid":"abc","vin":[],"vout":[]}' }
+
+    it 'returns parsed JSON decoded transaction on success' do
+      http_client = fake(200, decoded_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:decode_tx, '01000000')
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data['txid']).to eq('abc')
+    end
+
+    it 'sends POST to /tx/decode' do
+      http_client = fake(200, decoded_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:decode_tx, '01000000')
+
+      expect(http_client.last_uri.path).to end_with('/tx/decode')
+      expect(http_client.last_request).to be_a(Net::HTTP::Post)
+    end
+
+    it 'sends { txhex: ... } as the body' do
+      http_client = fake(200, decoded_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:decode_tx, 'deadbeef')
+
+      body = JSON.parse(http_client.last_request.body)
+      expect(body).to have_key('txhex')
+      expect(body['txhex']).to eq('deadbeef')
+    end
+
+    it 'returns Result::Error on 400 (malformed hex)' do
+      http_client = fake(400, 'bad request')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:decode_tx, 'not_valid_hex')
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(false)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_script_history — confirmed transaction history for a script
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_script_history)' do
+    let(:script_hash)   { 'e' * 64 }
+    let(:history_array) { [{ 'tx_hash' => 'abc', 'height' => 800_000 }].to_json }
+
+    it 'returns a JSON array of history entries on success' do
+      http_client = fake(200, history_array)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_script_history, script_hash)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to be_an(Array)
+      expect(result.data.first['tx_hash']).to eq('abc')
+    end
+
+    it 'sends GET to /script/{script_hash}/confirmed/history' do
+      http_client = fake(200, '[]')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_script_history, script_hash)
+
+      expect(http_client.last_uri.path).to end_with("/script/#{script_hash}/confirmed/history")
+    end
+
+    it 'returns Result::NotFound on 404' do
+      http_client = fake(404, 'not found')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_script_history, script_hash)
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+
+    it 'returns Result::Error(retryable: true) on 500' do
+      http_client = fake(500, 'error')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_script_history, script_hash)
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_script_all_unspent — all UTXOs (confirmed + unconfirmed) for a script
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_script_all_unspent)' do
+    let(:script_hash) { 'd' * 64 }
+    let(:utxo_array)  { [{ 'tx_hash' => 'fff', 'tx_pos' => 1, 'value' => 9_000, 'height' => 0 }].to_json }
+
+    it 'returns a JSON array of UTXOs on success' do
+      http_client = fake(200, utxo_array)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_script_all_unspent, script_hash)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to be_an(Array)
+      expect(result.data.length).to eq(1)
+    end
+
+    it 'sends GET to /script/{script_hash}/unspent/all' do
+      http_client = fake(200, '[]')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_script_all_unspent, script_hash)
+
+      expect(http_client.last_uri.path).to end_with("/script/#{script_hash}/unspent/all")
+    end
+
+    it 'returns Result::NotFound on 404' do
+      http_client = fake(404, 'not found')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_script_all_unspent, script_hash)
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_script_unspent_bulk — confirmed UTXOs for multiple scripts (escape hatch)
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_script_unspent_bulk)' do
+    let(:hashes)    { ['a' * 64, 'b' * 64] }
+    let(:bulk_json) { '{"aaa...":[],"bbb...":[]}' }
+
+    it 'returns parsed JSON on success' do
+      http_client = fake(200, bulk_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_script_unspent_bulk, hashes)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to be_a(Hash)
+    end
+
+    it 'sends POST to /scripts/confirmed/unspent' do
+      http_client = fake(200, bulk_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_script_unspent_bulk, hashes)
+
+      expect(http_client.last_uri.path).to end_with('/scripts/confirmed/unspent')
+      expect(http_client.last_request).to be_a(Net::HTTP::Post)
+    end
+
+    it 'sends a bare JSON array of script hash strings as the body' do
+      http_client = fake(200, bulk_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_script_unspent_bulk, hashes)
+
+      body = JSON.parse(http_client.last_request.body)
+      expect(body).to be_an(Array)
+      expect(body).to eq(hashes)
+    end
+
+    it 'returns Result::Error(retryable: true) on 500' do
+      http_client = fake(500, 'server error')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_script_unspent_bulk, hashes)
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # API key auth
   # ---------------------------------------------------------------------------
 

--- a/gem/bsv-sdk/spec/bsv/network/protocols/woc_rest_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/woc_rest_spec.rb
@@ -112,12 +112,14 @@ RSpec.describe BSV::Network::Protocols::WoCREST do # rubocop:disable RSpec/SpecF
   # ---------------------------------------------------------------------------
 
   describe '.commands' do
-    it 'declares all 12 expected commands' do
+    it 'declares all expected commands' do
       expected = %i[
-        current_height get_block_header
+        current_height get_chain_info get_block_header get_block_headers
         get_tx get_merkle_path broadcast get_tx_status
-        get_utxos is_utxo valid_root
-        get_script_unspent get_balance health
+        get_utxos is_utxo is_utxo_bulk valid_root
+        get_script_unspent get_balance
+        get_unconfirmed_balance get_history is_address_used
+        health
       ]
       expected.each do |cmd|
         expect(described_class.commands).to include(cmd),
@@ -708,6 +710,198 @@ RSpec.describe BSV::Network::Protocols::WoCREST do # rubocop:disable RSpec/SpecF
 
       expect(http_client.last_uri.path).to end_with('/txs/status')
       expect(http_client.last_request).to be_a(Net::HTTP::Post)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_chain_info — full chain info object
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_chain_info)' do
+    let(:chain_info_json) { '{"chain":"main","blocks":812345,"bestblockhash":"abcd1234"}' }
+
+    it 'returns parsed JSON chain info on success' do
+      http_client = fake(200, chain_info_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_chain_info)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data['blocks']).to eq(812_345)
+      expect(result.data['bestblockhash']).to eq('abcd1234')
+    end
+
+    it 'sends GET to /chain/info' do
+      http_client = fake(200, chain_info_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_chain_info)
+
+      expect(http_client.last_uri.path).to end_with('/chain/info')
+    end
+
+    it 'returns Result::NotFound on 404' do
+      http_client = fake(404, 'not found')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_chain_info)
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_block_headers — bulk header sync
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_block_headers)' do
+    let(:headers_json) do
+      [
+        { 'hash' => 'abc', 'height' => 800_000, 'merkleroot' => 'dead' },
+        { 'hash' => 'def', 'height' => 800_001, 'merkleroot' => 'beef' }
+      ].to_json
+    end
+
+    it 'returns a JSON array of block headers on success' do
+      http_client = fake(200, headers_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_block_headers)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to be_an(Array)
+      expect(result.data.length).to eq(2)
+      expect(result.data[0]['height']).to eq(800_000)
+    end
+
+    it 'sends GET to /block/headers' do
+      http_client = fake(200, headers_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_block_headers)
+
+      expect(http_client.last_uri.path).to end_with('/block/headers')
+    end
+
+    it 'returns Result::NotFound on 404' do
+      http_client = fake(404, 'not found')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_block_headers)
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_unconfirmed_balance
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_unconfirmed_balance)' do
+    it 'returns parsed JSON balance object on success' do
+      body = '{"unconfirmed":25000}'
+      http_client = fake(200, body)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_unconfirmed_balance, '1AddressBSV')
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data['unconfirmed']).to eq(25_000)
+    end
+
+    it 'sends GET to /address/{address}/unconfirmed/balance' do
+      http_client = fake(200, '{"unconfirmed":0}')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_unconfirmed_balance, '1TestAddr')
+
+      expect(http_client.last_uri.path).to end_with('/address/1TestAddr/unconfirmed/balance')
+    end
+
+    it 'returns Result::NotFound on 404' do
+      http_client = fake(404, 'not found')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_unconfirmed_balance, '1UnknownAddress')
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_history — confirmed transaction history
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_history)' do
+    let(:history_json) do
+      [
+        { 'tx_hash' => 'abc123', 'height' => 800_000 },
+        { 'tx_hash' => 'def456', 'height' => 800_001 }
+      ].to_json
+    end
+
+    it 'returns a JSON array of history entries on success' do
+      http_client = fake(200, history_json)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_history, '1AddressBSV')
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to be_an(Array)
+      expect(result.data.length).to eq(2)
+      expect(result.data[0]['tx_hash']).to eq('abc123')
+    end
+
+    it 'sends GET to /address/{address}/confirmed/history' do
+      http_client = fake(200, '[]')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_history, '1TestAddr')
+
+      expect(http_client.last_uri.path).to end_with('/address/1TestAddr/confirmed/history')
+    end
+
+    it 'returns Result::NotFound on 404' do
+      http_client = fake(404, 'not found')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_history, '1UnknownAddress')
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # is_address_used — HD wallet gap detection
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:is_address_used)' do
+    it 'returns parsed JSON response on success' do
+      http_client = fake(200, 'true')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:is_address_used, '1AddressBSV')
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to be(true)
+    end
+
+    it 'sends GET to /address/{address}/used' do
+      http_client = fake(200, 'false')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:is_address_used, '1TestAddr')
+
+      expect(http_client.last_uri.path).to end_with('/address/1TestAddr/used')
+    end
+
+    it 'returns Result::NotFound on 404' do
+      http_client = fake(404, 'not found')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:is_address_used, '1UnknownAddress')
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
     end
   end
 

--- a/gem/bsv-sdk/spec/bsv/network/protocols/woc_rest_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/woc_rest_spec.rb
@@ -115,10 +115,12 @@ RSpec.describe BSV::Network::Protocols::WoCREST do # rubocop:disable RSpec/SpecF
     it 'declares all expected commands' do
       expected = %i[
         current_height get_chain_info get_block_header get_block_headers
-        get_tx get_merkle_path broadcast get_tx_status
+        get_tx get_tx_details get_output_script get_opreturn
+        get_merkle_path broadcast decode_tx get_tx_status get_tx_hex_bulk
         get_utxos is_utxo is_utxo_bulk valid_root
-        get_script_unspent get_balance
-        get_unconfirmed_balance get_history is_address_used
+        get_script_unspent get_script_history get_script_all_unspent get_script_unspent_bulk
+        get_balance get_unconfirmed_balance get_history is_address_used
+        get_exchange_rate get_fee_recommendation get_mempool_info
         health
       ]
       expected.each do |cmd|
@@ -466,6 +468,94 @@ RSpec.describe BSV::Network::Protocols::WoCREST do # rubocop:disable RSpec/SpecF
 
       expect(result).to be_a(BSV::Network::Result::Error)
       expect(result.message).to include('missing spent field')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # is_utxo_bulk — bulk spent check (escape hatch)
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:is_utxo_bulk)' do
+    let(:first_txid) { 'a' * 64 }
+    let(:second_txid) { 'b' * 64 }
+
+    it 'returns a hash mapping outpoints to booleans — mix of spent and unspent' do
+      response = [
+        { 'txid' => first_txid, 'vout' => 0, 'spent' => false },
+        { 'txid' => second_txid, 'vout' => 1, 'spent' => true }
+      ].to_json
+      http_client = fake(200, response)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:is_utxo_bulk, [{ txid: first_txid, vout: 0 }, { txid: second_txid, vout: 1 }])
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data["#{first_txid}.0"]).to be(true)
+      expect(result.data["#{second_txid}.1"]).to be(false)
+    end
+
+    it 'sends POST to /utxos/spent with correct body format' do
+      response = [{ 'txid' => first_txid, 'vout' => 0, 'spent' => false }].to_json
+      http_client = fake(200, response)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:is_utxo_bulk, [{ txid: first_txid, vout: 0 }])
+
+      expect(http_client.last_uri.path).to end_with('/utxos/spent')
+      expect(http_client.last_request).to be_a(Net::HTTP::Post)
+      body = JSON.parse(http_client.last_request.body)
+      expect(body).to be_an(Array)
+      expect(body.first).to include('txid' => first_txid, 'vout' => 0)
+    end
+
+    it 'returns an empty hash for an empty input array without making an HTTP request' do
+      http_client = fake(500, 'should not be called')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:is_utxo_bulk, [])
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data).to eq({})
+    end
+
+    it 'treats outpoints absent from the response as spent (false)' do
+      # Response only includes one of the two queried outpoints
+      response = [{ 'txid' => first_txid, 'vout' => 0, 'spent' => false }].to_json
+      http_client = fake(200, response)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:is_utxo_bulk, [{ txid: first_txid, vout: 0 }, { txid: second_txid, vout: 1 }])
+
+      expect(result.data["#{first_txid}.0"]).to be(true)
+      expect(result.data["#{second_txid}.1"]).to be(false)
+    end
+
+    it 'returns Result::Error(retryable: true) on 500' do
+      http_client = fake(500, 'server error')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:is_utxo_bulk, [{ txid: first_txid, vout: 0 }])
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+
+    it 'returns Result::NotFound on 404' do
+      http_client = fake(404, 'not found')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:is_utxo_bulk, [{ txid: first_txid, vout: 0 }])
+
+      expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+
+    it 'returns Result::Error on malformed (non-array) response body' do
+      http_client = fake(200, '{"not":"an array"}')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:is_utxo_bulk, [{ txid: first_txid, vout: 0 }])
+
+      expect(result).to be_a(BSV::Network::Result::Error)
     end
   end
 
@@ -902,6 +992,114 @@ RSpec.describe BSV::Network::Protocols::WoCREST do # rubocop:disable RSpec/SpecF
       result = protocol.call(:is_address_used, '1UnknownAddress')
 
       expect(result).to be_a(BSV::Network::Result::NotFound)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_exchange_rate
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_exchange_rate)' do
+    it 'returns parsed JSON exchange rate on success' do
+      body = '{"rate":62500.0,"currency":"USD"}'
+      http_client = fake(200, body)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_exchange_rate)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data['rate']).to eq(62_500.0)
+    end
+
+    it 'sends GET to /exchangerate' do
+      http_client = fake(200, '{"rate":62500.0}')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_exchange_rate)
+
+      expect(http_client.last_uri.path).to end_with('/exchangerate')
+    end
+
+    it 'returns Result::Error(retryable: true) on 500' do
+      http_client = fake(500, 'server error')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_exchange_rate)
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_fee_recommendation
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_fee_recommendation)' do
+    it 'returns parsed JSON fee recommendation on success' do
+      body = '{"miningFee":{"satoshis":1,"bytes":1000}}'
+      http_client = fake(200, body)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_fee_recommendation)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data['miningFee']).to be_a(Hash)
+    end
+
+    it 'sends GET to /feerecommendation' do
+      http_client = fake(200, '{"miningFee":{}}')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_fee_recommendation)
+
+      expect(http_client.last_uri.path).to end_with('/feerecommendation')
+    end
+
+    it 'returns Result::Error(retryable: true) on 500' do
+      http_client = fake(500, 'server error')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_fee_recommendation)
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_mempool_info
+  # ---------------------------------------------------------------------------
+
+  describe '#call(:get_mempool_info)' do
+    it 'returns parsed JSON mempool info on success' do
+      body = '{"size":1234,"bytes":5000000}'
+      http_client = fake(200, body)
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_mempool_info)
+
+      expect(result).to be_a(BSV::Network::Result::Success)
+      expect(result.data['size']).to eq(1234)
+    end
+
+    it 'sends GET to /mempool/info' do
+      http_client = fake(200, '{"size":0}')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      protocol.call(:get_mempool_info)
+
+      expect(http_client.last_uri.path).to end_with('/mempool/info')
+    end
+
+    it 'returns Result::Error(retryable: true) on 500' do
+      http_client = fake(500, 'server error')
+      protocol = described_class.new(network: :main, http_client: http_client)
+
+      result = protocol.call(:get_mempool_info)
+
+      expect(result).to be_a(BSV::Network::Result::Error)
+      expect(result.retryable?).to be(true)
     end
   end
 


### PR DESCRIPTION
## Summary
- Add `:is_utxo_bulk` with escape hatch for batch UTXO verification (janitor P1)
- Add 5 SPV/wallet/address commands: chain_info, block_headers, unconfirmed_balance, history, is_address_used
- Add 8 transaction/script commands: tx_details, output_script, opreturn, tx_hex_bulk, decode_tx, script_history, script_all_unspent, script_unspent_bulk
- Add 3 utility commands: exchange_rate, fee_recommendation, mempool_info
- WoCREST now has 30 endpoints (up from 14)

## Test plan
- [x] All SDK specs pass (3866 examples, 0 failures)
- [x] RuboCop clean (399 files, no offences)

Closes #550, closes #551, closes #552, closes #553, closes #528

Generated with [Claude Code](https://claude.com/claude-code)
