### PR TITLE
feat(wallet): restore chain data methods (sync_utxos, get_height, get_header_for_height)

### DIFF
--- a/gem/bsv-sdk/lib/bsv/network/whats_on_chain.rb
+++ b/gem/bsv-sdk/lib/bsv/network/whats_on_chain.rb
@@ -6,8 +6,10 @@ module BSV
     # from the BSV network.
     #
     # Any object responding to #fetch_utxos(address),
-    # #fetch_transaction(txid), #current_height, and
-    # #get_block_header(height) can serve as a chain data source;
+    # #fetch_transaction(txid), #current_height,
+    # #get_block_header(height), and optionally
+    # #valid_root_for_height?(root_hex, height) can serve as a chain
+    # data source;
     # this class implements that contract by delegating to
     # Protocols::WoCREST.
     #

--- a/gem/bsv-sdk/lib/bsv/network/whats_on_chain.rb
+++ b/gem/bsv-sdk/lib/bsv/network/whats_on_chain.rb
@@ -5,8 +5,9 @@ module BSV
     # WhatsOnChain chain data provider for reading transactions and UTXOs
     # from the BSV network.
     #
-    # Any object responding to #fetch_utxos(address) and
-    # #fetch_transaction(txid) can serve as a chain data provider;
+    # Any object responding to #fetch_utxos(address),
+    # #fetch_transaction(txid), #current_height, and
+    # #get_block_header(height) can serve as a chain data source;
     # this class implements that contract by delegating to
     # Protocols::WoCREST.
     #
@@ -60,6 +61,41 @@ module BSV
         raise_on_error(result)
 
         BSV::Transaction::Transaction.from_hex(result.data)
+      end
+
+      # Return the current blockchain height.
+      # @return [Integer]
+      # @raise [BSV::Network::ChainProviderError] on network or API error
+      def current_height
+        result = @protocol.call(:current_height)
+        raise_on_error(result)
+
+        result.data
+      end
+
+      # Fetch the block header for a given height.
+      # @param height [Integer] block height
+      # @return [Hash] parsed block header JSON
+      # @raise [BSV::Network::ChainProviderError] on network or API error
+      def get_block_header(height)
+        result = @protocol.call(:get_block_header, height)
+        raise_on_error(result)
+
+        result.data
+      end
+
+      # Verify that a merkle root is valid for the given block height.
+      # @param root [String] expected merkle root as hex
+      # @param height [Integer] block height
+      # @return [Boolean]
+      # @raise [BSV::Network::ChainProviderError] on network or API error
+      def valid_root_for_height?(root, height)
+        result = @protocol.call(:valid_root, root, height)
+        return false if result.not_found?
+
+        raise_on_error(result)
+
+        result.data == true
       end
 
       private

--- a/gem/bsv-sdk/lib/bsv/network/whats_on_chain.rb
+++ b/gem/bsv-sdk/lib/bsv/network/whats_on_chain.rb
@@ -87,10 +87,11 @@ module BSV
       end
 
       # Verify that a merkle root is valid for the given block height.
+      # Returns +false+ when the block is not found (404); raises on other errors.
       # @param root [String] expected merkle root as hex
       # @param height [Integer] block height
       # @return [Boolean]
-      # @raise [BSV::Network::ChainProviderError] on network or API error
+      # @raise [BSV::Network::ChainProviderError] on network or non-404 API error
       def valid_root_for_height?(root, height)
         result = @protocol.call(:valid_root, root, height)
         return false if result.not_found?

--- a/gem/bsv-sdk/spec/bsv/network/whats_on_chain_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/whats_on_chain_spec.rb
@@ -138,4 +138,109 @@ RSpec.describe BSV::Network::WhatsOnChain do
       end
     end
   end
+
+  describe '#current_height' do
+    it 'returns the current block height as an integer' do
+      chain_info = { 'blocks' => 875_123 }.to_json
+      http = mock_http.new(200, chain_info)
+      provider = described_class.new(http_client: http)
+
+      height = provider.current_height
+
+      expect(height).to eq(875_123)
+    end
+
+    it 'sends GET to the chain info endpoint' do
+      chain_info = { 'blocks' => 800_000 }.to_json
+      http = mock_http.new(200, chain_info)
+      provider = described_class.new(http_client: http)
+
+      provider.current_height
+
+      expect(http.last_uri.to_s).to eq(
+        'https://api.whatsonchain.com/v1/bsv/main/chain/info'
+      )
+    end
+
+    it 'raises ChainProviderError on HTTP error' do
+      http = mock_http.new(503, 'Service unavailable')
+      provider = described_class.new(http_client: http)
+
+      expect { provider.current_height }.to raise_error(BSV::Network::ChainProviderError)
+    end
+  end
+
+  describe '#get_block_header' do
+    let(:block_header_body) do
+      {
+        'hash' => '0000000000000000040fb5f4a3f8bc5516b5a7a4b5f4a3f8bc5516b5a7a4b00',
+        'height' => 800_000,
+        'merkleroot' => 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890'
+      }.to_json
+    end
+
+    it 'returns the parsed block header hash' do
+      http = mock_http.new(200, block_header_body)
+      provider = described_class.new(http_client: http)
+
+      header = provider.get_block_header(800_000)
+
+      expect(header).to be_a(Hash)
+      expect(header['height']).to eq(800_000)
+      expect(header['merkleroot']).to eq('abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890')
+    end
+
+    it 'sends GET to the correct block header URL' do
+      http = mock_http.new(200, block_header_body)
+      provider = described_class.new(http_client: http)
+
+      provider.get_block_header(800_000)
+
+      expect(http.last_uri.to_s).to eq(
+        'https://api.whatsonchain.com/v1/bsv/main/block/800000/header'
+      )
+    end
+
+    it 'raises ChainProviderError on HTTP error' do
+      http = mock_http.new(404, 'Block not found')
+      provider = described_class.new(http_client: http)
+
+      expect { provider.get_block_header(999_999_999) }.to raise_error(BSV::Network::ChainProviderError)
+    end
+  end
+
+  describe '#valid_root_for_height?' do
+    let(:merkle_root) { 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890' }
+
+    let(:block_header_body) do
+      { 'merkleroot' => merkle_root }.to_json
+    end
+
+    it 'returns true when the merkle root matches' do
+      http = mock_http.new(200, block_header_body)
+      provider = described_class.new(http_client: http)
+
+      result = provider.valid_root_for_height?(merkle_root, 800_000)
+
+      expect(result).to be(true)
+    end
+
+    it 'returns false when the merkle root does not match' do
+      http = mock_http.new(200, block_header_body)
+      provider = described_class.new(http_client: http)
+
+      result = provider.valid_root_for_height?('000000', 800_000)
+
+      expect(result).to be(false)
+    end
+
+    it 'returns false when the block is not found' do
+      http = mock_http.new(404, 'Not found')
+      provider = described_class.new(http_client: http)
+
+      result = provider.valid_root_for_height?(merkle_root, 999_999_999)
+
+      expect(result).to be(false)
+    end
+  end
 end

--- a/gem/bsv-wallet/lib/bsv/wallet/client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet/client.rb
@@ -131,12 +131,15 @@ module BSV
         utxos = @chain_data_source.fetch_utxos(address)
         return 0 if utxos.empty?
 
-        imported = 0
-        utxos.each do |utxo|
-          outpoint = "#{utxo.tx_hash}.#{utxo.tx_pos}"
-          next if output_exists?(outpoint)
+        # Group UTXOs by tx_hash to minimise WoC API calls — rate limiting
+        # is aggressive and penalties are harsh, so one fetch per transaction
+        # is far better than one fetch per UTXO.
+        tx_cache = {}
+        new_utxos = utxos.reject { |u| output_exists?("#{u.tx_hash}.#{u.tx_pos}") }
+        return 0 if new_utxos.empty?
 
-          tx = @chain_data_source.fetch_transaction(utxo.tx_hash)
+        new_utxos.each do |utxo|
+          tx = tx_cache[utxo.tx_hash] ||= @chain_data_source.fetch_transaction(utxo.tx_hash)
 
           pos = utxo.tx_pos
           unless pos.is_a?(Integer) && pos >= 0 && pos < tx.outputs.length
@@ -144,6 +147,7 @@ module BSV
           end
 
           locking_script_hex = tx.outputs[pos].locking_script.to_hex
+          outpoint = "#{utxo.tx_hash}.#{utxo.tx_pos}"
 
           @storage.store_output({
                                   outpoint: outpoint,
@@ -156,10 +160,9 @@ module BSV
                                   source_tx_hex: tx.to_hex
                                 })
           @storage.store_transaction(utxo.tx_hash, tx.to_hex)
-          imported += 1
         end
 
-        imported
+        new_utxos.length
       end
 
       # --- UTXO Pool & Settings ---

--- a/gem/bsv-wallet/lib/bsv/wallet/client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet/client.rb
@@ -113,9 +113,53 @@ module BSV
         @broadcast_queue.broadcast_enabled?
       end
 
-      # Raises {UnsupportedActionError}.
+      # Discovers UTXOs on-chain for the wallet's identity address and imports
+      # any that are not already in local storage.
+      #
+      # Requires either a substrate or a chain_data_source. When both are present,
+      # the substrate takes priority.
+      #
+      # @return [Integer] number of UTXOs imported (0 if nothing new)
+      # @raise [UnsupportedActionError] when neither substrate nor chain_data_source is set
+      # @raise [WalletError] when a fetched transaction has an out-of-bounds tx_pos
       def sync_utxos
-        raise UnsupportedActionError, 'sync_utxos requires a remote substrate or custom integration'
+        return @substrate.sync_utxos if @substrate
+
+        raise UnsupportedActionError, 'sync_utxos requires a chain_data_source or remote substrate' unless @chain_data_source
+
+        address = identity_address
+        utxos = @chain_data_source.fetch_utxos(address)
+        return 0 if utxos.empty?
+
+        imported = 0
+        utxos.each do |utxo|
+          outpoint = "#{utxo.tx_hash}.#{utxo.tx_pos}"
+          next if output_exists?(outpoint)
+
+          tx = @chain_data_source.fetch_transaction(utxo.tx_hash)
+
+          pos = utxo.tx_pos
+          unless pos.is_a?(Integer) && pos >= 0 && pos < tx.outputs.length
+            raise WalletError, "Invalid tx_pos #{pos.inspect} for #{utxo.tx_hash} (#{tx.outputs.length} outputs)"
+          end
+
+          locking_script_hex = tx.outputs[pos].locking_script.to_hex
+
+          @storage.store_output({
+                                  outpoint: outpoint,
+                                  satoshis: utxo.satoshis,
+                                  locking_script: locking_script_hex,
+                                  basket: 'default',
+                                  tags: [],
+                                  derivation_type: :identity,
+                                  state: :spendable,
+                                  source_tx_hex: tx.to_hex
+                                })
+          @storage.store_transaction(utxo.tx_hash, tx.to_hex)
+          imported += 1
+        end
+
+        imported
       end
 
       # --- UTXO Pool & Settings ---

--- a/gem/bsv-wallet/lib/bsv/wallet/client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet/client.rb
@@ -146,12 +146,23 @@ module BSV
             raise WalletError, "Invalid tx_pos #{pos.inspect} for #{utxo.tx_hash} (#{tx.outputs.length} outputs)"
           end
 
-          locking_script_hex = tx.outputs[pos].locking_script.to_hex
+          output = tx.outputs[pos]
+          output_satoshis = output.satoshis
+
+          # The transaction output is the authoritative source for satoshis —
+          # a mismatch with the UTXO API would produce invalid sighashes.
+          if !utxo.satoshis.nil? && utxo.satoshis != output_satoshis
+            raise WalletError,
+                  "UTXO value mismatch for #{utxo.tx_hash}.#{pos}: " \
+                  "chain reported #{utxo.satoshis}, tx output is #{output_satoshis}"
+          end
+
+          locking_script_hex = output.locking_script.to_hex
           outpoint = "#{utxo.tx_hash}.#{utxo.tx_pos}"
 
           @storage.store_output({
                                   outpoint: outpoint,
-                                  satoshis: utxo.satoshis,
+                                  satoshis: output_satoshis,
                                   locking_script: locking_script_hex,
                                   basket: 'default',
                                   tags: [],

--- a/gem/bsv-wallet/lib/bsv/wallet/client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet/client.rb
@@ -135,7 +135,8 @@ module BSV
         # is aggressive and penalties are harsh, so one fetch per transaction
         # is far better than one fetch per UTXO.
         tx_cache = {}
-        new_utxos = utxos.reject { |u| output_exists?("#{u.tx_hash}.#{u.tx_pos}") }
+        new_utxos = utxos.uniq { |u| "#{u.tx_hash}.#{u.tx_pos}" }
+                         .reject { |u| output_exists?("#{u.tx_hash}.#{u.tx_pos}") }
         return 0 if new_utxos.empty?
 
         new_utxos.each do |utxo|

--- a/gem/bsv-wallet/lib/bsv/wallet/client.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet/client.rb
@@ -50,6 +50,10 @@ module BSV
       # @return [Interface, nil] the optional substrate for remote wallet delegation
       attr_reader :substrate
 
+      # @return [#current_height, #get_block_header, #fetch_utxos, #fetch_transaction, nil]
+      #   optional chain data source for SPV and block header lookups
+      attr_reader :chain_data_source
+
       # @param key [BSV::Primitives::PrivateKey, String, KeyDeriver] signing key
       # @param storage [Store] persistence adapter (default: Store::File.new)
       # @param allow_memory_store [Boolean] set +true+ to suppress the MemoryStore safety guard
@@ -62,6 +66,8 @@ module BSV
       # @param broadcaster [#broadcast, nil] optional broadcaster
       # @param broadcast_queue [BroadcastQueue, nil] optional broadcast queue; defaults to BroadcastQueue::Inline
       # @param substrate [Interface, nil] optional remote wallet substrate
+      # @param chain_data_source [#current_height, #get_block_header, #fetch_utxos, #fetch_transaction, nil]
+      #   optional chain data source for SPV and block header lookups
       def initialize(
         key,
         storage: Store::File.new,
@@ -74,6 +80,7 @@ module BSV
         broadcaster: nil,
         broadcast_queue: nil,
         substrate: nil,
+        chain_data_source: nil,
         allow_memory_store: false
       )
         if storage.is_a?(Store::Memory) && !storage.is_a?(Store::File) && !allow_memory_store
@@ -84,6 +91,7 @@ module BSV
 
         @key_deriver = key.is_a?(KeyDeriver) ? key : KeyDeriver.new(key)
         @substrate = substrate
+        @chain_data_source = chain_data_source
         @storage = storage
         @network = network
         @proof_store = proof_store || LocalProofStore.new(storage)

--- a/gem/bsv-wallet/lib/bsv/wallet/client/brc100/network.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet/client/brc100/network.rb
@@ -7,26 +7,43 @@ module BSV
       module Network
         # Returns the current blockchain height.
         #
-        # Requires a substrate — raises {UnsupportedActionError} locally.
+        # Delegates to the substrate when configured. Falls back to the local
+        # chain data source when present. Raises {UnsupportedActionError} when
+        # neither is available.
         #
         # @return [Hash] { height: Integer }
         def get_height(args = {}, originator: nil)
           return @substrate.get_height(args, originator: originator) if @substrate
 
-          raise UnsupportedActionError, 'get_height requires a remote substrate'
+          raise UnsupportedActionError, 'get_height requires a chain data source or remote substrate' unless @chain_data_source
+
+          { height: @chain_data_source.current_height }
         end
 
         # Returns the block header at the given height.
         #
-        # Requires a substrate — raises {UnsupportedActionError} locally.
+        # Delegates to the substrate when configured; falls back to the local
+        # chain data source otherwise.
+        #
+        # Note: BRC-100 specifies +{ header: String }+ (80-byte raw hex), but the
+        # Ruby SDK returns the richer WoC JSON hash (containing +hash+,
+        # +merkleroot+, +previousblockhash+, +time+, +nonce+, +bits+,
+        # +version+, and +height+) under the +header+ key. This is strictly more
+        # useful and avoids error-prone byte-order reassembly; there is no
+        # cross-SDK precedent to conflict with.
         #
         # @param args [Hash]
-        # @option args [Integer] :height block height
-        # @return [Hash] { header: String } 80-byte hex-encoded block header
+        # @option args [Integer] :height block height (must be >= 0)
+        # @return [Hash] { header: Hash } WoC block header JSON
         def get_header_for_height(args, originator: nil)
           return @substrate.get_header_for_height(args, originator: originator) if @substrate
 
-          raise UnsupportedActionError, 'get_header_for_height requires a remote substrate'
+          raise UnsupportedActionError, 'get_header_for_height requires a chain_data_source or remote substrate' unless @chain_data_source
+
+          height = args[:height]
+          raise InvalidParameterError.new('height', 'a non-negative Integer') unless height.is_a?(Integer) && !height.negative?
+
+          { header: @chain_data_source.get_block_header(height) }
         end
 
         # Returns the network this wallet is configured for.

--- a/gem/bsv-wallet/lib/bsv/wallet/client/brc100/network.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet/client/brc100/network.rb
@@ -26,11 +26,14 @@ module BSV
         # chain data source otherwise.
         #
         # Note: BRC-100 specifies +{ header: String }+ (80-byte raw hex), but the
-        # Ruby SDK returns the richer WoC JSON hash (containing +hash+,
+        # local fallback returns the richer WoC JSON hash (containing +hash+,
         # +merkleroot+, +previousblockhash+, +time+, +nonce+, +bits+,
         # +version+, and +height+) under the +header+ key. This is strictly more
-        # useful and avoids error-prone byte-order reassembly; there is no
-        # cross-SDK precedent to conflict with.
+        # useful for local callers and avoids error-prone byte-order reassembly.
+        #
+        # *Warning:* the WalletWire binary serialiser expects +header+ to be a
+        # hex string. This local fallback should not be used behind a wire
+        # transport without first converting the JSON hash to raw 80-byte hex.
         #
         # @param args [Hash]
         # @option args [Integer] :height block height (must be >= 0)

--- a/gem/bsv-wallet/lib/bsv/wallet/client/brc100/network.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet/client/brc100/network.rb
@@ -15,7 +15,7 @@ module BSV
         def get_height(args = {}, originator: nil)
           return @substrate.get_height(args, originator: originator) if @substrate
 
-          raise UnsupportedActionError, 'get_height requires a chain data source or remote substrate' unless @chain_data_source
+          raise UnsupportedActionError, 'get_height requires a chain_data_source or remote substrate' unless @chain_data_source
 
           { height: @chain_data_source.current_height }
         end

--- a/gem/bsv-wallet/lib/bsv/wallet/client/brc100/transaction.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet/client/brc100/transaction.rb
@@ -175,7 +175,8 @@ module BSV
           beef_binary = args[:tx].pack('C*')
           beef = BSV::Transaction::Beef.from_binary(beef_binary)
 
-          raise WalletError, 'BEEF verification failed: the bundle is structurally invalid' unless beef.verify(nil)
+          chain_tracker = @chain_data_source.respond_to?(:valid_root_for_height?) ? @chain_data_source : nil
+          raise WalletError, 'BEEF verification failed: the bundle is structurally invalid' unless beef.verify(chain_tracker)
 
           tx = extract_subject_transaction(beef)
 

--- a/gem/bsv-wallet/lib/bsv/wallet/client/brc100/transaction.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet/client/brc100/transaction.rb
@@ -178,7 +178,16 @@ module BSV
           # Use the chain data source for SPV merkle root verification when available;
           # fall back to structural-only verification otherwise.
           chain_tracker = @chain_data_source if @chain_data_source.respond_to?(:valid_root_for_height?)
-          raise WalletError, 'BEEF verification failed: the bundle is structurally invalid' unless beef.verify(chain_tracker)
+          unless beef.verify(chain_tracker)
+            # Distinguish SPV failures from structural invalidity so callers
+            # can tell whether the problem is the BEEF itself or the merkle root.
+            message = if chain_tracker && beef.verify(nil)
+                        'BEEF verification failed: merkle root not confirmed by chain tracker'
+                      else
+                        'BEEF verification failed: the bundle is structurally invalid'
+                      end
+            raise WalletError, message
+          end
 
           tx = extract_subject_transaction(beef)
 

--- a/gem/bsv-wallet/lib/bsv/wallet/client/brc100/transaction.rb
+++ b/gem/bsv-wallet/lib/bsv/wallet/client/brc100/transaction.rb
@@ -175,7 +175,9 @@ module BSV
           beef_binary = args[:tx].pack('C*')
           beef = BSV::Transaction::Beef.from_binary(beef_binary)
 
-          chain_tracker = @chain_data_source.respond_to?(:valid_root_for_height?) ? @chain_data_source : nil
+          # Use the chain data source for SPV merkle root verification when available;
+          # fall back to structural-only verification otherwise.
+          chain_tracker = @chain_data_source if @chain_data_source.respond_to?(:valid_root_for_height?)
           raise WalletError, 'BEEF verification failed: the bundle is structurally invalid' unless beef.verify(chain_tracker)
 
           tx = extract_subject_transaction(beef)

--- a/gem/bsv-wallet/spec/bsv/wallet/chain_data_source_integration_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet/chain_data_source_integration_spec.rb
@@ -1,0 +1,308 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+require 'json'
+
+RSpec.describe 'WhatsOnChain as chain_data_source integration' do
+  # -----------------------------------------------------------------------
+  # Routing HTTP mock
+  #
+  # Responds to request(uri, req) and returns a Struct with #code and #body.
+  # Routes are registered as URI substring => [code, body].
+  # -----------------------------------------------------------------------
+  let(:routing_http) do
+    Class.new do
+      def initialize
+        @routes = {}
+      end
+
+      # Register a URI substring pattern → [code, body] pair.
+      def stub(pattern, code, body)
+        @routes[pattern] = [code.to_s, body.to_s]
+      end
+
+      def request(uri, _req)
+        uri_str = uri.to_s
+        found = @routes.find { |pattern, _| uri_str.include?(pattern) }
+        code, body = found ? found.last : ['404', 'not found']
+        Struct.new(:code, :body).new(code, body)
+      end
+    end.new
+  end
+  # -----------------------------------------------------------------------
+  # Shared WoC response bodies
+  # -----------------------------------------------------------------------
+
+  let(:chain_info_body) { JSON.generate('blocks' => 850_000) }
+  let(:block_header_body) do
+    JSON.generate(
+      'hash' => '000000000000000002a4dc25b9ea1a2c327a6a2e7e1c98f0f00b12b8be85f9b',
+      'merkleroot' => 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+      'previousblockhash' => '000000000000000001234567890abcdef1234567890abcdef1234567890abcd',
+      'time' => 1_700_000_000,
+      'nonce' => 12_345_678,
+      'bits' => '1a123456',
+      'version' => 536_870_912,
+      'height' => 850_000
+    )
+  end
+
+  let(:private_key) { BSV::Primitives::PrivateKey.generate }
+
+  # Derive the address the client uses for sync_utxos.
+  let(:address) do
+    private_key.public_key.address(network: :mainnet)
+  end
+
+  # Build a real transaction with one P2PKH output to the wallet's address.
+  let(:sample_tx) do
+    tx = BSV::Transaction::Transaction.new
+    tx.add_output(
+      BSV::Transaction::TransactionOutput.new(
+        satoshis: 75_000,
+        locking_script: BSV::Script::Script.p2pkh_lock(private_key.public_key.hash160)
+      )
+    )
+    tx
+  end
+
+  let(:sample_txid) { sample_tx.txid_hex }
+  let(:sample_tx_hex) { sample_tx.to_hex }
+
+  # Second transaction for idempotency and multi-UTXO tests.
+  let(:sample_tx2) do
+    tx = BSV::Transaction::Transaction.new
+    tx.add_output(
+      BSV::Transaction::TransactionOutput.new(
+        satoshis: 30_000,
+        locking_script: BSV::Script::Script.p2pkh_lock(private_key.public_key.hash160)
+      )
+    )
+    tx
+  end
+
+  let(:sample_tx2id) { sample_tx2.txid_hex }
+  let(:sample_tx2_hex) { sample_tx2.to_hex }
+
+  # -----------------------------------------------------------------------
+  # Helpers
+  # -----------------------------------------------------------------------
+
+  def make_woc(http)
+    BSV::Network::WhatsOnChain.new(http_client: http)
+  end
+
+  def make_client(woc, storage = nil)
+    storage ||= BSV::Wallet::Store::Memory.new
+    BSV::Wallet::Client.new(
+      private_key,
+      storage: storage,
+      chain_data_source: woc,
+      allow_memory_store: true
+    )
+  end
+
+  def utxo_body_for(*txids_and_positions)
+    entries = txids_and_positions.map do |(txid, pos, satoshis)|
+      { 'tx_hash' => txid, 'tx_pos' => pos, 'value' => satoshis, 'height' => 800_000 }
+    end
+    JSON.generate(entries)
+  end
+
+  # -----------------------------------------------------------------------
+  # 1. get_height integration
+  # -----------------------------------------------------------------------
+
+  describe 'get_height end-to-end' do
+    it 'returns height from stubbed WoC /chain/info response' do
+      routing_http.stub('/chain/info', 200, chain_info_body)
+      client = make_client(make_woc(routing_http))
+
+      expect(client.get_height).to eq({ height: 850_000 })
+    end
+
+    it 'propagates ChainProviderError when WoC returns 500' do
+      routing_http.stub('/chain/info', 500, 'Internal Server Error')
+      client = make_client(make_woc(routing_http))
+
+      expect { client.get_height }.to raise_error(BSV::Network::ChainProviderError)
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # 2. get_header_for_height integration
+  # -----------------------------------------------------------------------
+
+  describe 'get_header_for_height end-to-end' do
+    it 'returns header data from stubbed WoC block header response' do
+      routing_http.stub('/block/', 200, block_header_body)
+      client = make_client(make_woc(routing_http))
+
+      result = client.get_header_for_height({ height: 850_000 })
+      expect(result).to have_key(:header)
+      expect(result[:header]).to include('merkleroot')
+      expect(result[:header]['height']).to eq(850_000)
+    end
+
+    it 'returns a hash keyed with :header' do
+      routing_http.stub('/block/', 200, block_header_body)
+      client = make_client(make_woc(routing_http))
+
+      result = client.get_header_for_height({ height: 850_000 })
+      expect(result).to be_a(Hash)
+      expect(result.keys).to eq([:header])
+    end
+
+    it 'propagates ChainProviderError when WoC returns 404 for block header' do
+      routing_http.stub('/block/', 404, 'Block not found')
+      client = make_client(make_woc(routing_http))
+
+      expect { client.get_header_for_height({ height: 9_999_999 }) }
+        .to raise_error(BSV::Network::ChainProviderError)
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # 3. sync_utxos happy path — imports UTXOs into storage
+  # -----------------------------------------------------------------------
+
+  describe 'sync_utxos end-to-end — happy path' do
+    before do
+      routing_http.stub('/unspent', 200, utxo_body_for([sample_txid, 0, 75_000],
+                                                       [sample_tx2id, 0, 30_000]))
+      routing_http.stub(sample_txid, 200, sample_tx_hex)
+      routing_http.stub(sample_tx2id, 200, sample_tx2_hex)
+    end
+
+    it 'imports 2 UTXOs and returns 2' do
+      client = make_client(make_woc(routing_http))
+
+      expect(client.sync_utxos).to eq(2)
+    end
+
+    it 'stores outputs with correct satoshis' do
+      storage = BSV::Wallet::Store::Memory.new
+      client = make_client(make_woc(routing_http), storage)
+      client.sync_utxos
+
+      satoshis = storage.find_outputs({ include_spent: false }).map { |o| o[:satoshis] }.sort
+      expect(satoshis).to eq([30_000, 75_000])
+    end
+
+    it 'stores outputs in the default basket' do
+      storage = BSV::Wallet::Store::Memory.new
+      client = make_client(make_woc(routing_http), storage)
+      client.sync_utxos
+
+      baskets = storage.find_outputs({ include_spent: false }).map { |o| o[:basket] }
+      expect(baskets).to all(eq('default'))
+    end
+
+    it 'stores outputs with state :spendable' do
+      storage = BSV::Wallet::Store::Memory.new
+      client = make_client(make_woc(routing_http), storage)
+      client.sync_utxos
+
+      states = storage.find_outputs({ include_spent: false }).map { |o| o[:state].to_s }
+      expect(states).to all(eq('spendable'))
+    end
+
+    it 'stores outputs with derivation_type :identity' do
+      storage = BSV::Wallet::Store::Memory.new
+      client = make_client(make_woc(routing_http), storage)
+      client.sync_utxos
+
+      types = storage.find_outputs({ include_spent: false }).map { |o| o[:derivation_type].to_s }
+      expect(types).to all(eq('identity'))
+    end
+
+    it 'stores raw transaction hex for each imported transaction' do
+      storage = BSV::Wallet::Store::Memory.new
+      client = make_client(make_woc(routing_http), storage)
+      client.sync_utxos
+
+      expect(storage.find_transaction(sample_txid)).to eq(sample_tx_hex)
+      expect(storage.find_transaction(sample_tx2id)).to eq(sample_tx2_hex)
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # 4. sync_utxos idempotency — second call returns 0
+  # -----------------------------------------------------------------------
+
+  describe 'sync_utxos idempotency' do
+    before do
+      routing_http.stub('/unspent', 200, utxo_body_for([sample_txid, 0, 75_000]))
+      routing_http.stub(sample_txid, 200, sample_tx_hex)
+    end
+
+    it 'returns 1 on first call and 0 on second' do
+      client = make_client(make_woc(routing_http))
+
+      expect(client.sync_utxos).to eq(1)
+      expect(client.sync_utxos).to eq(0)
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # 5. sync_utxos with no UTXOs
+  # -----------------------------------------------------------------------
+
+  describe 'sync_utxos with no UTXOs on chain' do
+    it 'returns 0 and makes no fetch_transaction calls' do
+      routing_http.stub('/unspent', 200, '[]')
+      client = make_client(make_woc(routing_http))
+
+      expect(client.sync_utxos).to eq(0)
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # 6. Error cases — no chain_data_source
+  # -----------------------------------------------------------------------
+
+  describe 'error cases — no chain_data_source configured' do
+    subject(:client) do
+      BSV::Wallet::Client.new(
+        private_key,
+        storage: BSV::Wallet::Store::Memory.new,
+        allow_memory_store: true
+      )
+    end
+
+    it 'raises UnsupportedActionError for get_height' do
+      expect { client.get_height }.to raise_error(BSV::Wallet::UnsupportedActionError)
+    end
+
+    it 'raises UnsupportedActionError for get_header_for_height' do
+      expect { client.get_header_for_height({ height: 100 }) }
+        .to raise_error(BSV::Wallet::UnsupportedActionError)
+    end
+
+    it 'raises UnsupportedActionError for sync_utxos' do
+      expect { client.sync_utxos }.to raise_error(BSV::Wallet::UnsupportedActionError)
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # 7. Network error propagation — WoC returns 500
+  # -----------------------------------------------------------------------
+
+  describe 'sync_utxos network error propagation' do
+    it 'propagates ChainProviderError when UTXO fetch returns 500' do
+      routing_http.stub('/unspent', 500, 'Internal Server Error')
+      client = make_client(make_woc(routing_http))
+
+      expect { client.sync_utxos }.to raise_error(BSV::Network::ChainProviderError)
+    end
+
+    it 'propagates ChainProviderError when transaction fetch returns 500' do
+      routing_http.stub('/unspent', 200, utxo_body_for([sample_txid, 0, 75_000]))
+      routing_http.stub('/tx/', 500, 'Internal Server Error')
+      client = make_client(make_woc(routing_http))
+
+      expect { client.sync_utxos }.to raise_error(BSV::Network::ChainProviderError)
+    end
+  end
+end

--- a/gem/bsv-wallet/spec/bsv/wallet/client_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet/client_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+
+RSpec.describe BSV::Wallet::Client do
+  let(:private_key) { BSV::Primitives::PrivateKey.generate }
+  let(:storage) { BSV::Wallet::Store::Memory.new }
+
+  describe '#initialize' do
+    context 'without chain_data_source' do
+      it 'defaults chain_data_source to nil' do
+        client = described_class.new(private_key, storage: storage, allow_memory_store: true)
+
+        expect(client.chain_data_source).to be_nil
+      end
+    end
+
+    context 'with chain_data_source' do
+      let(:chain_data_source) { double('chain_data_source') } # rubocop:disable RSpec/VerifiedDoubles
+
+      it 'stores the chain_data_source' do
+        client = described_class.new(
+          private_key,
+          storage: storage,
+          chain_data_source: chain_data_source,
+          allow_memory_store: true
+        )
+
+        expect(client.chain_data_source).to be(chain_data_source)
+      end
+    end
+  end
+end

--- a/gem/bsv-wallet/spec/bsv/wallet/internalize_chain_tracker_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet/internalize_chain_tracker_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+
+RSpec.describe 'internalize_action BEEF chain tracker verification' do
+  let(:private_key) { BSV::Primitives::PrivateKey.generate }
+  let(:pub_key)     { private_key.public_key }
+  let(:storage)     { BSV::Wallet::Store::Memory.new }
+
+  # A simple source transaction with one output.
+  let(:source_tx) do
+    tx = BSV::Transaction::Transaction.new
+    tx.add_output(
+      BSV::Transaction::TransactionOutput.new(
+        satoshis: 5000,
+        locking_script: BSV::Script::Script.p2pkh_lock(pub_key.hash160)
+      )
+    )
+    tx
+  end
+
+  # A minimal merkle proof for the source transaction.
+  let(:merkle_path) do
+    txid_bytes = source_tx.txid.reverse
+    sibling    = ("\xCD" * 32).b
+    tx_elem      = BSV::Transaction::MerklePath::PathElement.new(offset: 0, hash: txid_bytes, txid: true)
+    sibling_elem = BSV::Transaction::MerklePath::PathElement.new(offset: 1, hash: sibling)
+    BSV::Transaction::MerklePath.new(block_height: 800_000, path: [[tx_elem, sibling_elem]])
+  end
+
+  # Computed root hex (what a chain tracker would be asked to confirm).
+  let(:root_hex) { merkle_path.compute_root.reverse.unpack1('H*') }
+
+  # A valid BEEF carrying source_tx (proven) + subject_tx (raw).
+  let(:beef_binary) do
+    source_tx.merkle_path = merkle_path
+
+    subject_tx = BSV::Transaction::Transaction.new
+    subject_tx.add_input(
+      BSV::Transaction::TransactionInput.new(
+        prev_tx_id: BSV::Transaction::TransactionInput.txid_from_hex(source_tx.txid_hex),
+        prev_tx_out_index: 0,
+        unlocking_script: BSV::Script::Script.new
+      )
+    )
+    subject_tx.add_output(
+      BSV::Transaction::TransactionOutput.new(
+        satoshis: 4000,
+        locking_script: BSV::Script::Script.p2pkh_lock(pub_key.hash160)
+      )
+    )
+
+    beef = BSV::Transaction::Beef.new
+    bump_idx = beef.merge_bump(merkle_path)
+    beef.transactions << BSV::Transaction::Beef::BeefTx.new(
+      format: BSV::Transaction::Beef::FORMAT_RAW_TX_AND_BUMP,
+      transaction: source_tx,
+      bump_index: bump_idx
+    )
+    beef.transactions << BSV::Transaction::Beef::BeefTx.new(
+      format: BSV::Transaction::Beef::FORMAT_RAW_TX,
+      transaction: subject_tx
+    )
+
+    beef.to_binary
+  end
+
+  let(:internalize_args) do
+    {
+      tx: beef_binary.unpack('C*'),
+      description: 'payment received',
+      outputs: [
+        {
+          output_index: 0,
+          protocol: 'basket insertion',
+          insertion_remittance: { basket: 'inbound payments' }
+        }
+      ]
+    }
+  end
+
+  def build_wallet(chain_data_source: nil)
+    BSV::Wallet::Client.new(
+      private_key,
+      storage: storage,
+      allow_memory_store: true,
+      chain_data_source: chain_data_source
+    )
+  end
+
+  describe 'without a chain_data_source' do
+    it 'accepts valid BEEF using structural-only verification' do
+      wallet = build_wallet
+
+      expect { wallet.internalize_action(internalize_args) }.not_to raise_error
+    end
+  end
+
+  describe 'with a chain_data_source that responds to valid_root_for_height?' do
+    it 'passes the chain_data_source to beef.verify' do
+      chain_tracker = double('chain_tracker') # rubocop:disable RSpec/VerifiedDoubles
+      allow(chain_tracker).to receive(:respond_to?).with(:valid_root_for_height?).and_return(true)
+      allow(chain_tracker).to receive(:valid_root_for_height?).and_return(true)
+
+      wallet = build_wallet(chain_data_source: chain_tracker)
+
+      expect { wallet.internalize_action(internalize_args) }.not_to raise_error
+    end
+
+    it 'raises WalletError when the chain tracker rejects the merkle root' do
+      chain_tracker = double('chain_tracker') # rubocop:disable RSpec/VerifiedDoubles
+      allow(chain_tracker).to receive(:respond_to?).with(:valid_root_for_height?).and_return(true)
+      allow(chain_tracker).to receive(:valid_root_for_height?).and_return(false)
+
+      wallet = build_wallet(chain_data_source: chain_tracker)
+
+      expect { wallet.internalize_action(internalize_args) }
+        .to raise_error(BSV::Wallet::WalletError, /structurally invalid/)
+    end
+  end
+
+  describe 'with a chain_data_source that does NOT respond to valid_root_for_height?' do
+    it 'falls back to beef.verify(nil) — structural verification only' do
+      chain_source = double('chain_source') # rubocop:disable RSpec/VerifiedDoubles
+      allow(chain_source).to receive(:respond_to?).with(:valid_root_for_height?).and_return(false)
+
+      wallet = build_wallet(chain_data_source: chain_source)
+
+      expect { wallet.internalize_action(internalize_args) }.not_to raise_error
+    end
+  end
+end

--- a/gem/bsv-wallet/spec/bsv/wallet/internalize_chain_tracker_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet/internalize_chain_tracker_spec.rb
@@ -98,22 +98,33 @@ RSpec.describe 'internalize_action BEEF chain tracker verification' do
   end
 
   describe 'with a chain_data_source that responds to valid_root_for_height?' do
-    it 'passes the chain_data_source to beef.verify' do
-      chain_tracker = double('chain_tracker') # rubocop:disable RSpec/VerifiedDoubles
-      allow(chain_tracker).to receive(:respond_to?).with(:valid_root_for_height?).and_return(true)
-      allow(chain_tracker).to receive(:valid_root_for_height?).and_return(true)
+    # Use a real object that genuinely responds to valid_root_for_height?
+    # instead of stubbing respond_to?, which is brittle on Ruby 2.7 where
+    # the two-arg form (symbol, include_private) causes mock mismatches.
+    let(:accepting_tracker) do
+      obj = Object.new
+      def obj.valid_root_for_height?(_root, _height)
+        true
+      end
+      obj
+    end
 
-      wallet = build_wallet(chain_data_source: chain_tracker)
+    let(:rejecting_tracker) do
+      obj = Object.new
+      def obj.valid_root_for_height?(_root, _height)
+        false
+      end
+      obj
+    end
+
+    it 'passes the chain_data_source to beef.verify' do
+      wallet = build_wallet(chain_data_source: accepting_tracker)
 
       expect { wallet.internalize_action(internalize_args) }.not_to raise_error
     end
 
     it 'raises WalletError when the chain tracker rejects the merkle root' do
-      chain_tracker = double('chain_tracker') # rubocop:disable RSpec/VerifiedDoubles
-      allow(chain_tracker).to receive(:respond_to?).with(:valid_root_for_height?).and_return(true)
-      allow(chain_tracker).to receive(:valid_root_for_height?).and_return(false)
-
-      wallet = build_wallet(chain_data_source: chain_tracker)
+      wallet = build_wallet(chain_data_source: rejecting_tracker)
 
       expect { wallet.internalize_action(internalize_args) }
         .to raise_error(BSV::Wallet::WalletError, /merkle root not confirmed/)
@@ -122,8 +133,7 @@ RSpec.describe 'internalize_action BEEF chain tracker verification' do
 
   describe 'with a chain_data_source that does NOT respond to valid_root_for_height?' do
     it 'falls back to beef.verify(nil) — structural verification only' do
-      chain_source = double('chain_source') # rubocop:disable RSpec/VerifiedDoubles
-      allow(chain_source).to receive(:respond_to?).with(:valid_root_for_height?).and_return(false)
+      chain_source = Object.new
 
       wallet = build_wallet(chain_data_source: chain_source)
 

--- a/gem/bsv-wallet/spec/bsv/wallet/internalize_chain_tracker_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet/internalize_chain_tracker_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'internalize_action BEEF chain tracker verification' do
       wallet = build_wallet(chain_data_source: chain_tracker)
 
       expect { wallet.internalize_action(internalize_args) }
-        .to raise_error(BSV::Wallet::WalletError, /structurally invalid/)
+        .to raise_error(BSV::Wallet::WalletError, /merkle root not confirmed/)
     end
   end
 

--- a/gem/bsv-wallet/spec/bsv/wallet/network_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet/network_spec.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+
+RSpec.describe BSV::Wallet::Client do
+  let(:private_key) { BSV::Primitives::PrivateKey.generate }
+  let(:storage) { BSV::Wallet::Store::Memory.new }
+  let(:chain_data_source) { double('chain_data_source') } # rubocop:disable RSpec/VerifiedDoubles
+
+  describe '#get_height' do
+    context 'when neither substrate nor chain_data_source is configured' do
+      subject(:client) { described_class.new(private_key, storage: storage, allow_memory_store: true) }
+
+      it 'raises UnsupportedActionError' do
+        expect { client.get_height }.to raise_error(BSV::Wallet::UnsupportedActionError)
+      end
+
+      it 'includes a helpful message' do
+        expect { client.get_height }
+          .to raise_error(BSV::Wallet::UnsupportedActionError, /chain data source or remote substrate/)
+      end
+    end
+
+    context 'when chain_data_source is configured (no substrate)' do
+      subject(:client) do
+        described_class.new(
+          private_key,
+          storage: storage,
+          chain_data_source: chain_data_source,
+          allow_memory_store: true
+        )
+      end
+
+      it 'returns the height from the chain data source' do
+        allow(chain_data_source).to receive(:current_height).and_return(850_000)
+
+        expect(client.get_height).to eq({ height: 850_000 })
+      end
+
+      it 'wraps the result in a hash with a :height key' do
+        allow(chain_data_source).to receive(:current_height).and_return(1)
+
+        result = client.get_height
+        expect(result).to be_a(Hash)
+        expect(result).to have_key(:height)
+      end
+
+      it 'passes through height 0 (genesis) unchanged' do
+        allow(chain_data_source).to receive(:current_height).and_return(0)
+
+        expect(client.get_height).to eq({ height: 0 })
+      end
+
+      it 'propagates errors from the chain data source' do
+        allow(chain_data_source).to receive(:current_height).and_raise(StandardError, 'network error')
+
+        expect { client.get_height }.to raise_error(StandardError, 'network error')
+      end
+    end
+
+    context 'when both substrate and chain_data_source are configured' do
+      subject(:client) do
+        described_class.new(
+          private_key,
+          storage: storage,
+          substrate: substrate,
+          chain_data_source: chain_data_source,
+          allow_memory_store: true
+        )
+      end
+      let(:substrate) { double('substrate') } # rubocop:disable RSpec/VerifiedDoubles
+
+      it 'delegates to the substrate, not the chain data source' do
+        allow(substrate).to receive(:get_height).and_return({ height: 999_999 })
+        allow(chain_data_source).to receive(:current_height)
+
+        expect(client.get_height).to eq({ height: 999_999 })
+        expect(chain_data_source).not_to have_received(:current_height)
+      end
+
+      it 'forwards args and originator to the substrate' do
+        allow(substrate).to receive(:get_height).with({}, originator: 'test').and_return({ height: 1 })
+
+        client.get_height({}, originator: 'test')
+
+        expect(substrate).to have_received(:get_height).with({}, originator: 'test')
+      end
+    end
+  end
+
+  describe '#get_header_for_height' do
+    let(:sample_header) do
+      {
+        'hash' => '000000000000000002a4dc25b9ea1a2c327a6a2e7e1c98f0f00b12b8be85f9b',
+        'merkleroot' => 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+        'previousblockhash' => '000000000000000001234567890abcdef1234567890abcdef1234567890abcd',
+        'time' => 1_700_000_000,
+        'nonce' => 12_345_678,
+        'bits' => '1a123456',
+        'version' => 536_870_912,
+        'height' => 800_000
+      }
+    end
+
+    context 'when neither substrate nor chain_data_source is configured' do
+      subject(:client) { described_class.new(private_key, storage: storage, allow_memory_store: true) }
+
+      it 'raises UnsupportedActionError' do
+        expect { client.get_header_for_height({ height: 800_000 }) }
+          .to raise_error(BSV::Wallet::UnsupportedActionError)
+      end
+
+      it 'includes a helpful message' do
+        expect { client.get_header_for_height({ height: 800_000 }) }
+          .to raise_error(BSV::Wallet::UnsupportedActionError, /chain_data_source or remote substrate/)
+      end
+    end
+
+    context 'when chain_data_source is configured (no substrate)' do
+      subject(:client) do
+        described_class.new(
+          private_key,
+          storage: storage,
+          chain_data_source: chain_data_source,
+          allow_memory_store: true
+        )
+      end
+
+      it 'returns the header from the chain data source' do
+        allow(chain_data_source).to receive(:get_block_header).with(800_000).and_return(sample_header)
+
+        expect(client.get_header_for_height({ height: 800_000 })).to eq({ header: sample_header })
+      end
+
+      it 'wraps the result in a hash with a :header key' do
+        allow(chain_data_source).to receive(:get_block_header).with(800_000).and_return(sample_header)
+
+        result = client.get_header_for_height({ height: 800_000 })
+        expect(result).to be_a(Hash)
+        expect(result).to have_key(:header)
+      end
+
+      it 'allows height 0 (genesis block)' do
+        genesis_header = sample_header.merge('height' => 0)
+        allow(chain_data_source).to receive(:get_block_header).with(0).and_return(genesis_header)
+
+        expect(client.get_header_for_height({ height: 0 })).to eq({ header: genesis_header })
+      end
+
+      it 'raises InvalidParameterError for negative height' do
+        expect { client.get_header_for_height({ height: -1 }) }
+          .to raise_error(BSV::Wallet::InvalidParameterError)
+      end
+
+      it 'raises InvalidParameterError for a non-integer height' do
+        expect { client.get_header_for_height({ height: '800000' }) }
+          .to raise_error(BSV::Wallet::InvalidParameterError)
+      end
+
+      it 'raises InvalidParameterError for nil height' do
+        expect { client.get_header_for_height({ height: nil }) }
+          .to raise_error(BSV::Wallet::InvalidParameterError)
+      end
+
+      it 'raises InvalidParameterError for a float height' do
+        expect { client.get_header_for_height({ height: 800_000.0 }) }
+          .to raise_error(BSV::Wallet::InvalidParameterError)
+      end
+
+      it 'propagates errors from the chain data source' do
+        allow(chain_data_source).to receive(:get_block_header).and_raise(StandardError, 'network error')
+
+        expect { client.get_header_for_height({ height: 800_000 }) }
+          .to raise_error(StandardError, 'network error')
+      end
+    end
+
+    context 'when both substrate and chain_data_source are configured' do
+      subject(:client) do
+        described_class.new(
+          private_key,
+          storage: storage,
+          substrate: substrate,
+          chain_data_source: chain_data_source,
+          allow_memory_store: true
+        )
+      end
+      let(:substrate) { double('substrate') } # rubocop:disable RSpec/VerifiedDoubles
+
+      it 'delegates to the substrate, not the chain data source' do
+        allow(substrate).to receive(:get_header_for_height).and_return({ header: sample_header })
+        allow(chain_data_source).to receive(:get_block_header)
+
+        expect(client.get_header_for_height({ height: 800_000 })).to eq({ header: sample_header })
+        expect(chain_data_source).not_to have_received(:get_block_header)
+      end
+
+      it 'forwards args and originator to the substrate' do
+        allow(substrate).to receive(:get_header_for_height)
+          .with({ height: 800_000 }, originator: 'test')
+          .and_return({ header: sample_header })
+
+        client.get_header_for_height({ height: 800_000 }, originator: 'test')
+
+        expect(substrate).to have_received(:get_header_for_height)
+          .with({ height: 800_000 }, originator: 'test')
+      end
+    end
+  end
+end

--- a/gem/bsv-wallet/spec/bsv/wallet/network_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet/network_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe BSV::Wallet::Client do
 
       it 'includes a helpful message' do
         expect { client.get_height }
-          .to raise_error(BSV::Wallet::UnsupportedActionError, /chain data source or remote substrate/)
+          .to raise_error(BSV::Wallet::UnsupportedActionError, /chain_data_source or remote substrate/)
       end
     end
 

--- a/gem/bsv-wallet/spec/bsv/wallet/sync_utxos_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet/sync_utxos_spec.rb
@@ -71,8 +71,8 @@ RSpec.describe BSV::Wallet::Client do
         )
       end
 
-      let(:tx_a) { make_tx }
-      let(:tx_b) { make_tx }
+      let(:tx_a) { make_tx(satoshis: 1000) }
+      let(:tx_b) { make_tx(satoshis: 2000) }
 
       before do
         allow(chain_data_source).to receive(:fetch_utxos).and_return([
@@ -134,8 +134,8 @@ RSpec.describe BSV::Wallet::Client do
       end
 
       before do
-        tx_a = make_tx
-        tx_b = make_tx
+        tx_a = make_tx(satoshis: 1000)
+        tx_b = make_tx(satoshis: 2000)
         allow(chain_data_source).to receive(:fetch_utxos).and_return([
                                                                        make_utxo('aaa', 0, 1000),
                                                                        make_utxo('bbb', 0, 2000)
@@ -195,6 +195,34 @@ RSpec.describe BSV::Wallet::Client do
       it 'accepts tx_pos 0 (first output)' do
         tx = make_tx(output_count: 2)
         allow(chain_data_source).to receive(:fetch_utxos).and_return([make_utxo('aaa', 0, 1000)])
+        allow(chain_data_source).to receive(:fetch_transaction).with('aaa').and_return(tx)
+
+        expect(client.sync_utxos).to eq(1)
+      end
+    end
+
+    context 'with chain_data_source and satoshis mismatch' do
+      subject(:client) do
+        described_class.new(
+          private_key,
+          storage: storage,
+          chain_data_source: chain_data_source,
+          allow_memory_store: true
+        )
+      end
+
+      it 'raises WalletError when UTXO API value differs from transaction output' do
+        tx = make_tx(output_count: 1, satoshis: 1000)
+        # UTXO API reports 9999 but the actual output has 1000
+        allow(chain_data_source).to receive(:fetch_utxos).and_return([make_utxo('aaa', 0, 9999)])
+        allow(chain_data_source).to receive(:fetch_transaction).with('aaa').and_return(tx)
+
+        expect { client.sync_utxos }.to raise_error(BSV::Wallet::WalletError, /UTXO value mismatch/)
+      end
+
+      it 'accepts when UTXO API value matches transaction output' do
+        tx = make_tx(output_count: 1, satoshis: 5000)
+        allow(chain_data_source).to receive(:fetch_utxos).and_return([make_utxo('aaa', 0, 5000)])
         allow(chain_data_source).to receive(:fetch_transaction).with('aaa').and_return(tx)
 
         expect(client.sync_utxos).to eq(1)

--- a/gem/bsv-wallet/spec/bsv/wallet/sync_utxos_spec.rb
+++ b/gem/bsv-wallet/spec/bsv/wallet/sync_utxos_spec.rb
@@ -1,0 +1,257 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-wallet'
+
+RSpec.describe BSV::Wallet::Client do
+  let(:private_key) { BSV::Primitives::PrivateKey.generate }
+  let(:storage) { BSV::Wallet::Store::Memory.new }
+  let(:chain_data_source) { double('chain_data_source') } # rubocop:disable RSpec/VerifiedDoubles
+
+  def make_utxo(tx_hash, tx_pos, satoshis)
+    BSV::Network::UTXO.new(tx_hash: tx_hash, tx_pos: tx_pos, satoshis: satoshis)
+  end
+
+  def make_tx(output_count: 1, satoshis: 1000)
+    tx = BSV::Transaction::Transaction.new
+    output_count.times do
+      locking_script = BSV::Script::Script.p2pkh_lock(private_key.public_key.hash160)
+      tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: satoshis, locking_script: locking_script))
+    end
+    tx
+  end
+
+  describe '#sync_utxos' do
+    context 'when neither substrate nor chain_data_source is configured' do
+      subject(:client) { described_class.new(private_key, storage: storage, allow_memory_store: true) }
+
+      it 'raises UnsupportedActionError' do
+        expect { client.sync_utxos }.to raise_error(BSV::Wallet::UnsupportedActionError)
+      end
+
+      it 'includes a helpful message' do
+        expect { client.sync_utxos }
+          .to raise_error(BSV::Wallet::UnsupportedActionError, /chain_data_source or remote substrate/)
+      end
+    end
+
+    context 'with chain_data_source and no chain UTXOs' do
+      subject(:client) do
+        described_class.new(
+          private_key,
+          storage: storage,
+          chain_data_source: chain_data_source,
+          allow_memory_store: true
+        )
+      end
+
+      before do
+        allow(chain_data_source).to receive(:fetch_utxos).and_return([])
+        allow(chain_data_source).to receive(:fetch_transaction)
+      end
+
+      it 'returns 0' do
+        expect(client.sync_utxos).to eq(0)
+      end
+
+      it 'does not call fetch_transaction' do
+        client.sync_utxos
+
+        expect(chain_data_source).not_to have_received(:fetch_transaction)
+      end
+    end
+
+    context 'with chain_data_source and UTXOs not yet in storage' do
+      subject(:client) do
+        described_class.new(
+          private_key,
+          storage: storage,
+          chain_data_source: chain_data_source,
+          allow_memory_store: true
+        )
+      end
+
+      let(:tx_a) { make_tx }
+      let(:tx_b) { make_tx }
+
+      before do
+        allow(chain_data_source).to receive(:fetch_utxos).and_return([
+                                                                       make_utxo('aaa', 0, 1000),
+                                                                       make_utxo('bbb', 0, 2000)
+                                                                     ])
+        allow(chain_data_source).to receive(:fetch_transaction).with('aaa').and_return(tx_a)
+        allow(chain_data_source).to receive(:fetch_transaction).with('bbb').and_return(tx_b)
+      end
+
+      it 'returns the number of UTXOs imported' do
+        expect(client.sync_utxos).to eq(2)
+      end
+
+      it 'stores each output with derivation_type :identity' do
+        client.sync_utxos
+
+        types = storage.find_outputs({ include_spent: false }).map { |o| o[:derivation_type].to_s }
+        expect(types).to all(eq('identity'))
+      end
+
+      it 'stores each output with state :spendable' do
+        client.sync_utxos
+
+        states = storage.find_outputs({ include_spent: false }).map { |o| o[:state].to_s }
+        expect(states).to all(eq('spendable'))
+      end
+
+      it 'stores each output with basket default' do
+        client.sync_utxos
+
+        baskets = storage.find_outputs({ include_spent: false }).map { |o| o[:basket] }
+        expect(baskets).to all(eq('default'))
+      end
+
+      it 'stores the correct satoshis' do
+        client.sync_utxos
+
+        satoshis = storage.find_outputs({ include_spent: false }).map { |o| o[:satoshis] }.sort
+        expect(satoshis).to eq([1000, 2000])
+      end
+
+      it 'stores the raw transactions' do
+        client.sync_utxos
+
+        expect(storage.find_transaction('aaa')).to eq(tx_a.to_hex)
+        expect(storage.find_transaction('bbb')).to eq(tx_b.to_hex)
+      end
+    end
+
+    context 'with chain_data_source, idempotent when all UTXOs already stored' do
+      subject(:client) do
+        described_class.new(
+          private_key,
+          storage: storage,
+          chain_data_source: chain_data_source,
+          allow_memory_store: true
+        )
+      end
+
+      before do
+        tx_a = make_tx
+        tx_b = make_tx
+        allow(chain_data_source).to receive(:fetch_utxos).and_return([
+                                                                       make_utxo('aaa', 0, 1000),
+                                                                       make_utxo('bbb', 0, 2000)
+                                                                     ])
+        allow(chain_data_source).to receive(:fetch_transaction).with('aaa').and_return(tx_a)
+        allow(chain_data_source).to receive(:fetch_transaction).with('bbb').and_return(tx_b)
+      end
+
+      it 'returns 2 on first import, 0 on second' do
+        expect(client.sync_utxos).to eq(2)
+        expect(client.sync_utxos).to eq(0)
+      end
+
+      it 'partially imports new UTXOs while skipping known ones' do
+        # Import aaa and bbb
+        client.sync_utxos
+
+        # Chain now also has ccc
+        tx_c = make_tx(satoshis: 3000)
+        allow(chain_data_source).to receive(:fetch_utxos).and_return([
+                                                                       make_utxo('aaa', 0, 1000),
+                                                                       make_utxo('bbb', 0, 2000),
+                                                                       make_utxo('ccc', 0, 3000)
+                                                                     ])
+        allow(chain_data_source).to receive(:fetch_transaction).with('ccc').and_return(tx_c)
+
+        expect(client.sync_utxos).to eq(1)
+      end
+    end
+
+    context 'with chain_data_source and out-of-bounds tx_pos' do
+      subject(:client) do
+        described_class.new(
+          private_key,
+          storage: storage,
+          chain_data_source: chain_data_source,
+          allow_memory_store: true
+        )
+      end
+
+      it 'raises WalletError when tx_pos exceeds output count' do
+        tx = make_tx(output_count: 1)
+        allow(chain_data_source).to receive(:fetch_utxos).and_return([make_utxo('aaa', 5, 1000)])
+        allow(chain_data_source).to receive(:fetch_transaction).with('aaa').and_return(tx)
+
+        expect { client.sync_utxos }.to raise_error(BSV::Wallet::WalletError, /Invalid tx_pos/)
+      end
+
+      it 'raises WalletError when tx_pos is negative' do
+        tx = make_tx(output_count: 2)
+        allow(chain_data_source).to receive(:fetch_utxos).and_return([make_utxo('aaa', -1, 1000)])
+        allow(chain_data_source).to receive(:fetch_transaction).with('aaa').and_return(tx)
+
+        expect { client.sync_utxos }.to raise_error(BSV::Wallet::WalletError, /Invalid tx_pos/)
+      end
+
+      it 'accepts tx_pos 0 (first output)' do
+        tx = make_tx(output_count: 2)
+        allow(chain_data_source).to receive(:fetch_utxos).and_return([make_utxo('aaa', 0, 1000)])
+        allow(chain_data_source).to receive(:fetch_transaction).with('aaa').and_return(tx)
+
+        expect(client.sync_utxos).to eq(1)
+      end
+    end
+
+    context 'with chain_data_source and network errors' do
+      subject(:client) do
+        described_class.new(
+          private_key,
+          storage: storage,
+          chain_data_source: chain_data_source,
+          allow_memory_store: true
+        )
+      end
+
+      it 'propagates errors from fetch_utxos' do
+        allow(chain_data_source).to receive(:fetch_utxos).and_raise(StandardError, 'network error')
+
+        expect { client.sync_utxos }.to raise_error(StandardError, 'network error')
+      end
+
+      it 'propagates errors from fetch_transaction' do
+        allow(chain_data_source).to receive(:fetch_utxos).and_return([make_utxo('aaa', 0, 1000)])
+        allow(chain_data_source).to receive(:fetch_transaction).and_raise(StandardError, 'network error')
+
+        expect { client.sync_utxos }.to raise_error(StandardError, 'network error')
+      end
+    end
+
+    context 'when substrate is configured (takes priority)' do
+      subject(:client) do
+        described_class.new(
+          private_key,
+          storage: storage,
+          substrate: substrate,
+          chain_data_source: chain_data_source,
+          allow_memory_store: true
+        )
+      end
+
+      let(:substrate) { double('substrate') } # rubocop:disable RSpec/VerifiedDoubles
+
+      it 'delegates to the substrate and returns its result' do
+        allow(substrate).to receive(:sync_utxos).and_return(3)
+
+        expect(client.sync_utxos).to eq(3)
+      end
+
+      it 'does not call chain_data_source when substrate is set' do
+        allow(substrate).to receive(:sync_utxos).and_return(0)
+        allow(chain_data_source).to receive(:fetch_utxos)
+
+        client.sync_utxos
+
+        expect(chain_data_source).not_to have_received(:fetch_utxos)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Expanded `BSV::Network::WhatsOnChain` with `current_height`, `get_block_header`, and `valid_root_for_height?` methods
- Added `chain_data_source:` constructor param to `BSV::Wallet::Client`
- Restored `get_height` and `get_header_for_height` in the Network concern with local chain data fallback
- Restored `sync_utxos` -- discovers on-chain UTXOs via the SDK network layer and imports them into storage
- Restored BEEF SPV merkle root verification in `internalize_action` when a chain tracker is available
- 18 integration specs exercising all restored methods end-to-end with stubbed HTTP

These methods were incorrectly stubbed with `UnsupportedActionError` in commit 1b0be0b when the `ChainProvider` abstraction was removed. The underlying SDK network primitives already existed -- only the wallet-level wiring was missing.

## Acceptance criteria verification

- [x] `sync_utxos` discovers on-chain UTXOs via the SDK network layer and imports new ones into storage
- [x] `get_height` returns the current blockchain height locally (no substrate required)
- [x] `get_header_for_height` returns the block header at a given height locally (no substrate required)
- [x] All three methods still delegate to `@substrate` when one is configured
- [x] Chain data source is injectable for testing
- [x] Specs cover the happy path, idempotency (sync_utxos), and error cases
- [x] No new `ChainProvider` abstraction -- direct SDK network layer usage

## Test plan

- [x] SDK specs pass (3942 examples, 0 failures)
- [x] Wallet specs pass (1279 examples, 0 failures)
- [x] Integration specs cover happy path, idempotency, and error cases
- [x] RuboCop clean (416 files, no offences)
- [x] Acceptance criteria verified against code

Closes #595
