### PR TITLE
feat: implement Transaction SPV verification (#593)

### DIFF
--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -553,9 +553,11 @@ module BSV
       # @param chain_tracker [ChainTracker] chain tracker for merkle root validation
       # @param fee_model [FeeModel, nil] optional fee model to validate the root transaction's fee
       # @return [true] on successful verification
-      # @raise [ArgumentError] if a source transaction or unlocking script is missing
-      # @raise [BSV::Script::ScriptError] if script execution fails
-      # @raise [VerificationError] for merkle path failures, fee validation, or output overflow
+      # @raise [VerificationError] with code +:invalid_merkle_proof+ if a merkle proof is invalid
+      # @raise [VerificationError] with code +:insufficient_fee+ if the fee is below the model's threshold
+      # @raise [VerificationError] with code +:output_overflow+ if outputs exceed inputs
+      # @raise [VerificationError] with code +:script_failure+ if script execution fails
+      # @raise [VerificationError] with code +:missing_source+ if an input is missing required source data
       def verify(chain_tracker:, fee_model: nil)
         verified = {}
         queue = [self]
@@ -581,8 +583,26 @@ module BSV
 
           # Verify each input
           tx.inputs.each_with_index do |input, index|
+            # Populate source data from source_transaction when not already set.
+            # Matches the TS SDK pattern: sourceOutput is read directly from
+            # source_transaction.outputs[sourceOutputIndex] during verify.
+            if input.source_transaction
+              source_output = input.source_transaction.outputs[input.prev_tx_out_index]
+              if source_output
+                input.source_locking_script ||= source_output.locking_script
+                input.source_satoshis ||= source_output.satoshis
+              end
+            end
+
             verify_input_requirements(tx, input, index)
-            tx.verify_input(index)
+            begin
+              tx.verify_input(index)
+            rescue BSV::Script::ScriptError => e
+              raise VerificationError.new(
+                :script_failure,
+                "script verification failed for input #{index} of transaction #{tx.txid_hex}: #{e.message}"
+              )
+            end
 
             # Enqueue source transaction for verification if not yet verified
             source_tx = input.source_transaction
@@ -742,9 +762,18 @@ module BSV
 
       def verify_input_requirements(tx, input, index)
         tx_id = tx.txid_hex
-        raise ArgumentError, "input #{index} of transaction #{tx_id} has no unlocking script" if input.unlocking_script.nil?
-        raise ArgumentError, "input #{index} of transaction #{tx_id} has no source locking script" if input.source_locking_script.nil?
-        raise ArgumentError, "input #{index} of transaction #{tx_id} has no source satoshis" if input.source_satoshis.nil?
+        if input.unlocking_script.nil?
+          raise VerificationError.new(:missing_source,
+                                      "input #{index} of transaction #{tx_id} has no unlocking script")
+        end
+        if input.source_locking_script.nil?
+          raise VerificationError.new(:missing_source,
+                                      "input #{index} of transaction #{tx_id} has no source locking script")
+        end
+        return unless input.source_satoshis.nil?
+
+        raise VerificationError.new(:missing_source,
+                                    "input #{index} of transaction #{tx_id} has no source satoshis")
       end
 
       def verify_fee(fee_model)

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -550,6 +550,22 @@ module BSV
       #    provided fee model.
       # 4. Checks that total outputs do not exceed total inputs.
       #
+      # == Semantic Divergences from Reference SDKs
+      #
+      # This implementation raises +VerificationError+ for all failure modes.
+      # The TypeScript and Python SDKs return +false+ for script failures and
+      # output overflow. The Go SDK propagates errors (not booleans) for script
+      # failures, aligning with the Ruby approach.
+      #
+      # Rationale: raising provides structured error information (+#code+,
+      # +#message+, +#cause+) that a boolean cannot convey. Consumers can
+      # rescue +VerificationError+ and inspect +#code+ for specifics.
+      #
+      # Divergence summary:
+      # - +:output_overflow+ — Ruby raises; TS/Python return +false+; Go omits the check
+      # - +:script_failure+ — Ruby raises; TS/Python return +false+; Go also propagates errors
+      # - +:missing_source+ — Ruby raises; consistent with TS/Go/Python (all raise/error)
+      #
       # @param chain_tracker [ChainTracker] chain tracker for merkle root validation
       # @param fee_model [FeeModel, nil] optional fee model to validate the root transaction's fee
       # @return [true] on successful verification

--- a/gem/bsv-sdk/lib/bsv/transaction/verification_error.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/verification_error.rb
@@ -7,6 +7,15 @@ module BSV
     # Carries a machine-readable code alongside a human-readable message,
     # matching the typed error pattern used by the Go SDK
     # (ErrInvalidMerklePath, ErrFeeTooLow, ErrScriptVerificationFailed).
+    #
+    # == Error Codes
+    #
+    # - +:invalid_merkle_proof+ — merkle path verification failed against the chain tracker
+    # - +:insufficient_fee+ — transaction fee is below the fee model's requirement
+    # - +:output_overflow+ — total outputs exceed total inputs
+    # - +:script_failure+ — script interpreter rejected an input (original +ScriptError+ in +#cause+)
+    # - +:missing_source+ — required input data (unlocking script, source locking script,
+    #   or source satoshis) is absent
     class VerificationError < StandardError
       # @return [Symbol] the error code
       attr_reader :code

--- a/gem/bsv-sdk/lib/bsv/transaction/verification_error.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/verification_error.rb
@@ -14,6 +14,8 @@ module BSV
       INVALID_MERKLE_PROOF = :invalid_merkle_proof
       INSUFFICIENT_FEE = :insufficient_fee
       OUTPUT_OVERFLOW = :output_overflow
+      SCRIPT_FAILURE = :script_failure
+      MISSING_SOURCE = :missing_source
 
       # @param code [Symbol] error code
       # @param message [String] human-readable description

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_verify_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_verify_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe BSV::Transaction::Transaction do
           }
       end
 
-      it 'raises when source locking script is missing' do
+      it 'raises when source locking script is missing (no source_transaction to fall back to)' do
         source_tx = build_source_tx
         source_tx.merkle_path = make_merkle_path
 
@@ -307,8 +307,7 @@ RSpec.describe BSV::Transaction::Transaction do
         )
         input.source_satoshis = 100_000
         input.unlocking_script = BSV::Script::Script.from_asm('OP_TRUE')
-        input.source_transaction = source_tx
-        # No source_locking_script
+        # No source_locking_script and no source_transaction to fall back to
         tx.add_input(input)
         tx.add_output(BSV::Transaction::TransactionOutput.new(
                         satoshis: 90_000,
@@ -322,7 +321,7 @@ RSpec.describe BSV::Transaction::Transaction do
           }
       end
 
-      it 'raises when source satoshis is missing' do
+      it 'raises when source satoshis is missing (no source_transaction to fall back to)' do
         source_tx = build_source_tx
         source_tx.merkle_path = make_merkle_path
 
@@ -333,8 +332,7 @@ RSpec.describe BSV::Transaction::Transaction do
         )
         input.unlocking_script = BSV::Script::Script.from_asm('OP_TRUE')
         input.source_locking_script = lock_script
-        input.source_transaction = source_tx
-        # No source_satoshis
+        # No source_satoshis and no source_transaction to fall back to
         tx.add_input(input)
         tx.add_output(BSV::Transaction::TransactionOutput.new(
                         satoshis: 90_000,

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_verify_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_verify_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe BSV::Transaction::Transaction do
         expect(tx.verify(chain_tracker: chain_tracker)).to be true
       end
 
-      it 'raises ScriptError when scripts fail' do
+      it 'raises VerificationError(:script_failure) when scripts fail' do
         source_tx = build_source_tx
         source_tx.merkle_path = make_merkle_path
 
@@ -113,7 +113,11 @@ RSpec.describe BSV::Transaction::Transaction do
         tx.inputs[0].unlocking_script = BSV::Script::Script.from_asm('OP_0')
 
         expect { tx.verify(chain_tracker: chain_tracker) }
-          .to raise_error(BSV::Script::ScriptError)
+          .to raise_error(BSV::Transaction::VerificationError) { |e|
+            expect(e.code).to eq(:script_failure)
+            expect(e.message).to include('input 0')
+            expect(e.cause).to be_a(BSV::Script::ScriptError)
+          }
       end
     end
 
@@ -286,7 +290,10 @@ RSpec.describe BSV::Transaction::Transaction do
                       ))
 
         expect { tx.verify(chain_tracker: chain_tracker) }
-          .to raise_error(ArgumentError, /no unlocking script/)
+          .to raise_error(BSV::Transaction::VerificationError) { |e|
+            expect(e.code).to eq(:missing_source)
+            expect(e.message).to include('no unlocking script')
+          }
       end
 
       it 'raises when source locking script is missing' do
@@ -309,7 +316,10 @@ RSpec.describe BSV::Transaction::Transaction do
                       ))
 
         expect { tx.verify(chain_tracker: chain_tracker) }
-          .to raise_error(ArgumentError, /no source locking script/)
+          .to raise_error(BSV::Transaction::VerificationError) { |e|
+            expect(e.code).to eq(:missing_source)
+            expect(e.message).to include('no source locking script')
+          }
       end
 
       it 'raises when source satoshis is missing' do
@@ -332,7 +342,10 @@ RSpec.describe BSV::Transaction::Transaction do
                       ))
 
         expect { tx.verify(chain_tracker: chain_tracker) }
-          .to raise_error(ArgumentError, /no source satoshis/)
+          .to raise_error(BSV::Transaction::VerificationError) { |e|
+            expect(e.code).to eq(:missing_source)
+            expect(e.message).to include('no source satoshis')
+          }
       end
     end
 

--- a/gem/bsv-sdk/spec/conformance/spv_verify_beef_spec.rb
+++ b/gem/bsv-sdk/spec/conformance/spv_verify_beef_spec.rb
@@ -1,0 +1,225 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'base64'
+
+# Protocol conformance: BEEF-based SPV verification (Transaction#verify)
+#
+# Parses real BEEF bundles from the reference SDK test vectors and runs
+# Transaction#verify against them. This validates end-to-end cross-SDK
+# conformance for SPV verification using actual BEEF-encoded data rather
+# than hand-built mocked transactions.
+#
+# Reference implementations:
+#   Go SDK:  TestSPVVerify, TestSPVVerifyScripts, TestSPVVerifyWithSufficientFee,
+#            TestSPVVerifyWithInsufficientFee (transaction/spv_test.go)
+#   TS SDK:  "Verifies the transaction from the BEEF spec",
+#            "Verifies tx scripts only when our input has no MerklePath"
+#
+# Vectors sourced from: spec/conformance/vectors/beef.vectors.json
+
+SPV_BEEF_VECTORS = ConformanceVectors.load('beef.vectors.json')['vectors']
+                                     .to_h { |v| [v['label'], v] }
+                                     .freeze
+
+# A chain tracker that always accepts any merkle root as valid.
+# Used for BEEF conformance tests where we trust the embedded proofs
+# and simply want to exercise the verification logic itself.
+class AlwaysTrueChainTracker < BSV::Transaction::ChainTracker
+  def valid_root_for_height?(_root, _height)
+    true
+  end
+
+  def current_height
+    900_000
+  end
+end
+
+RSpec.describe 'BEEF-based SPV verification conformance' do
+  let(:always_true_tracker) { AlwaysTrueChainTracker.new }
+
+  let(:brc62_hex)      { SPV_BEEF_VECTORS.fetch('BRC62Hex')['data'] }
+  let(:beef_base64)    { SPV_BEEF_VECTORS.fetch('BEEF')['data'] }
+  let(:beef_set_hex)   { SPV_BEEF_VECTORS.fetch('BEEFSet')['data'] }
+  let(:issue96_hex)    { SPV_BEEF_VECTORS.fetch('Issue96BeefHex')['data'] }
+
+  # --- Happy-path verification with always-true chain tracker ---
+
+  describe 'BRC62Hex (V1 BEEF)' do
+    subject(:tx) { BSV::Transaction::Transaction.from_beef_hex(brc62_hex) }
+
+    it 'parses successfully and verifies with always-true chain tracker' do
+      expect(tx.verify(chain_tracker: always_true_tracker)).to be true
+    end
+  end
+
+  describe 'BEEF base64 (V1 multi-transaction BEEF)' do
+    subject(:tx) do
+      data = Base64.strict_decode64(beef_base64)
+      BSV::Transaction::Transaction.from_beef(data)
+    end
+
+    it 'parses successfully and verifies with always-true chain tracker' do
+      expect(tx.verify(chain_tracker: always_true_tracker)).to be true
+    end
+  end
+
+  describe 'BEEFSet (V2 BEEF)' do
+    subject(:tx) { BSV::Transaction::Transaction.from_beef_hex(beef_set_hex) }
+
+    it 'parses successfully and verifies with always-true chain tracker' do
+      expect(tx.verify(chain_tracker: always_true_tracker)).to be true
+    end
+  end
+
+  describe 'Issue96BeefHex (V1 BEEF — regression for "no leaves at height: 1")' do
+    subject(:tx) { BSV::Transaction::Transaction.from_beef_hex(issue96_hex) }
+
+    it 'parses successfully and verifies with always-true chain tracker' do
+      expect(tx.verify(chain_tracker: always_true_tracker)).to be true
+    end
+  end
+
+  # --- Fee model integration (Go SDK: TestSPVVerifyWithSufficientFee / TestSPVVerifyWithInsufficientFee) ---
+
+  describe 'fee model integration using BRC62Hex' do
+    subject(:tx) { BSV::Transaction::Transaction.from_beef_hex(brc62_hex) }
+
+    it 'verifies when fee model rate is low (passes)' do
+      # 1 sat/kB is effectively zero — any real transaction fee will exceed this
+      fee_model = BSV::Transaction::FeeModels::SatoshisPerKilobyte.new(value: 1)
+      expect(tx.verify(chain_tracker: always_true_tracker, fee_model: fee_model)).to be true
+    end
+
+    it 'raises VerificationError(:insufficient_fee) when fee model rate is extremely high' do
+      # 1_000_000 sat/kB means roughly 1 sat/byte minimum — most test vectors
+      # carry very small fees, so this should trigger an insufficient fee error
+      fee_model = BSV::Transaction::FeeModels::SatoshisPerKilobyte.new(value: 1_000_000)
+      expect { tx.verify(chain_tracker: always_true_tracker, fee_model: fee_model) }
+        .to raise_error(BSV::Transaction::VerificationError) { |e|
+          expect(e.code).to eq(:insufficient_fee)
+        }
+    end
+  end
+
+  # --- Corrupt merkle proof ---
+
+  describe 'corrupt merkle proof' do
+    it 'raises VerificationError(:invalid_merkle_proof) when a BUMP hash is flipped' do
+      tx = BSV::Transaction::Transaction.from_beef_hex(brc62_hex)
+
+      # Find a mined ancestor (one that has a merkle_path attached)
+      mined_tx = nil
+      queue = [tx]
+      visited = {}
+      until queue.empty?
+        candidate = queue.shift
+        next if visited[candidate.txid_hex]
+
+        visited[candidate.txid_hex] = true
+        if candidate.merkle_path
+          mined_tx = candidate
+          break
+        end
+        candidate.inputs.each do |input|
+          queue << input.source_transaction if input.source_transaction
+        end
+      end
+
+      expect(mined_tx).not_to be_nil, 'expected BEEF to contain at least one mined ancestor'
+
+      # Record the correct merkle root so we can build a tracker that rejects
+      # any other root. This means when we corrupt a sibling hash the recomputed
+      # root will differ and the tracker will return false.
+      original_path = mined_tx.merkle_path
+      correct_root = original_path.compute_root_hex(mined_tx.txid_hex)
+      correct_height = original_path.block_height
+
+      root_checking_tracker = Class.new(BSV::Transaction::ChainTracker) do
+        define_method(:valid_root_for_height?) do |root, height|
+          # Only accept the originally computed root at the recorded height
+          root == correct_root && height == correct_height
+        end
+
+        def current_height
+          900_000
+        end
+      end.new
+
+      # Verify the uncorrupted BEEF succeeds with this tracker
+      expect(tx.verify(chain_tracker: root_checking_tracker)).to be true
+
+      # Now corrupt the merkle path: flip every byte in a non-txid sibling hash
+      # at level 0 so the recomputed root will not match.
+      original_levels = original_path.path
+
+      corrupted_levels = original_levels.map.with_index do |level, level_idx|
+        if level_idx.zero?
+          level.map do |elem|
+            next elem if elem.txid || elem.duplicate || elem.hash.nil?
+
+            corrupted_hash = elem.hash.bytes.map { |b| b ^ 0xFF }.pack('C*')
+            BSV::Transaction::MerklePath::PathElement.new(
+              offset: elem.offset,
+              hash: corrupted_hash,
+              txid: false,
+              duplicate: false
+            )
+          end
+        else
+          level
+        end
+      end
+
+      corrupted_path = BSV::Transaction::MerklePath.new(
+        block_height: original_path.block_height,
+        path: corrupted_levels
+      )
+
+      # Re-parse a fresh copy so the source_locking_script population is clean
+      tx2 = BSV::Transaction::Transaction.from_beef_hex(brc62_hex)
+      mined_tx2 = nil
+      queue2 = [tx2]
+      visited2 = {}
+      until queue2.empty?
+        candidate = queue2.shift
+        next if visited2[candidate.txid_hex]
+
+        visited2[candidate.txid_hex] = true
+        if candidate.merkle_path
+          mined_tx2 = candidate
+          break
+        end
+        candidate.inputs.each do |input|
+          queue2 << input.source_transaction if input.source_transaction
+        end
+      end
+
+      mined_tx2.merkle_path = corrupted_path
+
+      expect { tx2.verify(chain_tracker: root_checking_tracker) }
+        .to raise_error(BSV::Transaction::VerificationError) { |e|
+          expect(e.code).to eq(:invalid_merkle_proof)
+        }
+    end
+  end
+
+  # --- Tampered transaction ---
+
+  describe 'tampered subject transaction' do
+    it 'fails verification when an output amount is modified' do
+      tx = BSV::Transaction::Transaction.from_beef_hex(brc62_hex)
+
+      # Corrupt the subject transaction's first output satoshi value.
+      # This will cause the output ≤ input check or script verification to fail,
+      # since the ancestry chain's source_satoshis no longer match what the
+      # scripts expect.
+      original_satoshis = tx.outputs[0].satoshis
+      tx.outputs[0].satoshis = original_satoshis + 1_000_000
+
+      # After tampering, the output total exceeds the input total: outputs > inputs
+      expect { tx.verify(chain_tracker: always_true_tracker) }
+        .to raise_error(BSV::Transaction::VerificationError)
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/conformance/spv_verify_spec.rb
+++ b/gem/bsv-sdk/spec/conformance/spv_verify_spec.rb
@@ -117,6 +117,8 @@ RSpec.describe BSV::Transaction::Transaction do # rubocop:disable RSpec/Multiple
     # TS/Python: verify outputs ≤ inputs
     # TS: lines 935-948 — sums outputs and inputs, returns false if violated
     # Python: lines 451-457 — returns output_total <= input_total
+    # Go: omits this check entirely
+    # Ruby divergence: raises VerificationError(:output_overflow) instead of returning false
     it 'checks output ≤ input constraint (TS/Python pattern)' do
       source_tx = build_source_tx(satoshis: 100_000)
       source_tx.merkle_path = valid_merkle_path
@@ -174,9 +176,10 @@ RSpec.describe BSV::Transaction::Transaction do # rubocop:disable RSpec/Multiple
     end
 
     # All three SDKs: script execution for each input
-    # TS: Spend.validate() for each input
-    # Go: interpreter.Execute() for each input
-    # Python: Spend.validate() for each input
+    # TS: Spend.validate() for each input — returns false on failure
+    # Go: interpreter.Execute() for each input — returns wrapped error on failure
+    # Python: Spend.validate() for each input — returns false on failure
+    # Ruby divergence: raises VerificationError(:script_failure) on failure (original ScriptError in #cause)
     it 'executes scripts for each input (all SDKs)' do
       source_tx = build_source_tx
       source_tx.merkle_path = valid_merkle_path


### PR DESCRIPTION
## Summary
- Add BEEF-based SPV verification conformance tests against Go SDK reference vectors (#607)
- Unify all `Transaction#verify` errors under `VerificationError` with structured error codes: `:invalid_merkle_proof`, `:insufficient_fee`, `:output_overflow`, `:script_failure`, `:missing_source` (#608)
- Document semantic divergences from TS/Python SDKs (raise vs return false) (#609)

## Test plan
- [x] All specs pass (3923 examples, 0 failures)
- [x] RuboCop clean (1 pre-existing warning unrelated to this PR)
- [x] BEEF conformance vectors from Go SDK all verify successfully
- [x] Fee model validation works (pass and fail cases)
- [x] Corrupt merkle proof and tampered transaction correctly rejected
- [x] Acceptance criteria for #593 verified

Closes #593

Generated with [Claude Code](https://claude.com/claude-code)
