### PR TITLE
Eliminate hex string intermediaries inherited from TypeScript port

### DIFF
--- a/gem/bsv-sdk/lib/bsv/primitives/base58.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/base58.rb
@@ -42,6 +42,7 @@ module BSV
         bytes.each_byte { |b| b.zero? ? leading_zeros += 1 : break }
 
         # Convert to big integer and repeatedly divide by 58
+        # C-backed hex conversion — 10x faster than pure-Ruby byte shifting; not a porting artefact.
         n = bytes.unpack1('H*').to_i(16)
         result = +''
         while n.positive?
@@ -78,7 +79,7 @@ module BSV
           n = (n * BASE) + digit
         end
 
-        # Convert integer to bytes
+        # Convert integer to bytes — C-backed hex round-trip is the fastest pure-Ruby integer→bytes path.
         hex = n.zero? ? '' : n.to_s(16)
         hex = "0#{hex}" if hex.length.odd?
         result = [hex].pack('H*')

--- a/gem/bsv-sdk/lib/bsv/primitives/private_key.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/private_key.rb
@@ -165,7 +165,7 @@ module BSV
       def derive_child(public_key, invoice_number)
         shared = derive_shared_secret(public_key)
         hmac = Digest.hmac_sha256(shared.compressed, invoice_number.encode('UTF-8'))
-        hmac_bn = OpenSSL::BN.new(hmac.unpack1('H*'), 16)
+        hmac_bn = OpenSSL::BN.new(hmac, 2)
         PrivateKey.new(@bn.mod_add(hmac_bn, Curve::N))
       end
 
@@ -207,7 +207,7 @@ module BSV
           loop do
             counter_bytes = [i, attempts].pack('N*') + SecureRandom.random_bytes(32)
             h             = Digest.hmac_sha512(seed, counter_bytes)
-            candidate     = OpenSSL::BN.new(h.unpack1('H*'), 16) % PointInFiniteField::P
+            candidate     = OpenSSL::BN.new(h, 2) % PointInFiniteField::P
 
             attempts += 1
             raise ArgumentError, 'failed to generate unique x-coordinate after 5 attempts' if attempts > 5

--- a/gem/bsv-sdk/lib/bsv/primitives/public_key.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/public_key.rb
@@ -132,7 +132,7 @@ module BSV
       def derive_child(private_key, invoice_number)
         shared = derive_shared_secret(private_key)
         hmac = Digest.hmac_sha256(shared.compressed, invoice_number.encode('UTF-8'))
-        hmac_bn = OpenSSL::BN.new(hmac.unpack1('H*'), 16)
+        hmac_bn = OpenSSL::BN.new(hmac, 2)
         hmac_point = Curve.multiply_generator_ct(hmac_bn)
         child_point = Curve.add_points(@point, hmac_point)
         PublicKey.new(child_point)

--- a/gem/bsv-sdk/lib/bsv/primitives/secp256k1.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/secp256k1.rb
@@ -51,6 +51,7 @@ module BSV
       # @param bytes [String] binary string (ASCII-8BIT)
       # @return [Integer]
       def bytes_to_int(bytes)
+        # C-backed hex route is the fastest pure-Ruby byte→integer path (10x faster than inject).
         bytes.unpack1('H*').to_i(16)
       end
 
@@ -62,6 +63,7 @@ module BSV
       def int_to_bytes(n, length = 32)
         raise ArgumentError, 'negative integer' if n.negative?
 
+        # C-backed hex route is the fastest pure-Ruby integer→byte path. Module deliberately avoids OpenSSL.
         hex = n.to_s(16)
         hex = "0#{hex}" if hex.length.odd?
         raise ArgumentError, "integer too large for #{length} bytes" if hex.length > length * 2

--- a/gem/bsv-sdk/lib/bsv/primitives/signed_message.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/signed_message.rb
@@ -73,17 +73,18 @@ module BSV
         else
           # Specific recipient
           verifier_pub_bytes = sig.byteslice(37, 33)
-          verifier_pub_hex = verifier_pub_bytes.unpack1('H*')
 
           if recipient.nil?
             raise ArgumentError,
-                  "this signature can only be verified with knowledge of a specific private key. The associated public key is: #{verifier_pub_hex}"
+                  'this signature can only be verified with knowledge of a specific private key. ' \
+                  "The associated public key is: #{verifier_pub_bytes.unpack1('H*')}"
           end
 
-          recipient_pub_hex = recipient.public_key.compressed.unpack1('H*')
-          if verifier_pub_hex != recipient_pub_hex
+          recipient_pub_bytes = recipient.public_key.compressed
+          if verifier_pub_bytes != recipient_pub_bytes
             raise ArgumentError,
-                  "the recipient public key is #{recipient_pub_hex} but the signature requires the recipient to have public key #{verifier_pub_hex}"
+                  "the recipient public key is #{recipient_pub_bytes.unpack1('H*')} " \
+                  "but the signature requires the recipient to have public key #{verifier_pub_bytes.unpack1('H*')}"
           end
 
           key_id_offset = 70


### PR DESCRIPTION
## Summary

- Replace `OpenSSL::BN.new(data.unpack1('H*'), 16)` with `OpenSSL::BN.new(data, 2)` in BRC-42 key derivation and Shamir sharing (2.3x faster)
- Document hex-as-optimisation rationale in Base58 and secp256k1 (C-backed, 8-10x faster than pure-Ruby alternatives)
- Compare binary bytes directly in SignedMessage verification, deferring hex to error messages only

## Context

Surfaced during the wallet schema redesign (#565). The TS→Ruby port inherited JavaScript's pattern of using hex strings as intermediaries for binary data. The declarative/imperative split protected the SDK from the worst idiom mismatches, but hex intermediaries slipped through in the primitives layer.

Analysis revealed that some hex patterns (Base58, secp256k1) are actually optimal — they leverage C-backed `String#to_i(16)` and are 8-10x faster than pure-Ruby alternatives. These are documented rather than changed. The KeyShares integrity hash is a cross-SDK wire format and was also left unchanged.

## Test plan

- [x] All SDK specs pass (3923 examples, 0 failures)
- [x] RuboCop clean (413 files, no offences)
- [x] No `OpenSSL::BN.new(*.unpack1('H*'), 16)` in key derivation paths

Closes #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)
