### PR TITLE
fix(wallet): set state on internalised outputs

### DIFF
--- a/gem/bsv-wallet/lib/bsv/wallet/client/brc100/transaction.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet/client/brc100/transaction.rb
@@ -934,6 +934,7 @@ module BSV
                                   locking_script: tx_output.locking_script.to_hex,
                                   basket: 'default',
                                   spendable: true,
+                                  state: :spendable,
                                   sender_identity_key: sender_key,
                                   derivation_prefix: prefix,
                                   derivation_suffix: suffix,
@@ -957,6 +958,7 @@ module BSV
                                   tags: remittance[:tags] || [],
                                   custom_instructions: remittance[:custom_instructions],
                                   spendable: true,
+                                  state: :spendable,
                                   source_tx_hex: tx_hex
                                 })
         end


### PR DESCRIPTION
## Summary

- `internalize_payment` and `internalize_basket` now write `state: :spendable` explicitly when storing outputs, matching `create_action` / `store_change_outputs` behaviour
- Aligns with TS wallet-toolbox, which sets explicit state on received payments

Closes #464

## Test plan

- [x] All 991 wallet specs pass
- [ ] Verify internalised outputs have `state = 'spendable'` in postgres after receiving a payment

🤖 Generated with [Claude Code](https://claude.com/claude-code)