### PR TITLE
feat: extended debug instrumentation — sighash, interpreter, ARC, ancestry, ProtoWallet

### DIFF
--- a/.claude/plans/20260502-extended-debug-instrumentation.md
+++ b/.claude/plans/20260502-extended-debug-instrumentation.md
@@ -1,0 +1,107 @@
+# Extended Debug Instrumentation: Sighash, Interpreter, EF Fallback, Ancestry, ProtoWallet
+
+## Context
+
+Following the txid consistency audit (#686), the SDK now has a `BSV.logger` infrastructure. This extends debug instrumentation to the five areas where silent failures cost the most debugging time: sighash preimage construction, script interpreter execution, EF format fallback, BEEF ancestry traversal, and ProtoWallet key derivation.
+
+## Plan
+
+### 1. Sighash preimage instrumentation (`transaction.rb`)
+
+Add logging to `sighash_preimage` showing each BIP-143 component as display-order hex. When a signature fails verification, developers can diff their preimage against a known-good one component by component.
+
+**`sighash_preimage`** (after building buf, before return) — log all 10 components:
+```
+[Sighash] input=0 type=0x41 hashPrevouts=abc... hashSequence=def...
+          scriptCode=76a9... value=100000 hashOutputs=012...
+```
+
+**`sighash`** — log the final 32-byte digest.
+
+**`hash_prevouts`**, **`hash_sequence`**, **`hash_outputs`** — no separate logging needed; the preimage log captures the output.
+
+### 2. Script interpreter instrumentation (`interpreter.rb`, `crypto.rb`)
+
+Three levels of logging:
+
+**a) Execution entry/exit** (`execute` method) — log script start, which script (unlock/lock), chunk count, and final result:
+```
+[Interpreter] === unlock_script (12 chunks) ===
+[Interpreter] === lock_script (5 chunks) ===
+[Interpreter] final stack: [true] -> success
+```
+
+**b) Opcode-level trace** (`execute_opcode`) — log each executed opcode with stack depth. Skip data pushes to reduce noise:
+```
+[Interpreter] OP_DUP (stack: 2)
+[Interpreter] OP_HASH160 (stack: 3)
+[Interpreter] OP_EQUALVERIFY (stack: 3)
+[Interpreter] OP_CHECKSIG (stack: 2)
+```
+
+**c) Signature verification detail** (`verify_checksig` in crypto.rb) — log the sighash type, pubkey fingerprint, and verification result:
+```
+[Interpreter] CHECKSIG: sighash_type=0x41 pubkey=02ab...cd result=true
+```
+
+### 3. EF format fallback (`arc.rb`)
+
+Log when `to_ef_hex` fails and the fallback to raw hex triggers, including which input caused the failure:
+```
+[ARC] EF serialisation failed: input 2 is missing source_satoshis — falling back to raw hex
+```
+
+### 4. BEEF ancestry collection (`transaction.rb`)
+
+**`collect_ancestors_recursive`** — log merkle_path stops and skipped inputs:
+```
+[Transaction] ancestor: <dtxid> proven at height 800000 (leaf stop)
+[Transaction] ancestor: <dtxid> input 1 has no source_transaction (skipped)
+```
+
+**`build_beef_bumps`** — log grouping and extraction:
+```
+[Transaction] BEEF: 5 ancestors, 3 proven across 2 block heights
+```
+
+### 5. ProtoWallet key derivation (`proto_wallet.rb`, `key_deriver.rb`)
+
+**`create_signature`** — log counterparty (especially when defaulting to 'anyone'):
+```
+[ProtoWallet] create_signature: protocol=[2, "certificate signature"] key_id="..." counterparty=anyone
+```
+
+**`verify_signature`** — log counterparty, for_self flag, and result:
+```
+[ProtoWallet] verify_signature: counterparty=<hex> for_self=false result=valid
+```
+
+**`derive_private_key` / `derive_public_key`** — log the invoice number and derivation direction:
+```
+[KeyDeriver] derive_public_key: invoice="2-certificate signature-type serial" for_self=false
+```
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `gem/bsv-sdk/lib/bsv/transaction/transaction.rb` | Sighash preimage + ancestry logging |
+| `gem/bsv-sdk/lib/bsv/script/interpreter/interpreter.rb` | Execution entry/exit + opcode trace |
+| `gem/bsv-sdk/lib/bsv/script/interpreter/operations/crypto.rb` | CHECKSIG detail logging |
+| `gem/bsv-sdk/lib/bsv/network/protocols/arc.rb` | EF fallback logging |
+| `gem/bsv-sdk/lib/bsv/wallet/proto_wallet.rb` | Sign/verify logging |
+| `gem/bsv-sdk/lib/bsv/wallet/proto_wallet/key_deriver.rb` | Derivation path logging |
+
+## Design principles
+
+- All logging uses `BSV.logger&.debug { ... }` — block form, zero cost when nil
+- Display-order hex for txids (human-readable), truncated where appropriate
+- No logging of private keys, signatures, or secret material — only fingerprints and metadata
+- Opcode trace is intentionally verbose (it's debug level) — developers want full trace when they enable it
+
+## Verification
+
+```bash
+bundle exec rake spec:sdk   # all existing specs pass
+bundle exec rubocop          # lint check
+```

--- a/gem/bsv-sdk/lib/bsv-sdk.rb
+++ b/gem/bsv-sdk/lib/bsv-sdk.rb
@@ -10,7 +10,8 @@ module BSV
     # No logger is configured by default — zero overhead when unused.
     # Consumers opt in via:
     #
-    #   BSV.logger = Logger.new($stdout, level: :debug)
+    #   require 'logger'
+    #   BSV.logger = Logger.new($stdout).tap { |l| l.level = Logger::DEBUG }
     #
     # @return [Logger, nil]
     attr_accessor :logger

--- a/gem/bsv-sdk/lib/bsv/network/protocols/arc.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/arc.rb
@@ -138,7 +138,8 @@ module BSV
         # lacks source_satoshis / source_locking_script.
         def ef_hex_with_fallback(tx)
           tx.to_ef_hex
-        rescue ArgumentError
+        rescue ArgumentError => e
+          BSV.logger&.debug { "[ARC] EF serialisation failed: #{e.message} — falling back to raw hex" }
           tx.to_hex
         end
 

--- a/gem/bsv-sdk/lib/bsv/script/interpreter/interpreter.rb
+++ b/gem/bsv-sdk/lib/bsv/script/interpreter/interpreter.rb
@@ -89,10 +89,12 @@ module BSV
 
       def execute
         scripts = [@unlock_script, @lock_script]
+        script_names = %w[unlock_script lock_script]
 
         scripts.each_with_index do |script, script_idx|
           @current_script = script
           chunks = script.chunks
+          BSV.logger&.debug { "[Interpreter] === #{script_names[script_idx]} (#{chunks.length} chunks) ===" }
 
           chunks.each_with_index do |chunk, chunk_idx|
             @current_chunk_idx = chunk_idx
@@ -115,6 +117,7 @@ module BSV
         end
 
         check_final_stack
+        BSV.logger&.debug { "[Interpreter] final stack: #{@dstack.length} items -> success" }
         true
       end
 
@@ -156,6 +159,10 @@ module BSV
           return
         end
 
+        BSV.logger&.debug do
+          name = Opcodes.name_for(opcode) || format('0x%02x', opcode)
+          "[Interpreter]   #{name} (stack: #{@dstack.length})"
+        end
         dispatch_opcode(opcode, chunk)
       end
 

--- a/gem/bsv-sdk/lib/bsv/script/interpreter/operations/crypto.rb
+++ b/gem/bsv-sdk/lib/bsv/script/interpreter/operations/crypto.rb
@@ -126,7 +126,13 @@ module BSV
 
             pubkey = BSV::Primitives::PublicKey.from_bytes(pubkey_bytes)
             hash = @tx.sighash(@input_index, sighash_type, subscript: sub_script)
-            pubkey.verify(hash, sig)
+            result = pubkey.verify(hash, sig)
+            BSV.logger&.debug do
+              pk_hex = pubkey_bytes.unpack1('H*')
+              "[Interpreter] CHECKSIG: sighash_type=0x#{format('%02x', sighash_type)} " \
+                "pubkey=#{pk_hex[0, 8]}...#{pk_hex[-4..]} result=#{result}"
+            end
+            result
           rescue ArgumentError
             false
           end

--- a/gem/bsv-sdk/lib/bsv/transaction/merkle_path.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/merkle_path.rb
@@ -253,7 +253,7 @@ module BSV
         BSV::Primitives::Hex.validate_wtxid!(wtxid, name: 'wtxid') if wtxid
         BSV.logger&.debug do
           dtxid = wtxid&.reverse&.unpack1('H*')
-          "[MerklePath] compute_root: wtxid=#{dtxid} block_height=#{@block_height} levels=#{@path.length}"
+          "[MerklePath] compute_root: dtxid=#{dtxid} block_height=#{@block_height} levels=#{@path.length}"
         end
         return wtxid if @path.length == 1 && @path[0].length == 1
 

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -329,6 +329,11 @@ module BSV
         ancestors = collect_ancestors
 
         bump_index_by_height = build_beef_bumps(beef, ancestors)
+        BSV.logger&.debug do
+          proven = ancestors.count(&:merkle_path)
+          "[Transaction] BEEF: #{ancestors.length} ancestors, #{proven} proven " \
+            "across #{bump_index_by_height.length} block heights"
+        end
 
         ancestors.each do |tx|
           entry = if tx.merkle_path
@@ -480,6 +485,17 @@ module BSV
         # 10. sighash type (4 LE) — includes FORKID flag
         buf << [sighash_type].pack('V')
 
+        BSV.logger&.debug do
+          hp = buf.byteslice(4, 32).unpack1('H*')
+          hs = buf.byteslice(36, 32).unpack1('H*')
+          ho = buf.byteslice(-40, 32).unpack1('H*')
+          sc = script_bytes.unpack1('H*')
+          "[Sighash] input=#{input_index} type=0x#{format('%02x', sighash_type)} " \
+            "hashPrevouts=#{hp} hashSequence=#{hs} " \
+            "scriptCode=#{sc[0, 40]}#{'...' if sc.length > 40} " \
+            "value=#{input.source_satoshis} hashOutputs=#{ho}"
+        end
+
         buf
       end
 
@@ -490,7 +506,9 @@ module BSV
       # @param subscript [Script::Script, nil] override locking script for the input
       # @return [String] 32-byte sighash digest
       def sighash(input_index, sighash_type = Sighash::ALL_FORK_ID, subscript: nil)
-        BSV::Primitives::Digest.sha256d(sighash_preimage(input_index, sighash_type, subscript: subscript))
+        digest = BSV::Primitives::Digest.sha256d(sighash_preimage(input_index, sighash_type, subscript: subscript))
+        BSV.logger&.debug { "[Sighash] digest=#{digest.unpack1('H*')}" }
+        digest
       end
 
       # --- Signing ---
@@ -879,9 +897,16 @@ module BSV
         wtxid = tx.wtxid
         return if seen.key?(wtxid)
 
-        unless tx.merkle_path
-          tx.inputs.each do |input|
-            next unless input.source_transaction
+        if tx.merkle_path
+          BSV.logger&.debug do
+            "[Transaction] ancestor: #{tx.dtxid_hex} proven at height #{tx.merkle_path.block_height} (leaf stop)"
+          end
+        else
+          tx.inputs.each_with_index do |input, idx|
+            unless input.source_transaction
+              BSV.logger&.debug { "[Transaction] ancestor: #{tx.dtxid_hex} input #{idx} has no source_transaction (skipped)" }
+              next
+            end
 
             collect_ancestors_recursive(input.source_transaction, seen, result)
           end

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -488,12 +488,14 @@ module BSV
         BSV.logger&.debug do
           hp = buf.byteslice(4, 32).unpack1('H*')
           hs = buf.byteslice(36, 32).unpack1('H*')
-          ho = buf.byteslice(-40, 32).unpack1('H*')
+          op = input.outpoint_binary.unpack1('H*')
           sc = script_bytes.unpack1('H*')
+          ho = buf.byteslice(-40, 32).unpack1('H*')
           "[Sighash] input=#{input_index} type=0x#{format('%02x', sighash_type)} " \
-            "hashPrevouts=#{hp} hashSequence=#{hs} " \
-            "scriptCode=#{sc[0, 40]}#{'...' if sc.length > 40} " \
-            "value=#{input.source_satoshis} hashOutputs=#{ho}"
+            "version=#{@version} hashPrevouts=#{hp} hashSequence=#{hs} " \
+            "outpoint=#{op} scriptCode=#{sc[0, 40]}#{'...' if sc.length > 40} " \
+            "value=#{input.source_satoshis} seq=#{input.sequence} " \
+            "hashOutputs=#{ho} locktime=#{@lock_time}"
         end
 
         buf

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -396,7 +396,7 @@ module BSV
       # @return [String] 32-byte transaction ID in wire byte order
       def wtxid
         id = BSV::Primitives::Digest.sha256d(to_binary)
-        BSV.logger&.debug { "[Transaction] wtxid computed: #{id.reverse.unpack1('H*')}" }
+        BSV.logger&.debug { "[Transaction] wtxid computed (dtxid=#{id.reverse.unpack1('H*')})" }
         id
       end
 

--- a/gem/bsv-sdk/lib/bsv/wallet/proto_wallet.rb
+++ b/gem/bsv-sdk/lib/bsv/wallet/proto_wallet.rb
@@ -127,6 +127,7 @@ module BSV
                            counterparty: nil, privileged: false, privileged_reason: nil,
                            seek_permission: true, originator: nil)
         counterparty ||= 'anyone'
+        BSV.logger&.debug { "[ProtoWallet] create_signature: protocol=#{protocol_id} key_id=#{key_id.inspect} counterparty=#{counterparty}" }
         priv_key = @key_deriver.derive_private_key(protocol_id, key_id, counterparty)
 
         hash = if hash_to_directly_sign
@@ -156,6 +157,10 @@ module BSV
                            privileged: false, privileged_reason: nil,
                            seek_permission: true, originator: nil)
         counterparty ||= 'self'
+        BSV.logger&.debug do
+          "[ProtoWallet] verify_signature: protocol=#{protocol_id} key_id=#{key_id.inspect} " \
+            "counterparty=#{counterparty} for_self=#{for_self}"
+        end
 
         pub_key = @key_deriver.derive_public_key(
           protocol_id, key_id, counterparty, for_self: for_self

--- a/gem/bsv-sdk/lib/bsv/wallet/proto_wallet.rb
+++ b/gem/bsv-sdk/lib/bsv/wallet/proto_wallet.rb
@@ -174,6 +174,7 @@ module BSV
 
         sig   = BSV::Primitives::Signature.from_der(bytes_to_string(signature))
         valid = pub_key.verify(hash, sig)
+        BSV.logger&.debug { "[ProtoWallet] verify_signature result=#{valid}" }
 
         raise InvalidSignatureError unless valid
 

--- a/gem/bsv-sdk/lib/bsv/wallet/proto_wallet/key_deriver.rb
+++ b/gem/bsv-sdk/lib/bsv/wallet/proto_wallet/key_deriver.rb
@@ -45,6 +45,7 @@ module BSV
           Validators.validate_protocol_id!(protocol_id)
           Validators.validate_key_id!(key_id)
           invoice = compute_invoice_number(protocol_id, key_id)
+          BSV.logger&.debug { "[KeyDeriver] derive_public_key: invoice=#{invoice.inspect} for_self=#{for_self}" }
           counterparty_pub = resolve_counterparty(counterparty)
 
           if for_self
@@ -64,6 +65,7 @@ module BSV
           Validators.validate_protocol_id!(protocol_id)
           Validators.validate_key_id!(key_id)
           invoice = compute_invoice_number(protocol_id, key_id)
+          BSV.logger&.debug { "[KeyDeriver] derive_private_key: invoice=#{invoice.inspect}" }
           counterparty_pub = resolve_counterparty(counterparty)
           @root_key.derive_child(counterparty_pub, invoice)
         end


### PR DESCRIPTION
## Summary

Extends `BSV.logger` instrumentation (#686) to the five areas where silent failures cost the most debugging time. Closes #688.

### Sighash preimage
- Logs all 10 BIP-143 components as hex (hashPrevouts, hashSequence, scriptCode, value, hashOutputs)
- Logs the final 32-byte sighash digest
- Developers can now diff component-by-component when a signature fails verification

### Script interpreter
- Logs script entry/exit with script type and chunk count
- Opcode-level trace: opcode name + stack depth at each step
- CHECKSIG detail: sighash type, pubkey fingerprint, verification result

### ARC EF fallback
- Logs which input caused `to_ef_hex` failure and that raw hex fallback was used

### BEEF ancestry
- Logs merkle_path leaf stops (with block height)
- Logs inputs skipped due to missing `source_transaction` (with input index)
- Summary log: ancestor count, proven count, block height count

### ProtoWallet key derivation
- Logs `create_signature`/`verify_signature` params (protocol, key_id, counterparty, for_self)
- Logs KeyDeriver invoice number and derivation direction

All logging uses `BSV.logger&.debug { }` — zero overhead when unused. No private keys or secret material logged.

## Test plan

- [x] All 5044 existing specs pass
- [x] RuboCop clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)