### PR TITLE
feat!: enforce wtxid/dtxid naming convention throughout SDK (#677)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,16 @@ The script system has two distinct layers with different responsibilities:
 
 A script being parseable but failing execution is not a bug — it's the distinction between these two layers working correctly.
 
+### Transaction ID Convention
+
+Transaction IDs use an explicit naming convention to prevent byte-order bugs:
+
+- **`wtxid`** — wire-order binary (32 bytes). Used internally, in storage, and across all Ruby interfaces.
+- **`dtxid` / `dtxid_hex`** — display-order hex (64 chars). Used only at JSON and UI boundaries.
+- **`txid`** — reserved for spec-mandated names (BRC-100, BRC-74, ARC API), always with a boundary comment.
+
+Any method that accepts a txid parameter must validate the format using `BSV::Primitives::Hex.validate_wtxid!` or `BSV::Primitives::Hex.validate_dtxid_hex!`. This catches byte-order mismatches at call time rather than producing silent corruption. See `docs/guides/wtxid-dtxid.md` for the full rationale.
+
 ## Cryptography
 
 Elliptic curve operations (secp256k1) are provided by the [`secp256k1-native`](https://github.com/sgbett/secp256k1-native) gem — a pure Ruby implementation ported from the TypeScript reference SDK, with an optional native C extension that accelerates field, scalar, and Jacobian point operations (~22× speedup). The `bsv-sdk` exposes these as `BSV::Primitives::Secp256k1` and `BSV::Primitives::Secp256k1Native`. An OpenSSL compatibility shim (`openssl_ec_shim.rb`) replaces `OpenSSL::PKey::EC` classes so consumer code continues to use the same API. See the [secp256k1-native documentation](https://github.com/sgbett/secp256k1-native/blob/master/docs/secp256k1.md) for implementation details.

--- a/docs/general/naming-conventions.md
+++ b/docs/general/naming-conventions.md
@@ -40,7 +40,7 @@ Ruby treats attribute access and method calls identically, so `get_` is redundan
 # TS:   beef.getBumps()     → Ruby: beef.bumps
 ```
 
-Note: `tx.txid` returns the transaction ID as **raw bytes** (for binary comparison). Use `tx.txid_hex` for the hex-encoded display form that most TS/Go APIs return from `getTxid()`.
+Note: `tx.wtxid` returns the transaction ID as **wire-order binary** (for computation and storage). Use `tx.dtxid` for the display-order hex that most TS/Go APIs return from `getTxid()`. See the **[wtxid/dtxid guide](../guides/wtxid-dtxid.md)** for the full convention.
 
 ### 4. Setters use assignment syntax
 
@@ -129,7 +129,7 @@ wallet.create_action(
 
 This is the subtlest distinction. TypeScript uses `toX()` for both *derived properties* (things the object has or computes about itself) and *format conversions* (encoding the object in a different representation). Ruby splits them:
 
-- **Derived property** — bare noun: `key.public_key`, `key.address`, `tx.txid`
+- **Derived property** — bare noun: `key.public_key`, `key.address`, `tx.wtxid`
 - **Format conversion** — `to_` prefix: `key.to_wif`, `tx.to_hex`, `script.to_asm`
 
 The rule of thumb: if the return value is another *object* in the domain model, it's a property. If the return value is a *serialised representation* of the same object, it's a conversion.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -71,7 +71,7 @@ tx = BSV::Transaction::Transaction.new
 # Add an input (referencing a previous UTXO)
 input = BSV::Transaction::TransactionInput.new(
   prev_wtxid: BSV::Transaction::TransactionInput.wtxid_from_hex(
-    'a477af6b2667c29670467e4e0728b685ee07b240235771862318e29ddbe58458'
+    '5884e5db9de218238671572340b207ee85b628074e7e467096c267266baf77a4'
   ),
   prev_tx_out_index: 0
 )

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -57,6 +57,8 @@ address = public_key.address
 
 This example builds a P2PKH transaction that spends one input and creates two outputs: an OP_RETURN data carrier and a change output.
 
+> **Transaction IDs:** The SDK uses `wtxid` for wire-order binary (the native byte order of SHA-256d hashes) and `dtxid` for display-order hex (the reversed format shown by block explorers). Internally, everything is wire order — conversion to display order happens only at JSON and UI boundaries. See the **[wtxid/dtxid guide](wtxid-dtxid.md)** for the full rationale.
+
 ```ruby
 # Set up keys
 private_key = BSV::Primitives::PrivateKey.generate
@@ -68,7 +70,7 @@ tx = BSV::Transaction::Transaction.new
 
 # Add an input (referencing a previous UTXO)
 input = BSV::Transaction::TransactionInput.new(
-  prev_tx_id: BSV::Transaction::TransactionInput.txid_from_hex(
+  prev_wtxid: BSV::Transaction::TransactionInput.wtxid_from_hex(
     'a477af6b2667c29670467e4e0728b685ee07b240235771862318e29ddbe58458'
   ),
   prev_tx_out_index: 0
@@ -96,7 +98,7 @@ tx.sign(0, private_key)
 # Broadcast via Arcade (GorillaPool)
 arc = BSV::Network::ARC.default
 response = arc.broadcast(tx)
-puts response.txid
+puts response.txid  # display-order hex (ARC API boundary)
 ```
 
 ## Using Templates for Signing
@@ -108,7 +110,7 @@ tx = BSV::Transaction::Transaction.new
 
 # Create inputs with templates
 input = BSV::Transaction::TransactionInput.new(
-  prev_tx_id: BSV::Transaction::TransactionInput.txid_from_hex(utxo_txid),
+  prev_wtxid: BSV::Transaction::TransactionInput.wtxid_from_hex(utxo_txid),
   prev_tx_out_index: 0
 )
 input.source_satoshis = 50_000
@@ -129,7 +131,7 @@ If you already know the TypeScript or Go BSV SDKs, most of the API is a direct t
 | TS / Go | Ruby | Notes |
 |---|---|---|
 | `key.toPublicKey()` | `key.public_key` | Derived properties are bare nouns, not `to_*` methods |
-| `tx.getTxid()` | `tx.txid_hex` | No `get_` prefix (use `txid` for raw bytes) |
+| `tx.getTxid()` | `tx.dtxid` | Display-order hex; `tx.wtxid` for wire-order binary |
 | `input.setSourceSatoshis(5000)` | `input.source_satoshis = 5000` | Setters use assignment syntax |
 | `tx.toHex()` | `tx.to_hex` | Format conversions keep `to_` |
 | `Transaction.fromBinary(data)` | `Transaction.from_binary(data)` | Constructors use `from_` |

--- a/docs/guides/wtxid-dtxid.md
+++ b/docs/guides/wtxid-dtxid.md
@@ -126,6 +126,17 @@ If you're writing code that touches transaction IDs, the decision is simple:
 
 There is no third case. If you find yourself reaching for `txid` without either prefix, stop and determine which of the two you actually need.
 
+## Runtime validation
+
+Because `wtxid` and `dtxid` have distinct physical formats — 32-byte binary vs 64-character hex — the SDK validates at every entry point. Pass a hex string where binary is expected and you get an immediate `ArgumentError` with a diagnostic message:
+
+```
+ArgumentError: expected 32-byte wire-order wtxid for prev_wtxid,
+got 64-byte string (looks like a hex txid — use wtxid_from_hex to convert)
+```
+
+This is only possible because the naming convention enforces a consistent type split. When everything was called `txid`, there was no way to know what format a parameter expected without reading the implementation. With `wtxid` and `dtxid`, the format is encoded in the name — and the SDK enforces it.
+
 ## BRC-74 note
 
 `MerklePath::PathElement` has a `txid` boolean attribute. This is **not** a transaction ID value — it's a BRC-74 spec field that flags whether a given leaf in the merkle path is a transaction (as opposed to a provided hash). The name comes from the specification and is not subject to the wtxid/dtxid convention.

--- a/docs/guides/wtxid-dtxid.md
+++ b/docs/guides/wtxid-dtxid.md
@@ -126,24 +126,6 @@ If you're writing code that touches transaction IDs, the decision is simple:
 
 There is no third case. If you find yourself reaching for `txid` without either prefix, stop and determine which of the two you actually need.
 
-## Format constants
-
-The SDK defines two constants for downstream consumers that need to make byte order explicit in API responses:
-
-```ruby
-BSV::TXID_FORMAT_WIRE    # => 'wire'
-BSV::TXID_FORMAT_DISPLAY # => 'display'
-```
-
-These are available for inclusion in API response metadata, configuration, or documentation. They make the byte order self-describing rather than assumed:
-
-```ruby
-{
-  txid: tx.dtxid,
-  txid_format: BSV::TXID_FORMAT_DISPLAY
-}
-```
-
 ## BRC-74 note
 
 `MerklePath::PathElement` has a `txid` boolean attribute. This is **not** a transaction ID value — it's a BRC-74 spec field that flags whether a given leaf in the merkle path is a transaction (as opposed to a provided hash). The name comes from the specification and is not subject to the wtxid/dtxid convention.

--- a/docs/guides/wtxid-dtxid.md
+++ b/docs/guides/wtxid-dtxid.md
@@ -1,0 +1,149 @@
+# Transaction IDs: wtxid and dtxid
+
+## Why two representations?
+
+A transaction ID is a SHA-256d hash — 32 bytes. Those bytes have a natural order, the order the hash function produces them. This is the **wire order**: the byte sequence you find inside serialised transactions, block headers, and merkle trees. Every time Bitcoin's binary protocol references a transaction, it uses this order.
+
+But early Bitcoin had a cosmetic quirk. When Satoshi wrote the RPC code to display transaction and block hashes as hex strings, the bytes were reversed. The likely reason: SHA-256d hashes used as proof-of-work targets have leading zero bytes, and reversing puts those zeros at the front of the displayed string, making difficulty visually obvious. A block hash like `000000000019d6689c...` reads naturally as "many leading zeros = hard to find".
+
+This reversed representation became the **display order** — the format shown by block explorers, returned by JSON-RPC calls, and copy-pasted by developers. It stuck, and every Bitcoin-derived system has inherited it.
+
+The consequence is that Bitcoin has always had two ways to express the same 32-byte hash, with no reliable way to tell which one you're holding. The variable name `txid` could mean either. This ambiguity has caused an extraordinary number of bugs across every Bitcoin implementation over the past 15+ years, from double-counted transactions to malformed merkle proofs.
+
+## The SDK's naming convention
+
+This SDK eliminates the ambiguity by making the byte order explicit in every name:
+
+| Name | Type | Byte order | When to use |
+|------|------|-----------|-------------|
+| `wtxid` | Binary string (32 bytes) | Wire order | Internal computation, storage, binary protocols |
+| `dtxid` / `dtxid_hex` | Hex string (64 chars) | Display order | JSON APIs, user interfaces, logs, block explorers |
+| `txid` | Varies | Spec-mandated | Only where an external specification requires this exact name |
+
+**`wtxid`** — wire-order transaction ID. The raw bytes as SHA-256d produces them, and as they appear in serialised Bitcoin data. This is what you store, compare, and compute with.
+
+**`dtxid`** — display-order transaction ID. The bytes reversed and hex-encoded. This is what you show to humans and send over JSON interfaces.
+
+**`txid`** — reserved for cases where an external specification (BRC-100, BRC-74, ARC API) mandates this exact field name. These always appear with a boundary comment explaining which spec requires them and what byte order is expected.
+
+### Examples
+
+```ruby
+tx = BSV::Transaction::Transaction.from_hex(raw_hex)
+
+# Wire order — for computation, storage, binary protocols
+tx.wtxid            # => 32-byte binary string
+tx.inputs.first.prev_wtxid  # => 32 bytes referencing the previous output
+
+# Display order — for JSON, UIs, logs
+tx.dtxid            # => "a1b2c3d4..." (64-char hex, reversed bytes)
+tx.dtxid_hex        # => same as dtxid
+
+# Conversion at input boundaries
+BSV::Transaction::TransactionInput.wtxid_from_hex("a1b2c3d4...")
+# => 32-byte binary (reverses the hex back to wire order)
+
+# Display conversion on inputs
+tx.inputs.first.dtxid_hex   # => display-order hex of the referenced tx
+```
+
+## Wire order by default
+
+The SDK's internal principle is straightforward: **use wire order everywhere, convert only when forced to**.
+
+Transaction IDs are born in wire order — `SHA256d(serialised_tx)` produces wire-order bytes. Reversing them to display order and back again is wasted work and a source of bugs. So the SDK keeps everything in wire order internally and only converts to display order at the boundaries where an external system demands it.
+
+This means:
+
+- **All internal variables** hold `wtxid` (wire-order binary)
+- **All method parameters** that accept transaction IDs expect wire-order binary
+- **Cross-gem interfaces** (SDK → wallet, SDK → attest) pass wire-order binary
+- **Storage** uses wire-order binary (bytea columns, binary fields)
+- **Merkle computations** use wire-order throughout — no reversals inside the tree
+- **Beef serialisation** uses wire-order throughout — transaction references, dedup keys, sorting
+
+No conversion happens until you reach a boundary that requires display order.
+
+### The boundaries
+
+Conversion to display order (`dtxid`) happens at exactly two kinds of boundary:
+
+**1. JSON interfaces**
+
+Any API that serialises data as JSON. JSON has no binary type, so transaction IDs must be hex-encoded. By convention (inherited from Bitcoin's RPC layer), JSON APIs use display-order hex.
+
+```ruby
+# ARC broadcast response
+{ "txid" => "a1b2c3d4..." }  # display-order hex — ARC API spec
+
+# BRC-100 create_action return value
+{ txid: tx.dtxid }            # display-order hex — BRC-100 spec
+
+# WhatsOnChain REST API
+"/tx/#{tx.dtxid}"             # display-order hex in URL path
+```
+
+**2. User interfaces**
+
+Any context where a human reads a transaction ID: HTML pages, CLI output, log messages, error messages, block explorer links.
+
+```ruby
+# Log message
+logger.info("Broadcast #{tx.dtxid}")
+
+# Error message
+raise "Input #{input.dtxid_hex} not found"
+
+# Link to block explorer
+"https://whatsonchain.com/tx/#{tx.dtxid}"
+```
+
+### What is NOT a boundary
+
+These are internal interfaces — they stay in wire order:
+
+- **Ruby method calls** between SDK classes (Transaction, Beef, MerklePath)
+- **Ruby method calls** between gems (bsv-sdk, bsv-wallet, bsv-attest)
+- **Database storage** (PostgreSQL bytea, binary columns)
+- **Binary serialisation** (transaction format, BEEF format, merkle paths)
+- **Hash table keys** for deduplication or indexing
+- **Comparisons** between transaction IDs
+
+```ruby
+# Internal — always wire order
+beef.find_transaction(tx.wtxid)
+merkle_path.compute_root(tx.wtxid)
+seen[tx.wtxid] = true
+input.prev_wtxid == source_tx.wtxid
+```
+
+### The conversion rule
+
+If you're writing code that touches transaction IDs, the decision is simple:
+
+1. Am I producing JSON output or displaying text to a human? → Use `dtxid`
+2. Everything else → Use `wtxid`
+
+There is no third case. If you find yourself reaching for `txid` without either prefix, stop and determine which of the two you actually need.
+
+## Format constants
+
+The SDK defines two constants for downstream consumers that need to make byte order explicit in API responses:
+
+```ruby
+BSV::TXID_FORMAT_WIRE    # => 'wire'
+BSV::TXID_FORMAT_DISPLAY # => 'display'
+```
+
+These are available for inclusion in API response metadata, configuration, or documentation. They make the byte order self-describing rather than assumed:
+
+```ruby
+{
+  txid: tx.dtxid,
+  txid_format: BSV::TXID_FORMAT_DISPLAY
+}
+```
+
+## BRC-74 note
+
+`MerklePath::PathElement` has a `txid` boolean attribute. This is **not** a transaction ID value — it's a BRC-74 spec field that flags whether a given leaf in the merkle path is a transaction (as opposed to a provided hash). The name comes from the specification and is not subject to the wtxid/dtxid convention.

--- a/docs/sdk/transaction.md
+++ b/docs/sdk/transaction.md
@@ -11,7 +11,7 @@ Each input references a previous transaction output (UTXO) by its wire-order tra
 ```ruby
 input = BSV::Transaction::TransactionInput.new(
   prev_wtxid: BSV::Transaction::TransactionInput.wtxid_from_hex(
-    'a477af6b2667c29670467e4e0728b685ee07b240235771862318e29ddbe58458'
+    '5884e5db9de218238671572340b207ee85b628074e7e467096c267266baf77a4'
   ),
   prev_tx_out_index: 0
 )

--- a/docs/sdk/transaction.md
+++ b/docs/sdk/transaction.md
@@ -6,11 +6,11 @@ The `BSV::Transaction` module handles building, signing, serialising, and verify
 
 ### Inputs
 
-Each input references a previous transaction output (UTXO) by its transaction ID and output index:
+Each input references a previous transaction output (UTXO) by its wire-order transaction ID and output index:
 
 ```ruby
 input = BSV::Transaction::TransactionInput.new(
-  prev_tx_id: BSV::Transaction::TransactionInput.txid_from_hex(
+  prev_wtxid: BSV::Transaction::TransactionInput.wtxid_from_hex(
     'a477af6b2667c29670467e4e0728b685ee07b240235771862318e29ddbe58458'
   ),
   prev_tx_out_index: 0
@@ -21,10 +21,7 @@ input.source_satoshis = 100_000
 input.source_locking_script = BSV::Script::Script.p2pkh_lock(pubkey_hash)
 ```
 
-!!! note "Byte Order"
-    `txid_from_hex` converts a display-order hex txid to internal byte order
-    (reversed). This is needed because Bitcoin stores txids in little-endian
-    internally but displays them in big-endian.
+`wtxid_from_hex` converts a display-order hex txid to wire-order binary (the native byte order used internally). See the **[wtxid/dtxid guide](../guides/wtxid-dtxid.md)** for why.
 
 ### Outputs
 
@@ -139,8 +136,8 @@ tx, bytes_consumed = BSV::Transaction::Transaction.from_binary_with_offset(data,
 ### Transaction ID
 
 ```ruby
-txid = tx.txid         # 32 bytes (internal byte order)
-txid = tx.txid_hex     # 64-char hex (display order)
+wtxid = tx.wtxid       # 32 bytes (wire order — for computation and storage)
+dtxid = tx.dtxid       # 64-char hex (display order — for JSON and UIs)
 ```
 
 ## Fee Estimation
@@ -289,7 +286,7 @@ recipient_lock = BSV::Script::Script.p2pkh_lock(recipient.public_key.hash160)
 tx = BSV::Transaction::Transaction.new
 
 input = BSV::Transaction::TransactionInput.new(
-  prev_tx_id: BSV::Transaction::TransactionInput.txid_from_hex(utxo_txid),
+  prev_wtxid: BSV::Transaction::TransactionInput.wtxid_from_hex(utxo_txid),
   prev_tx_out_index: 0
 )
 input.source_satoshis = 1_000_000
@@ -313,5 +310,5 @@ tx.add_output(BSV::Transaction::TransactionOutput.new(
 # Sign and serialise
 tx.sign_all
 puts tx.to_hex
-puts "txid: #{tx.txid_hex}"
+puts "txid: #{tx.dtxid}"
 ```

--- a/gem/bsv-sdk/lib/bsv-sdk.rb
+++ b/gem/bsv-sdk/lib/bsv-sdk.rb
@@ -3,6 +3,12 @@
 require_relative 'bsv/version'
 
 module BSV
+  # Byte-order format identifiers for transaction IDs.
+  # Downstream consumers (wallet, HTTP APIs) use these constants in API
+  # responses to make byte order explicit rather than assumed.
+  TXID_FORMAT_WIRE    = 'wire'
+  TXID_FORMAT_DISPLAY = 'display'
+
   autoload :Primitives,  'bsv/primitives'
   autoload :Script,      'bsv/script'
   autoload :Transaction, 'bsv/transaction'

--- a/gem/bsv-sdk/lib/bsv-sdk.rb
+++ b/gem/bsv-sdk/lib/bsv-sdk.rb
@@ -3,12 +3,6 @@
 require_relative 'bsv/version'
 
 module BSV
-  # Byte-order format identifiers for transaction IDs.
-  # Downstream consumers (wallet, HTTP APIs) use these constants in API
-  # responses to make byte order explicit rather than assumed.
-  TXID_FORMAT_WIRE    = 'wire'
-  TXID_FORMAT_DISPLAY = 'display'
-
   autoload :Primitives,  'bsv/primitives'
   autoload :Script,      'bsv/script'
   autoload :Transaction, 'bsv/transaction'

--- a/gem/bsv-sdk/lib/bsv/auth/certificate.rb
+++ b/gem/bsv-sdk/lib/bsv/auth/certificate.rb
@@ -124,7 +124,7 @@ module BSV
         certifier_bytes = data.byteslice(pos, 33)
         pos += 33
 
-        txid_bytes = data.byteslice(pos, 32)
+        wtxid = data.byteslice(pos, 32)
         pos += 32
         output_index, vi_len = BSV::Transaction::VarInt.decode(data, pos)
         pos += vi_len
@@ -158,7 +158,7 @@ module BSV
           serial_number: Base64.strict_encode64(serial_bytes),
           subject: subject_bytes.unpack1('H*'),
           certifier: certifier_bytes.unpack1('H*'),
-          revocation_outpoint: "#{txid_bytes.unpack1('H*')}.#{output_index}",
+          revocation_outpoint: "#{wtxid.unpack1('H*')}.#{output_index}",
           fields: fields,
           signature: signature
         )

--- a/gem/bsv-sdk/lib/bsv/auth/certificate.rb
+++ b/gem/bsv-sdk/lib/bsv/auth/certificate.rb
@@ -124,7 +124,8 @@ module BSV
         certifier_bytes = data.byteslice(pos, 33)
         pos += 33
 
-        wtxid = data.byteslice(pos, 32)
+        # Outpoint txid bytes — stored as-is from the display-order hex in revocation_outpoint.
+        outpoint_txid = data.byteslice(pos, 32)
         pos += 32
         output_index, vi_len = BSV::Transaction::VarInt.decode(data, pos)
         pos += vi_len
@@ -158,7 +159,7 @@ module BSV
           serial_number: Base64.strict_encode64(serial_bytes),
           subject: subject_bytes.unpack1('H*'),
           certifier: certifier_bytes.unpack1('H*'),
-          revocation_outpoint: "#{wtxid.unpack1('H*')}.#{output_index}",
+          revocation_outpoint: "#{outpoint_txid.unpack1('H*')}.#{output_index}",
           fields: fields,
           signature: signature
         )

--- a/gem/bsv-sdk/lib/bsv/identity/client.rb
+++ b/gem/bsv-sdk/lib/bsv/identity/client.rb
@@ -207,6 +207,7 @@ module BSV
         raise 'Revoke failed: no transaction found in BEEF' unless tx
         raise 'Revoke failed: outputIndex out of range' if output_idx >= tx.outputs.length
 
+        # Overlay API boundary: outpoint uses display-order hex txid as per overlay convention
         txid = tx.txid_hex
         outpoint = "#{txid}.#{output_idx}"
 

--- a/gem/bsv-sdk/lib/bsv/mcp/tools/broadcast_p2pkh.rb
+++ b/gem/bsv-sdk/lib/bsv/mcp/tools/broadcast_p2pkh.rb
@@ -154,7 +154,7 @@ module BSV
           selected_utxos.each do |utxo|
             locking_script = p2pkh_lock_for(sender_address)
             input = BSV::Transaction::TransactionInput.new(
-              prev_tx_id: BSV::Transaction::TransactionInput.txid_from_hex(utxo.tx_hash),
+              prev_wtxid: BSV::Transaction::TransactionInput.wtxid_from_hex(utxo.tx_hash),
               prev_tx_out_index: utxo.tx_pos
             )
             input.source_satoshis = utxo.satoshis

--- a/gem/bsv-sdk/lib/bsv/mcp/tools/broadcast_p2pkh.rb
+++ b/gem/bsv-sdk/lib/bsv/mcp/tools/broadcast_p2pkh.rb
@@ -116,7 +116,7 @@ module BSV
           return Helpers.error_response("Broadcast failed: #{arc_result.message}") unless arc_result.success?
 
           result = {
-            txid: arc_result.data[:txid],
+            txid: arc_result.data[:txid], # MCP tool boundary: display-order hex from ARC response
             tx_status: arc_result.data[:tx_status],
             hex: tx.to_hex
           }

--- a/gem/bsv-sdk/lib/bsv/mcp/tools/helpers.rb
+++ b/gem/bsv-sdk/lib/bsv/mcp/tools/helpers.rb
@@ -25,7 +25,7 @@ module BSV
         # @return [Hash]
         def self.transaction_to_h(tx)
           {
-            txid: tx.txid_hex,
+            txid: tx.txid_hex, # MCP tool boundary: display-order hex for human consumption
             version: tx.version,
             lock_time: tx.lock_time,
             inputs: tx.inputs.each_with_index.map { |inp, i| input_to_h(inp, i) },

--- a/gem/bsv-sdk/lib/bsv/mcp/tools/helpers.rb
+++ b/gem/bsv-sdk/lib/bsv/mcp/tools/helpers.rb
@@ -38,7 +38,7 @@ module BSV
         def self.input_to_h(input, _index)
           unlock_script = input.unlocking_script
           {
-            prev_txid: input.prev_tx_id.reverse.unpack1('H*'),
+            prev_txid: input.dtxid_hex,
             vout: input.prev_tx_out_index,
             script_hex: unlock_script ? unlock_script.to_hex : '',
             script_asm: unlock_script ? unlock_script.to_asm : '',

--- a/gem/bsv-sdk/lib/bsv/network/broadcast_error.rb
+++ b/gem/bsv-sdk/lib/bsv/network/broadcast_error.rb
@@ -3,6 +3,7 @@
 module BSV
   module Network
     class BroadcastError < StandardError
+      # ARC API boundary: display-order hex txid as returned by the ARC error response.
       attr_reader :status_code, :txid, :arc_status
 
       def initialize(message, status_code: nil, txid: nil, arc_status: nil)

--- a/gem/bsv-sdk/lib/bsv/network/broadcast_response.rb
+++ b/gem/bsv-sdk/lib/bsv/network/broadcast_response.rb
@@ -3,6 +3,7 @@
 module BSV
   module Network
     class BroadcastResponse
+      # ARC API boundary: display-order hex txid as returned by the ARC broadcast endpoint.
       attr_reader :txid, :tx_status, :message, :extra_info, :block_hash, :block_height, :timestamp, :competing_txs
 
       def initialize(attrs = {})

--- a/gem/bsv-sdk/lib/bsv/network/protocols/arc.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/arc.rb
@@ -269,7 +269,7 @@ module BSV
         # same field set as broadcast responses rather than the raw parsed JSON.
         # Also checks for rejection status and missing txid (malformed 2xx).
         #
-        # @param txid [String] the transaction ID to query
+        # @param txid [String] ARC API boundary: display-order hex transaction ID to query
         # @return [Result::Success, Result::Error, Result::NotFound]
         def call_get_tx_status(txid, **)
           response = default_call(:get_tx_status, txid)
@@ -306,7 +306,7 @@ module BSV
         # @return [Hash]
         def arc_data_from(body)
           {
-            txid: body['txid'],
+            txid: body['txid'], # ARC API boundary: display-order hex from the ARC JSON response
             tx_status: body['txStatus'],
             message: body['title'],
             extra_info: body['extraInfo'],

--- a/gem/bsv-sdk/lib/bsv/network/protocols/taal_binary.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/taal_binary.rb
@@ -53,6 +53,7 @@ module BSV
           code = response.code.to_i
           body = parse_json_body(response.body)
 
+          # TAAL API boundary: display-order hex txid from the TAAL broadcast response
           return Result::Success.new(data: { txid: body['txid'] }) if already_known?(body) && body['txid']
 
           retryable = code == 429 || (500..599).cover?(code)

--- a/gem/bsv-sdk/lib/bsv/network/protocols/woc_rest.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/woc_rest.rb
@@ -175,7 +175,7 @@ module BSV
         # The +script_hash:+ keyword is accepted for future fallback support
         # but not used in this implementation.
         #
-        # @param txid        [String]  transaction ID
+        # @param txid        [String]  WoC API boundary: display-order hex transaction ID
         # @param vout        [Integer] output index
         # @param script_hash [String, nil] ignored
         # @return [Result::Success<Boolean>, Result::Error, Result::NotFound]
@@ -242,6 +242,7 @@ module BSV
           return result unless result.success?
 
           # WoC returns plain-text txid — result.data is the raw body string
+          # WoC API boundary: display-order hex txid returned as plain text
           Result::Success.new(data: { txid: result.data.to_s.strip })
         end
 

--- a/gem/bsv-sdk/lib/bsv/overlay/lookup_resolver.rb
+++ b/gem/bsv-sdk/lib/bsv/overlay/lookup_resolver.rb
@@ -334,6 +334,7 @@ module BSV
         beef_data    = output['beef'] || output[:beef]
         output_index = (output['outputIndex'] || output[:output_index] || 0).to_i
 
+        # Overlay API boundary: outpoint key uses display-order txid bytes (via Transaction#txid)
         txid =
           begin
             beef = parse_beef(beef_data)

--- a/gem/bsv-sdk/lib/bsv/overlay/topic_broadcaster.rb
+++ b/gem/bsv-sdk/lib/bsv/overlay/topic_broadcaster.rb
@@ -110,7 +110,7 @@ module BSV
 
         OverlayBroadcastResult.new(
           status: 'success',
-          txid: tx.txid_hex,
+          txid: tx.txid_hex, # Overlay API boundary: display-order hex txid for the broadcast result
           message: "Sent to #{successful.size} Overlay Service host(s)."
         )
       end

--- a/gem/bsv-sdk/lib/bsv/overlay/types.rb
+++ b/gem/bsv-sdk/lib/bsv/overlay/types.rb
@@ -82,6 +82,7 @@ module BSV
       # @return [String] result status ('success' or 'error')
       attr_reader :status
 
+      # Overlay API boundary: display-order hex txid echoed from the broadcast response.
       # @return [String, nil] transaction identifier (present on success)
       attr_reader :txid
 

--- a/gem/bsv-sdk/lib/bsv/primitives/hex.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/hex.rb
@@ -72,6 +72,46 @@ module BSV
       def self.encode(bytes)
         bytes.unpack1('H*')
       end
+
+      # Validate that +value+ is a 32-byte wire-order transaction ID.
+      #
+      # @param value [String] expected 32-byte binary string
+      # @param name [String] label for the error message (e.g. +'prev_wtxid'+)
+      # @return [String] the input value (pass-through for chaining)
+      # @raise [ArgumentError] if +value+ is not a 32-byte binary string
+      def self.validate_wtxid!(value, name: 'wtxid')
+        unless value.is_a?(String) && value.bytesize == 32
+          hint = if value.is_a?(String) && value.bytesize == 64 && value.match?(HEX_RE)
+                   ' (looks like a hex txid — use wtxid_from_hex to convert)'
+                 else
+                   ''
+                 end
+          size = value.is_a?(String) ? "#{value.bytesize}-byte string" : value.class.to_s
+          raise ArgumentError,
+                "expected 32-byte wire-order wtxid for #{name}, got #{size}#{hint}"
+        end
+        value
+      end
+
+      # Validate that +value+ is a 64-character display-order hex transaction ID.
+      #
+      # @param value [String] expected 64-char hex string
+      # @param name [String] label for the error message (e.g. +'dtxid_hex'+)
+      # @return [String] the input value (pass-through for chaining)
+      # @raise [ArgumentError] if +value+ is not a 64-char hex string
+      def self.validate_dtxid_hex!(value, name: 'dtxid_hex')
+        unless value.is_a?(String) && value.length == 64 && value.match?(HEX_RE)
+          hint = if value.is_a?(String) && value.bytesize == 32 && !value.match?(HEX_RE)
+                   ' (looks like binary bytes — use dtxid_hex or unpack to convert)'
+                 else
+                   ''
+                 end
+          size = value.is_a?(String) ? "#{value.length}-char string" : value.class.to_s
+          raise ArgumentError,
+                "expected 64-char display-order hex for #{name}, got #{size}#{hint}"
+        end
+        value
+      end
     end
   end
 end

--- a/gem/bsv-sdk/lib/bsv/registry/client.rb
+++ b/gem/bsv-sdk/lib/bsv/registry/client.rb
@@ -155,6 +155,7 @@ module BSV
         verify_ownership(registered_definition)
 
         definition_type = registered_definition.definition_type
+        # Registry API boundary: outpoint uses display-order hex txid from RegisteredDefinition
         outpoint = "#{registered_definition.txid}.#{registered_definition.output_index}"
 
         create_result = @wallet.create_action(
@@ -415,7 +416,7 @@ module BSV
 
         RegisteredDefinition.new(
           definition_data: definition_data,
-          txid: tx.txid_hex,
+          txid: tx.txid_hex, # Registry API boundary: display-order hex txid
           output_index: output_idx,
           locking_script: locking_script.to_hex,
           beef: beef_raw,
@@ -434,6 +435,7 @@ module BSV
         outpoint_str = output[:outpoint] || output['outpoint']
         return nil unless outpoint_str
 
+        # Registry API boundary: outpoint string uses display-order hex txid by convention
         txid, output_idx_str = outpoint_str.split('.')
         output_idx = output_idx_str.to_i
 

--- a/gem/bsv-sdk/lib/bsv/registry/types.rb
+++ b/gem/bsv-sdk/lib/bsv/registry/types.rb
@@ -188,6 +188,7 @@ module BSV
       # @return [String] the definition type (see {DefinitionType})
       attr_reader :definition_type
 
+      # Registry API boundary: display-order hex txid from the outpoint string held in the registry token.
       # @return [String] transaction ID of the containing UTXO
       attr_reader :txid
 

--- a/gem/bsv-sdk/lib/bsv/transaction/beef.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef.rb
@@ -80,6 +80,12 @@ module BSV
         def txid
           wtxid&.reverse
         end
+
+        # Display-order transaction ID (alias for {#txid}).
+        #
+        # Mirrors the wallet gem's +DisplayTxid+ pattern.
+        # @return [String, nil] 32-byte txid
+        alias dtxid txid
       end
 
       # @return [Integer] BEEF version constant
@@ -99,6 +105,12 @@ module BSV
       def subject_txid
         @subject_wtxid&.reverse
       end
+
+      # Display-order subject txid (alias for {#subject_txid}).
+      #
+      # Mirrors the wallet gem's +DisplayTxid+ pattern.
+      # @return [String, nil] 32-byte display-order txid, or nil
+      alias subject_dtxid subject_txid
 
       # @param version [Integer] BEEF version constant (default: BEEF_V1, matching to_binary's
       #   default for ARC compatibility; from_binary overwrites this with the parsed version)

--- a/gem/bsv-sdk/lib/bsv/transaction/beef.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef.rb
@@ -545,7 +545,7 @@ module BSV
           changed = false
           pending.reject! do |bt|
             all_inputs_known = bt.transaction.inputs.all? do |input|
-              known_wtxids.include?(input.prev_tx_id)
+              known_wtxids.include?(input.prev_wtxid)
             end
             if all_inputs_known
               known_wtxids.add(bt.wtxid)
@@ -604,7 +604,7 @@ module BSV
           next unless bt.transaction
 
           bt.transaction.inputs.each do |input|
-            dep_idx = txid_index[input.prev_tx_id]
+            dep_idx = txid_index[input.prev_wtxid]
             next unless dep_idx
 
             dependents[dep_idx] << i
@@ -728,9 +728,9 @@ module BSV
             next unless beef_tx.transaction
 
             # Wire inputs to ancestors already in the map (BEEF is dependency-ordered).
-            # Both prev_tx_id and wtxid are wire-order — no conversion needed.
+            # Both prev_wtxid and wtxid are wire-order — no conversion needed.
             beef_tx.transaction.inputs.each do |input|
-              source = tx_map[input.prev_tx_id]
+              source = tx_map[input.prev_wtxid]
               input.source_transaction = source if source
             end
 
@@ -795,7 +795,7 @@ module BSV
         tx.inputs.each do |input|
           next if input.source_transaction
 
-          source = find_transaction(input.prev_tx_id)
+          source = find_transaction(input.prev_wtxid)
           input.source_transaction = source if source
         end
       end

--- a/gem/bsv-sdk/lib/bsv/transaction/beef.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef.rb
@@ -13,7 +13,7 @@ module BSV
     #
     # @example Parse a BEEF bundle and find a transaction
     #   beef = BSV::Transaction::Beef.from_hex(beef_hex)
-    #   tx = beef.find_transaction(txid_bytes)
+    #   tx = beef.find_transaction(wtxid)
     class Beef
       # @!group Version constants
 

--- a/gem/bsv-sdk/lib/bsv/transaction/beef.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef.rb
@@ -593,8 +593,8 @@ module BSV
       def sort_transactions!
         return self if @transactions.length <= 1
 
-        txid_index = {}
-        @transactions.each_with_index { |bt, i| txid_index[bt.wtxid] = i }
+        wtxid_index = {}
+        @transactions.each_with_index { |bt, i| wtxid_index[bt.wtxid] = i }
 
         # Build adjacency: for each tx, which other txs must come before it?
         in_degree = Array.new(@transactions.length, 0)
@@ -604,7 +604,7 @@ module BSV
           next unless bt.transaction
 
           bt.transaction.inputs.each do |input|
-            dep_idx = txid_index[input.prev_wtxid]
+            dep_idx = wtxid_index[input.prev_wtxid]
             next unless dep_idx
 
             dependents[dep_idx] << i

--- a/gem/bsv-sdk/lib/bsv/transaction/beef.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef.rb
@@ -58,6 +58,7 @@ module BSV
         def initialize(format:, transaction: nil, known_wtxid: nil, bump_index: nil)
           raise ArgumentError, 'FORMAT_RAW_TX_AND_BUMP requires a bump_index' if format == FORMAT_RAW_TX_AND_BUMP && bump_index.nil?
 
+          BSV::Primitives::Hex.validate_wtxid!(known_wtxid, name: 'known_wtxid') if known_wtxid
           @format = format
           @transaction = transaction
           @known_wtxid = known_wtxid
@@ -249,6 +250,7 @@ module BSV
       # @param subject_wtxid [String] 32-byte wire-order subject transaction ID
       # @return [String] raw Atomic BEEF binary
       def to_atomic_binary(subject_wtxid)
+        BSV::Primitives::Hex.validate_wtxid!(subject_wtxid, name: 'subject_wtxid')
         buf = [ATOMIC_BEEF].pack('V')
         # subject_wtxid is already in wire (internal) byte order — write as-is.
         buf << subject_wtxid.b
@@ -264,6 +266,7 @@ module BSV
       # @param wtxid [String] 32-byte wire-order wtxid
       # @return [Transaction, nil] the matching transaction, or nil
       def find_transaction(wtxid)
+        BSV::Primitives::Hex.validate_wtxid!(wtxid, name: 'wtxid')
         @transactions.each do |beef_tx|
           return beef_tx.transaction if beef_tx.wtxid == wtxid
         end
@@ -278,6 +281,7 @@ module BSV
       # @param wtxid [String] 32-byte wire-order wtxid
       # @return [MerklePath, nil] the merkle path, or nil if not found
       def find_bump(wtxid)
+        BSV::Primitives::Hex.validate_wtxid!(wtxid, name: 'wtxid')
         # Check transaction-table entries first (fast path)
         bt = @transactions.find { |entry| entry.wtxid == wtxid && entry.format == FORMAT_RAW_TX_AND_BUMP }
         return bt.transaction&.merkle_path || (bt.bump_index && @bumps[bt.bump_index]) if bt
@@ -293,6 +297,7 @@ module BSV
       # @param wtxid [String] 32-byte wire-order wtxid
       # @return [Transaction, nil] the transaction with wired inputs, or nil
       def find_transaction_for_signing(wtxid)
+        BSV::Primitives::Hex.validate_wtxid!(wtxid, name: 'wtxid')
         tx = find_transaction(wtxid)
         return unless tx
 
@@ -306,6 +311,7 @@ module BSV
       # @param wtxid [String] 32-byte wire-order wtxid
       # @return [Transaction, nil] the transaction with full proof tree, or nil
       def find_atomic_transaction(wtxid)
+        BSV::Primitives::Hex.validate_wtxid!(wtxid, name: 'wtxid')
         tx = find_transaction(wtxid)
         return unless tx
 
@@ -506,6 +512,7 @@ module BSV
       # @param wtxid [String] 32-byte wire-order wtxid
       # @return [BeefTx, nil] the converted entry, or nil if not found
       def make_txid_only(wtxid)
+        BSV::Primitives::Hex.validate_wtxid!(wtxid, name: 'wtxid')
         idx = @transactions.index { |bt| bt.wtxid == wtxid }
         return unless idx
 

--- a/gem/bsv-sdk/lib/bsv/transaction/beef.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef.rb
@@ -76,17 +76,21 @@ module BSV
           end
         end
 
-        # Display-order transaction ID.
-        # @return [String, nil] 32-byte txid
+        # Display-order transaction ID as binary bytes.
+        # @return [String, nil] 32-byte display-order txid
         def txid
           wtxid&.reverse
         end
 
-        # Display-order transaction ID (alias for {#txid}).
+        # Display-order transaction ID as a hex string.
         #
-        # Mirrors the wallet gem's +DisplayTxid+ pattern.
-        # @return [String, nil] 32-byte txid
-        alias dtxid txid
+        # +dtxid+ always returns a 64-char hex string suitable for JSON
+        # and UI boundaries.
+        #
+        # @return [String, nil] hex-encoded transaction ID (display order)
+        def dtxid
+          wtxid&.reverse&.unpack1('H*')
+        end
       end
 
       # @return [Integer] BEEF version constant
@@ -101,17 +105,18 @@ module BSV
       # @return [String, nil] 32-byte wire-order subject txid (Atomic BEEF only)
       attr_reader :subject_wtxid
 
-      # Display-order subject txid (Atomic BEEF only).
+      # Display-order subject txid as binary bytes (Atomic BEEF only).
       # @return [String, nil] 32-byte display-order txid, or nil
       def subject_txid
         @subject_wtxid&.reverse
       end
 
-      # Display-order subject txid (alias for {#subject_txid}).
+      # Display-order subject txid as a hex string (Atomic BEEF only).
       #
-      # Mirrors the wallet gem's +DisplayTxid+ pattern.
-      # @return [String, nil] 32-byte display-order txid, or nil
-      alias subject_dtxid subject_txid
+      # @return [String, nil] hex-encoded display-order txid, or nil
+      def subject_dtxid
+        @subject_wtxid&.reverse&.unpack1('H*')
+      end
 
       # @param version [Integer] BEEF version constant (default: BEEF_V1, matching to_binary's
       #   default for ARC compatibility; from_binary overwrites this with the parsed version)

--- a/gem/bsv-sdk/lib/bsv/transaction/merkle_path.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/merkle_path.rb
@@ -165,10 +165,10 @@ module BSV
       #   hash; the caller must look up the height separately)
       # @return [MerklePath] a BRC-74 merkle path equivalent to the TSC proof
       def self.from_tsc(dtxid_hex:, index:, nodes:, block_height:)
-        txid_bytes = [dtxid_hex].pack('H*').reverse
+        wtxid = [dtxid_hex].pack('H*').reverse
 
         # Level 0 always contains the txid leaf.
-        level0 = [PathElement.new(offset: index, hash: txid_bytes, txid: true)]
+        level0 = [PathElement.new(offset: index, hash: wtxid, txid: true)]
 
         # A single-tx block has no siblings — the txid IS the merkle root.
         return new(block_height: block_height, path: [level0]) if nodes.empty?
@@ -319,12 +319,12 @@ module BSV
       # @param chain_tracker [ChainTracker] chain tracker to verify the root against
       # @return [Boolean] true if the computed root matches the block at this height
       def verify(dtxid_hex, chain_tracker)
-        txid_bytes = [dtxid_hex].pack('H*').reverse
-        txid_leaf = @path[0].find { |l| l.hash == txid_bytes }
+        wtxid = [dtxid_hex].pack('H*').reverse
+        tx_leaf = @path[0].find { |l| l.hash == wtxid }
 
         # Offset 0 in a block's merkle tree is always the coinbase transaction —
         # a Bitcoin protocol invariant. Apply the 100-block maturity check.
-        if txid_leaf&.offset&.zero?
+        if tx_leaf&.offset&.zero?
           current = chain_tracker.current_height
           return false if current - @block_height < 100
         end

--- a/gem/bsv-sdk/lib/bsv/transaction/merkle_path.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/merkle_path.rb
@@ -255,7 +255,7 @@ module BSV
         indexed = build_indexed_path
 
         tx_leaf = @path[0].find { |l| l.hash == wtxid }
-        raise ArgumentError, 'the BUMP does not contain the txid' unless tx_leaf
+        raise ArgumentError, 'the BUMP does not contain the given wtxid' unless tx_leaf
 
         working = tx_leaf.hash
         index = tx_leaf.offset
@@ -460,15 +460,15 @@ module BSV
       #   txid is not present in the source path's level 0, or the
       #   extracted path's root does not match the source root
       def extract(wtxid_hashes)
-        raise ArgumentError, 'at least one txid must be provided to extract' if wtxid_hashes.empty?
+        raise ArgumentError, 'at least one wtxid must be provided to extract' if wtxid_hashes.empty?
 
         original_root = compute_root
         indexed = build_indexed_path
 
         # Build a level-0 hash → offset lookup
-        txid_to_offset = {}
+        wtxid_to_offset = {}
         @path[0].each do |leaf|
-          txid_to_offset[leaf.hash] = leaf.offset if leaf.hash
+          wtxid_to_offset[leaf.hash] = leaf.offset if leaf.hash
         end
 
         max_offset = @path[0].map(&:offset).max || 0
@@ -476,15 +476,15 @@ module BSV
 
         needed = Array.new(tree_height) { {} }
 
-        wtxid_hashes.each do |txid|
-          tx_offset = txid_to_offset[txid]
+        wtxid_hashes.each do |wtxid_hash|
+          tx_offset = wtxid_to_offset[wtxid_hash]
           if tx_offset.nil?
             raise ArgumentError,
-                  "transaction ID #{txid.reverse.unpack1('H*')} not found in the Merkle Path"
+                  "wtxid #{wtxid_hash.reverse.unpack1('H*')} not found in the Merkle Path"
           end
 
-          # Level 0: the txid leaf itself + its tree sibling
-          needed[0][tx_offset] = PathElement.new(offset: tx_offset, hash: txid, txid: true)
+          # Level 0: the transaction leaf itself + its tree sibling
+          needed[0][tx_offset] = PathElement.new(offset: tx_offset, hash: wtxid_hash, txid: true)
           sib0_offset = tx_offset ^ 1
           unless needed[0].key?(sib0_offset)
             sib = offset_leaf(indexed, 0, sib0_offset)

--- a/gem/bsv-sdk/lib/bsv/transaction/merkle_path.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/merkle_path.rb
@@ -165,6 +165,7 @@ module BSV
       #   hash; the caller must look up the height separately)
       # @return [MerklePath] a BRC-74 merkle path equivalent to the TSC proof
       def self.from_tsc(dtxid_hex:, index:, nodes:, block_height:)
+        BSV::Primitives::Hex.validate_dtxid_hex!(dtxid_hex, name: 'dtxid_hex')
         wtxid = [dtxid_hex].pack('H*').reverse
 
         # Level 0 always contains the txid leaf.
@@ -248,6 +249,7 @@ module BSV
       # @raise [ArgumentError] if the wtxid is not found in the path
       def compute_root(wtxid = nil)
         wtxid ||= @path[0].find(&:hash)&.hash
+        BSV::Primitives::Hex.validate_wtxid!(wtxid, name: 'wtxid') if wtxid
         return wtxid if @path.length == 1 && @path[0].length == 1
 
         indexed = build_indexed_path
@@ -319,6 +321,7 @@ module BSV
       # @param chain_tracker [ChainTracker] chain tracker to verify the root against
       # @return [Boolean] true if the computed root matches the block at this height
       def verify(dtxid_hex, chain_tracker)
+        BSV::Primitives::Hex.validate_dtxid_hex!(dtxid_hex, name: 'dtxid_hex')
         wtxid = [dtxid_hex].pack('H*').reverse
         tx_leaf = @path[0].find { |l| l.hash == wtxid }
 

--- a/gem/bsv-sdk/lib/bsv/transaction/merkle_path.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/merkle_path.rb
@@ -21,7 +21,8 @@ module BSV
       # @!attribute [r] hash
       #   @return [String, nil] 32-byte hash (nil when duplicate)
       # @!attribute [r] txid
-      #   @return [Boolean] whether this leaf is a transaction ID
+      #   @return [Boolean] BRC-74 flag — whether this leaf represents a transaction in
+      #     the merkle tree (the 0x02 bit in the BRC-74 serialisation). Not a txid value.
       # @!attribute [r] duplicate
       #   @return [Boolean] whether this leaf duplicates its sibling
       class PathElement
@@ -29,7 +30,9 @@ module BSV
 
         # @param offset [Integer] position index within the tree level
         # @param hash [String, nil] 32-byte hash (nil when duplicate)
-        # @param txid [Boolean] whether this leaf is a transaction ID
+        # @param txid [Boolean] BRC-74 flag — true when this leaf represents a transaction
+        #   in the tree (the 0x02 bit in the BRC-74 serialisation). This is NOT a txid
+        #   value; it is a boolean presence flag mandated by the BRC-74 specification.
         # @param duplicate [Boolean] whether this leaf duplicates its sibling
         def initialize(offset:, hash: nil, txid: false, duplicate: false)
           @offset = offset
@@ -147,22 +150,22 @@ module BSV
       # @example Convert a WoC TSC proof
       #   tsc = JSON.parse(woc_response).first
       #   mp = BSV::Transaction::MerklePath.from_tsc(
-      #     txid:         tsc['txOrId'],
+      #     dtxid_hex:    tsc['txOrId'],
       #     index:        tsc['index'],
       #     nodes:        tsc['nodes'],
       #     block_height: 612_251
       #   )
       #   mp.compute_root_hex(tsc['txOrId']) #=> the block's merkle root
       #
-      # @param txid [String] hex-encoded transaction ID in display byte order
+      # @param dtxid_hex [String] hex-encoded transaction ID in display byte order
       # @param index [Integer] the transaction's position in the block
       # @param nodes [Array<String>] sibling hashes leaf-to-root, each a 32-byte
       #   hex string in display byte order, or +"*"+ for a duplicate node
       # @param block_height [Integer] the block's height (TSC carries the block
       #   hash; the caller must look up the height separately)
       # @return [MerklePath] a BRC-74 merkle path equivalent to the TSC proof
-      def self.from_tsc(txid:, index:, nodes:, block_height:)
-        txid_bytes = [txid].pack('H*').reverse
+      def self.from_tsc(dtxid_hex:, index:, nodes:, block_height:)
+        txid_bytes = [dtxid_hex].pack('H*').reverse
 
         # Level 0 always contains the txid leaf.
         level0 = [PathElement.new(offset: index, hash: txid_bytes, txid: true)]
@@ -240,16 +243,16 @@ module BSV
 
       # Recompute the merkle root from this path and a transaction ID.
       #
-      # @param txid [String, nil] 32-byte txid in internal byte order (auto-detected if nil)
-      # @return [String] 32-byte merkle root in internal byte order
-      # @raise [ArgumentError] if the txid is not found in the path
-      def compute_root(txid = nil)
-        txid ||= @path[0].find(&:hash)&.hash
-        return txid if @path.length == 1 && @path[0].length == 1
+      # @param wtxid [String, nil] 32-byte txid in wire byte order (auto-detected if nil)
+      # @return [String] 32-byte merkle root in wire byte order
+      # @raise [ArgumentError] if the wtxid is not found in the path
+      def compute_root(wtxid = nil)
+        wtxid ||= @path[0].find(&:hash)&.hash
+        return wtxid if @path.length == 1 && @path[0].length == 1
 
         indexed = build_indexed_path
 
-        tx_leaf = @path[0].find { |l| l.hash == txid }
+        tx_leaf = @path[0].find { |l| l.hash == wtxid }
         raise ArgumentError, 'the BUMP does not contain the txid' unless tx_leaf
 
         working = tx_leaf.hash
@@ -289,11 +292,11 @@ module BSV
 
       # Recompute the merkle root and return it as a hex string.
       #
-      # @param txid_hex [String, nil] hex-encoded txid (display order)
+      # @param dtxid_hex [String, nil] hex-encoded txid (display order)
       # @return [String] hex-encoded merkle root (display order)
-      def compute_root_hex(txid_hex = nil)
-        txid = txid_hex ? [txid_hex].pack('H*').reverse : nil
-        compute_root(txid).reverse.unpack1('H*')
+      def compute_root_hex(dtxid_hex = nil)
+        wtxid = dtxid_hex ? [dtxid_hex].pack('H*').reverse : nil
+        compute_root(wtxid).reverse.unpack1('H*')
       end
 
       # --- Verification ---
@@ -312,11 +315,11 @@ module BSV
       # and accepts immature ones — the opposite of the intended behaviour. The correct
       # logic is: reject when `current_height - block_height < 100` (immature).
       #
-      # @param txid_hex [String] hex-encoded transaction ID (display order)
+      # @param dtxid_hex [String] hex-encoded transaction ID (display order)
       # @param chain_tracker [ChainTracker] chain tracker to verify the root against
       # @return [Boolean] true if the computed root matches the block at this height
-      def verify(txid_hex, chain_tracker)
-        txid_bytes = [txid_hex].pack('H*').reverse
+      def verify(dtxid_hex, chain_tracker)
+        txid_bytes = [dtxid_hex].pack('H*').reverse
         txid_leaf = @path[0].find { |l| l.hash == txid_bytes }
 
         # Offset 0 in a block's merkle tree is always the coinbase transaction —
@@ -326,7 +329,7 @@ module BSV
           return false if current - @block_height < 100
         end
 
-        root_hex = compute_root_hex(txid_hex)
+        root_hex = compute_root_hex(dtxid_hex)
         chain_tracker.valid_root_for_height?(root_hex, @block_height)
       end
 
@@ -445,16 +448,16 @@ module BSV
       #
       # Matches the TS SDK's +MerklePath.extract+ behaviour.
       #
-      # @param txid_hashes [Array<String>] 32-byte txids in internal byte
+      # @param wtxid_hashes [Array<String>] 32-byte txids in wire byte
       #   order (reverse of display order). To pass hex strings, use
-      #   +txid_hexes.map { |h| [h].pack('H*').reverse }+.
+      #   +dtxid_hexes.map { |h| [h].pack('H*').reverse }+.
       # @return [MerklePath] a new trimmed compound path proving only the
       #   requested txids
-      # @raise [ArgumentError] if +txid_hashes+ is empty, any requested
+      # @raise [ArgumentError] if +wtxid_hashes+ is empty, any requested
       #   txid is not present in the source path's level 0, or the
       #   extracted path's root does not match the source root
-      def extract(txid_hashes)
-        raise ArgumentError, 'at least one txid must be provided to extract' if txid_hashes.empty?
+      def extract(wtxid_hashes)
+        raise ArgumentError, 'at least one txid must be provided to extract' if wtxid_hashes.empty?
 
         original_root = compute_root
         indexed = build_indexed_path
@@ -470,7 +473,7 @@ module BSV
 
         needed = Array.new(tree_height) { {} }
 
-        txid_hashes.each do |txid|
+        wtxid_hashes.each do |txid|
           tx_offset = txid_to_offset[txid]
           if tx_offset.nil?
             raise ArgumentError,

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -589,17 +589,17 @@ module BSV
 
         until queue.empty?
           tx = queue.shift
-          tx_id = tx.txid_hex
-          next if verified[tx_id]
+          wtxid = tx.wtxid
+          next if verified[wtxid]
 
           # Merkle path short-circuit: proven transaction needs no input verification
           if tx.merkle_path
-            unless tx.merkle_path.verify(tx_id, chain_tracker)
+            unless tx.merkle_path.verify(tx.txid_hex, chain_tracker)
               raise VerificationError.new(:invalid_merkle_proof,
-                                          "invalid merkle proof for transaction #{tx_id}")
+                                          "invalid merkle proof for transaction #{tx.txid_hex}")
             end
 
-            verified[tx_id] = true
+            verified[wtxid] = true
             next
           end
 
@@ -631,13 +631,13 @@ module BSV
 
             # Enqueue source transaction for verification if not yet verified
             source_tx = input.source_transaction
-            queue << source_tx if source_tx && !verified[source_tx.txid_hex]
+            queue << source_tx if source_tx && !verified[source_tx.wtxid]
           end
 
           # Output ≤ input check
           verify_output_constraint(tx)
 
-          verified[tx_id] = true
+          verified[wtxid] = true
         end
 
         true
@@ -786,19 +786,19 @@ module BSV
       end
 
       def verify_input_requirements(tx, input, index)
-        tx_id = tx.txid_hex
+        dtxid_hex = tx.txid_hex
         if input.unlocking_script.nil?
           raise VerificationError.new(:missing_source,
-                                      "input #{index} of transaction #{tx_id} has no unlocking script")
+                                      "input #{index} of transaction #{dtxid_hex} has no unlocking script")
         end
         if input.source_locking_script.nil?
           raise VerificationError.new(:missing_source,
-                                      "input #{index} of transaction #{tx_id} has no source locking script")
+                                      "input #{index} of transaction #{dtxid_hex} has no source locking script")
         end
         return unless input.source_satoshis.nil?
 
         raise VerificationError.new(:missing_source,
-                                    "input #{index} of transaction #{tx_id} has no source satoshis")
+                                    "input #{index} of transaction #{dtxid_hex} has no source satoshis")
       end
 
       def verify_fee(fee_model)
@@ -852,7 +852,7 @@ module BSV
 
       # Collect this transaction and all its ancestors in dependency order
       # (ancestors first, self last). Stops recursion at transactions with
-      # a merkle_path (proven leaves). Deduplicates by txid.
+      # a merkle_path (proven leaves). Deduplicates by wtxid (wire-order bytes).
       def collect_ancestors
         seen = {}
         result = []
@@ -861,8 +861,8 @@ module BSV
       end
 
       def collect_ancestors_recursive(tx, seen, result)
-        txid = tx.txid
-        return if seen.key?(txid)
+        wtxid = tx.wtxid
+        return if seen.key?(wtxid)
 
         unless tx.merkle_path
           tx.inputs.each do |input|
@@ -872,7 +872,7 @@ module BSV
           end
         end
 
-        seen[txid] = true
+        seen[wtxid] = true
         result << tx
       end
 
@@ -895,8 +895,8 @@ module BSV
           merged = txs.first.merkle_path.dup
           txs.drop(1).each { |t| merged.combine(t.merkle_path) }
 
-          txid_hashes = txs.map(&:wtxid)
-          clean = merged.extract(txid_hashes)
+          wtxid_hashes = txs.map(&:wtxid)
+          clean = merged.extract(wtxid_hashes)
 
           bump_index_by_height[height] = beef.bumps.length
           beef.bumps << clean

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -415,17 +415,17 @@ module BSV
         txid.unpack1('H*')
       end
 
-      # Display-order transaction ID (alias for {#txid}).
+      # Display-order transaction ID as a hex string.
       #
-      # Mirrors the wallet gem's +DisplayTxid+ pattern. Use this alias in contexts
-      # where it is important to make the byte-order intent explicit.
+      # Mirrors the wallet gem's +DisplayTxid+ pattern. +dtxid+ always returns
+      # a 64-char hex string suitable for JSON and UI boundaries.
       #
-      # @return [String] 32-byte transaction ID in display byte order
-      alias dtxid txid
+      # @return [String] hex-encoded transaction ID (display order)
+      alias dtxid txid_hex
 
-      # Display-order transaction ID as a hex string (alias for {#txid_hex}).
+      # Display-order transaction ID as a hex string (alias for {#dtxid}).
       #
-      # @return [String] hex-encoded transaction ID
+      # @return [String] hex-encoded transaction ID (display order)
       alias dtxid_hex txid_hex
 
       # --- Sighash (BIP-143 with FORKID) ---

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -391,7 +391,7 @@ module BSV
       # Wire-order transaction ID (raw SHA-256d of the serialised tx).
       #
       # Used by BEEF, BUMPs, and merkle paths, which all work in wire byte order
-      # to match {TransactionInput#prev_tx_id}.
+      # to match {TransactionInput#prev_wtxid}.
       #
       # @return [String] 32-byte transaction ID in wire byte order
       def wtxid

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -415,6 +415,19 @@ module BSV
         txid.unpack1('H*')
       end
 
+      # Display-order transaction ID (alias for {#txid}).
+      #
+      # Mirrors the wallet gem's +DisplayTxid+ pattern. Use this alias in contexts
+      # where it is important to make the byte-order intent explicit.
+      #
+      # @return [String] 32-byte transaction ID in display byte order
+      alias dtxid txid
+
+      # Display-order transaction ID as a hex string (alias for {#txid_hex}).
+      #
+      # @return [String] hex-encoded transaction ID
+      alias dtxid_hex txid_hex
+
       # --- Sighash (BIP-143 with FORKID) ---
 
       # Build the BIP-143 sighash preimage for an input.

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction_input.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction_input.rb
@@ -8,8 +8,8 @@ module BSV
     # output index (the "outpoint"), and provide an unlocking script to
     # satisfy the locking script conditions.
     class TransactionInput
-      # @return [String] 32-byte transaction ID of the output being spent (internal byte order)
-      attr_reader :prev_tx_id
+      # @return [String] 32-byte wire-order transaction ID of the output being spent
+      attr_reader :prev_wtxid
 
       # @return [Integer] index of the output within the previous transaction
       attr_reader :prev_tx_out_index
@@ -32,12 +32,12 @@ module BSV
       # @return [UnlockingScriptTemplate, nil] template for deferred signing
       attr_accessor :unlocking_script_template
 
-      # @param prev_tx_id [String] 32-byte transaction ID (internal byte order)
+      # @param prev_wtxid [String] 32-byte wire-order transaction ID
       # @param prev_tx_out_index [Integer] output index in the previous transaction
       # @param unlocking_script [Script::Script, nil] unlocking script (nil if unsigned)
       # @param sequence [Integer] sequence number
-      def initialize(prev_tx_id:, prev_tx_out_index:, unlocking_script: nil, sequence: 0xFFFFFFFF)
-        @prev_tx_id = prev_tx_id.b
+      def initialize(prev_wtxid:, prev_tx_out_index:, unlocking_script: nil, sequence: 0xFFFFFFFF)
+        @prev_wtxid = prev_wtxid.b
         @prev_tx_out_index = prev_tx_out_index
         @unlocking_script = unlocking_script
         @sequence = sequence
@@ -48,7 +48,7 @@ module BSV
       # @return [String] binary input (outpoint + varint + script + sequence)
       def to_binary
         script_bytes = @unlocking_script ? @unlocking_script.to_binary : ''.b
-        @prev_tx_id +
+        @prev_wtxid +
           [@prev_tx_out_index].pack('V') +
           VarInt.encode(script_bytes.bytesize) +
           script_bytes +
@@ -66,7 +66,7 @@ module BSV
                 "truncated input: need 36 bytes for outpoint at offset #{offset}, got #{data.bytesize - offset}"
         end
 
-        prev_tx_id = data.byteslice(offset, 32)
+        prev_wtxid = data.byteslice(offset, 32)
         prev_tx_out_index = data.byteslice(offset + 32, 4).unpack1('V')
         offset += 36
 
@@ -90,7 +90,7 @@ module BSV
 
         total = 36 + vi_size + script_len + 4
         input = new(
-          prev_tx_id: prev_tx_id,
+          prev_wtxid: prev_wtxid,
           prev_tx_out_index: prev_tx_out_index,
           unlocking_script: unlocking_script,
           sequence: sequence
@@ -98,26 +98,26 @@ module BSV
         [input, total]
       end
 
-      # Convert a hex transaction ID to internal byte order (reversed).
+      # Convert a display-order hex transaction ID to wire-order bytes.
       #
       # @param hex [String] hex-encoded transaction ID (display order)
-      # @return [String] 32-byte transaction ID in internal byte order
-      def self.txid_from_hex(hex)
+      # @return [String] 32-byte transaction ID in wire byte order
+      def self.wtxid_from_hex(hex)
         [hex].pack('H*').reverse
       end
 
-      # Serialise the outpoint (prev_tx_id + output index) as binary.
+      # Serialise the outpoint (prev_wtxid + output index) as binary.
       #
       # @return [String] 36-byte outpoint
       def outpoint_binary
-        @prev_tx_id + [@prev_tx_out_index].pack('V')
+        @prev_wtxid + [@prev_tx_out_index].pack('V')
       end
 
-      # The previous transaction ID in hex (display order).
+      # The previous transaction ID in display-order hex.
       #
-      # @return [String] hex-encoded transaction ID
-      def txid_hex
-        @prev_tx_id.reverse.unpack1('H*')
+      # @return [String] hex-encoded transaction ID (display order)
+      def dtxid_hex
+        @prev_wtxid.reverse.unpack1('H*')
       end
     end
   end

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction_input.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction_input.rb
@@ -37,6 +37,7 @@ module BSV
       # @param unlocking_script [Script::Script, nil] unlocking script (nil if unsigned)
       # @param sequence [Integer] sequence number
       def initialize(prev_wtxid:, prev_tx_out_index:, unlocking_script: nil, sequence: 0xFFFFFFFF)
+        BSV::Primitives::Hex.validate_wtxid!(prev_wtxid, name: 'prev_wtxid')
         @prev_wtxid = prev_wtxid.b
         @prev_tx_out_index = prev_tx_out_index
         @unlocking_script = unlocking_script
@@ -103,6 +104,7 @@ module BSV
       # @param hex [String] hex-encoded transaction ID (display order)
       # @return [String] 32-byte transaction ID in wire byte order
       def self.wtxid_from_hex(hex)
+        BSV::Primitives::Hex.validate_dtxid_hex!(hex, name: 'wtxid_from_hex input')
         [hex].pack('H*').reverse
       end
 

--- a/gem/bsv-sdk/lib/bsv/wallet/interface/brc100.rb
+++ b/gem/bsv-sdk/lib/bsv/wallet/interface/brc100.rb
@@ -38,10 +38,12 @@ module BSV
         #   - :basket [String] optional basket name for UTXO tracking
         #   - :custom_instructions [String] application-specific context
         #   - :tags [Array<String>] output tags for filtering
-        # @return [Hash] :txid, :tx, :no_send_change, :send_with_results, :signable_transaction
+        # @return [Hash] BRC-100 spec-mandated keys: :txid (display-order hex), :tx, :no_send_change,
+        #   :send_with_results, :signable_transaction
         def create_action(description:, input_beef: nil, inputs: nil, outputs: nil,
                           lock_time: nil, version: nil, labels: nil,
                           sign_and_process: true, accept_delayed_broadcast: true,
+                          # BRC-100 spec-mandated parameter names — display-order hex txids
                           trust_self: nil, known_txids: nil, return_txid_only: false,
                           no_send: false, no_send_change: nil, send_with: nil,
                           randomize_outputs: true, originator: nil)
@@ -53,7 +55,8 @@ module BSV
         # @param spends [Hash{Integer => Hash}] input index => { unlocking_script:, sequence_number: }
         # @param reference [String] reference returned by {#create_action}
         def sign_action(spends:, reference:,
-                        accept_delayed_broadcast: true, return_txid_only: false,
+                        accept_delayed_broadcast: true,
+                        return_txid_only: false, # BRC-100 spec-mandated parameter name
                         no_send: false, send_with: nil, originator: nil)
           raise NotImplementedError
         end

--- a/gem/bsv-sdk/spec/bsv/overlay/admin_token_template_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/overlay/admin_token_template_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe BSV::Overlay::AdminTokenTemplate do
       # Source transaction: contains the locked output.
       source_tx = BSV::Transaction::Transaction.new
       dummy_input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: "\x00" * 32,
+        prev_wtxid: "\x00" * 32,
         prev_tx_out_index: 0
       )
       dummy_input.source_locking_script = BSV::Script::Script.p2pkh_lock("\x00" * 20)
@@ -314,7 +314,7 @@ RSpec.describe BSV::Overlay::AdminTokenTemplate do
       # Spending transaction: spends the locked output.
       spend_tx = BSV::Transaction::Transaction.new
       spend_input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: [source_tx.txid_hex].pack('H*'),
+        prev_wtxid: source_tx.wtxid,
         prev_tx_out_index: 0,
         sequence: 0xffffffff
       )

--- a/gem/bsv-sdk/spec/bsv/script/interpreter/hardening_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/script/interpreter/hardening_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe 'A6 Interpreter Hardening' do
 
       tx = BSV::Transaction::Transaction.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: "\x00" * 32,
+        prev_wtxid: "\x00" * 32,
         prev_tx_out_index: 0
       )
       input.source_locking_script = lock_script

--- a/gem/bsv-sdk/spec/bsv/script/interpreter/interpreter_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/script/interpreter/interpreter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe BSV::Script::Interpreter do
 
     tx = BSV::Transaction::Transaction.new
     input = BSV::Transaction::TransactionInput.new(
-      prev_tx_id: "\x00" * 32,
+      prev_wtxid: "\x00" * 32,
       prev_tx_out_index: 0
     )
     input.source_locking_script = lock_script
@@ -40,7 +40,7 @@ RSpec.describe BSV::Script::Interpreter do
 
     tx = BSV::Transaction::Transaction.new
     input = BSV::Transaction::TransactionInput.new(
-      prev_tx_id: "\x00" * 32,
+      prev_wtxid: "\x00" * 32,
       prev_tx_out_index: 0
     )
     input.source_locking_script = lock_script
@@ -67,7 +67,7 @@ RSpec.describe BSV::Script::Interpreter do
 
     tx = BSV::Transaction::Transaction.new
     input = BSV::Transaction::TransactionInput.new(
-      prev_tx_id: "\x00" * 32,
+      prev_wtxid: "\x00" * 32,
       prev_tx_out_index: 0
     )
     input.source_locking_script = lock_script
@@ -268,7 +268,7 @@ RSpec.describe BSV::Script::Interpreter do
       )
 
       tx = BSV::Transaction::Transaction.new
-      input = BSV::Transaction::TransactionInput.new(prev_tx_id: "\x00" * 32, prev_tx_out_index: 0)
+      input = BSV::Transaction::TransactionInput.new(prev_wtxid: "\x00" * 32, prev_tx_out_index: 0)
       input.source_locking_script = lock_script
       input.source_satoshis = 100_000
       tx.add_input(input)
@@ -301,7 +301,7 @@ RSpec.describe BSV::Script::Interpreter do
       )
 
       tx = BSV::Transaction::Transaction.new
-      input = BSV::Transaction::TransactionInput.new(prev_tx_id: "\x00" * 32, prev_tx_out_index: 0)
+      input = BSV::Transaction::TransactionInput.new(prev_wtxid: "\x00" * 32, prev_tx_out_index: 0)
       input.source_locking_script = lock_script
       input.source_satoshis = 100_000
       tx.add_input(input)

--- a/gem/bsv-sdk/spec/bsv/script/interpreter/operations/chronicle_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/script/interpreter/operations/chronicle_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Chronicle opcodes' do
   def build_ver_tx(version:)
     tx = BSV::Transaction::Transaction.new(version: version)
     input = BSV::Transaction::TransactionInput.new(
-      prev_tx_id: "\x00" * 32,
+      prev_wtxid: "\x00" * 32,
       prev_tx_out_index: 0
     )
     dummy_lock = BSV::Script::Script.new

--- a/gem/bsv-sdk/spec/bsv/script/interpreter/operations/crypto_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/script/interpreter/operations/crypto_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe BSV::Script::Interpreter do
 
     tx = BSV::Transaction::Transaction.new
     input = BSV::Transaction::TransactionInput.new(
-      prev_tx_id: "\x00" * 32,
+      prev_wtxid: "\x00" * 32,
       prev_tx_out_index: 0
     )
     input.source_locking_script = lock_script
@@ -45,7 +45,7 @@ RSpec.describe BSV::Script::Interpreter do
 
     tx = BSV::Transaction::Transaction.new
     input = BSV::Transaction::TransactionInput.new(
-      prev_tx_id: "\x00" * 32,
+      prev_wtxid: "\x00" * 32,
       prev_tx_out_index: 0
     )
     input.source_locking_script = lock_script
@@ -185,7 +185,7 @@ RSpec.describe BSV::Script::Interpreter do
       lock_script = BSV::Script::Script.from_asm("#{pub.to_hex} OP_CHECKSIGVERIFY OP_1")
 
       tx = BSV::Transaction::Transaction.new
-      input = BSV::Transaction::TransactionInput.new(prev_tx_id: "\x00" * 32, prev_tx_out_index: 0)
+      input = BSV::Transaction::TransactionInput.new(prev_wtxid: "\x00" * 32, prev_tx_out_index: 0)
       input.source_locking_script = lock_script
       input.source_satoshis = 100_000
       tx.add_input(input)
@@ -221,7 +221,7 @@ RSpec.describe BSV::Script::Interpreter do
 
       tx = BSV::Transaction::Transaction.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: "\x00" * 32, prev_tx_out_index: 0
+        prev_wtxid: "\x00" * 32, prev_tx_out_index: 0
       )
       input.source_locking_script = lock_script
       input.source_satoshis = 100_000
@@ -259,7 +259,7 @@ RSpec.describe BSV::Script::Interpreter do
 
       tx = BSV::Transaction::Transaction.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: "\x00" * 32, prev_tx_out_index: 0
+        prev_wtxid: "\x00" * 32, prev_tx_out_index: 0
       )
       input.source_locking_script = lock_script
       input.source_satoshis = 100_000
@@ -297,7 +297,7 @@ RSpec.describe BSV::Script::Interpreter do
 
       tx = BSV::Transaction::Transaction.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: "\x00" * 32, prev_tx_out_index: 0
+        prev_wtxid: "\x00" * 32, prev_tx_out_index: 0
       )
       input.source_locking_script = lock_script
       input.source_satoshis = 100_000
@@ -334,7 +334,7 @@ RSpec.describe BSV::Script::Interpreter do
       lock_script = BSV::Script::Script.p2ms_lock(1, [pub.compressed])
 
       tx = BSV::Transaction::Transaction.new
-      input = BSV::Transaction::TransactionInput.new(prev_tx_id: "\x00" * 32, prev_tx_out_index: 0)
+      input = BSV::Transaction::TransactionInput.new(prev_wtxid: "\x00" * 32, prev_tx_out_index: 0)
       input.source_locking_script = lock_script
       input.source_satoshis = 100_000
       tx.add_input(input)

--- a/gem/bsv-sdk/spec/bsv/script/push_drop_template_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/script/push_drop_template_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe 'BSV::Script::PushDropTemplate' do
   def build_spending_tx(lock_script, satoshis:)
     tx = BSV::Transaction::Transaction.new
     input = BSV::Transaction::TransactionInput.new(
-      prev_tx_id: "\x00" * 32,
+      prev_wtxid: "\x00" * 32,
       prev_tx_out_index: 0
     )
     input.source_locking_script = lock_script

--- a/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe BSV::Transaction::Beef do
       expect(wired_inputs).not_to be_empty
 
       wired_inputs.each do |input|
-        expect(input.source_transaction.txid_hex).to eq(input.txid_hex)
+        expect(input.source_transaction.txid_hex).to eq(input.dtxid_hex)
       end
     end
   end
@@ -378,13 +378,13 @@ RSpec.describe BSV::Transaction::Beef do
 
       # Build a child spending both
       child = BSV::Transaction::Transaction.new
-      input_a = BSV::Transaction::TransactionInput.new(prev_tx_id: ancestor_a.wtxid, prev_tx_out_index: 0)
+      input_a = BSV::Transaction::TransactionInput.new(prev_wtxid: ancestor_a.wtxid, prev_tx_out_index: 0)
       input_a.source_transaction = ancestor_a
       input_a.source_satoshis = 5000
       input_a.source_locking_script = lock
       child.add_input(input_a)
 
-      input_b = BSV::Transaction::TransactionInput.new(prev_tx_id: ancestor_b.wtxid, prev_tx_out_index: 0)
+      input_b = BSV::Transaction::TransactionInput.new(prev_wtxid: ancestor_b.wtxid, prev_tx_out_index: 0)
       input_b.source_transaction = ancestor_b
       input_b.source_satoshis = 3000
       input_b.source_locking_script = lock
@@ -483,10 +483,10 @@ RSpec.describe BSV::Transaction::Beef do
       tx_b.merkle_path = path_b
 
       child = BSV::Transaction::Transaction.new
-      input_a = BSV::Transaction::TransactionInput.new(prev_tx_id: tx_a.wtxid, prev_tx_out_index: 0)
+      input_a = BSV::Transaction::TransactionInput.new(prev_wtxid: tx_a.wtxid, prev_tx_out_index: 0)
       input_a.source_transaction = tx_a
       child.add_input(input_a)
-      input_b = BSV::Transaction::TransactionInput.new(prev_tx_id: tx_b.wtxid, prev_tx_out_index: 0)
+      input_b = BSV::Transaction::TransactionInput.new(prev_wtxid: tx_b.wtxid, prev_tx_out_index: 0)
       input_b.source_transaction = tx_b
       child.add_input(input_b)
       child.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 150, locking_script: lock))
@@ -637,7 +637,7 @@ RSpec.describe BSV::Transaction::Beef do
         tx_real.merkle_path = contaminated_bump
 
         c = BSV::Transaction::Transaction.new
-        input = BSV::Transaction::TransactionInput.new(prev_tx_id: tx_real.wtxid, prev_tx_out_index: 0)
+        input = BSV::Transaction::TransactionInput.new(prev_wtxid: tx_real.wtxid, prev_tx_out_index: 0)
         input.source_transaction = tx_real
         c.add_input(input)
         c.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 400, locking_script: lock))
@@ -1228,21 +1228,21 @@ RSpec.describe BSV::Transaction::Beef do
   describe '#sort_transactions! cycle handling (F5.5)' do
     it 'moves cyclic transactions to @txs_not_valid' do
       # A real txid cycle is impossible (txid is a hash of the tx, which includes
-      # the input prev_tx_id). We test cycle detection by using mocked transaction
+      # the input prev_wtxid). We test cycle detection by using mocked transaction
       # objects with stable fake wtxids that reference each other.
       #
       # sort_transactions! logic:
       #   txid_index[bt.wtxid] = i  (wire-order wtxid from BeefTx#wtxid)
-      #   dep_idx = txid_index[input.prev_tx_id]
-      #   (prev_tx_id is also wire-order — direct lookup, no reversal needed)
+      #   dep_idx = txid_index[input.prev_wtxid]
+      #   (prev_wtxid is also wire-order — direct lookup, no reversal needed)
       #
-      # For a cycle: input_a.prev_tx_id must == wtxid_b (wire-order).
+      # For a cycle: input_a.prev_wtxid must == wtxid_b (wire-order).
       wtxid_a = BSV::Primitives::Digest.sha256('fake_tx_a') # wire order
       wtxid_b = BSV::Primitives::Digest.sha256('fake_tx_b')
 
-      # prev_tx_id (wire) of A's input must equal wtxid_b so the sort sees a dep B→A
-      input_a = instance_double(BSV::Transaction::TransactionInput, prev_tx_id: wtxid_b)
-      input_b = instance_double(BSV::Transaction::TransactionInput, prev_tx_id: wtxid_a)
+      # prev_wtxid (wire) of A's input must equal wtxid_b so the sort sees a dep B→A
+      input_a = instance_double(BSV::Transaction::TransactionInput, prev_wtxid: wtxid_b)
+      input_b = instance_double(BSV::Transaction::TransactionInput, prev_wtxid: wtxid_a)
 
       tx_a = instance_double(BSV::Transaction::Transaction, wtxid: wtxid_a, inputs: [input_a])
       tx_b = instance_double(BSV::Transaction::Transaction, wtxid: wtxid_b, inputs: [input_b])

--- a/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
@@ -391,20 +391,18 @@ RSpec.describe BSV::Transaction::Beef do
 
       ancestor_a = BSV::Transaction::Transaction.new
       ancestor_a.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 5000, locking_script: lock))
-      txid_a_hex = ancestor_a.txid.unpack1('H*')
       ancestor_a.merkle_path = BSV::Transaction::MerklePath.new(
         block_height: 800_000,
-        path: [[pe.new(offset: 0, hash: txid_a_hex, txid: true),
-                pe.new(offset: 1, hash: 'aa' * 32)]]
+        path: [[pe.new(offset: 0, hash: ancestor_a.wtxid, txid: true),
+                pe.new(offset: 1, hash: ['aa' * 32].pack('H*'))]]
       )
 
       ancestor_b = BSV::Transaction::Transaction.new(version: 2)
       ancestor_b.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 3000, locking_script: lock))
-      txid_b_hex = ancestor_b.txid.unpack1('H*')
       ancestor_b.merkle_path = BSV::Transaction::MerklePath.new(
         block_height: 800_000,
-        path: [[pe.new(offset: 2, hash: txid_b_hex, txid: true),
-                pe.new(offset: 3, hash: 'bb' * 32)]]
+        path: [[pe.new(offset: 2, hash: ancestor_b.wtxid, txid: true),
+                pe.new(offset: 3, hash: ['bb' * 32].pack('H*'))]]
       )
 
       # Build a child spending both

--- a/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
@@ -282,28 +282,28 @@ RSpec.describe BSV::Transaction::Beef do
   end
 
   describe 'BeefTx#dtxid' do
-    it 'is an alias for txid on a raw entry' do
+    it 'returns display-order hex on a raw entry' do
       beef = described_class.from_hex(beef_set_hex)
       bt = beef.transactions.find(&:transaction)
-      expect(bt.dtxid).to eq(bt.txid)
+      expect(bt.dtxid).to eq(bt.txid.unpack1('H*'))
     end
 
-    it 'is an alias for txid on a txid-only entry' do
+    it 'returns display-order hex on a txid-only entry' do
       bt = described_class::BeefTx.new(
         format: described_class::FORMAT_TXID_ONLY,
         known_wtxid: "\x01".b * 32
       )
-      expect(bt.dtxid).to eq(bt.txid)
+      expect(bt.dtxid).to eq(bt.txid.unpack1('H*'))
     end
   end
 
   describe '#subject_dtxid' do
-    it 'is an alias for subject_txid on an Atomic BEEF' do
+    it 'returns display-order hex on an Atomic BEEF' do
       beef = described_class.from_hex(beef_set_hex)
       last_tx = beef.transactions.last.transaction
       atomic_bytes = beef.to_atomic_binary(last_tx.wtxid)
       parsed = described_class.from_binary(atomic_bytes)
-      expect(parsed.subject_dtxid).to eq(parsed.subject_txid)
+      expect(parsed.subject_dtxid).to eq(parsed.subject_txid.unpack1('H*'))
     end
 
     it 'returns nil on a non-Atomic BEEF' do

--- a/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
@@ -281,6 +281,37 @@ RSpec.describe BSV::Transaction::Beef do
     end
   end
 
+  describe 'BeefTx#dtxid' do
+    it 'is an alias for txid on a raw entry' do
+      beef = described_class.from_hex(beef_set_hex)
+      bt = beef.transactions.find(&:transaction)
+      expect(bt.dtxid).to eq(bt.txid)
+    end
+
+    it 'is an alias for txid on a txid-only entry' do
+      bt = described_class::BeefTx.new(
+        format: described_class::FORMAT_TXID_ONLY,
+        known_wtxid: "\x01".b * 32
+      )
+      expect(bt.dtxid).to eq(bt.txid)
+    end
+  end
+
+  describe '#subject_dtxid' do
+    it 'is an alias for subject_txid on an Atomic BEEF' do
+      beef = described_class.from_hex(beef_set_hex)
+      last_tx = beef.transactions.last.transaction
+      atomic_bytes = beef.to_atomic_binary(last_tx.wtxid)
+      parsed = described_class.from_binary(atomic_bytes)
+      expect(parsed.subject_dtxid).to eq(parsed.subject_txid)
+    end
+
+    it 'returns nil on a non-Atomic BEEF' do
+      beef = described_class.from_hex(beef_set_hex)
+      expect(beef.subject_dtxid).to be_nil
+    end
+  end
+
   describe 'Atomic BEEF' do
     it 'round-trips via to_atomic_binary and from_binary' do
       beef = described_class.from_hex(beef_set_hex)

--- a/gem/bsv-sdk/spec/bsv/transaction/benford_distribution_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/benford_distribution_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'Benford change distribution — statistical validation' do # rub
     def build_tx(input_sats:, output_sats:, change_count:)
       tx = tx_class.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: BSV::Primitives::Digest.sha256d('test'),
+        prev_wtxid: BSV::Primitives::Digest.sha256d('test'),
         prev_tx_out_index: 0
       )
       input.source_satoshis = input_sats

--- a/gem/bsv-sdk/spec/bsv/transaction/merkle_path_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/merkle_path_spec.rb
@@ -290,8 +290,8 @@ RSpec.describe BSV::Transaction::MerklePath do
       expect(compound_txids).not_to include(upper_target_hash)
     end
 
-    it 'raises when txid_hashes is empty' do
-      expect { mp.extract([]) }.to raise_error(ArgumentError, /at least one txid/)
+    it 'raises when wtxid_hashes is empty' do
+      expect { mp.extract([]) }.to raise_error(ArgumentError, /at least one wtxid/)
     end
 
     it 'raises when a requested txid is not in the source path' do

--- a/gem/bsv-sdk/spec/bsv/transaction/merkle_path_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/merkle_path_spec.rb
@@ -456,7 +456,7 @@ RSpec.describe BSV::Transaction::MerklePath do
 
     let(:woc_path) do
       described_class.from_tsc(
-        txid: woc_txid,
+        dtxid_hex: woc_txid,
         index: woc_index,
         nodes: woc_nodes,
         block_height: woc_block_height
@@ -511,7 +511,7 @@ RSpec.describe BSV::Transaction::MerklePath do
     context 'with a single-tx block' do
       it 'produces a one-level path containing only the txid' do
         mp = described_class.from_tsc(
-          txid: woc_txid,
+          dtxid_hex: woc_txid,
           index: 0,
           nodes: [],
           block_height: 100
@@ -542,7 +542,7 @@ RSpec.describe BSV::Transaction::MerklePath do
 
       it 'computes the correct root when level 0 has a duplicate sibling' do
         mp = described_class.from_tsc(
-          txid: txid_hex,
+          dtxid_hex: txid_hex,
           index: 2,
           nodes: ['*', level1[0].reverse.unpack1('H*')],
           block_height: 50
@@ -552,7 +552,7 @@ RSpec.describe BSV::Transaction::MerklePath do
 
       it 'marks the duplicate level-0 sibling as duplicate' do
         mp = described_class.from_tsc(
-          txid: txid_hex,
+          dtxid_hex: txid_hex,
           index: 2,
           nodes: ['*', level1[0].reverse.unpack1('H*')],
           block_height: 50
@@ -564,7 +564,7 @@ RSpec.describe BSV::Transaction::MerklePath do
 
       it 'round-trips a path with duplicate nodes' do
         mp = described_class.from_tsc(
-          txid: txid_hex,
+          dtxid_hex: txid_hex,
           index: 2,
           nodes: ['*', level1[0].reverse.unpack1('H*')],
           block_height: 50
@@ -588,7 +588,7 @@ RSpec.describe BSV::Transaction::MerklePath do
 
       it 'computes the correct root from a hand-built TSC proof' do
         mp = described_class.from_tsc(
-          txid: leaves[2].reverse.unpack1('H*'),
+          dtxid_hex: leaves[2].reverse.unpack1('H*'),
           index: 2,
           nodes: [
             leaves[3].reverse.unpack1('H*'),  # level-0 sibling

--- a/gem/bsv-sdk/spec/bsv/transaction/p2pkh_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/p2pkh_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe BSV::Transaction::P2PKH do
   let(:tx) do
     tx = BSV::Transaction::Transaction.new
     input = BSV::Transaction::TransactionInput.new(
-      prev_tx_id: "\x01".b * 32,
+      prev_wtxid: "\x01".b * 32,
       prev_tx_out_index: 0
     )
     input.source_satoshis = 100_000
@@ -43,7 +43,7 @@ RSpec.describe BSV::Transaction::P2PKH do
       # Sign with direct method
       direct_tx = BSV::Transaction::Transaction.new
       input1 = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: "\x01".b * 32,
+        prev_wtxid: "\x01".b * 32,
         prev_tx_out_index: 0
       )
       input1.source_satoshis = 100_000

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_ef_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_ef_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: "\x01".b * 32,
+          prev_wtxid: "\x01".b * 32,
           prev_tx_out_index: 0
         )
         input.source_satoshis = 50_000
@@ -53,7 +53,7 @@ RSpec.describe BSV::Transaction::Transaction do
       it 'raises when source_satoshis and source_locking_script both absent and no source_transaction' do
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: "\x01".b * 32,
+          prev_wtxid: "\x01".b * 32,
           prev_tx_out_index: 0
         )
         tx.add_input(input)
@@ -64,7 +64,7 @@ RSpec.describe BSV::Transaction::Transaction do
       it 'raises when source_locking_script absent and no source_transaction' do
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: "\x01".b * 32,
+          prev_wtxid: "\x01".b * 32,
           prev_tx_out_index: 0
         )
         input.source_satoshis = 1000
@@ -83,7 +83,7 @@ RSpec.describe BSV::Transaction::Transaction do
         # Build unlocking script with full explicit fields, then strip source_satoshis
         prep_tx = described_class.new
         prep_input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: "\x02".b * 32,
+          prev_wtxid: "\x02".b * 32,
           prev_tx_out_index: 0
         )
         prep_input.source_satoshis = 75_000
@@ -94,7 +94,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: "\x02".b * 32,
+          prev_wtxid: "\x02".b * 32,
           prev_tx_out_index: 0
         )
         input.unlocking_script = prep_tx.inputs[0].unlocking_script
@@ -122,7 +122,7 @@ RSpec.describe BSV::Transaction::Transaction do
         # Build and sign a tx with explicit fields, then strip them to simulate a BEEF-parsed input
         prep_tx = described_class.new
         prep_input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: "\x05".b * 32,
+          prev_wtxid: "\x05".b * 32,
           prev_tx_out_index: 0
         )
         prep_input.source_satoshis = 75_000
@@ -134,7 +134,7 @@ RSpec.describe BSV::Transaction::Transaction do
         # Simulate BEEF-parsed input: has unlocking_script + source_transaction, no explicit source fields
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: "\x05".b * 32,
+          prev_wtxid: "\x05".b * 32,
           prev_tx_out_index: 0
         )
         input.unlocking_script = prep_tx.inputs[0].unlocking_script
@@ -160,7 +160,7 @@ RSpec.describe BSV::Transaction::Transaction do
         # Build unlocking script using a separate signed tx
         prep_tx = described_class.new
         prep_input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: "\x03".b * 32,
+          prev_wtxid: "\x03".b * 32,
           prev_tx_out_index: 0
         )
         prep_input.source_satoshis = 50_000
@@ -171,7 +171,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: "\x03".b * 32,
+          prev_wtxid: "\x03".b * 32,
           prev_tx_out_index: 0
         )
         input.unlocking_script = prep_tx.inputs[0].unlocking_script
@@ -197,7 +197,7 @@ RSpec.describe BSV::Transaction::Transaction do
         # Prepare a signed unlocking script for input1
         prep_tx = described_class.new
         prep_input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: "\x02".b * 32,
+          prev_wtxid: "\x02".b * 32,
           prev_tx_out_index: 0
         )
         prep_input.source_satoshis = 30_000
@@ -209,14 +209,14 @@ RSpec.describe BSV::Transaction::Transaction do
         tx = described_class.new
 
         # Input 0: explicit fields
-        input0 = BSV::Transaction::TransactionInput.new(prev_tx_id: "\x01".b * 32, prev_tx_out_index: 0)
+        input0 = BSV::Transaction::TransactionInput.new(prev_wtxid: "\x01".b * 32, prev_tx_out_index: 0)
         input0.source_satoshis = 20_000
         input0.source_locking_script = lock_script
         input0.unlocking_script_template = BSV::Transaction::P2PKH.new(priv)
         tx.add_input(input0)
 
         # Input 1: only source_transaction (no explicit source_satoshis / source_locking_script)
-        input1 = BSV::Transaction::TransactionInput.new(prev_tx_id: "\x02".b * 32, prev_tx_out_index: 0)
+        input1 = BSV::Transaction::TransactionInput.new(prev_wtxid: "\x02".b * 32, prev_tx_out_index: 0)
         input1.source_transaction = source_tx
         input1.unlocking_script = prep_tx.inputs[0].unlocking_script
         tx.add_input(input1)
@@ -241,7 +241,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: "\x04".b * 32,
+          prev_wtxid: "\x04".b * 32,
           prev_tx_out_index: 99 # out of range
         )
         input.source_transaction = source_tx
@@ -259,7 +259,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: "\x01".b * 32,
+          prev_wtxid: "\x01".b * 32,
           prev_tx_out_index: 0
         )
         input.source_satoshis = 50_000
@@ -321,7 +321,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: BSV::Primitives::Digest.sha256d('test source tx'),
+          prev_wtxid: BSV::Primitives::Digest.sha256d('test source tx'),
           prev_tx_out_index: 0
         )
         input.source_satoshis = 100_000
@@ -346,7 +346,7 @@ RSpec.describe BSV::Transaction::Transaction do
         tx = described_class.new
         3.times do |i|
           input = BSV::Transaction::TransactionInput.new(
-            prev_tx_id: BSV::Primitives::Digest.sha256d("source #{i}"),
+            prev_wtxid: BSV::Primitives::Digest.sha256d("source #{i}"),
             prev_tx_out_index: i
           )
           input.source_satoshis = 50_000 + i
@@ -376,7 +376,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: BSV::Primitives::Digest.sha256d('source tx'),
+          prev_wtxid: BSV::Primitives::Digest.sha256d('source tx'),
           prev_tx_out_index: 0
         )
         input.source_satoshis = 100_000
@@ -398,7 +398,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: "\x01".b * 32,
+          prev_wtxid: "\x01".b * 32,
           prev_tx_out_index: 0
         )
         input.source_satoshis = 50_000

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_fee_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_fee_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe BSV::Transaction::Transaction do
     def build_tx(input_sats:, output_sats:, change_sats: 0, change_count: 1)
       tx = described_class.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: BSV::Primitives::Digest.sha256d('test'),
+        prev_wtxid: BSV::Primitives::Digest.sha256d('test'),
         prev_tx_out_index: 0
       )
       input.source_satoshis = input_sats
@@ -125,7 +125,7 @@ RSpec.describe BSV::Transaction::Transaction do
       it 'works without change outputs' do
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: BSV::Primitives::Digest.sha256d('test'),
+          prev_wtxid: BSV::Primitives::Digest.sha256d('test'),
           prev_tx_out_index: 0
         )
         input.source_satoshis = 100_000

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_input_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_input_spec.rb
@@ -4,25 +4,25 @@ require 'spec_helper'
 
 RSpec.describe BSV::Transaction::TransactionInput do
   let(:txid_hex) { 'a477af6b2667c29670467e4e0728b685ee07b240235771862318e29ddbe58458' }
-  let(:txid_internal) { described_class.txid_from_hex(txid_hex) }
+  let(:txid_internal) { described_class.wtxid_from_hex(txid_hex) }
 
-  describe '.txid_from_hex' do
-    it 'converts display-order hex to internal byte order (reversed)' do
+  describe '.wtxid_from_hex' do
+    it 'converts display-order hex to wire byte order (reversed)' do
       expect(txid_internal.bytesize).to eq(32)
       expect(txid_internal.unpack1('H*')).to eq('5884e5db9de218238671572340b207ee85b628074e7e467096c267266baf77a4')
     end
   end
 
-  describe '#txid_hex' do
+  describe '#dtxid_hex' do
     it 'returns the display-order hex of the previous txid' do
-      input = described_class.new(prev_tx_id: txid_internal, prev_tx_out_index: 0)
-      expect(input.txid_hex).to eq(txid_hex)
+      input = described_class.new(prev_wtxid: txid_internal, prev_tx_out_index: 0)
+      expect(input.dtxid_hex).to eq(txid_hex)
     end
   end
 
   describe '#to_binary' do
     it 'serialises an unsigned input (empty script)' do
-      input = described_class.new(prev_tx_id: txid_internal, prev_tx_out_index: 1)
+      input = described_class.new(prev_wtxid: txid_internal, prev_tx_out_index: 1)
       binary = input.to_binary
 
       # 32 txid + 4 vout + 1 varint(0) + 0 script + 4 sequence = 41
@@ -36,7 +36,7 @@ RSpec.describe BSV::Transaction::TransactionInput do
     it 'serialises an input with an unlocking script' do
       script = BSV::Script::Script.from_hex('0102')
       input = described_class.new(
-        prev_tx_id: txid_internal,
+        prev_wtxid: txid_internal,
         prev_tx_out_index: 0,
         unlocking_script: script
       )
@@ -51,14 +51,14 @@ RSpec.describe BSV::Transaction::TransactionInput do
   describe '.from_binary' do
     it 'deserialises and round-trips' do
       input = described_class.new(
-        prev_tx_id: txid_internal,
+        prev_wtxid: txid_internal,
         prev_tx_out_index: 3,
         sequence: 0xFFFFFFFE
       )
       binary = input.to_binary
 
       parsed, bytes_consumed = described_class.from_binary(binary)
-      expect(parsed.prev_tx_id).to eq(txid_internal)
+      expect(parsed.prev_wtxid).to eq(txid_internal)
       expect(parsed.prev_tx_out_index).to eq(3)
       expect(parsed.unlocking_script).to be_nil
       expect(parsed.sequence).to eq(0xFFFFFFFE)
@@ -66,18 +66,18 @@ RSpec.describe BSV::Transaction::TransactionInput do
     end
 
     it 'parses from an offset' do
-      input = described_class.new(prev_tx_id: txid_internal, prev_tx_out_index: 0)
+      input = described_class.new(prev_wtxid: txid_internal, prev_tx_out_index: 0)
       padding = "\xFF".b * 10
       data = padding + input.to_binary
 
       parsed, = described_class.from_binary(data, 10)
-      expect(parsed.txid_hex).to eq(txid_hex)
+      expect(parsed.dtxid_hex).to eq(txid_hex)
     end
   end
 
   describe '#sequence=' do
     it 'allows the sequence to be mutated after construction' do
-      input = described_class.new(prev_tx_id: txid_internal, prev_tx_out_index: 0)
+      input = described_class.new(prev_wtxid: txid_internal, prev_tx_out_index: 0)
       expect(input.sequence).to eq(0xFFFFFFFF)
 
       input.sequence = 0x00000001
@@ -85,7 +85,7 @@ RSpec.describe BSV::Transaction::TransactionInput do
     end
 
     it 'reflects the new sequence in to_binary' do
-      input = described_class.new(prev_tx_id: txid_internal, prev_tx_out_index: 0)
+      input = described_class.new(prev_wtxid: txid_internal, prev_tx_out_index: 0)
       input.sequence = 0x00000001
 
       binary = input.to_binary
@@ -93,7 +93,7 @@ RSpec.describe BSV::Transaction::TransactionInput do
     end
 
     it 'serialises correctly when mutated from 0xFFFFFFFF to 0' do
-      input = described_class.new(prev_tx_id: txid_internal, prev_tx_out_index: 0, sequence: 0xFFFFFFFF)
+      input = described_class.new(prev_wtxid: txid_internal, prev_tx_out_index: 0, sequence: 0xFFFFFFFF)
       input.sequence = 0
 
       binary = input.to_binary
@@ -106,7 +106,7 @@ RSpec.describe BSV::Transaction::TransactionInput do
 
   describe '#outpoint_binary' do
     it 'returns 36-byte outpoint (txid + vout)' do
-      input = described_class.new(prev_tx_id: txid_internal, prev_tx_out_index: 2)
+      input = described_class.new(prev_wtxid: txid_internal, prev_tx_out_index: 2)
       outpoint = input.outpoint_binary
 
       expect(outpoint.bytesize).to eq(36)

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
@@ -61,12 +61,12 @@ RSpec.describe BSV::Transaction::Transaction do
   end
 
   describe '#dtxid / #dtxid_hex' do
-    it 'is an alias for txid' do
+    it 'returns display-order hex (same as txid_hex)' do
       tx = described_class.from_hex(vector1_hex)
-      expect(tx.dtxid).to eq(tx.txid)
+      expect(tx.dtxid).to eq(tx.txid_hex)
     end
 
-    it 'is an alias for txid_hex' do
+    it 'dtxid_hex is an alias for txid_hex' do
       tx = described_class.from_hex(vector1_hex)
       expect(tx.dtxid_hex).to eq(tx.txid_hex)
     end

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe BSV::Transaction::Transaction do
       # input_index 0 but no outputs
       tx_no_outputs = described_class.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: "\x01".b * 32,
+        prev_wtxid: "\x01".b * 32,
         prev_tx_out_index: 0
       )
       input.source_satoshis = 100_000
@@ -322,7 +322,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
       tx = described_class.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: "\x01".b * 32,
+        prev_wtxid: "\x01".b * 32,
         prev_tx_out_index: 0
       )
       input.source_satoshis = 100_000
@@ -357,7 +357,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
       2.times do
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: "\x02".b * 32,
+          prev_wtxid: "\x02".b * 32,
           prev_tx_out_index: 0
         )
         input.source_satoshis = 50_000
@@ -385,7 +385,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
     def build_input(prev_byte: "\x01".b, satoshis: 100_000)
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: prev_byte * 32,
+        prev_wtxid: prev_byte * 32,
         prev_tx_out_index: 0
       )
       input.source_satoshis = satoshis
@@ -497,7 +497,7 @@ RSpec.describe BSV::Transaction::Transaction do
     it 'estimates fee for unsigned inputs with template' do
       tx = described_class.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: "\x00".b * 32,
+        prev_wtxid: "\x00".b * 32,
         prev_tx_out_index: 0
       )
       input.source_satoshis = 100_000
@@ -525,7 +525,7 @@ RSpec.describe BSV::Transaction::Transaction do
       dummy_key = BSV::Primitives::PrivateKey.generate
       3.times do |i|
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: "\x00".b * 32,
+          prev_wtxid: "\x00".b * 32,
           prev_tx_out_index: i
         )
         input.source_satoshis = 50_000
@@ -547,7 +547,7 @@ RSpec.describe BSV::Transaction::Transaction do
     it 'estimates fee for a transaction with an OP_RETURN output' do
       tx = described_class.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: "\x00".b * 32,
+        prev_wtxid: "\x00".b * 32,
         prev_tx_out_index: 0
       )
       input.source_satoshis = 100_000
@@ -571,7 +571,7 @@ RSpec.describe BSV::Transaction::Transaction do
     it 'scales fee with satoshis_per_byte rate' do
       tx = described_class.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: "\x00".b * 32,
+        prev_wtxid: "\x00".b * 32,
         prev_tx_out_index: 0
       )
       input.source_satoshis = 100_000
@@ -598,7 +598,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
       tx = described_class.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: BSV::Primitives::Digest.sha256d('utxo'),
+        prev_wtxid: BSV::Primitives::Digest.sha256d('utxo'),
         prev_tx_out_index: 0
       )
       input.source_satoshis = 100_000
@@ -620,7 +620,7 @@ RSpec.describe BSV::Transaction::Transaction do
       tx = described_class.new
 
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: "\x00".b * 32,
+        prev_wtxid: "\x00".b * 32,
         prev_tx_out_index: 0
       )
       input.source_satoshis = 100_000
@@ -639,7 +639,7 @@ RSpec.describe BSV::Transaction::Transaction do
     it 'raises when any input has nil source_satoshis' do
       tx = described_class.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: "\x00".b * 32,
+        prev_wtxid: "\x00".b * 32,
         prev_tx_out_index: 0
       )
       # source_satoshis intentionally not set
@@ -660,7 +660,7 @@ RSpec.describe BSV::Transaction::Transaction do
     def tx_with_input_sats(input_sats)
       tx = described_class.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: "\x00".b * 32,
+        prev_wtxid: "\x00".b * 32,
         prev_tx_out_index: 0
       )
       input.source_satoshis = input_sats
@@ -721,10 +721,10 @@ RSpec.describe BSV::Transaction::Transaction do
     end
 
     # Wire an input from parent_tx output 0 into child_tx.
-    # prev_tx_id must be in wire byte order.
+    # prev_wtxid must be in wire byte order.
     def add_input(child_tx, parent_tx)
       inp = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: parent_tx.wtxid, prev_tx_out_index: 0
+        prev_wtxid: parent_tx.wtxid, prev_tx_out_index: 0
       )
       inp.source_transaction = parent_tx
       inp.source_satoshis = parent_tx.outputs[0].satoshis
@@ -867,7 +867,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
       # Fund with a UTXO
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: BSV::Primitives::Digest.sha256d('fake utxo'),
+        prev_wtxid: BSV::Primitives::Digest.sha256d('fake utxo'),
         prev_tx_out_index: 0
       )
       input.source_satoshis = 1_000_000

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
@@ -60,6 +60,18 @@ RSpec.describe BSV::Transaction::Transaction do
     end
   end
 
+  describe '#dtxid / #dtxid_hex' do
+    it 'is an alias for txid' do
+      tx = described_class.from_hex(vector1_hex)
+      expect(tx.dtxid).to eq(tx.txid)
+    end
+
+    it 'is an alias for txid_hex' do
+      tx = described_class.from_hex(vector1_hex)
+      expect(tx.dtxid_hex).to eq(tx.txid_hex)
+    end
+  end
+
   describe 'parsed structure' do
     it 'correctly parses vector 1 inputs and outputs' do
       tx = described_class.from_hex(vector1_hex)

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_verify_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_verify_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe BSV::Transaction::Transaction do
       tx = described_class.new
       # Coinbase-like input (no real source needed)
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: BSV::Primitives::Digest.sha256d('source'),
+        prev_wtxid: BSV::Primitives::Digest.sha256d('source'),
         prev_tx_out_index: 0
       )
       input.unlocking_script = BSV::Script::Script.from_asm('OP_TRUE')
@@ -34,7 +34,7 @@ RSpec.describe BSV::Transaction::Transaction do
     def build_spending_tx(source_tx, output_sats: 90_000)
       tx = described_class.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: source_tx.wtxid,
+        prev_wtxid: source_tx.wtxid,
         prev_tx_out_index: 0
       )
       input.source_satoshis = source_tx.outputs[0].satoshis
@@ -163,7 +163,7 @@ RSpec.describe BSV::Transaction::Transaction do
         tx = described_class.new
         [0, 0].each_with_index do |out_idx, _i|
           input = BSV::Transaction::TransactionInput.new(
-            prev_tx_id: source_tx.wtxid,
+            prev_wtxid: source_tx.wtxid,
             prev_tx_out_index: out_idx
           )
           input.source_satoshis = source_tx.outputs[0].satoshis
@@ -251,7 +251,7 @@ RSpec.describe BSV::Transaction::Transaction do
         # Use OP_TRUE scripts so script verification passes despite invalid amounts
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: source_tx.wtxid,
+          prev_wtxid: source_tx.wtxid,
           prev_tx_out_index: 0
         )
         input.source_satoshis = 100_000
@@ -276,7 +276,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: source_tx.wtxid,
+          prev_wtxid: source_tx.wtxid,
           prev_tx_out_index: 0
         )
         input.source_satoshis = 100_000
@@ -302,7 +302,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: source_tx.wtxid,
+          prev_wtxid: source_tx.wtxid,
           prev_tx_out_index: 0
         )
         input.source_satoshis = 100_000
@@ -327,7 +327,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
         tx = described_class.new
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: source_tx.wtxid,
+          prev_wtxid: source_tx.wtxid,
           prev_tx_out_index: 0
         )
         input.unlocking_script = BSV::Script::Script.from_asm('OP_TRUE')

--- a/gem/bsv-sdk/spec/bsv_spec.rb
+++ b/gem/bsv-sdk/spec/bsv_spec.rb
@@ -6,24 +6,4 @@ RSpec.describe BSV do
   it 'has a version number' do
     expect(BSV::VERSION).not_to be_nil
   end
-
-  describe 'TXID_FORMAT_WIRE' do
-    it 'equals "wire"' do
-      expect(BSV::TXID_FORMAT_WIRE).to eq('wire')
-    end
-
-    it 'is frozen' do
-      expect(BSV::TXID_FORMAT_WIRE).to be_frozen
-    end
-  end
-
-  describe 'TXID_FORMAT_DISPLAY' do
-    it 'equals "display"' do
-      expect(BSV::TXID_FORMAT_DISPLAY).to eq('display')
-    end
-
-    it 'is frozen' do
-      expect(BSV::TXID_FORMAT_DISPLAY).to be_frozen
-    end
-  end
 end

--- a/gem/bsv-sdk/spec/bsv_spec.rb
+++ b/gem/bsv-sdk/spec/bsv_spec.rb
@@ -6,4 +6,24 @@ RSpec.describe BSV do
   it 'has a version number' do
     expect(BSV::VERSION).not_to be_nil
   end
+
+  describe 'TXID_FORMAT_WIRE' do
+    it 'equals "wire"' do
+      expect(BSV::TXID_FORMAT_WIRE).to eq('wire')
+    end
+
+    it 'is frozen' do
+      expect(BSV::TXID_FORMAT_WIRE).to be_frozen
+    end
+  end
+
+  describe 'TXID_FORMAT_DISPLAY' do
+    it 'equals "display"' do
+      expect(BSV::TXID_FORMAT_DISPLAY).to eq('display')
+    end
+
+    it 'is frozen' do
+      expect(BSV::TXID_FORMAT_DISPLAY).to be_frozen
+    end
+  end
 end

--- a/gem/bsv-sdk/spec/conformance/fee_model_spec.rb
+++ b/gem/bsv-sdk/spec/conformance/fee_model_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe BSV::Transaction::Transaction do
     def build_funded_tx(input_sats:, output_sats:)
       tx = described_class.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: BSV::Primitives::Digest.sha256d('conformance'),
+        prev_wtxid: BSV::Primitives::Digest.sha256d('conformance'),
         prev_tx_out_index: 0
       )
       input.source_satoshis = input_sats

--- a/gem/bsv-sdk/spec/conformance/spv_verify_spec.rb
+++ b/gem/bsv-sdk/spec/conformance/spv_verify_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe BSV::Transaction::Transaction do # rubocop:disable RSpec/Multiple
     def build_source_tx(satoshis: 100_000)
       tx = described_class.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: BSV::Primitives::Digest.sha256d('conformance'),
+        prev_wtxid: BSV::Primitives::Digest.sha256d('conformance'),
         prev_tx_out_index: 0
       )
       input.unlocking_script = BSV::Script::Script.from_asm('OP_TRUE')
@@ -39,7 +39,7 @@ RSpec.describe BSV::Transaction::Transaction do # rubocop:disable RSpec/Multiple
     def build_spending_tx(source_tx, output_sats: 90_000)
       tx = described_class.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: source_tx.wtxid,
+        prev_wtxid: source_tx.wtxid,
         prev_tx_out_index: 0
       )
       input.source_satoshis = source_tx.outputs[0].satoshis
@@ -125,7 +125,7 @@ RSpec.describe BSV::Transaction::Transaction do # rubocop:disable RSpec/Multiple
 
       tx = described_class.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: source_tx.wtxid,
+        prev_wtxid: source_tx.wtxid,
         prev_tx_out_index: 0
       )
       input.source_satoshis = 100_000
@@ -156,7 +156,7 @@ RSpec.describe BSV::Transaction::Transaction do # rubocop:disable RSpec/Multiple
       tx = described_class.new
       2.times do
         input = BSV::Transaction::TransactionInput.new(
-          prev_tx_id: source_tx.wtxid,
+          prev_wtxid: source_tx.wtxid,
           prev_tx_out_index: 0
         )
         input.source_satoshis = source_tx.outputs[0].satoshis
@@ -214,7 +214,7 @@ RSpec.describe BSV::Transaction::FeeModel do
     it 'SatoshisPerKilobyte integrates with verify' do
       source_tx = BSV::Transaction::Transaction.new
       input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: BSV::Primitives::Digest.sha256d('fee-test'),
+        prev_wtxid: BSV::Primitives::Digest.sha256d('fee-test'),
         prev_tx_out_index: 0
       )
       input.unlocking_script = BSV::Script::Script.from_asm('OP_TRUE')
@@ -231,7 +231,7 @@ RSpec.describe BSV::Transaction::FeeModel do
 
       tx = BSV::Transaction::Transaction.new
       spend_input = BSV::Transaction::TransactionInput.new(
-        prev_tx_id: source_tx.wtxid,
+        prev_wtxid: source_tx.wtxid,
         prev_tx_out_index: 0
       )
       spend_input.source_satoshis = 100_000

--- a/gem/bsv-sdk/spec/support/testnet_wallet.rb
+++ b/gem/bsv-sdk/spec/support/testnet_wallet.rb
@@ -65,7 +65,7 @@ module TestnetWallet
   # Convert a WoC UTXO hash into a TransactionInput with source metadata attached.
   def utxo_to_input(utxo, locking_script)
     input = BSV::Transaction::TransactionInput.new(
-      prev_tx_id: BSV::Transaction::TransactionInput.txid_from_hex(utxo['tx_hash']),
+      prev_wtxid: BSV::Transaction::TransactionInput.wtxid_from_hex(utxo['tx_hash']),
       prev_tx_out_index: utxo['tx_pos']
     )
     input.source_satoshis = utxo['value']


### PR DESCRIPTION
## Summary

Enforces the `wtxid`/`dtxid` naming convention throughout the SDK, matching the convention established in the wallet gem (bsv-wallet#38). This eliminates ambiguous `txid` variable names where byte order was unclear.

**Breaking changes:**
- `TransactionInput#prev_tx_id` → `#prev_wtxid` (no backward-compat alias — pre-1.0)
- `TransactionInput.txid_from_hex` → `.wtxid_from_hex`
- `TransactionInput#txid_hex` → `#dtxid_hex`
- `MerklePath#compute_root(txid)` → `#compute_root(wtxid)`
- `MerklePath#compute_root_hex(txid_hex)` → `#compute_root_hex(dtxid_hex)`
- `MerklePath#verify(txid_hex, ...)` → `#verify(dtxid_hex, ...)`
- `MerklePath#extract(txid_hashes)` → `#extract(wtxid_hashes)`
- `MerklePath.from_tsc(txid:, ...)` → `.from_tsc(dtxid_hex:, ...)`

**Changes by sub-issue:**
- Renamed `TransactionInput#prev_tx_id` → `#prev_wtxid`, `.txid_from_hex` → `.wtxid_from_hex`, `#txid_hex` → `#dtxid_hex` (#678)
- Renamed internal `txid` variables in Transaction/Beef to `wtxid`/`dtxid_hex` (#679)
- Added `dtxid` display aliases on Transaction, BeefTx, and Beef (#680)
- Renamed MerklePath parameters to `wtxid`/`dtxid_hex` convention (#681)
- Added boundary comments to all spec-mandated `txid` names (#682)
- Defined `BSV::TXID_FORMAT_WIRE` and `BSV::TXID_FORMAT_DISPLAY` constants (#683)

## Test plan

- [x] Full test suite passes (5035 examples, 0 failures, 22 pending)
- [x] RuboCop clean (323 files, no offences)
- [x] No remaining `prev_tx_id` references in lib/
- [x] All internal variables use `wtxid` for wire-order values
- [x] Boundary comments on all spec-mandated `txid` names (BRC-100, ARC, Overlay, Registry, BRC-74)
- [x] `dtxid`/`dtxid_hex` aliases verified on Transaction, BeefTx, Beef
- [x] `BSV::TXID_FORMAT_WIRE` and `BSV::TXID_FORMAT_DISPLAY` constants defined

Closes #677
