### PR TITLE
chore: release bsv-sdk v0.13.0

### DIFF
--- a/gem/bsv-sdk/CHANGELOG.md
+++ b/gem/bsv-sdk/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to the `bsv-sdk` gem are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this gem adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.0 — 2026-04-21
+
+### Added
+- Protocol layer: base class with declarative DSL, HTTP dispatch, and Result value types
+- WoCREST protocol with transaction detail, script query, exchange rate, fee, mempool, SPV, wallet, and address commands
+- ARC protocol with broadcast escape hatches and enriched response data
+- TAALBinary protocol with binary broadcast support
+- Chaintracks and Ordinals protocols with base_url override
+- Provider configuration container with block DSL and `.default(testnet:)` pattern
+- Provider introspection and capability matrix
+- Concrete provider defaults for GorillaPool, WhatsOnChain, and TAAL
+
+### Changed
+- Facades (ARC, WhatsOnChain, ChainTracker) hollowed out to delegate via Protocol
+- Removed `BSV::MAINNET_URL`/`TESTNET_URL` constants and ENV var reading — provider defaults are the single source of truth
+- Removed `BASE_URL` from protocols — `base_url:` is now mandatory
+- Wallet namespace reorganisation: `Store` and `BroadcastQueue` collaborators namespaced under `Client`
+- `ProtoWallet` and `WalletClient` replaced with `Client`
+
+### Fixed
+- Ruby 2.7 kwargs compatibility in `Protocol#call` and TAALBinary spec doubles
+- Nil-guard on WoCREST broadcast and ARC status metadata
+- ARC status rejection checks and TAALBinary nil-txid guard
+- `BSV::Wallet::Wallet` autoload failure in multi-gem setup
+- SimpleCov coverage gate now requires `COVERAGE=true` explicitly
+
 ## 0.12.1 — 2026-04-16
 
 ### Fixed

--- a/gem/bsv-sdk/lib/bsv/version.rb
+++ b/gem/bsv-sdk/lib/bsv/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BSV
-  VERSION = '0.12.1'
+  VERSION = '0.13.0'
 end


### PR DESCRIPTION
## Summary

- Bump `bsv-sdk` version to 0.13.0
- Add changelog entry covering the network protocol layer, provider system, facade refactoring, wallet namespace changes, and bug fixes since v0.12.1

Once CI passes, merge and then tag `v0.13.0` on master for the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)