### PR TITLE
feat(transaction): add wtxid and enforce wire-order throughout Beef (#666)

### DIFF
--- a/gem/bsv-sdk/lib/bsv/transaction/beef.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef.rb
@@ -66,13 +66,15 @@ module BSV
 
         # The transaction ID for this entry.
         #
-        # @return [String, nil] 32-byte txid in display byte order
-        def txid
+        # @param wire [Boolean] when +true+, returns wire byte order; default +false+ (display order).
+        #   Ignored for FORMAT_TXID_ONLY entries — the stored txid is returned as-is.
+        # @return [String, nil] 32-byte txid
+        def txid(wire: false)
           case @format
           when FORMAT_TXID_ONLY
             @known_txid
           else
-            @transaction&.txid
+            @transaction&.txid(wire: wire)
           end
         end
       end

--- a/gem/bsv-sdk/lib/bsv/transaction/beef.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef.rb
@@ -91,8 +91,14 @@ module BSV
       # @return [Array<BeefTx>] the transactions in dependency order
       attr_reader :transactions
 
-      # @return [String, nil] 32-byte subject txid (Atomic BEEF only)
-      attr_reader :subject_txid
+      # @return [String, nil] 32-byte wire-order subject txid (Atomic BEEF only)
+      attr_reader :subject_wtxid
+
+      # Display-order subject txid (Atomic BEEF only).
+      # @return [String, nil] 32-byte display-order txid, or nil
+      def subject_txid
+        @subject_wtxid&.reverse
+      end
 
       # @param version [Integer] BEEF version constant (default: BEEF_V1, matching to_binary's
       #   default for ARC compatibility; from_binary overwrites this with the parsed version)
@@ -102,7 +108,7 @@ module BSV
         @version = version
         @bumps = bumps
         @transactions = transactions
-        @subject_txid = nil
+        @subject_wtxid = nil
       end
 
       # --- Deserialisation ---
@@ -138,9 +144,9 @@ module BSV
             raise ArgumentError, "truncated Atomic BEEF: need 36 bytes at offset #{offset}, got #{remaining}"
           end
 
-          # Atomic BEEF stores the subject txid in internal byte order (little-endian
-          # hash order), matching JS and Go SDKs. Reverse to display order for internal use.
-          beef.instance_variable_set(:@subject_txid, data.byteslice(offset, 32).reverse)
+          # Atomic BEEF stores the subject txid in wire (internal / little-endian) byte order,
+          # matching JS and Go SDKs. Store as-is in @subject_wtxid (wire-order).
+          beef.instance_variable_set(:@subject_wtxid, data.byteslice(offset, 32))
           offset += 32
           inner_version = data.byteslice(offset, 4).unpack1('V')
           offset += 4
@@ -228,13 +234,12 @@ module BSV
 
       # Serialise as Atomic BEEF (BRC-95), wrapping V2 data with a subject txid.
       #
-      # @param subject_txid [String] 32-byte subject transaction ID
+      # @param subject_wtxid [String] 32-byte wire-order subject transaction ID
       # @return [String] raw Atomic BEEF binary
-      def to_atomic_binary(subject_txid)
+      def to_atomic_binary(subject_wtxid)
         buf = [ATOMIC_BEEF].pack('V')
-        # Write subject txid in internal byte order (reverse of display order),
-        # matching JS and Go SDK conventions for Bitcoin binary formats.
-        buf << subject_txid.b.reverse
+        # subject_wtxid is already in wire (internal) byte order — write as-is.
+        buf << subject_wtxid.b
         # BRC-95: inner envelope is always V2
         buf << to_binary(version: BEEF_V2)
         buf
@@ -242,42 +247,41 @@ module BSV
 
       # --- Lookup ---
 
-      # Find a transaction in the bundle by its transaction ID.
+      # Find a transaction in the bundle by its wire-order transaction ID.
       #
-      # @param txid [String] 32-byte txid in display byte order
+      # @param wtxid [String] 32-byte wire-order wtxid
       # @return [Transaction, nil] the matching transaction, or nil
-      def find_transaction(txid)
+      def find_transaction(wtxid)
         @transactions.each do |beef_tx|
-          return beef_tx.transaction if beef_tx.transaction&.txid == txid
+          return beef_tx.transaction if beef_tx.wtxid == wtxid
         end
         nil
       end
 
-      # Find the merkle path (BUMP) for a transaction by its txid.
+      # Find the merkle path (BUMP) for a transaction by its wire-order txid.
       #
       # First checks the transaction-table entries, then scans @bumps directly
-      # for a BUMP whose level-0 leaves contain the txid.
+      # for a BUMP whose level-0 leaves contain the wtxid.
       #
-      # @param txid [String] 32-byte txid in display byte order
+      # @param wtxid [String] 32-byte wire-order wtxid
       # @return [MerklePath, nil] the merkle path, or nil if not found
-      def find_bump(txid)
+      def find_bump(wtxid)
         # Check transaction-table entries first (fast path)
-        bt = @transactions.find { |entry| entry.txid == txid && entry.format == FORMAT_RAW_TX_AND_BUMP }
+        bt = @transactions.find { |entry| entry.wtxid == wtxid && entry.format == FORMAT_RAW_TX_AND_BUMP }
         return bt.transaction&.merkle_path || (bt.bump_index && @bumps[bt.bump_index]) if bt
 
-        # F5.8: also scan @bumps directly for a path containing the txid leaf
-        txid_internal = txid.reverse
+        # F5.8: also scan @bumps directly for a path containing the wtxid leaf
         @bumps.find do |bump|
-          bump.path[0]&.any? { |leaf| leaf.hash == txid_internal }
+          bump.path[0]&.any? { |leaf| leaf.hash == wtxid }
         end
       end
 
       # Find a transaction with all source_transactions wired for signing.
       #
-      # @param txid [String] 32-byte txid in display byte order
+      # @param wtxid [String] 32-byte wire-order wtxid
       # @return [Transaction, nil] the transaction with wired inputs, or nil
-      def find_transaction_for_signing(txid)
-        tx = find_transaction(txid)
+      def find_transaction_for_signing(wtxid)
+        tx = find_transaction(wtxid)
         return unless tx
 
         wire_inputs(tx)
@@ -287,10 +291,10 @@ module BSV
       # Find a transaction and recursively wire its ancestry (source transactions
       # and merkle paths) for atomic proof validation.
       #
-      # @param txid [String] 32-byte txid in display byte order
+      # @param wtxid [String] 32-byte wire-order wtxid
       # @return [Transaction, nil] the transaction with full proof tree, or nil
-      def find_atomic_transaction(txid)
-        tx = find_transaction(txid)
+      def find_atomic_transaction(wtxid)
+        tx = find_transaction(wtxid)
         return unless tx
 
         wire_ancestry(tx)
@@ -299,10 +303,10 @@ module BSV
 
       # Serialise as Atomic BEEF (BRC-95) hex string.
       #
-      # @param subject_txid [String] 32-byte subject transaction ID
+      # @param subject_wtxid [String] 32-byte wire-order subject transaction ID
       # @return [String] hex-encoded Atomic BEEF
-      def to_atomic_hex(subject_txid)
-        to_atomic_binary(subject_txid).unpack1('H*')
+      def to_atomic_hex(subject_wtxid)
+        to_atomic_binary(subject_wtxid).unpack1('H*')
       end
 
       # --- Merge operations ---
@@ -367,10 +371,10 @@ module BSV
       # @param tx [Transaction] the transaction to merge
       # @return [BeefTx] the (possibly existing or upgraded) BeefTx entry
       def merge_transaction(tx)
-        txid = tx.txid
+        wtxid = tx.wtxid
 
         # Check for existing entry and upgrade if a stronger format is available
-        existing_idx = @transactions.index { |bt| bt.txid == txid }
+        existing_idx = @transactions.index { |bt| bt.wtxid == wtxid }
         if existing_idx
           existing = @transactions[existing_idx]
           upgraded = upgrade_beef_tx(existing, tx)
@@ -414,7 +418,7 @@ module BSV
           tx.merkle_path = @bumps[bump_index]
         end
 
-        existing_idx = @transactions.index { |bt| bt.txid == tx.txid }
+        existing_idx = @transactions.index { |bt| bt.wtxid == tx.wtxid }
         if existing_idx
           existing = @transactions[existing_idx]
           upgraded = upgrade_beef_tx(existing, tx, bump_index: bump_index)
@@ -457,7 +461,7 @@ module BSV
 
             @transactions << BeefTx.new(format: FORMAT_TXID_ONLY, known_wtxid: beef_tx.known_wtxid)
           else
-            next if @transactions.any? { |bt| bt.txid == beef_tx.txid }
+            next if @transactions.any? { |bt| bt.wtxid == beef_tx.wtxid }
 
             if beef_tx.format == FORMAT_RAW_TX_AND_BUMP && beef_tx.bump_index
               new_idx = bump_remap[beef_tx.bump_index]
@@ -487,13 +491,13 @@ module BSV
 
       # Convert a transaction entry to TXID-only format.
       #
-      # @param txid [String] 32-byte txid in display byte order
+      # @param wtxid [String] 32-byte wire-order wtxid
       # @return [BeefTx, nil] the converted entry, or nil if not found
-      def make_txid_only(txid)
-        idx = @transactions.index { |bt| bt.txid == txid }
+      def make_txid_only(wtxid)
+        idx = @transactions.index { |bt| bt.wtxid == wtxid }
         return unless idx
 
-        @transactions[idx] = BeefTx.new(format: FORMAT_TXID_ONLY, known_wtxid: txid.reverse)
+        @transactions[idx] = BeefTx.new(format: FORMAT_TXID_ONLY, known_wtxid: wtxid)
       end
 
       # --- Validation ---
@@ -531,9 +535,9 @@ module BSV
           end
         end
 
-        known_txids = build_known_txids(allow_txid_only)
+        known_wtxids = build_known_wtxids(allow_txid_only)
 
-        pending = @transactions.select { |bt| bt.transaction && !known_txids.include?(bt.txid) }
+        pending = @transactions.select { |bt| bt.transaction && !known_wtxids.include?(bt.wtxid) }
 
         # Iteratively resolve: if all inputs of a tx are known, it becomes known
         changed = true
@@ -541,10 +545,10 @@ module BSV
           changed = false
           pending.reject! do |bt|
             all_inputs_known = bt.transaction.inputs.all? do |input|
-              known_txids.include?(input.prev_tx_id.reverse)
+              known_wtxids.include?(input.prev_tx_id)
             end
             if all_inputs_known
-              known_txids.add(bt.txid)
+              known_wtxids.add(bt.wtxid)
               changed = true
             end
             all_inputs_known
@@ -590,7 +594,7 @@ module BSV
         return self if @transactions.length <= 1
 
         txid_index = {}
-        @transactions.each_with_index { |bt, i| txid_index[bt.txid] = i }
+        @transactions.each_with_index { |bt, i| txid_index[bt.wtxid] = i }
 
         # Build adjacency: for each tx, which other txs must come before it?
         in_degree = Array.new(@transactions.length, 0)
@@ -600,7 +604,7 @@ module BSV
           next unless bt.transaction
 
           bt.transaction.inputs.each do |input|
-            dep_idx = txid_index[input.prev_tx_id.reverse]
+            dep_idx = txid_index[input.prev_tx_id]
             next unless dep_idx
 
             dependents[dep_idx] << i
@@ -623,8 +627,8 @@ module BSV
 
         # F5.5: preserve unsortable (cyclic) transactions rather than silently dropping them
         if sorted.length < @transactions.length
-          sorted_set = sorted.to_set(&:txid)
-          @txs_not_valid = @transactions.reject { |bt| sorted_set.include?(bt.txid) }
+          sorted_set = sorted.to_set(&:wtxid)
+          @txs_not_valid = @transactions.reject { |bt| sorted_set.include?(bt.wtxid) }
         end
 
         @transactions = sorted
@@ -723,14 +727,14 @@ module BSV
           beef.transactions.each do |beef_tx|
             next unless beef_tx.transaction
 
-            # Wire inputs to ancestors already in the map (BEEF is dependency-ordered)
+            # Wire inputs to ancestors already in the map (BEEF is dependency-ordered).
+            # Both prev_tx_id and wtxid are wire-order — no conversion needed.
             beef_tx.transaction.inputs.each do |input|
-              # prev_tx_id is wire byte order; txid keys are display byte order (reversed)
-              source = tx_map[input.prev_tx_id.reverse]
+              source = tx_map[input.prev_tx_id]
               input.source_transaction = source if source
             end
 
-            tx_map[beef_tx.transaction.txid] = beef_tx.transaction
+            tx_map[beef_tx.transaction.wtxid] = beef_tx.transaction
           end
         end
       end
@@ -772,15 +776,15 @@ module BSV
         # FORMAT_RAW_TX_AND_BUMP is already the strongest — no upgrade needed
       end
 
-      # Build a set of txids that are "known" (proven or txid-only).
-      def build_known_txids(allow_txid_only)
+      # Build a set of wire-order wtxids that are "known" (proven or txid-only).
+      def build_known_wtxids(allow_txid_only)
         known = Set.new
         @transactions.each do |bt|
           case bt.format
           when FORMAT_RAW_TX_AND_BUMP
-            known.add(bt.txid)
+            known.add(bt.wtxid)
           when FORMAT_TXID_ONLY
-            known.add(bt.txid) if allow_txid_only
+            known.add(bt.wtxid) if allow_txid_only
           end
         end
         known
@@ -791,7 +795,7 @@ module BSV
         tx.inputs.each do |input|
           next if input.source_transaction
 
-          source = find_transaction(input.prev_tx_id.reverse)
+          source = find_transaction(input.prev_tx_id)
           input.source_transaction = source if source
         end
       end
@@ -803,7 +807,7 @@ module BSV
           next unless input.source_transaction
 
           source = input.source_transaction
-          source.merkle_path ||= find_bump(source.txid)
+          source.merkle_path ||= find_bump(source.wtxid)
           wire_ancestry(source)
         end
       end

--- a/gem/bsv-sdk/lib/bsv/transaction/beef.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef.rb
@@ -341,7 +341,7 @@ module BSV
         level0_internal = level0_leaves.map(&:hash).compact.to_set
         @transactions.each_with_index do |bt, i|
           next unless bt.format == FORMAT_RAW_TX && bt.transaction
-          next unless level0_internal.include?(bt.transaction.txid.reverse)
+          next unless level0_internal.include?(bt.transaction.txid(wire: true))
 
           bt.transaction.merkle_path ||= bump
           @transactions[i] = BeefTx.new(
@@ -522,7 +522,7 @@ module BSV
 
           # The txid must appear as a leaf in the BUMP and compute a valid root
           begin
-            bump.compute_root(bt.transaction.txid.reverse)
+            bump.compute_root(bt.transaction.txid(wire: true))
           rescue ArgumentError
             return false
           end

--- a/gem/bsv-sdk/lib/bsv/transaction/beef.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef.rb
@@ -44,38 +44,41 @@ module BSV
         # @return [Transaction, nil] the transaction (nil for TXID-only entries)
         attr_reader :transaction
 
-        # @return [String, nil] 32-byte txid for TXID-only entries
-        attr_reader :known_txid
+        # @return [String, nil] 32-byte wire-order wtxid for TXID-only entries
+        attr_reader :known_wtxid
 
         # @return [Integer, nil] index into the BEEF bumps array
         attr_reader :bump_index
 
         # @param format [Integer] format flag
         # @param transaction [Transaction, nil] the transaction
-        # @param known_txid [String, nil] 32-byte txid for TXID-only entries
+        # @param known_wtxid [String, nil] 32-byte wire-order wtxid for TXID-only entries
         # @param bump_index [Integer, nil] index into the bumps array
         # @raise [ArgumentError] if format is FORMAT_RAW_TX_AND_BUMP without a bump_index
-        def initialize(format:, transaction: nil, known_txid: nil, bump_index: nil)
+        def initialize(format:, transaction: nil, known_wtxid: nil, bump_index: nil)
           raise ArgumentError, 'FORMAT_RAW_TX_AND_BUMP requires a bump_index' if format == FORMAT_RAW_TX_AND_BUMP && bump_index.nil?
 
           @format = format
           @transaction = transaction
-          @known_txid = known_txid
+          @known_wtxid = known_wtxid
           @bump_index = bump_index
         end
 
-        # The transaction ID for this entry.
-        #
-        # @param wire [Boolean] when +true+, returns wire byte order; default +false+ (display order).
-        #   Ignored for FORMAT_TXID_ONLY entries — the stored txid is returned as-is.
-        # @return [String, nil] 32-byte txid
-        def txid(wire: false)
+        # Wire-order transaction ID.
+        # @return [String, nil] 32-byte wtxid
+        def wtxid
           case @format
           when FORMAT_TXID_ONLY
-            @known_txid
+            @known_wtxid
           else
-            @transaction&.txid(wire: wire)
+            @transaction&.wtxid
           end
+        end
+
+        # Display-order transaction ID.
+        # @return [String, nil] 32-byte txid
+        def txid
+          wtxid&.reverse
         end
       end
 
@@ -341,7 +344,7 @@ module BSV
         level0_internal = level0_leaves.map(&:hash).compact.to_set
         @transactions.each_with_index do |bt, i|
           next unless bt.format == FORMAT_RAW_TX && bt.transaction
-          next unless level0_internal.include?(bt.transaction.txid(wire: true))
+          next unless level0_internal.include?(bt.transaction.wtxid)
 
           bt.transaction.merkle_path ||= bump
           @transactions[i] = BeefTx.new(
@@ -450,9 +453,9 @@ module BSV
         other.transactions.each do |beef_tx|
           case beef_tx.format
           when FORMAT_TXID_ONLY
-            next if @transactions.any? { |bt| bt.txid == beef_tx.known_txid }
+            next if @transactions.any? { |bt| bt.wtxid == beef_tx.known_wtxid }
 
-            @transactions << BeefTx.new(format: FORMAT_TXID_ONLY, known_txid: beef_tx.known_txid)
+            @transactions << BeefTx.new(format: FORMAT_TXID_ONLY, known_wtxid: beef_tx.known_wtxid)
           else
             next if @transactions.any? { |bt| bt.txid == beef_tx.txid }
 
@@ -490,7 +493,7 @@ module BSV
         idx = @transactions.index { |bt| bt.txid == txid }
         return unless idx
 
-        @transactions[idx] = BeefTx.new(format: FORMAT_TXID_ONLY, known_txid: txid)
+        @transactions[idx] = BeefTx.new(format: FORMAT_TXID_ONLY, known_wtxid: txid.reverse)
       end
 
       # --- Validation ---
@@ -522,7 +525,7 @@ module BSV
 
           # The txid must appear as a leaf in the BUMP and compute a valid root
           begin
-            bump.compute_root(bt.transaction.txid(wire: true))
+            bump.compute_root(bt.transaction.wtxid)
           rescue ArgumentError
             return false
           end
@@ -663,14 +666,13 @@ module BSV
 
             case format
             when FORMAT_TXID_ONLY
-              # Wire stores txid in internal (little-endian) byte order;
-              # reverse to display order so BeefTx#txid is consistent with
-              # Transaction#txid across all format types.
+              # Wire stores txid in internal (little-endian / wire) byte order;
+              # store as-is in known_wtxid so it matches Transaction#wtxid.
               raise ArgumentError, 'truncated BEEF: not enough bytes for TXID_ONLY entry' if offset + 32 > data.bytesize
 
-              known_txid = data.byteslice(offset, 32).reverse
+              known_wtxid = data.byteslice(offset, 32)
               offset += 32
-              beef.transactions << BeefTx.new(format: FORMAT_TXID_ONLY, known_txid: known_txid)
+              beef.transactions << BeefTx.new(format: FORMAT_TXID_ONLY, known_wtxid: known_wtxid)
             when FORMAT_RAW_TX_AND_BUMP
               bump_index, vi_size = VarInt.decode(data, offset)
               offset += vi_size
@@ -822,8 +824,8 @@ module BSV
         case beef_tx.format
         when FORMAT_TXID_ONLY
           buf << [FORMAT_TXID_ONLY].pack('C')
-          # Reverse display-order txid back to wire (internal) byte order.
-          buf << beef_tx.known_txid.reverse
+          # known_wtxid is already wire (internal) byte order.
+          buf << beef_tx.known_wtxid
         when FORMAT_RAW_TX_AND_BUMP
           buf << [FORMAT_RAW_TX_AND_BUMP].pack('C')
           buf << VarInt.encode(beef_tx.bump_index)

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -370,11 +370,11 @@ module BSV
       #   or nil if the BEEF is empty or contains no raw transaction entries
       def self.from_beef(data)
         beef = Beef.from_binary(data)
-        subject_txid = beef.subject_txid ||
-                       beef.transactions.reverse.find(&:transaction)&.transaction&.txid
-        return nil unless subject_txid
+        subject_wtxid = beef.subject_wtxid ||
+                        beef.transactions.reverse.find(&:transaction)&.transaction&.wtxid
+        return nil unless subject_wtxid
 
-        beef.find_atomic_transaction(subject_txid)
+        beef.find_atomic_transaction(subject_wtxid)
       end
 
       # Parse a BEEF hex string and return the subject transaction.

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -388,17 +388,24 @@ module BSV
 
       # --- Transaction ID ---
 
-      # Compute the transaction ID (double-SHA-256 of the serialised tx).
+      # Wire-order transaction ID (raw SHA-256d of the serialised tx).
       #
-      # By default returns display byte order (reversed from the natural hash).
-      # Pass +wire: true+ to return wire byte order (natural SHA-256d hash),
-      # which matches {TransactionInput#prev_tx_id}.
+      # Used by BEEF, BUMPs, and merkle paths, which all work in wire byte order
+      # to match {TransactionInput#prev_tx_id}.
       #
-      # @param wire [Boolean] when +true+, returns wire byte order; default +false+ (display order)
-      # @return [String] 32-byte transaction ID
-      def txid(wire: false)
-        digest = BSV::Primitives::Digest.sha256d(to_binary)
-        wire ? digest : digest.reverse
+      # @return [String] 32-byte transaction ID in wire byte order
+      def wtxid
+        BSV::Primitives::Digest.sha256d(to_binary)
+      end
+
+      # Display-order transaction ID (reversed from the natural SHA-256d hash).
+      #
+      # This is the conventional human-readable representation used in block
+      # explorers, wallets, and all user-facing contexts.
+      #
+      # @return [String] 32-byte transaction ID in display byte order
+      def txid
+        wtxid.reverse
       end
 
       # The transaction ID as a hex string (display byte order).
@@ -888,7 +895,7 @@ module BSV
           merged = txs.first.merkle_path.dup
           txs.drop(1).each { |t| merged.combine(t.merkle_path) }
 
-          txid_hashes = txs.map { |t| t.txid(wire: true) }
+          txid_hashes = txs.map(&:wtxid)
           clean = merged.extract(txid_hashes)
 
           bump_index_by_height[height] = beef.bumps.length

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -388,15 +388,17 @@ module BSV
 
       # --- Transaction ID ---
 
-      # Compute the transaction ID (double-SHA-256 of the serialised tx, byte-reversed).
+      # Compute the transaction ID (double-SHA-256 of the serialised tx).
       #
-      # Returns display byte order (reversed from the natural hash).
-      # Compare with {TransactionInput#prev_tx_id} which stores wire byte
-      # order (natural hash). Use +.reverse+ to convert between the two.
+      # By default returns display byte order (reversed from the natural hash).
+      # Pass +wire: true+ to return wire byte order (natural SHA-256d hash),
+      # which matches {TransactionInput#prev_tx_id}.
       #
-      # @return [String] 32-byte transaction ID in display byte order
-      def txid
-        BSV::Primitives::Digest.sha256d(to_binary).reverse
+      # @param wire [Boolean] when +true+, returns wire byte order; default +false+ (display order)
+      # @return [String] 32-byte transaction ID
+      def txid(wire: false)
+        digest = BSV::Primitives::Digest.sha256d(to_binary)
+        wire ? digest : digest.reverse
       end
 
       # The transaction ID as a hex string (display byte order).

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -888,7 +888,7 @@ module BSV
           merged = txs.first.merkle_path.dup
           txs.drop(1).each { |t| merged.combine(t.merkle_path) }
 
-          txid_hashes = txs.map { |t| t.txid.reverse }
+          txid_hashes = txs.map { |t| t.txid(wire: true) }
           clean = merged.extract(txid_hashes)
 
           bump_index_by_height[height] = beef.bumps.length

--- a/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
@@ -378,13 +378,13 @@ RSpec.describe BSV::Transaction::Beef do
 
       # Build a child spending both
       child = BSV::Transaction::Transaction.new
-      input_a = BSV::Transaction::TransactionInput.new(prev_tx_id: ancestor_a.txid, prev_tx_out_index: 0)
+      input_a = BSV::Transaction::TransactionInput.new(prev_tx_id: ancestor_a.wtxid, prev_tx_out_index: 0)
       input_a.source_transaction = ancestor_a
       input_a.source_satoshis = 5000
       input_a.source_locking_script = lock
       child.add_input(input_a)
 
-      input_b = BSV::Transaction::TransactionInput.new(prev_tx_id: ancestor_b.txid, prev_tx_out_index: 0)
+      input_b = BSV::Transaction::TransactionInput.new(prev_tx_id: ancestor_b.wtxid, prev_tx_out_index: 0)
       input_b.source_transaction = ancestor_b
       input_b.source_satoshis = 3000
       input_b.source_locking_script = lock
@@ -483,10 +483,10 @@ RSpec.describe BSV::Transaction::Beef do
       tx_b.merkle_path = path_b
 
       child = BSV::Transaction::Transaction.new
-      input_a = BSV::Transaction::TransactionInput.new(prev_tx_id: tx_a.txid, prev_tx_out_index: 0)
+      input_a = BSV::Transaction::TransactionInput.new(prev_tx_id: tx_a.wtxid, prev_tx_out_index: 0)
       input_a.source_transaction = tx_a
       child.add_input(input_a)
-      input_b = BSV::Transaction::TransactionInput.new(prev_tx_id: tx_b.txid, prev_tx_out_index: 0)
+      input_b = BSV::Transaction::TransactionInput.new(prev_tx_id: tx_b.wtxid, prev_tx_out_index: 0)
       input_b.source_transaction = tx_b
       child.add_input(input_b)
       child.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 150, locking_script: lock))
@@ -637,7 +637,7 @@ RSpec.describe BSV::Transaction::Beef do
         tx_real.merkle_path = contaminated_bump
 
         c = BSV::Transaction::Transaction.new
-        input = BSV::Transaction::TransactionInput.new(prev_tx_id: tx_real.txid, prev_tx_out_index: 0)
+        input = BSV::Transaction::TransactionInput.new(prev_tx_id: tx_real.wtxid, prev_tx_out_index: 0)
         input.source_transaction = tx_real
         c.add_input(input)
         c.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 400, locking_script: lock))

--- a/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe BSV::Transaction::Beef do
       beef = described_class.new
       beef.transactions << described_class::BeefTx.new(
         format: described_class::FORMAT_TXID_ONLY,
-        known_txid: "\x01".b * 32
+        known_wtxid: "\x01".b * 32
       )
       beef
     end
@@ -216,7 +216,7 @@ RSpec.describe BSV::Transaction::Beef do
       parsed = described_class.from_binary(bytes)
       expect(parsed.transactions.length).to eq(1)
       expect(parsed.transactions.first.format).to eq(described_class::FORMAT_TXID_ONLY)
-      expect(parsed.transactions.first.known_txid).to eq("\x01".b * 32)
+      expect(parsed.transactions.first.known_wtxid).to eq("\x01".b * 32)
     end
 
     it 'V2 round-trip preserves the TXID-only entry' do
@@ -268,14 +268,14 @@ RSpec.describe BSV::Transaction::Beef do
   end
 
   describe '#find_transaction' do
-    it 'finds a transaction by txid' do
+    it 'finds a transaction by wtxid' do
       beef = described_class.from_hex(beef_set_hex)
       first_tx = beef.transactions.first.transaction
-      found = beef.find_transaction(first_tx.txid)
+      found = beef.find_transaction(first_tx.wtxid)
       expect(found).to eq(first_tx)
     end
 
-    it 'returns nil for unknown txid' do
+    it 'returns nil for unknown wtxid' do
       beef = described_class.from_hex(beef_set_hex)
       expect(beef.find_transaction("\x00".b * 32)).to be_nil
     end
@@ -285,22 +285,22 @@ RSpec.describe BSV::Transaction::Beef do
     it 'round-trips via to_atomic_binary and from_binary' do
       beef = described_class.from_hex(beef_set_hex)
       last_tx = beef.transactions.last.transaction
-      subject_txid = last_tx.txid
+      subject_wtxid = last_tx.wtxid
 
-      atomic_bytes = beef.to_atomic_binary(subject_txid)
+      atomic_bytes = beef.to_atomic_binary(subject_wtxid)
 
-      # Verify prefix and internal byte order (reversed from display order)
+      # Verify prefix and internal byte order (wire-order written directly)
       expect(atomic_bytes.byteslice(0, 4).unpack1('V')).to eq(described_class::ATOMIC_BEEF)
-      expect(atomic_bytes.byteslice(4, 32)).to eq(subject_txid.b.reverse)
+      expect(atomic_bytes.byteslice(4, 32)).to eq(subject_wtxid)
 
       # Parse back
       parsed = described_class.from_binary(atomic_bytes)
-      expect(parsed.subject_txid).to eq(subject_txid)
+      expect(parsed.subject_txid).to eq(last_tx.txid)
       expect(parsed.transactions.length).to eq(beef.transactions.length)
 
-      found = parsed.find_transaction(subject_txid)
+      found = parsed.find_transaction(subject_wtxid)
       expect(found).not_to be_nil
-      expect(found.txid).to eq(subject_txid)
+      expect(found.txid).to eq(last_tx.txid)
     end
   end
 
@@ -340,7 +340,7 @@ RSpec.describe BSV::Transaction::Beef do
       expect(rebuilt.transactions).not_to be_empty
 
       # The subject tx should be present
-      found = rebuilt.find_transaction(tx.txid)
+      found = rebuilt.find_transaction(tx.wtxid)
       expect(found).not_to be_nil
       expect(found.txid).to eq(tx.txid)
     end
@@ -445,7 +445,7 @@ RSpec.describe BSV::Transaction::Beef do
     let(:sibling0_hash) { BSV::Primitives::Digest.sha256('sibling_0') }
     let(:sibling3_hash) { BSV::Primitives::Digest.sha256('sibling_3') }
 
-    let(:leaf_hashes) { [sibling0_hash, tx_a.txid(wire: true), tx_b.txid(wire: true), sibling3_hash] }
+    let(:leaf_hashes) { [sibling0_hash, tx_a.wtxid, tx_b.wtxid, sibling3_hash] }
     let(:level1_hashes) do
       [
         mp_class.merkle_tree_parent(leaf_hashes[0], leaf_hashes[1]),
@@ -605,7 +605,7 @@ RSpec.describe BSV::Transaction::Beef do
       let(:phantom_sibling) { BSV::Primitives::Digest.sha256('sibling_leaf_3') }
 
       let(:leaf_hashes) do
-        [tx_real.txid(wire: true), tx_real_sibling, phantom_leaf, phantom_sibling]
+        [tx_real.wtxid, tx_real_sibling, phantom_leaf, phantom_sibling]
       end
       let(:level1_hashes) do
         [
@@ -657,7 +657,7 @@ RSpec.describe BSV::Transaction::Beef do
         bump = parsed.bumps[0]
         txid_leaves = bump.path[0].select(&:txid)
         expect(txid_leaves.length).to eq(1)
-        expect(txid_leaves[0].hash).to eq(tx_real.txid(wire: true))
+        expect(txid_leaves[0].hash).to eq(tx_real.wtxid)
       end
 
       it 'strips the phantom leaf hash from the emitted BUMP' do
@@ -669,7 +669,7 @@ RSpec.describe BSV::Transaction::Beef do
 
       it 'preserves the original merkle root through the rebuild' do
         parsed = described_class.from_binary(child.to_beef)
-        expect(parsed.bumps[0].compute_root(tx_real.txid(wire: true))).to eq(expected_root)
+        expect(parsed.bumps[0].compute_root(tx_real.wtxid)).to eq(expected_root)
       end
 
       it 'does not mutate the caller tx_real.merkle_path' do
@@ -695,7 +695,7 @@ RSpec.describe BSV::Transaction::Beef do
       let(:source_beef) { described_class.from_binary(Base64.decode64(File.read(fixture_path))) }
 
       def bundled_txid_hashes(beef)
-        beef.transactions.map { |bt| bt.txid(wire: true) }
+        beef.transactions.map(&:wtxid)
       end
 
       def count_phantoms(bump, bundled_hashes)
@@ -772,11 +772,11 @@ RSpec.describe BSV::Transaction::Beef do
     it 'returns the merkle path for a mined transaction' do
       beef = described_class.from_hex(beef_set_hex)
       mined = beef.transactions.find { |bt| bt.format == described_class::FORMAT_RAW_TX_AND_BUMP }
-      mp = beef.find_bump(mined.txid)
+      mp = beef.find_bump(mined.wtxid)
       expect(mp).to be_a(BSV::Transaction::MerklePath)
     end
 
-    it 'returns nil for unknown txid' do
+    it 'returns nil for unknown wtxid' do
       beef = described_class.from_hex(beef_set_hex)
       expect(beef.find_bump("\x00".b * 32)).to be_nil
     end
@@ -785,7 +785,7 @@ RSpec.describe BSV::Transaction::Beef do
       beef = described_class.from_hex(beef_set_hex)
       raw_only = beef.transactions.find { |bt| bt.format == described_class::FORMAT_RAW_TX }
       if raw_only
-        expect(beef.find_bump(raw_only.txid)).to be_nil
+        expect(beef.find_bump(raw_only.wtxid)).to be_nil
       else
         # All txs in this vector have BUMPs - skip
         skip 'no unproven transactions in this vector'
@@ -797,12 +797,12 @@ RSpec.describe BSV::Transaction::Beef do
     it 'returns a transaction with wired inputs' do
       beef = described_class.from_hex(beef_set_hex)
       last_tx = beef.transactions.last.transaction
-      found = beef.find_transaction_for_signing(last_tx.txid)
+      found = beef.find_transaction_for_signing(last_tx.wtxid)
       expect(found).to be_a(BSV::Transaction::Transaction)
       expect(found.txid).to eq(last_tx.txid)
     end
 
-    it 'returns nil for unknown txid' do
+    it 'returns nil for unknown wtxid' do
       beef = described_class.from_hex(beef_set_hex)
       expect(beef.find_transaction_for_signing("\x00".b * 32)).to be_nil
     end
@@ -812,7 +812,7 @@ RSpec.describe BSV::Transaction::Beef do
     it 'returns a transaction with recursive proof tree' do
       beef = described_class.from_hex(beef_set_hex)
       last_tx = beef.transactions.last.transaction
-      found = beef.find_atomic_transaction(last_tx.txid)
+      found = beef.find_atomic_transaction(last_tx.wtxid)
       expect(found).to be_a(BSV::Transaction::Transaction)
       expect(found.txid).to eq(last_tx.txid)
     end
@@ -821,11 +821,11 @@ RSpec.describe BSV::Transaction::Beef do
   describe '#to_atomic_hex' do
     it 'returns a hex-encoded Atomic BEEF' do
       beef = described_class.from_hex(beef_set_hex)
-      txid = beef.transactions.last.txid
-      hex = beef.to_atomic_hex(txid)
+      last_bt = beef.transactions.last
+      hex = beef.to_atomic_hex(last_bt.wtxid)
       expect(hex).to match(/\A[0-9a-f]+\z/)
       parsed = described_class.from_binary([hex].pack('H*'))
-      expect(parsed.subject_txid).to eq(txid)
+      expect(parsed.subject_txid).to eq(last_bt.txid)
     end
   end
 
@@ -1017,16 +1017,16 @@ RSpec.describe BSV::Transaction::Beef do
   describe '#make_txid_only' do
     it 'converts a transaction to TXID-only format' do
       beef = described_class.from_hex(beef_set_hex)
-      tx = beef.transactions.first.transaction
-      txid = tx.txid
+      first_bt = beef.transactions.first
+      display_txid = first_bt.txid
 
-      beef.make_txid_only(txid)
-      entry = beef.transactions.find { |bt| bt.txid == txid }
+      beef.make_txid_only(first_bt.wtxid)
+      entry = beef.transactions.find { |bt| bt.txid == display_txid }
       expect(entry.format).to eq(described_class::FORMAT_TXID_ONLY)
-      expect(entry.known_txid).to eq(txid)
+      expect(entry.known_wtxid).to eq(first_bt.wtxid)
     end
 
-    it 'returns nil for unknown txid' do
+    it 'returns nil for unknown wtxid' do
       beef = described_class.from_hex(beef_set_hex)
       expect(beef.make_txid_only("\x00".b * 32)).to be_nil
     end
@@ -1064,7 +1064,7 @@ RSpec.describe BSV::Transaction::Beef do
       beef = described_class.new
       beef.transactions << described_class::BeefTx.new(
         format: described_class::FORMAT_TXID_ONLY,
-        known_txid: "\x01".b * 32
+        known_wtxid: "\x01".b * 32
       )
       expect(beef.valid?).to be false
     end
@@ -1073,7 +1073,7 @@ RSpec.describe BSV::Transaction::Beef do
       beef = described_class.new
       beef.transactions << described_class::BeefTx.new(
         format: described_class::FORMAT_TXID_ONLY,
-        known_txid: "\x01".b * 32
+        known_wtxid: "\x01".b * 32
       )
       expect(beef.valid?(allow_txid_only: true)).to be true
     end
@@ -1217,7 +1217,7 @@ RSpec.describe BSV::Transaction::Beef do
       beef_with_txid_only = described_class.new
       beef_with_txid_only.transactions << described_class::BeefTx.new(
         format: described_class::FORMAT_TXID_ONLY,
-        known_txid: "\x01".b * 32
+        known_wtxid: "\x01".b * 32
       )
       expect(beef_with_txid_only.verify(nil, allow_txid_only: true)).to be true
       expect(beef_with_txid_only.verify(nil, allow_txid_only: false)).to be false
@@ -1229,26 +1229,23 @@ RSpec.describe BSV::Transaction::Beef do
     it 'moves cyclic transactions to @txs_not_valid' do
       # A real txid cycle is impossible (txid is a hash of the tx, which includes
       # the input prev_tx_id). We test cycle detection by using mocked transaction
-      # objects with stable fake txids that reference each other.
+      # objects with stable fake wtxids that reference each other.
       #
       # sort_transactions! logic:
-      #   txid_index[bt.txid] = i  (bt.txid is display order for RAW_TX entries)
-      #   dep_idx = txid_index[input.prev_tx_id.reverse]
-      #   (prev_tx_id is wire/internal; .reverse gives display order for lookup)
+      #   txid_index[bt.wtxid] = i  (wire-order wtxid from BeefTx#wtxid)
+      #   dep_idx = txid_index[input.prev_tx_id]
+      #   (prev_tx_id is also wire-order — direct lookup, no reversal needed)
       #
-      # For a cycle: input_a.prev_tx_id.reverse must == txid_b (display).
-      # So: input_a.prev_tx_id (wire) = txid_b.b (same bytes, since we define txid
-      # as a 32-byte string and prev_tx_id is just the reversed form of display txid).
-      txid_a = BSV::Primitives::Digest.sha256('fake_tx_a') # display order
-      txid_b = BSV::Primitives::Digest.sha256('fake_tx_b')
+      # For a cycle: input_a.prev_tx_id must == wtxid_b (wire-order).
+      wtxid_a = BSV::Primitives::Digest.sha256('fake_tx_a') # wire order
+      wtxid_b = BSV::Primitives::Digest.sha256('fake_tx_b')
 
-      # prev_tx_id (wire) must satisfy: prev_tx_id.reverse == txid of the other tx
-      # => prev_tx_id = txid.reverse (internal byte order)
-      input_a = instance_double(BSV::Transaction::TransactionInput, prev_tx_id: txid_b.reverse)
-      input_b = instance_double(BSV::Transaction::TransactionInput, prev_tx_id: txid_a.reverse)
+      # prev_tx_id (wire) of A's input must equal wtxid_b so the sort sees a dep B→A
+      input_a = instance_double(BSV::Transaction::TransactionInput, prev_tx_id: wtxid_b)
+      input_b = instance_double(BSV::Transaction::TransactionInput, prev_tx_id: wtxid_a)
 
-      tx_a = instance_double(BSV::Transaction::Transaction, txid: txid_a, inputs: [input_a])
-      tx_b = instance_double(BSV::Transaction::Transaction, txid: txid_b, inputs: [input_b])
+      tx_a = instance_double(BSV::Transaction::Transaction, wtxid: wtxid_a, inputs: [input_a])
+      tx_b = instance_double(BSV::Transaction::Transaction, wtxid: wtxid_b, inputs: [input_b])
 
       beef = described_class.new
       beef.transactions << described_class::BeefTx.new(format: described_class::FORMAT_RAW_TX, transaction: tx_a)
@@ -1303,12 +1300,11 @@ RSpec.describe BSV::Transaction::Beef do
       beef.transactions << described_class::BeefTx.new(format: described_class::FORMAT_RAW_TX, transaction: tx)
       expect(beef.transactions.first.format).to eq(described_class::FORMAT_RAW_TX)
 
-      # Now add a BUMP that covers this txid
-      txid_internal = tx.txid(wire: true)
+      # Now add a BUMP that covers this wtxid
       sibling = BSV::Primitives::Digest.sha256('sibling')
       bump = mp_class.new(
         block_height: 800_000,
-        path: [[pe.new(offset: 0, hash: txid_internal, txid: true),
+        path: [[pe.new(offset: 0, hash: tx.wtxid, txid: true),
                 pe.new(offset: 1, hash: sibling)]]
       )
       beef.merge_bump(bump)
@@ -1345,11 +1341,10 @@ RSpec.describe BSV::Transaction::Beef do
     end
 
     def make_bump(tx)
-      txid_internal = tx.txid(wire: true)
       sibling = BSV::Primitives::Digest.sha256('sibling')
       mp_class.new(
         block_height: 800_000,
-        path: [[pe.new(offset: 0, hash: txid_internal, txid: true),
+        path: [[pe.new(offset: 0, hash: tx.wtxid, txid: true),
                 pe.new(offset: 1, hash: sibling)]]
       )
     end
@@ -1359,7 +1354,7 @@ RSpec.describe BSV::Transaction::Beef do
       tx = make_tx
       txid = tx.txid
 
-      beef.transactions << described_class::BeefTx.new(format: described_class::FORMAT_TXID_ONLY, known_txid: txid)
+      beef.transactions << described_class::BeefTx.new(format: described_class::FORMAT_TXID_ONLY, known_wtxid: tx.wtxid)
       expect(beef.transactions.first.format).to eq(described_class::FORMAT_TXID_ONLY)
 
       beef.merge_transaction(tx)
@@ -1374,7 +1369,7 @@ RSpec.describe BSV::Transaction::Beef do
       txid = tx.txid
       tx.merkle_path = make_bump(tx)
 
-      beef.transactions << described_class::BeefTx.new(format: described_class::FORMAT_TXID_ONLY, known_txid: txid)
+      beef.transactions << described_class::BeefTx.new(format: described_class::FORMAT_TXID_ONLY, known_wtxid: tx.wtxid)
       beef.merge_transaction(tx)
 
       entry = beef.transactions.find { |bt| bt.txid == txid }
@@ -1404,7 +1399,7 @@ RSpec.describe BSV::Transaction::Beef do
       tx = make_tx
       txid = tx.txid
 
-      beef.transactions << described_class::BeefTx.new(format: described_class::FORMAT_TXID_ONLY, known_txid: txid)
+      beef.transactions << described_class::BeefTx.new(format: described_class::FORMAT_TXID_ONLY, known_wtxid: tx.wtxid)
       beef.merge_raw_tx(tx.to_binary)
 
       entry = beef.transactions.find { |bt| bt.txid == txid }
@@ -1437,25 +1432,24 @@ RSpec.describe BSV::Transaction::Beef do
       beef = described_class.new
       tx = BSV::Transaction::Transaction.new
       tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 100, locking_script: BSV::Script::Script.new))
-      txid_internal = tx.txid(wire: true)
 
       sibling = BSV::Primitives::Digest.sha256('sibling')
       bump = mp_class.new(
         block_height: 800_000,
-        path: [[pe.new(offset: 0, hash: txid_internal, txid: true),
+        path: [[pe.new(offset: 0, hash: tx.wtxid, txid: true),
                 pe.new(offset: 1, hash: sibling)]]
       )
       beef.bumps << bump
 
       # No transaction entry — should still find the BUMP via @bumps scan
-      found = beef.find_bump(tx.txid)
+      found = beef.find_bump(tx.wtxid)
       expect(found).to be(bump)
     end
 
     it 'prefers the transaction-table entry when both exist' do
       source = described_class.from_hex(brc62_hex)
       mined = source.transactions.find { |bt| bt.format == described_class::FORMAT_RAW_TX_AND_BUMP }
-      bump_via_table = source.find_bump(mined.txid)
+      bump_via_table = source.find_bump(mined.wtxid)
       expect(bump_via_table).to be_a(BSV::Transaction::MerklePath)
     end
   end

--- a/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
@@ -445,7 +445,7 @@ RSpec.describe BSV::Transaction::Beef do
     let(:sibling0_hash) { BSV::Primitives::Digest.sha256('sibling_0') }
     let(:sibling3_hash) { BSV::Primitives::Digest.sha256('sibling_3') }
 
-    let(:leaf_hashes) { [sibling0_hash, tx_a.txid.reverse, tx_b.txid.reverse, sibling3_hash] }
+    let(:leaf_hashes) { [sibling0_hash, tx_a.txid(wire: true), tx_b.txid(wire: true), sibling3_hash] }
     let(:level1_hashes) do
       [
         mp_class.merkle_tree_parent(leaf_hashes[0], leaf_hashes[1]),
@@ -605,7 +605,7 @@ RSpec.describe BSV::Transaction::Beef do
       let(:phantom_sibling) { BSV::Primitives::Digest.sha256('sibling_leaf_3') }
 
       let(:leaf_hashes) do
-        [tx_real.txid.reverse, tx_real_sibling, phantom_leaf, phantom_sibling]
+        [tx_real.txid(wire: true), tx_real_sibling, phantom_leaf, phantom_sibling]
       end
       let(:level1_hashes) do
         [
@@ -657,7 +657,7 @@ RSpec.describe BSV::Transaction::Beef do
         bump = parsed.bumps[0]
         txid_leaves = bump.path[0].select(&:txid)
         expect(txid_leaves.length).to eq(1)
-        expect(txid_leaves[0].hash).to eq(tx_real.txid.reverse)
+        expect(txid_leaves[0].hash).to eq(tx_real.txid(wire: true))
       end
 
       it 'strips the phantom leaf hash from the emitted BUMP' do
@@ -669,7 +669,7 @@ RSpec.describe BSV::Transaction::Beef do
 
       it 'preserves the original merkle root through the rebuild' do
         parsed = described_class.from_binary(child.to_beef)
-        expect(parsed.bumps[0].compute_root(tx_real.txid.reverse)).to eq(expected_root)
+        expect(parsed.bumps[0].compute_root(tx_real.txid(wire: true))).to eq(expected_root)
       end
 
       it 'does not mutate the caller tx_real.merkle_path' do
@@ -695,7 +695,7 @@ RSpec.describe BSV::Transaction::Beef do
       let(:source_beef) { described_class.from_binary(Base64.decode64(File.read(fixture_path))) }
 
       def bundled_txid_hashes(beef)
-        beef.transactions.map { |bt| bt.txid.reverse }
+        beef.transactions.map { |bt| bt.txid(wire: true) }
       end
 
       def count_phantoms(bump, bundled_hashes)
@@ -1304,7 +1304,7 @@ RSpec.describe BSV::Transaction::Beef do
       expect(beef.transactions.first.format).to eq(described_class::FORMAT_RAW_TX)
 
       # Now add a BUMP that covers this txid
-      txid_internal = tx.txid.reverse
+      txid_internal = tx.txid(wire: true)
       sibling = BSV::Primitives::Digest.sha256('sibling')
       bump = mp_class.new(
         block_height: 800_000,
@@ -1345,7 +1345,7 @@ RSpec.describe BSV::Transaction::Beef do
     end
 
     def make_bump(tx)
-      txid_internal = tx.txid.reverse
+      txid_internal = tx.txid(wire: true)
       sibling = BSV::Primitives::Digest.sha256('sibling')
       mp_class.new(
         block_height: 800_000,
@@ -1437,7 +1437,7 @@ RSpec.describe BSV::Transaction::Beef do
       beef = described_class.new
       tx = BSV::Transaction::Transaction.new
       tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 100, locking_script: BSV::Script::Script.new))
-      txid_internal = tx.txid.reverse
+      txid_internal = tx.txid(wire: true)
 
       sibling = BSV::Primitives::Digest.sha256('sibling')
       bump = mp_class.new(

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
@@ -707,12 +707,11 @@ RSpec.describe BSV::Transaction::Transaction do
 
     # Build a minimal proven ancestor with a synthetic merkle path.
     #
-    # PathElement hashes must be raw binary in internal byte order
-    # (i.e. txid.reverse — the wire order used by MerklePath serialisation).
+    # PathElement hashes must be in wire byte order (MerklePath serialisation).
     def proven_tx(satoshis: 1000, block_height: 800_000, offset: 0)
       tx = BSV::Transaction::Transaction.new
       tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: satoshis, locking_script: lock))
-      txid_internal = tx.txid.reverse # internal (wire) byte order
+      txid_internal = tx.txid(wire: true)
       sibling_hash  = BSV::Primitives::Digest.sha256("sibling_#{offset}") # 32 raw bytes
       tx.merkle_path = BSV::Transaction::MerklePath.new(
         block_height: block_height,
@@ -723,10 +722,10 @@ RSpec.describe BSV::Transaction::Transaction do
     end
 
     # Wire an input from parent_tx output 0 into child_tx.
-    # prev_tx_id must be in internal byte order (wire order = txid.reverse).
+    # prev_tx_id must be in wire byte order.
     def add_input(child_tx, parent_tx)
       inp = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: parent_tx.txid.reverse, prev_tx_out_index: 0
+        prev_tx_id: parent_tx.txid(wire: true), prev_tx_out_index: 0
       )
       inp.source_transaction = parent_tx
       inp.source_satoshis = parent_tx.outputs[0].satoshis
@@ -809,8 +808,8 @@ RSpec.describe BSV::Transaction::Transaction do
       subject.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 500, locking_script: lock))
       add_input(subject, ancestor)
 
-      # PathElement hashes use internal (wire) byte order: txid.reverse.
-      ancestor_txid_internal = ancestor.txid.reverse
+      # PathElement hashes use wire byte order.
+      ancestor_txid_internal = ancestor.txid(wire: true)
       sibling_hash           = BSV::Primitives::Digest.sha256('late_sibling')
       bump = BSV::Transaction::MerklePath.new(
         block_height: 850_000,

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
@@ -711,11 +711,10 @@ RSpec.describe BSV::Transaction::Transaction do
     def proven_tx(satoshis: 1000, block_height: 800_000, offset: 0)
       tx = BSV::Transaction::Transaction.new
       tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: satoshis, locking_script: lock))
-      txid_internal = tx.txid(wire: true)
-      sibling_hash  = BSV::Primitives::Digest.sha256("sibling_#{offset}") # 32 raw bytes
+      sibling_hash = BSV::Primitives::Digest.sha256("sibling_#{offset}") # 32 raw bytes
       tx.merkle_path = BSV::Transaction::MerklePath.new(
         block_height: block_height,
-        path: [[pe.new(offset: offset, hash: txid_internal, txid: true),
+        path: [[pe.new(offset: offset, hash: tx.wtxid, txid: true),
                 pe.new(offset: offset ^ 1, hash: sibling_hash)]]
       )
       tx
@@ -725,7 +724,7 @@ RSpec.describe BSV::Transaction::Transaction do
     # prev_tx_id must be in wire byte order.
     def add_input(child_tx, parent_tx)
       inp = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: parent_tx.txid(wire: true), prev_tx_out_index: 0
+        prev_tx_id: parent_tx.wtxid, prev_tx_out_index: 0
       )
       inp.source_transaction = parent_tx
       inp.source_satoshis = parent_tx.outputs[0].satoshis
@@ -809,11 +808,10 @@ RSpec.describe BSV::Transaction::Transaction do
       add_input(subject, ancestor)
 
       # PathElement hashes use wire byte order.
-      ancestor_txid_internal = ancestor.txid(wire: true)
-      sibling_hash           = BSV::Primitives::Digest.sha256('late_sibling')
+      sibling_hash = BSV::Primitives::Digest.sha256('late_sibling')
       bump = BSV::Transaction::MerklePath.new(
         block_height: 850_000,
-        path: [[pe.new(offset: 0, hash: ancestor_txid_internal, txid: true),
+        path: [[pe.new(offset: 0, hash: ancestor.wtxid, txid: true),
                 pe.new(offset: 1, hash: sibling_hash)]]
       )
 
@@ -850,7 +848,7 @@ RSpec.describe BSV::Transaction::Transaction do
       beef = BSV::Transaction::Beef.new
       beef.merge_transaction(subject)
       # Serialise as Atomic BEEF so subject_txid is embedded
-      binary = beef.to_atomic_binary(subject.txid)
+      binary = beef.to_atomic_binary(subject.wtxid)
 
       result = described_class.from_beef(binary)
       expect(result).not_to be_nil

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_verify_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_verify_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe BSV::Transaction::Transaction do
     def build_spending_tx(source_tx, output_sats: 90_000)
       tx = described_class.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: source_tx.txid,
+        prev_tx_id: source_tx.wtxid,
         prev_tx_out_index: 0
       )
       input.source_satoshis = source_tx.outputs[0].satoshis
@@ -163,7 +163,7 @@ RSpec.describe BSV::Transaction::Transaction do
         tx = described_class.new
         [0, 0].each_with_index do |out_idx, _i|
           input = BSV::Transaction::TransactionInput.new(
-            prev_tx_id: source_tx.txid,
+            prev_tx_id: source_tx.wtxid,
             prev_tx_out_index: out_idx
           )
           input.source_satoshis = source_tx.outputs[0].satoshis
@@ -251,7 +251,7 @@ RSpec.describe BSV::Transaction::Transaction do
         # Use OP_TRUE scripts so script verification passes despite invalid amounts
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: source_tx.txid,
+          prev_tx_id: source_tx.wtxid,
           prev_tx_out_index: 0
         )
         input.source_satoshis = 100_000
@@ -276,7 +276,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: source_tx.txid,
+          prev_tx_id: source_tx.wtxid,
           prev_tx_out_index: 0
         )
         input.source_satoshis = 100_000
@@ -302,7 +302,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: source_tx.txid,
+          prev_tx_id: source_tx.wtxid,
           prev_tx_out_index: 0
         )
         input.source_satoshis = 100_000
@@ -327,7 +327,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: source_tx.txid,
+          prev_tx_id: source_tx.wtxid,
           prev_tx_out_index: 0
         )
         input.unlocking_script = BSV::Script::Script.from_asm('OP_TRUE')

--- a/gem/bsv-sdk/spec/conformance/beef_spec.rb
+++ b/gem/bsv-sdk/spec/conformance/beef_spec.rb
@@ -60,8 +60,9 @@ RSpec.describe BSV::Transaction::Beef do
     # Go SDK: tx := beef.FindTransaction("b1fc0f44ba629dbdffab9e34fcc4faf9dbde3560a7365c55c26fe4daab052aac")
     it 'contains the expected transaction by txid (Go SDK reference)' do
       expected_hex = 'b1fc0f44ba629dbdffab9e34fcc4faf9dbde3560a7365c55c26fe4daab052aac'
-      expected_txid = [expected_hex].pack('H*')
-      tx = beef.find_transaction(expected_txid)
+      # find_transaction takes wire-order (internal) bytes — reverse the display-order hex
+      expected_wtxid = [expected_hex].pack('H*').reverse
+      tx = beef.find_transaction(expected_wtxid)
       expect(tx).not_to be_nil
       expect(tx.txid_hex).to eq(expected_hex)
     end
@@ -107,33 +108,34 @@ RSpec.describe BSV::Transaction::Beef do
   describe 'TXID_ONLY byte-order consistency (F5.1)' do
     it 'make_txid_only preserves display-order txid' do
       beef = described_class.from_hex(go_brc62_hex)
-      tx = beef.transactions.first
-      display_txid = tx.txid
+      bt = beef.transactions.first
+      display_txid = bt.txid
 
-      beef.make_txid_only(display_txid)
-      txid_only_entry = beef.transactions.find { |bt| bt.format == described_class::FORMAT_TXID_ONLY }
+      beef.make_txid_only(bt.wtxid)
+      txid_only_entry = beef.transactions.find { |entry| entry.format == described_class::FORMAT_TXID_ONLY }
       expect(txid_only_entry).not_to be_nil
       expect(txid_only_entry.txid).to eq(display_txid)
     end
 
     it 'TXID_ONLY round-trips through V2 serialise/parse' do
       beef = described_class.from_hex(go_brc62_hex)
-      original_txid = beef.transactions.first.txid
+      first_bt = beef.transactions.first
+      original_txid = first_bt.txid
 
-      beef.make_txid_only(original_txid)
+      beef.make_txid_only(first_bt.wtxid)
       v2_bytes = beef.to_binary(version: described_class::BEEF_V2)
       parsed = described_class.from_binary(v2_bytes)
 
-      txid_entry = parsed.transactions.find { |bt| bt.format == described_class::FORMAT_TXID_ONLY }
+      txid_entry = parsed.transactions.find { |entry| entry.format == described_class::FORMAT_TXID_ONLY }
       expect(txid_entry).not_to be_nil
       expect(txid_entry.txid).to eq(original_txid)
     end
 
     it 'TXID_ONLY entries are included in known txids set' do
       beef = described_class.from_hex(go_beef_set_hex)
-      display_txid = beef.transactions.first.txid
+      first_bt = beef.transactions.first
 
-      beef.make_txid_only(display_txid)
+      beef.make_txid_only(first_bt.wtxid)
       # With allow_txid_only, the converted entry must be findable
       # by its display-order txid in the known set
       expect(beef.valid?(allow_txid_only: true)).to be true
@@ -145,15 +147,15 @@ RSpec.describe BSV::Transaction::Beef do
   describe 'Atomic BEEF (BRC-95) conformance' do
     it 'wraps V2 with magic prefix and subject txid' do
       beef = described_class.from_hex(go_beef_set_hex)
-      subject_tx = beef.transactions.last.transaction
-      subject_txid = subject_tx.txid
+      last_bt = beef.transactions.last
+      subject_wtxid = last_bt.wtxid
 
-      atomic = beef.to_atomic_binary(subject_txid)
+      atomic = beef.to_atomic_binary(subject_wtxid)
 
       # BRC-95: first 4 bytes = 0x01010101
       expect(atomic.byteslice(0, 4).unpack1('V')).to eq(0x01010101)
-      # BRC-95: next 32 bytes = subject txid in internal byte order (reversed)
-      expect(atomic.byteslice(4, 32)).to eq(subject_txid.b.reverse)
+      # BRC-95: next 32 bytes = subject txid in wire (internal) byte order
+      expect(atomic.byteslice(4, 32)).to eq(subject_wtxid)
       # BRC-95: remainder is V2 BEEF
       inner_version = atomic.byteslice(36, 4).unpack1('V')
       expect(inner_version).to eq(described_class::BEEF_V2)
@@ -161,12 +163,12 @@ RSpec.describe BSV::Transaction::Beef do
 
     it 'round-trips through atomic serialise/parse' do
       beef = described_class.from_hex(go_beef_set_hex)
-      subject_txid = beef.transactions.last.txid
+      last_bt = beef.transactions.last
 
-      atomic = beef.to_atomic_binary(subject_txid)
+      atomic = beef.to_atomic_binary(last_bt.wtxid)
       parsed = described_class.from_binary(atomic)
 
-      expect(parsed.subject_txid).to eq(subject_txid)
+      expect(parsed.subject_txid).to eq(last_bt.txid)
       expect(parsed.transactions.length).to eq(beef.transactions.length)
     end
   end

--- a/gem/bsv-sdk/spec/conformance/spv_verify_spec.rb
+++ b/gem/bsv-sdk/spec/conformance/spv_verify_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe BSV::Transaction::Transaction do # rubocop:disable RSpec/Multiple
     def build_spending_tx(source_tx, output_sats: 90_000)
       tx = described_class.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: source_tx.txid,
+        prev_tx_id: source_tx.wtxid,
         prev_tx_out_index: 0
       )
       input.source_satoshis = source_tx.outputs[0].satoshis
@@ -125,7 +125,7 @@ RSpec.describe BSV::Transaction::Transaction do # rubocop:disable RSpec/Multiple
 
       tx = described_class.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: source_tx.txid,
+        prev_tx_id: source_tx.wtxid,
         prev_tx_out_index: 0
       )
       input.source_satoshis = 100_000
@@ -156,7 +156,7 @@ RSpec.describe BSV::Transaction::Transaction do # rubocop:disable RSpec/Multiple
       tx = described_class.new
       2.times do
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: source_tx.txid,
+          prev_tx_id: source_tx.wtxid,
           prev_tx_out_index: 0
         )
         input.source_satoshis = source_tx.outputs[0].satoshis
@@ -231,7 +231,7 @@ RSpec.describe BSV::Transaction::FeeModel do
 
       tx = BSV::Transaction::Transaction.new
       spend_input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: source_tx.txid,
+        prev_tx_id: source_tx.wtxid,
         prev_tx_out_index: 0
       )
       spend_input.source_satoshis = 100_000


### PR DESCRIPTION
## Summary
- Add `Transaction#wtxid` as the canonical wire-order txid accessor; `txid` remains for display-order presentation
- `BeefTx#wtxid` replaces `BeefTx#txid(wire:)` — always wire-order; `@known_wtxid` replaces `@known_txid`
- All Beef internals (comparisons, Sets, lookups, serialisation) now operate in wire-order — 9 unnecessary `.reverse` calls eliminated
- Beef public API methods (`find_bump`, `find_transaction`, `find_transaction_for_signing`, etc.) accept `wtxid` parameter
- 3 `.reverse` calls retained at explicit display-order boundaries (`BeefTx#txid`, `subject_txid` reader, chain tracker hex)

## Test plan
- [x] 5025 examples, 0 failures
- [x] RuboCop clean
- [x] No `txid(wire:` references remain in codebase
- [x] No `.reverse` inside Beef except at documented boundaries
- [x] All acceptance criteria verified against HLR #666

Closes #666
