### PR TITLE
fix(ci): merge SimpleCov results for accurate Codecov reporting

### DIFF
--- a/gem/bsv-attest/spec/spec_helper.rb
+++ b/gem/bsv-attest/spec/spec_helper.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 if ENV['COVERAGE']
-  require 'simplecov'
-  require 'simplecov-cobertura'
-  SimpleCov.start do
-    add_filter '/spec/'
-    formatter SimpleCov::Formatter::CoberturaFormatter
-  end
+  require_relative '../../../spec/simplecov_setup'
+  SimpleCov.command_name 'bsv-attest'
+  SimpleCov.start
 end
 
 require 'bsv-attest'

--- a/gem/bsv-sdk/spec/spec_helper.rb
+++ b/gem/bsv-sdk/spec/spec_helper.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 if ENV['COVERAGE']
-  require 'simplecov'
-  require 'simplecov-cobertura'
-  SimpleCov.start do
-    add_filter '/spec/'
-    formatter SimpleCov::Formatter::CoberturaFormatter
-  end
+  require_relative '../../../spec/simplecov_setup'
+  SimpleCov.command_name 'bsv-sdk'
+  SimpleCov.start
 end
 
 require 'bsv-sdk'

--- a/gem/bsv-wallet-postgres/spec/spec_helper.rb
+++ b/gem/bsv-wallet-postgres/spec/spec_helper.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 if ENV['COVERAGE']
-  require 'simplecov'
-  require 'simplecov-cobertura'
-  SimpleCov.start do
-    add_filter '/spec/'
-    formatter SimpleCov::Formatter::CoberturaFormatter
-  end
+  require_relative '../../../spec/simplecov_setup'
+  SimpleCov.command_name 'bsv-wallet-postgres'
+  SimpleCov.start
 end
 
 require 'bsv-wallet-postgres'

--- a/gem/bsv-wallet/spec/spec_helper.rb
+++ b/gem/bsv-wallet/spec/spec_helper.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 if ENV['COVERAGE']
-  require 'simplecov'
-  require 'simplecov-cobertura'
-  SimpleCov.start do
-    add_filter '/spec/'
-    formatter SimpleCov::Formatter::CoberturaFormatter
-  end
+  require_relative '../../../spec/simplecov_setup'
+  SimpleCov.command_name 'bsv-wallet'
+  SimpleCov.start
 end
 
 require 'bsv-wallet'

--- a/spec/simplecov_setup.rb
+++ b/spec/simplecov_setup.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'simplecov'
+require 'simplecov-cobertura'
+
+SimpleCov.root(File.expand_path('..', __dir__))
+SimpleCov.configure do
+  add_filter '/spec/'
+  add_filter %r{/migrations/}
+
+  track_files 'gem/*/lib/**/*.rb'
+
+  formatter SimpleCov::Formatter::CoberturaFormatter
+end


### PR DESCRIPTION
## Summary

- Codecov reported ~40% coverage for bsv-sdk when actual coverage is 97.4%
- Each gem's spec_helper independently started SimpleCov, writing to the same `coverage/coverage.xml` — last writer won
- File paths were gem-relative (`lib/bsv/...`) instead of repo-relative (`gem/bsv-sdk/lib/bsv/...`), so Codecov couldn't map them

Centralises SimpleCov config in `spec/simplecov_setup.rb` with unique `command_name` per gem so results merge correctly.

**Before:** 19 files, 66% line rate, wrong paths
**After:** 190 files, 91.84% line rate, correct paths

Closes #582

## Test plan

- [x] `COVERAGE=true bundle exec rake` produces merged report (`coverage/coverage.xml`) with all 4 gem names
- [x] Report contains 190 files with repo-relative paths (`gem/bsv-sdk/lib/...`)
- [x] `bundle exec rake` without COVERAGE passes all specs (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)