### PR TITLE
fix(ci): require COVERAGE=true to enable SimpleCov

### DIFF
--- a/gem/bsv-attest/spec/spec_helper.rb
+++ b/gem/bsv-attest/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if ENV['COVERAGE']
+if ENV['COVERAGE'].to_s == 'true'
   require_relative '../../../spec/simplecov_setup'
   SimpleCov.command_name 'bsv-attest'
   SimpleCov.start

--- a/gem/bsv-sdk/spec/spec_helper.rb
+++ b/gem/bsv-sdk/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if ENV['COVERAGE']
+if ENV['COVERAGE'].to_s == 'true'
   require_relative '../../../spec/simplecov_setup'
   SimpleCov.command_name 'bsv-sdk'
   SimpleCov.start

--- a/gem/bsv-wallet-postgres/spec/spec_helper.rb
+++ b/gem/bsv-wallet-postgres/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if ENV['COVERAGE']
+if ENV['COVERAGE'].to_s == 'true'
   require_relative '../../../spec/simplecov_setup'
   SimpleCov.command_name 'bsv-wallet-postgres'
   SimpleCov.start

--- a/gem/bsv-wallet/spec/spec_helper.rb
+++ b/gem/bsv-wallet/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if ENV['COVERAGE']
+if ENV['COVERAGE'].to_s == 'true'
   require_relative '../../../spec/simplecov_setup'
   SimpleCov.command_name 'bsv-wallet'
   SimpleCov.start


### PR DESCRIPTION
## Summary

- `ENV['COVERAGE']` is truthy for empty strings in Ruby, so SimpleCov ran on all 6 CI matrix versions instead of just Ruby 3.4
- Tighten check to `.to_s == 'true'` to match the CI workflow's explicit value

Follow-up to #582, addresses Copilot review feedback on #583.

## Test plan

- [x] No behaviour change — `COVERAGE=true` still enables SimpleCov
- [x] `COVERAGE=''` no longer triggers SimpleCov

🤖 Generated with [Claude Code](https://claude.com/claude-code)