### PR TITLE
feat: make mul constant-time by default, add mul_vt for variable-time

### DIFF
--- a/.claude/plans/20260429-653-invert-mul-ct-semantics.md
+++ b/.claude/plans/20260429-653-invert-mul-ct-semantics.md
@@ -1,0 +1,118 @@
+# Plan: Invert mul/mul_ct semantics — make CT the default
+
+## Context
+
+The SDK's `Point#mul` is variable-time wNAF, while `Point#mul_ct` is constant-time Montgomery ladder. This is backwards from OpenSSL convention where `EC_POINT_mul` is always constant-time. The secp256k1-native C extension gem is independently making the same change. We need to align the pure-Ruby `Point` class, the OpenSSL shim, the `Curve` module, and all callers.
+
+**Bonus fix:** `schnorr.rb:76` currently uses variable-time multiplication with a secret nonce — a timing side-channel bug. After this change, `multiply_point` becomes CT by default, fixing it automatically.
+
+## Target API
+
+| Method | Behaviour | Purpose |
+|--------|-----------|---------|
+| `mul` | Constant-time Montgomery ladder | Safe default (matches OpenSSL) |
+| `mul_vt` | Variable-time wNAF | Explicit opt-in for public scalars |
+| `mul_ct` | Alias for `mul` | Expressiveness / backward compat |
+
+---
+
+## Step 1 — Point class (`secp256k1.rb`)
+
+**File:** `gem/bsv-sdk/lib/bsv/primitives/secp256k1.rb`
+
+- **`Point#mul` (line 520):** Change body from `scalar_multiply_wnaf` to `scalar_multiply_ct`. Update docstring.
+- **New `Point#mul_vt`:** Insert after `mul`. Takes the old `mul` body (calls `scalar_multiply_wnaf`). Docstring warns "variable-time, public scalars only".
+- **`Point#mul_ct` (line 541):** Replace body with `alias mul_ct mul`. Keep docstring noting alias.
+
+Module-level `scalar_multiply_wnaf` and `scalar_multiply_ct` implementations: **no changes**. Native delegation list (`scalar_multiply_ct` on line ~619): **no changes** — still valid.
+
+## Step 2 — OpenSSL shim (`openssl_ec_shim.rb`)
+
+**File:** `gem/bsv-sdk/lib/bsv/primitives/openssl_ec_shim.rb`
+
+- **`BSVShimECPoint#mul` (line 69):** No code change (delegates to `@secp_point.mul` which is now CT). Update docstring.
+- **`BSVShimECPoint#mul_ct` (line 95):** No code change (delegates to alias). Update docstring.
+- **New `BSVShimECPoint#mul_vt`:** Delegates to `@secp_point.mul_vt(scalar)`.
+- Multi-scalar form in `mul` (lines 74-82): becomes CT — acceptable, only used by `add_points` Ruby 2.7 fallback with scalar=1.
+
+## Step 3 — Curve module (`curve.rb`)
+
+**File:** `gem/bsv-sdk/lib/bsv/primitives/curve.rb`
+
+- **`multiply_generator` (line 35):** Now CT via `G.mul`. Update docstring.
+- **`multiply_generator_ct` (line 46):** Still CT via `G.mul_ct` alias. Update docstring to note alias.
+- **New `multiply_generator_vt`:** Calls `G.mul_vt(scalar_bn)`.
+- **`multiply_point` (line 58):** Now CT via `point.mul`. Update docstring.
+- **`multiply_point_ct` (line 70):** Still CT via alias. Update docstring.
+- **New `multiply_point_vt`:** Calls `point.mul_vt(scalar_bn)`.
+
+## Step 4 — ECDSA callers (`ecdsa.rb`)
+
+**File:** `gem/bsv-sdk/lib/bsv/primitives/ecdsa.rb`
+
+Switch verification/recovery paths to explicit VT (public scalars, performance):
+
+- Line 85: `Curve.multiply_generator(u1)` → `Curve.multiply_generator_vt(u1)`
+- Line 86: `Curve.multiply_point(r_point, u2)` → `Curve.multiply_point_vt(r_point, u2)`
+- Line 115: `Curve.multiply_generator(u1)` → `Curve.multiply_generator_vt(u1)`
+- Line 116: `Curve.multiply_point(public_key_point, u2)` → `Curve.multiply_point_vt(public_key_point, u2)`
+- Line 134: `Curve.multiply_generator_ct(k)` → **no change** (secret nonce, CT correct)
+
+## Step 5 — Schnorr callers (`schnorr.rb`)
+
+**File:** `gem/bsv-sdk/lib/bsv/primitives/schnorr.rb`
+
+- Line 76: `Curve.multiply_point(public_key_b.point, nonce.bn)` → **no code change needed** (now CT by default, fixing the secret-nonce timing bug). Leave as `multiply_point` since the default is now safe.
+- Line 100: `Curve.multiply_generator(proof.z)` → `Curve.multiply_generator_vt(proof.z)`
+- Line 101: `Curve.multiply_point(public_key_a.point, e)` → `Curve.multiply_point_vt(public_key_a.point, e)`
+- Line 107: `Curve.multiply_point(public_key_b.point, proof.z)` → `Curve.multiply_point_vt(public_key_b.point, proof.z)`
+- Line 108: `Curve.multiply_point(shared_secret.point, e)` → `Curve.multiply_point_vt(shared_secret.point, e)`
+
+## Step 6 — No-change files (verify only)
+
+These already use `_ct` variants, which still work via alias:
+- `private_key.rb:132` — `multiply_generator_ct` (secret key)
+- `private_key.rb:151` — `multiply_point_ct` (ECDH)
+- `public_key.rb:118` — `multiply_point_ct` (ECDH)
+- `public_key.rb:136` — `multiply_generator_ct` (BRC-42 derivation)
+- `extended_key.rb:187` — `multiply_generator_ct` (BIP-32)
+- `extended_key.rb:299` — `multiply_generator_ct` (pubkey from privkey)
+
+## Step 7 — Tests
+
+### secp256k1_spec.rb
+- `describe '#mul'` tests (line ~246): update descriptions to say "constant-time". All math assertions unchanged.
+- `describe '#mul_ct'` tests (line ~296): update descriptions to note alias. Equivalence tests (`mul_ct` vs `mul`) now compare alias to itself — still valid but update descriptions.
+- **New** `describe '#mul_vt'`: mirror old `mul` test structure. Include equivalence test `mul_vt(k) == mul(k)`.
+
+### secp256k1_compliance_spec.rb
+- Update descriptions for `mul` / `mul_ct` sections.
+- **New** `mul_vt` compliance tests (matches mul for known multiples).
+
+### secp256k1_native_spec.rb
+- Line 576 (`g.mul(k)`): now tests CT path. Update description.
+- Line 684 (`g.mul(5)`): change to `g.mul_vt(5)` to test wNAF through native delegation. Add `g.mul(5)` CT test alongside.
+- Line 692 (`g.mul_ct(3)`): still valid via alias.
+- **New** test for `g.mul_vt` through native delegation.
+
+### curve_spec.rb
+- **New** `describe '.multiply_generator_vt'` and `describe '.multiply_point_vt'`.
+
+### OpenSSL shim compliance (spec/conformance/)
+- Existing `point_mul_spec.rb` / `point_mul_multi_spec.rb`: all pass unchanged.
+- **New** `mul_vt` shim tests.
+
+## Step 8 — Full regression
+
+```bash
+cd gem/bsv-sdk && bundle exec rspec
+```
+
+## Verification
+
+1. All existing tests pass (mathematical results identical regardless of CT vs VT)
+2. New `mul_vt` tests cover the variable-time path
+3. ECDSA sign/verify round-trip works
+4. Schnorr proof generate/verify round-trip works
+5. BIP-32 key derivation works
+6. ECIES encrypt/decrypt works

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'secp256k1-native', git: 'https://github.com/sgbett/secp256k1-native.git', branch: 'master'
+gem 'secp256k1-native', '~> 0.16'
 
 gemspec path: 'gem/bsv-sdk'
 gemspec path: 'gem/bsv-attest'

--- a/gem/bsv-sdk/bsv-sdk.gemspec
+++ b/gem/bsv-sdk/bsv-sdk.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'mcp', '~> 0.12'
-  spec.add_dependency 'secp256k1-native'
+  spec.add_dependency 'secp256k1-native', '>= 0.16'
 end

--- a/gem/bsv-sdk/lib/bsv/primitives/curve.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/curve.rb
@@ -25,10 +25,11 @@ module BSV
 
       module_function
 
-      # Multiply the generator point by a scalar (variable-time, wNAF).
+      # Multiply the generator point by a scalar (constant-time).
       #
-      # Suitable for public scalars only (e.g. verify paths). For secret
-      # scalars use {multiply_generator_ct}.
+      # Uses the Montgomery ladder by default, matching OpenSSL convention.
+      # Safe for both secret and public scalars. For explicit variable-time
+      # multiplication of public scalars, use {multiply_generator_vt}.
       #
       # @param scalar_bn [OpenSSL::BN] the scalar multiplier
       # @return [OpenSSL::PKey::EC::Point] the resulting curve point
@@ -38,19 +39,31 @@ module BSV
 
       # Multiply the generator point by a secret scalar (constant-time).
       #
-      # Uses the Montgomery ladder to avoid timing side-channels on the
-      # scalar. Use for key generation and signing.
+      # Alias for {multiply_generator} — retained for backward compatibility
+      # and expressiveness.
       #
       # @param scalar_bn [OpenSSL::BN] the secret scalar multiplier
       # @return [OpenSSL::PKey::EC::Point] the resulting curve point
       def multiply_generator_ct(scalar_bn)
-        G.mul_ct(scalar_bn)
+        G.mul(scalar_bn)
       end
 
-      # Multiply an arbitrary curve point by a scalar (variable-time, wNAF).
+      # Multiply the generator point by a public scalar (variable-time, wNAF).
       #
-      # Suitable for public scalars only. For secret scalars use
-      # {multiply_point_ct}.
+      # Faster than {multiply_generator} but leaks timing information about
+      # the scalar. Use only for public scalars (e.g. signature verification).
+      #
+      # @param scalar_bn [OpenSSL::BN] the public scalar multiplier
+      # @return [OpenSSL::PKey::EC::Point] the resulting curve point
+      def multiply_generator_vt(scalar_bn)
+        G.mul_vt(scalar_bn)
+      end
+
+      # Multiply an arbitrary curve point by a scalar (constant-time).
+      #
+      # Uses the Montgomery ladder by default, matching OpenSSL convention.
+      # Safe for both secret and public scalars. For explicit variable-time
+      # multiplication of public scalars, use {multiply_point_vt}.
       #
       # @param point [OpenSSL::PKey::EC::Point] the point to multiply
       # @param scalar_bn [OpenSSL::BN] the scalar multiplier
@@ -61,14 +74,26 @@ module BSV
 
       # Multiply an arbitrary curve point by a secret scalar (constant-time).
       #
-      # Uses the Montgomery ladder to avoid timing side-channels on the
-      # scalar. Use for ECDH shared-secret derivation.
+      # Alias for {multiply_point} — retained for backward compatibility
+      # and expressiveness.
       #
       # @param point [OpenSSL::PKey::EC::Point] the base point
       # @param scalar_bn [OpenSSL::BN] the secret scalar multiplier
       # @return [OpenSSL::PKey::EC::Point] the resulting curve point
       def multiply_point_ct(point, scalar_bn)
-        point.mul_ct(scalar_bn)
+        point.mul(scalar_bn)
+      end
+
+      # Multiply an arbitrary curve point by a public scalar (variable-time, wNAF).
+      #
+      # Faster than {multiply_point} but leaks timing information about
+      # the scalar. Use only for public scalars (e.g. signature verification).
+      #
+      # @param point [OpenSSL::PKey::EC::Point] the point to multiply
+      # @param scalar_bn [OpenSSL::BN] the public scalar multiplier
+      # @return [OpenSSL::PKey::EC::Point] the resulting curve point
+      def multiply_point_vt(point, scalar_bn)
+        point.mul_vt(scalar_bn)
       end
 
       # Add two curve points together.

--- a/gem/bsv-sdk/lib/bsv/primitives/ecdsa.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/ecdsa.rb
@@ -82,8 +82,8 @@ module BSV
         u1 = ((n - e) * r_inv) % n
         u2 = (s * r_inv) % n
 
-        p1 = Curve.multiply_generator(u1)
-        p2 = Curve.multiply_point(r_point, u2)
+        p1 = Curve.multiply_generator_vt(u1)
+        p2 = Curve.multiply_point_vt(r_point, u2)
         q = Curve.add_points(p1, p2)
 
         raise ArgumentError, 'recovered point is at infinity' if q.infinity?
@@ -112,8 +112,8 @@ module BSV
         u2 = (r * s_inv) % n
 
         # R' = u1*G + u2*Q
-        point1 = Curve.multiply_generator(u1)
-        point2 = Curve.multiply_point(public_key_point, u2)
+        point1 = Curve.multiply_generator_vt(u1)
+        point2 = Curve.multiply_point_vt(public_key_point, u2)
         result_point = Curve.add_points(point1, point2)
 
         return false if result_point.infinity?

--- a/gem/bsv-sdk/lib/bsv/primitives/openssl_ec_shim.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/openssl_ec_shim.rb
@@ -73,12 +73,14 @@ class BSVShimECPoint
   #
   # Also supports the multi-scalar form: +mul(bns, points)+ computes
   # <tt>bns[0]*self + bns[1]*points[0] + ...</tt>
+  # where +bns.length == points.length + 1+.
   #
   # @overload mul(scalar_bn)
   #   @param scalar_bn [OpenSSL::BN, Integer] the scalar multiplier
   # @overload mul(bns, points)
-  #   @param bns [Array<OpenSSL::BN>] array of scalar multipliers
-  #   @param points [Array<BSVShimECPoint>] array of additional points
+  #   @param bns [Array<OpenSSL::BN>] scalars; must have +points.length + 1+ elements
+  #   @param points [Array<BSVShimECPoint>] additional points
+  #   @raise [NoMethodError] if +bns+ and +points+ lengths are mismatched
   # @return [BSVShimECPoint]
   def mul(*args)
     if args.length == 1

--- a/gem/bsv-sdk/lib/bsv/primitives/openssl_ec_shim.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/openssl_ec_shim.rb
@@ -66,6 +66,20 @@ class BSVShimECPoint
     pt
   end
 
+  # Scalar multiplication: self * scalar (constant-time, Montgomery ladder).
+  #
+  # Matches OpenSSL convention where +EC_POINT_mul+ is always constant-time.
+  # Safe for both secret and public scalars.
+  #
+  # Also supports the multi-scalar form: +mul(bns, points)+ computes
+  # <tt>bns[0]*self + bns[1]*points[0] + ...</tt>
+  #
+  # @overload mul(scalar_bn)
+  #   @param scalar_bn [OpenSSL::BN, Integer] the scalar multiplier
+  # @overload mul(bns, points)
+  #   @param bns [Array<OpenSSL::BN>] array of scalar multipliers
+  #   @param points [Array<BSVShimECPoint>] array of additional points
+  # @return [BSVShimECPoint]
   def mul(*args)
     if args.length == 1
       scalar = bn_to_int(args[0])
@@ -85,16 +99,27 @@ class BSVShimECPoint
     end
   end
 
-  # Constant-time scalar multiplication via the Montgomery ladder.
+  # Constant-time scalar multiplication (alias for {#mul}).
   #
-  # Delegates to {BSV::Primitives::Secp256k1::Point#mul_ct} to ensure
-  # secret-scalar paths execute in constant time.
+  # Retained for backward compatibility and expressiveness. Delegates
+  # to {#mul}, which is constant-time by default.
   #
-  # @param scalar_bn [OpenSSL::BN, Integer] the secret scalar
+  # @param scalar_bn [OpenSSL::BN, Integer] the scalar multiplier
   # @return [BSVShimECPoint]
   def mul_ct(scalar_bn)
+    mul(scalar_bn)
+  end
+
+  # Variable-time scalar multiplication (wNAF).
+  #
+  # Faster than {#mul} but leaks timing information about the scalar.
+  # Use only for public scalars (e.g. signature verification).
+  #
+  # @param scalar_bn [OpenSSL::BN, Integer] the public scalar multiplier
+  # @return [BSVShimECPoint]
+  def mul_vt(scalar_bn)
     scalar = bn_to_int(scalar_bn)
-    result = @secp_point.mul_ct(scalar)
+    result = @secp_point.mul_vt(scalar)
     self.class.from_secp_point(@group, result)
   end
 

--- a/gem/bsv-sdk/lib/bsv/primitives/schnorr.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/schnorr.rb
@@ -97,15 +97,15 @@ module BSV
         e = compute_challenge(public_key_a, public_key_b, shared_secret, proof.s_prime, proof.r)
 
         # Equation 1: z·G == R + e·A
-        z_g = Curve.multiply_generator(proof.z)
-        e_a = Curve.multiply_point(public_key_a.point, e)
+        z_g = Curve.multiply_generator_vt(proof.z)
+        e_a = Curve.multiply_point_vt(public_key_a.point, e)
         r_plus_ea = Curve.add_points(proof.r.point, e_a)
 
         return false unless points_equal?(z_g, r_plus_ea)
 
         # Equation 2: z·B == S' + e·S
-        z_b = Curve.multiply_point(public_key_b.point, proof.z)
-        e_s = Curve.multiply_point(shared_secret.point, e)
+        z_b = Curve.multiply_point_vt(public_key_b.point, proof.z)
+        e_s = Curve.multiply_point_vt(shared_secret.point, e)
         sp_plus_es = Curve.add_points(proof.s_prime.point, e_s)
 
         points_equal?(z_b, sp_plus_es)

--- a/gem/bsv-sdk/spec/bsv/primitives/curve_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/primitives/curve_spec.rb
@@ -89,16 +89,14 @@ RSpec.describe BSV::Primitives::Curve do
   end
 
   describe '.multiply_generator_ct' do
-    it 'produces the same result as multiply_generator (constant-time path)' do
-      # 2G via constant-time must equal 2G via variable-time
+    it 'produces the same result as multiply_generator (both are CT)' do
       scalar = OpenSSL::BN.new('2', 10)
-      vt = described_class.multiply_generator(scalar)
+      default = described_class.multiply_generator(scalar)
       ct = described_class.multiply_generator_ct(scalar)
-      expect(ct.to_bn(:compressed).to_s(16)).to eq(vt.to_bn(:compressed).to_s(16))
+      expect(ct.to_bn(:compressed).to_s(16)).to eq(default.to_bn(:compressed).to_s(16))
     end
 
-    it 'matches a well-known point for a random scalar' do
-      # k = 7, expected = 7G
+    it 'matches a well-known point' do
       scalar = OpenSSL::BN.new('7', 10)
       expected = described_class.multiply_generator(scalar)
       result = described_class.multiply_generator_ct(scalar)
@@ -106,13 +104,39 @@ RSpec.describe BSV::Primitives::Curve do
     end
   end
 
+  describe '.multiply_generator_vt' do
+    it 'produces the same result as multiply_generator' do
+      scalar = OpenSSL::BN.new('2', 10)
+      default = described_class.multiply_generator(scalar)
+      vt = described_class.multiply_generator_vt(scalar)
+      expect(vt.to_bn(:compressed).to_s(16)).to eq(default.to_bn(:compressed).to_s(16))
+    end
+
+    it 'matches a well-known point' do
+      scalar = OpenSSL::BN.new('7', 10)
+      expected = described_class.multiply_generator(scalar)
+      result = described_class.multiply_generator_vt(scalar)
+      expect(result.to_bn(:compressed).to_s(16)).to eq(expected.to_bn(:compressed).to_s(16))
+    end
+  end
+
   describe '.multiply_point_ct' do
-    it 'produces the same result as multiply_point (constant-time path)' do
+    it 'produces the same result as multiply_point (both are CT)' do
       p2 = described_class.multiply_generator(OpenSSL::BN.new('2', 10))
       scalar = OpenSSL::BN.new('5', 10)
-      vt = described_class.multiply_point(p2, scalar)
+      default = described_class.multiply_point(p2, scalar)
       ct = described_class.multiply_point_ct(p2, scalar)
-      expect(ct.to_bn(:compressed).to_s(16)).to eq(vt.to_bn(:compressed).to_s(16))
+      expect(ct.to_bn(:compressed).to_s(16)).to eq(default.to_bn(:compressed).to_s(16))
+    end
+  end
+
+  describe '.multiply_point_vt' do
+    it 'produces the same result as multiply_point' do
+      p2 = described_class.multiply_generator(OpenSSL::BN.new('2', 10))
+      scalar = OpenSSL::BN.new('5', 10)
+      default = described_class.multiply_point(p2, scalar)
+      vt = described_class.multiply_point_vt(p2, scalar)
+      expect(vt.to_bn(:compressed).to_s(16)).to eq(default.to_bn(:compressed).to_s(16))
     end
   end
 end

--- a/gem/bsv-sdk/spec/bsv/primitives/secp256k1_compliance_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/primitives/secp256k1_compliance_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe 'secp256k1 compliance' do
       end
     end
 
-    context 'mul_ct matches mul for known multiples' do
+    context 'mul_ct (alias) matches mul for known multiples' do
       [1, 2, 3, 5, 7].each do |k|
         it "mul_ct(#{k}) == mul(#{k})" do
           expect(g.mul_ct(k)).to eq(g.mul(k))
@@ -257,6 +257,19 @@ RSpec.describe 'secp256k1 compliance' do
       it 'mul_ct(N-1) == mul(N-1)' do
         curve_n = BSV::Primitives::Secp256k1::N
         expect(g.mul_ct(curve_n - 1)).to eq(g.mul(curve_n - 1))
+      end
+    end
+
+    context 'mul_vt matches mul for known multiples' do
+      [1, 2, 3, 5, 7].each do |k|
+        it "mul_vt(#{k}) == mul(#{k})" do
+          expect(g.mul_vt(k)).to eq(g.mul(k))
+        end
+      end
+
+      it 'mul_vt(N-1) == mul(N-1)' do
+        curve_n = BSV::Primitives::Secp256k1::N
+        expect(g.mul_vt(curve_n - 1)).to eq(g.mul(curve_n - 1))
       end
     end
 

--- a/gem/bsv-sdk/spec/bsv/primitives/secp256k1_native_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/primitives/secp256k1_native_spec.rb
@@ -565,15 +565,24 @@ RSpec.describe 'BSV::Primitives::Secp256k1Native' do
   end
 
   describe 'Jacobian cross-validation: scalar multiply results via C point ops' do
-    # For each scalar k, verify that the Ruby scalar multiply (which delegates
-    # to jp_double/jp_add — C versions after native loading) produces the
-    # same affine point as the known pure-Ruby wNAF result.
+    # For each scalar k, verify that both mul (CT) and mul_vt (wNAF) produce
+    # the same affine point as the known pure-Ruby wNAF reference.
     [1, 2, 3, 7, 0xDEADBEEF].each do |k|
-      it "k=#{k}: scalar multiply produces correct affine point" do
+      it "k=#{k}: mul (CT) produces correct affine point" do
         ruby_jac = BSV::Primitives::Secp256k1.scalar_multiply_wnaf(k, gx, gy)
         affine   = BSV::Primitives::Secp256k1.jp_to_affine(ruby_jac)
         g        = BSV::Primitives::Secp256k1::Point.generator
         result   = g.mul(k)
+        expect(result.on_curve?).to be true
+        expect(result.x).to eq(affine[0])
+        expect(result.y).to eq(affine[1])
+      end
+
+      it "k=#{k}: mul_vt (wNAF) produces correct affine point" do
+        ruby_jac = BSV::Primitives::Secp256k1.scalar_multiply_wnaf(k, gx, gy)
+        affine   = BSV::Primitives::Secp256k1.jp_to_affine(ruby_jac)
+        g        = BSV::Primitives::Secp256k1::Point.generator
+        result   = g.mul_vt(k)
         expect(result.on_curve?).to be true
         expect(result.x).to eq(affine[0])
         expect(result.y).to eq(affine[1])
@@ -679,7 +688,7 @@ RSpec.describe 'BSV::Primitives::Secp256k1Native' do
       end
     end
 
-    it 'native delegation does not break scalar multiply via wNAF' do
+    it 'native delegation does not break mul (constant-time default)' do
       g      = BSV::Primitives::Secp256k1::Point.generator
       result = g.mul(5)
       expect(result.on_curve?).to be true
@@ -687,7 +696,15 @@ RSpec.describe 'BSV::Primitives::Secp256k1Native' do
       expect(result.y).to eq(SECP256K1_FIVE_G_Y)
     end
 
-    it 'native delegation does not break constant-time scalar multiply' do
+    it 'native delegation does not break mul_vt (variable-time wNAF)' do
+      g      = BSV::Primitives::Secp256k1::Point.generator
+      result = g.mul_vt(5)
+      expect(result.on_curve?).to be true
+      expect(result.x).to eq(SECP256K1_FIVE_G_X)
+      expect(result.y).to eq(SECP256K1_FIVE_G_Y)
+    end
+
+    it 'native delegation does not break mul_ct (alias for mul)' do
       g      = BSV::Primitives::Secp256k1::Point.generator
       result = g.mul_ct(3)
       expect(result.on_curve?).to be true

--- a/gem/bsv-sdk/spec/bsv/primitives/secp256k1_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/primitives/secp256k1_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe BSV::Primitives::Secp256k1 do
       end
     end
 
-    describe '#mul' do
+    describe '#mul (constant-time, Montgomery ladder)' do
       let(:g) { described_class.generator }
 
       it '1 * G = G' do
@@ -271,7 +271,6 @@ RSpec.describe BSV::Primitives::Secp256k1 do
       end
 
       it 'produces known 2*G coordinates' do
-        # Known 2*G for secp256k1
         two_g = g.mul(2)
         expect(two_g.x).to eq(0xC6047F9441ED7D6D3045406E95C07CD85C778E4B8CEF3CA7ABAC09B95C709EE5)
         expect(two_g.y).to eq(0x1AE168FEA63DC339A3C58419466CEAEEF7F632653266D0E1236431A950CFE52A)
@@ -293,7 +292,7 @@ RSpec.describe BSV::Primitives::Secp256k1 do
       end
     end
 
-    describe '#mul_ct (Montgomery ladder, constant-time)' do
+    describe '#mul_ct (alias for #mul)' do
       let(:g) { described_class.generator }
 
       it 'produces the same result as mul for scalar 1' do
@@ -334,12 +333,66 @@ RSpec.describe BSV::Primitives::Secp256k1 do
         expect(result.on_curve?).to be true
       end
 
-      it 'matches wNAF for the secp256k1 generator with scalar N-1' do
-        # This tests the edge case of the largest valid scalar
+      it 'matches mul for the secp256k1 generator with scalar N-1' do
         k = s::N - 1
         ct = g.mul_ct(k)
         vt = g.mul(k)
         expect(ct).to eq(vt)
+      end
+    end
+
+    describe '#mul_vt (variable-time, wNAF)' do
+      let(:g) { described_class.generator }
+
+      it '1 * G = G' do
+        expect(g.mul_vt(1)).to eq(g)
+      end
+
+      it '2 * G matches G + G' do
+        two_g = g.mul_vt(2)
+        g_plus_g = g.add(g)
+        expect(two_g).to eq(g_plus_g)
+      end
+
+      it '0 * G = infinity' do
+        expect(g.mul_vt(0).infinity?).to be true
+      end
+
+      it 'N * G = infinity' do
+        expect(g.mul_vt(s::N).infinity?).to be true
+      end
+
+      it '(N - 1) * G = -G' do
+        result = g.mul_vt(s::N - 1)
+        expect(result.x).to eq(g.x)
+        expect(result.y).to eq(s.fneg(g.y))
+      end
+
+      it 'produces known 2*G coordinates' do
+        two_g = g.mul_vt(2)
+        expect(two_g.x).to eq(0xC6047F9441ED7D6D3045406E95C07CD85C778E4B8CEF3CA7ABAC09B95C709EE5)
+        expect(two_g.y).to eq(0x1AE168FEA63DC339A3C58419466CEAEEF7F632653266D0E1236431A950CFE52A)
+      end
+
+      it 'produces known 3*G coordinates' do
+        three_g = g.mul_vt(3)
+        expect(three_g.x).to eq(0xF9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9)
+        expect(three_g.y).to eq(0x388F7B0F632DE8140FE337E62A37F3566500A99934C2231B6CB9FD7584B8E672)
+      end
+
+      it 'produces result on the curve' do
+        result = g.mul_vt(0xDEADBEEF)
+        expect(result.on_curve?).to be true
+      end
+
+      it 'infinity * scalar = infinity' do
+        expect(described_class.infinity.mul_vt(42).infinity?).to be true
+      end
+
+      it 'matches mul (CT) for several scalars' do
+        [1, 2, 3, 7, 0xDEADBEEFCAFEBABE, s::N - 1].each do |k|
+          expect(g.mul_vt(k)).to eq(g.mul(k)), "mismatch for k=#{k}"
+        end
       end
     end
 

--- a/gem/bsv-sdk/spec/bsv/primitives/secp256k1_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/primitives/secp256k1_spec.rb
@@ -336,8 +336,8 @@ RSpec.describe BSV::Primitives::Secp256k1 do
       it 'matches mul for the secp256k1 generator with scalar N-1' do
         k = s::N - 1
         ct = g.mul_ct(k)
-        vt = g.mul(k)
-        expect(ct).to eq(vt)
+        default = g.mul(k)
+        expect(ct).to eq(default)
       end
     end
 


### PR DESCRIPTION
## Summary

- Aligns with OpenSSL convention where `EC_POINT_mul` is always constant-time
- `mul` is now CT (Montgomery ladder) — safe default
- `mul_vt` is the new explicit opt-in for variable-time wNAF (public scalars)
- `mul_ct` retained as alias for backward compatibility
- ECDSA verify/recover and Schnorr verify switched to `_vt` (public scalars, performance)
- Fixes timing side-channel in Schnorr `generate_proof` where a secret nonce was multiplied using variable-time arithmetic
- Switches `secp256k1-native` from git source to released gem v0.16.0

Closes #653

## Test plan

- [x] All 4619 existing specs pass (0 failures)
- [x] New `mul_vt` tests added across secp256k1_spec, compliance spec, native spec
- [x] New `multiply_generator_vt` / `multiply_point_vt` Curve tests added
- [x] ECDSA sign/verify round-trip verified
- [x] Schnorr proof generate/verify round-trip verified
- [x] BIP-32 key derivation verified (no-change files use `_ct` alias)

🤖 Generated with [Claude Code](https://claude.com/claude-code)