### PR TITLE
test(wallet-postgres): adopt wallet-level conformance shared examples

### DIFF
--- a/gem/bsv-wallet-postgres/spec/bsv/wallet_postgres/postgres_store_spec.rb
+++ b/gem/bsv-wallet-postgres/spec/bsv/wallet_postgres/postgres_store_spec.rb
@@ -2,19 +2,34 @@
 
 require 'spec_helper'
 require 'bsv-wallet-postgres'
+require 'bsv/wallet/testing/store_conformance'
 
 RSpec.describe BSV::Wallet::PostgresStore, :postgres do
   let(:db) { POSTGRES_TEST_DB }
   let(:store) { described_class.new(db) }
+  let(:store_label) { 'PostgresStore' }
 
   before do
     POSTGRES_WALLET_TABLES.each { |t| db[t].truncate }
   end
 
-  # The full Store contract — same suite MemoryStore and
-  # FileStore drive. Running it here guarantees PostgresStore never
-  # drifts from the interface.
+  # --- Interface-level conformance ---
+  # Same suite MemoryStore and FileStore drive.
   it_behaves_like 'a storage adapter'
+
+  # --- Wallet-level conformance ---
+  # Exercises the store through realistic wallet operations.
+  it_behaves_like 'wallet auto-funding'
+  it_behaves_like 'wallet BEEF ancestry round-trip'
+  it_behaves_like 'wallet broadcast rollback'
+  it_behaves_like 'wallet certificate operations'
+  it_behaves_like 'wallet UTXO pending locks'
+  it_behaves_like 'wallet pool health'
+  it_behaves_like 'wallet proof round-trip'
+  it_behaves_like 'wallet local pool'
+  it_behaves_like 'wallet replenishment worker'
+  it_behaves_like 'wallet local proof store'
+  it_behaves_like 'wallet inline broadcast queue'
 
   describe 'postgres-specific behaviour' do
     describe 'output upsert semantics' do


### PR DESCRIPTION
## Summary

- Adds all 11 wallet-level shared example groups from `bsv-wallet`'s `store_conformance` suite to PostgresStore specs
- Exercises the adapter through realistic wallet operations (auto-funding, broadcast rollback, BEEF ancestry, certificates, UTXO pools, proof round-trips, etc.)
- Catches adapter bugs that interface-level CRUD tests alone would miss

## Current state

**15 of 406 specs fail** against the current PostgresStore. These are genuine adapter-level discrepancies (symbol vs string states, timestamp format mismatches, extra keys in JSONB round-trip) — exactly what the conformance tests are designed to surface. These will be resolved by #565 (schema redesign) which replaces the JSONB-blob implementation with a normalised schema.

## Changes

One file modified: `gem/bsv-wallet-postgres/spec/bsv/wallet_postgres/postgres_store_spec.rb`

Added:
```ruby
require 'bsv/wallet/testing/store_conformance'

it_behaves_like 'wallet auto-funding'
it_behaves_like 'wallet BEEF ancestry round-trip'
it_behaves_like 'wallet broadcast rollback'
it_behaves_like 'wallet certificate operations'
it_behaves_like 'wallet UTXO pending locks'
it_behaves_like 'wallet pool health'
it_behaves_like 'wallet proof round-trip'
it_behaves_like 'wallet local pool'
it_behaves_like 'wallet replenishment worker'
it_behaves_like 'wallet local proof store'
it_behaves_like 'wallet inline broadcast queue'
```

## Test plan
- [x] All 11 shared example groups load and execute against PostgreSQL
- [ ] 15 adapter-level failures to be resolved by #565 (schema redesign)
- [x] No regressions in existing interface-level or postgres-specific tests

Blocked by: #565
Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)