### PR TITLE
fix!: eliminate display-order binary txid from public API

### DIFF
--- a/gem/bsv-attest/lib/bsv/attest.rb
+++ b/gem/bsv-attest/lib/bsv/attest.rb
@@ -52,6 +52,7 @@ module BSV
       end
 
       def verify(data, txid, provider: nil)
+        BSV::Primitives::Hex.validate_dtxid_hex!(txid, name: 'verify txid')
         p = provider || configuration.provider
         raise ArgumentError, 'provider is required' unless p
 

--- a/gem/bsv-attest/lib/bsv/attest/response.rb
+++ b/gem/bsv-attest/lib/bsv/attest/response.rb
@@ -6,6 +6,7 @@ module BSV
       attr_reader :hash, :txid
 
       def initialize(hash:, txid:)
+        BSV::Primitives::Hex.validate_dtxid_hex!(txid, name: 'attest response txid')
         @hash = hash
         @txid = txid
       end

--- a/gem/bsv-sdk/lib/bsv/network/broadcast_error.rb
+++ b/gem/bsv-sdk/lib/bsv/network/broadcast_error.rb
@@ -8,6 +8,7 @@ module BSV
 
       def initialize(message, status_code: nil, txid: nil, arc_status: nil)
         @status_code = status_code
+        BSV::Primitives::Hex.validate_dtxid_hex!(txid, name: 'ARC error txid') if txid
         @txid = txid
         @arc_status = arc_status
         super(message)

--- a/gem/bsv-sdk/lib/bsv/network/broadcast_response.rb
+++ b/gem/bsv-sdk/lib/bsv/network/broadcast_response.rb
@@ -7,7 +7,9 @@ module BSV
       attr_reader :txid, :tx_status, :message, :extra_info, :block_hash, :block_height, :timestamp, :competing_txs
 
       def initialize(attrs = {})
-        @txid = attrs[:txid]
+        txid = attrs[:txid]
+        BSV::Primitives::Hex.validate_dtxid_hex!(txid, name: 'ARC broadcast txid') if txid
+        @txid = txid
         @tx_status = attrs[:tx_status]
         @message = attrs[:message]
         @extra_info = attrs[:extra_info]

--- a/gem/bsv-sdk/lib/bsv/overlay/lookup_resolver.rb
+++ b/gem/bsv-sdk/lib/bsv/overlay/lookup_resolver.rb
@@ -334,17 +334,17 @@ module BSV
         beef_data    = output['beef'] || output[:beef]
         output_index = (output['outputIndex'] || output[:output_index] || 0).to_i
 
-        # Overlay API boundary: outpoint key uses display-order txid bytes (via Transaction#txid)
-        txid =
+        # Overlay API boundary: outpoint key uses display-order hex txid
+        dtxid_hex =
           begin
             beef = parse_beef(beef_data)
             last = beef&.transactions&.last
-            last&.transaction&.txid
+            last&.transaction&.dtxid
           rescue StandardError
             nil
           end
 
-        txid ? "#{txid}.#{output_index}" : output.object_id.to_s
+        dtxid_hex ? "#{dtxid_hex}.#{output_index}" : output.object_id.to_s
       end
 
       # ---- Validation ----

--- a/gem/bsv-sdk/lib/bsv/overlay/lookup_resolver.rb
+++ b/gem/bsv-sdk/lib/bsv/overlay/lookup_resolver.rb
@@ -339,7 +339,7 @@ module BSV
           begin
             beef = parse_beef(beef_data)
             last = beef&.transactions&.last
-            last&.transaction&.dtxid
+            last&.dtxid
           rescue StandardError
             nil
           end

--- a/gem/bsv-sdk/lib/bsv/overlay/types.rb
+++ b/gem/bsv-sdk/lib/bsv/overlay/types.rb
@@ -102,6 +102,7 @@ module BSV
       # @param description [String, nil]
       def initialize(status:, txid: nil, message: nil, code: nil, description: nil)
         @status = status
+        BSV::Primitives::Hex.validate_dtxid_hex!(txid, name: 'overlay broadcast txid') if txid
         @txid = txid
         @message = message
         @code = code

--- a/gem/bsv-sdk/lib/bsv/registry/types.rb
+++ b/gem/bsv-sdk/lib/bsv/registry/types.rb
@@ -217,6 +217,7 @@ module BSV
       def initialize(definition_data:, txid:, output_index:, locking_script:, beef:, satoshis: 1)
         @definition_data = definition_data
         @definition_type = definition_data.definition_type
+        BSV::Primitives::Hex.validate_dtxid_hex!(txid, name: 'registry definition txid')
         @txid            = txid
         @output_index    = output_index
         @locking_script  = locking_script

--- a/gem/bsv-sdk/lib/bsv/transaction/beef.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef.rb
@@ -360,7 +360,7 @@ module BSV
         level0_internal = level0_leaves.map(&:hash).compact.to_set
         @transactions.each_with_index do |bt, i|
           next unless bt.format == FORMAT_RAW_TX && bt.transaction
-          next unless level0_internal.include?(bt.transaction.wtxid)
+          next unless level0_internal.include?(bt.wtxid)
 
           bt.transaction.merkle_path ||= bump
           @transactions[i] = BeefTx.new(
@@ -542,7 +542,7 @@ module BSV
 
           # The txid must appear as a leaf in the BUMP and compute a valid root
           begin
-            bump.compute_root(bt.transaction.wtxid)
+            bump.compute_root(bt.wtxid)
           rescue ArgumentError
             return false
           end
@@ -753,7 +753,7 @@ module BSV
               end
             end
 
-            tx_map[beef_tx.transaction.wtxid] = beef_tx.transaction
+            tx_map[beef_tx.wtxid] = beef_tx.transaction
           end
         end
       end

--- a/gem/bsv-sdk/lib/bsv/transaction/beef.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef.rb
@@ -76,12 +76,6 @@ module BSV
           end
         end
 
-        # Display-order transaction ID as binary bytes.
-        # @return [String, nil] 32-byte display-order txid
-        def txid
-          wtxid&.reverse
-        end
-
         # Display-order transaction ID as a hex string.
         #
         # +dtxid+ always returns a 64-char hex string suitable for JSON
@@ -104,12 +98,6 @@ module BSV
 
       # @return [String, nil] 32-byte wire-order subject txid (Atomic BEEF only)
       attr_reader :subject_wtxid
-
-      # Display-order subject txid as binary bytes (Atomic BEEF only).
-      # @return [String, nil] 32-byte display-order txid, or nil
-      def subject_txid
-        @subject_wtxid&.reverse
-      end
 
       # Display-order subject txid as a hex string (Atomic BEEF only).
       #

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -376,7 +376,7 @@ module BSV
       def self.from_beef(data)
         beef = Beef.from_binary(data)
         subject_wtxid = beef.subject_wtxid ||
-                        beef.transactions.reverse.find(&:transaction)&.transaction&.wtxid
+                        beef.transactions.reverse.find(&:transaction)&.wtxid
         return nil unless subject_wtxid
 
         beef.find_atomic_transaction(subject_wtxid)

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -362,11 +362,11 @@ module BSV
       # full ancestry wired, including late-bound BUMP attachment.
       #
       # For Atomic BEEFs (BRC-95), the subject transaction is identified by
-      # the embedded subject_txid field. For plain BEEFs, the last transaction
-      # with a raw tx entry is used as the subject.
+      # the embedded +subject_wtxid+ field. For plain BEEFs, the last
+      # transaction with a raw tx entry is used as the subject.
       #
       # Uses +find_atomic_transaction+ so that FORMAT_RAW_TX ancestors whose
-      # txid appears as a leaf in a separately-stored BUMP get their
+      # wtxid appears as a leaf in a separately-stored BUMP get their
       # +merkle_path+ wired correctly — a gap not covered by the initial
       # +wire_source_transactions+ pass in +Beef.from_binary+.
       #

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -405,21 +405,11 @@ module BSV
         id
       end
 
-      # Display-order transaction ID (reversed from the natural SHA-256d hash).
-      #
-      # This is the conventional human-readable representation used in block
-      # explorers, wallets, and all user-facing contexts.
-      #
-      # @return [String] 32-byte transaction ID in display byte order
-      def txid
-        wtxid.reverse
-      end
-
       # The transaction ID as a hex string (display byte order).
       #
-      # @return [String] hex-encoded transaction ID
+      # @return [String] 64-char hex-encoded transaction ID (display order)
       def txid_hex
-        txid.unpack1('H*')
+        wtxid.reverse.unpack1('H*')
       end
 
       # Display-order transaction ID as a hex string.

--- a/gem/bsv-sdk/spec/bsv/identity/client_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/identity/client_spec.rb
@@ -219,17 +219,17 @@ RSpec.describe 'BSV::Identity::Client' do
     let(:beef_bytes) { 'fake_beef_bytes' }
     let(:broadcaster) { instance_double(BSV::Overlay::TopicBroadcaster) }
     let(:broadcast_result) do
-      BSV::Overlay::OverlayBroadcastResult.new(status: 'success', txid: 'abc123', message: 'ok')
+      BSV::Overlay::OverlayBroadcastResult.new(status: 'success', txid: 'ab' * 32, message: 'ok')
     end
 
     before do
       allow(BSV::Script::PushDropTemplate).to receive(:new).and_return(mock_template)
       allow(wallet).to receive_messages(
         prove_certificate: { keyring_for_verifier: keyring },
-        create_action: { tx: beef_bytes, txid: 'abc123' }
+        create_action: { tx: beef_bytes, txid: 'ab' * 32 }
       )
       allow(BSV::Transaction::Transaction).to receive(:from_beef)
-        .and_return(instance_double(BSV::Transaction::Transaction, txid_hex: 'abc123'))
+        .and_return(instance_double(BSV::Transaction::Transaction, txid_hex: 'ab' * 32))
       allow(broadcaster).to receive(:broadcast).and_return(broadcast_result)
     end
 
@@ -335,7 +335,7 @@ RSpec.describe 'BSV::Identity::Client' do
     let(:mock_unlocker) { instance_double(BSV::Script::PushDropTemplate::Unlocker, sign: mock_script) }
     let(:mock_template) { instance_double(BSV::Script::PushDropTemplate, unlock: mock_unlocker) }
     let(:broadcast_result) do
-      BSV::Overlay::OverlayBroadcastResult.new(status: 'success', txid: 'deadbeef01', message: 'ok')
+      BSV::Overlay::OverlayBroadcastResult.new(status: 'success', txid: 'de' * 32, message: 'ok')
     end
 
     before do
@@ -347,12 +347,12 @@ RSpec.describe 'BSV::Identity::Client' do
         if kwargs[:inputs]
           { signable_transaction: { tx: beef_bytes, reference: 'REF123' } }
         else
-          { tx: beef_bytes, txid: 'deadbeef01' }
+          { tx: beef_bytes, txid: 'de' * 32 }
         end
       end
 
       allow(BSV::Transaction::Transaction).to receive(:from_beef).with(beef_bytes).and_return(partial_tx)
-      allow(wallet).to receive(:sign_action).and_return({ tx: 'signed_beef', txid: 'deadbeef01' })
+      allow(wallet).to receive(:sign_action).and_return({ tx: 'signed_beef', txid: 'de' * 32 })
       allow(BSV::Transaction::Transaction).to receive(:from_beef).with('signed_beef').and_return(signed_tx)
       allow(broadcaster).to receive(:broadcast).and_return(broadcast_result)
     end

--- a/gem/bsv-sdk/spec/bsv/network/broadcast_error_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/broadcast_error_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe BSV::Network::BroadcastError do
   end
 
   it 'stores message, status_code, and txid' do
-    error = described_class.new('rejected', status_code: 465, txid: 'abc123')
+    error = described_class.new('rejected', status_code: 465, txid: 'aa' * 32)
 
     expect(error.message).to eq('rejected')
     expect(error.status_code).to eq(465)
-    expect(error.txid).to eq('abc123')
+    expect(error.txid).to eq('aa' * 32)
   end
 
   it 'defaults status_code and txid to nil' do

--- a/gem/bsv-sdk/spec/bsv/network/broadcast_response_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/broadcast_response_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BSV::Network::BroadcastResponse do
   describe '#initialize' do
     it 'accepts all ARC response fields' do
       response = described_class.new(
-        txid: 'abc123',
+        txid: 'aa' * 32,
         tx_status: 'SEEN_ON_NETWORK',
         message: 'success',
         extra_info: 'info',
@@ -16,7 +16,7 @@ RSpec.describe BSV::Network::BroadcastResponse do
         competing_txs: ['def456']
       )
 
-      expect(response.txid).to eq('abc123')
+      expect(response.txid).to eq('aa' * 32)
       expect(response.tx_status).to eq('SEEN_ON_NETWORK')
       expect(response.message).to eq('success')
       expect(response.extra_info).to eq('info')

--- a/gem/bsv-sdk/spec/bsv/overlay/topic_broadcaster_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/overlay/topic_broadcaster_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe BSV::Overlay::TopicBroadcaster do
 
   let(:mock_tx) do
     tx = instance_double(BSV::Transaction::Transaction)
-    allow(tx).to receive_messages(to_beef: "\xbe\xef\x01", txid: mock_txid, txid_hex: mock_txid)
+    allow(tx).to receive_messages(to_beef: "\xbe\xef\x01", txid_hex: mock_txid)
     tx
   end
 

--- a/gem/bsv-sdk/spec/bsv/overlay/types_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/overlay/types_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'BSV::Overlay types' do
       subject(:result) do
         described_class.new(
           status: 'success',
-          txid: 'abc123',
+          txid: 'aa' * 32,
           message: 'Sent to 1 host.'
         )
       end
@@ -84,7 +84,7 @@ RSpec.describe 'BSV::Overlay types' do
       end
 
       it 'exposes txid' do
-        expect(result.txid).to eq('abc123')
+        expect(result.txid).to eq('aa' * 32)
       end
 
       it 'exposes message' do

--- a/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
@@ -285,7 +285,7 @@ RSpec.describe BSV::Transaction::Beef do
     it 'returns display-order hex on a raw entry' do
       beef = described_class.from_hex(beef_set_hex)
       bt = beef.transactions.find(&:transaction)
-      expect(bt.dtxid).to eq(bt.txid.unpack1('H*'))
+      expect(bt.dtxid).to eq(bt.wtxid.reverse.unpack1('H*'))
     end
 
     it 'returns display-order hex on a txid-only entry' do
@@ -293,7 +293,7 @@ RSpec.describe BSV::Transaction::Beef do
         format: described_class::FORMAT_TXID_ONLY,
         known_wtxid: "\x01".b * 32
       )
-      expect(bt.dtxid).to eq(bt.txid.unpack1('H*'))
+      expect(bt.dtxid).to eq(bt.wtxid.reverse.unpack1('H*'))
     end
   end
 
@@ -303,7 +303,7 @@ RSpec.describe BSV::Transaction::Beef do
       last_tx = beef.transactions.last.transaction
       atomic_bytes = beef.to_atomic_binary(last_tx.wtxid)
       parsed = described_class.from_binary(atomic_bytes)
-      expect(parsed.subject_dtxid).to eq(parsed.subject_txid.unpack1('H*'))
+      expect(parsed.subject_dtxid).to eq(parsed.subject_wtxid.reverse.unpack1('H*'))
     end
 
     it 'returns nil on a non-Atomic BEEF' do
@@ -326,12 +326,12 @@ RSpec.describe BSV::Transaction::Beef do
 
       # Parse back
       parsed = described_class.from_binary(atomic_bytes)
-      expect(parsed.subject_txid).to eq(last_tx.txid)
+      expect(parsed.subject_wtxid).to eq(last_tx.wtxid)
       expect(parsed.transactions.length).to eq(beef.transactions.length)
 
       found = parsed.find_transaction(subject_wtxid)
       expect(found).not_to be_nil
-      expect(found.txid).to eq(last_tx.txid)
+      expect(found.wtxid).to eq(last_tx.wtxid)
     end
   end
 
@@ -343,8 +343,8 @@ RSpec.describe BSV::Transaction::Beef do
       expect(tx).to be_a(BSV::Transaction::Transaction)
       # Subject tx is the last one in the bundle
       beef = described_class.from_hex(beef_set_hex)
-      expected_txid = beef.transactions.last.transaction.txid
-      expect(tx.txid).to eq(expected_txid)
+      expected_wtxid = beef.transactions.last.transaction.wtxid
+      expect(tx.wtxid).to eq(expected_wtxid)
     end
 
     it 'round-trips via from_beef_hex' do
@@ -373,7 +373,7 @@ RSpec.describe BSV::Transaction::Beef do
       # The subject tx should be present
       found = rebuilt.find_transaction(tx.wtxid)
       expect(found).not_to be_nil
-      expect(found.txid).to eq(tx.txid)
+      expect(found.wtxid).to eq(tx.wtxid)
     end
 
     it 'to_beef_hex returns a hex string' do
@@ -828,7 +828,7 @@ RSpec.describe BSV::Transaction::Beef do
       last_tx = beef.transactions.last.transaction
       found = beef.find_transaction_for_signing(last_tx.wtxid)
       expect(found).to be_a(BSV::Transaction::Transaction)
-      expect(found.txid).to eq(last_tx.txid)
+      expect(found.wtxid).to eq(last_tx.wtxid)
     end
 
     it 'returns nil for unknown wtxid' do
@@ -843,7 +843,7 @@ RSpec.describe BSV::Transaction::Beef do
       last_tx = beef.transactions.last.transaction
       found = beef.find_atomic_transaction(last_tx.wtxid)
       expect(found).to be_a(BSV::Transaction::Transaction)
-      expect(found.txid).to eq(last_tx.txid)
+      expect(found.wtxid).to eq(last_tx.wtxid)
     end
   end
 
@@ -854,7 +854,7 @@ RSpec.describe BSV::Transaction::Beef do
       hex = beef.to_atomic_hex(last_bt.wtxid)
       expect(hex).to match(/\A[0-9a-f]+\z/)
       parsed = described_class.from_binary([hex].pack('H*'))
-      expect(parsed.subject_txid).to eq(last_bt.txid)
+      expect(parsed.subject_wtxid).to eq(last_bt.wtxid)
     end
   end
 
@@ -959,8 +959,8 @@ RSpec.describe BSV::Transaction::Beef do
       beef.merge_transaction(subject_tx)
 
       expect(beef.transactions).not_to be_empty
-      txids = beef.transactions.map(&:txid)
-      expect(txids).to include(subject_tx.txid)
+      wtxids = beef.transactions.map(&:wtxid)
+      expect(wtxids).to include(subject_tx.wtxid)
     end
 
     it 'does not duplicate transactions' do
@@ -1047,10 +1047,10 @@ RSpec.describe BSV::Transaction::Beef do
     it 'converts a transaction to TXID-only format' do
       beef = described_class.from_hex(beef_set_hex)
       first_bt = beef.transactions.first
-      display_txid = first_bt.txid
+      original_wtxid = first_bt.wtxid
 
       beef.make_txid_only(first_bt.wtxid)
-      entry = beef.transactions.find { |bt| bt.txid == display_txid }
+      entry = beef.transactions.find { |bt| bt.wtxid == original_wtxid }
       expect(entry.format).to eq(described_class::FORMAT_TXID_ONLY)
       expect(entry.known_wtxid).to eq(first_bt.wtxid)
     end
@@ -1111,9 +1111,9 @@ RSpec.describe BSV::Transaction::Beef do
   describe '#sort_transactions!' do
     it 'preserves dependency order for already-sorted BEEF' do
       beef = described_class.from_hex(beef_set_hex)
-      original_txids = beef.transactions.map(&:txid)
+      original_wtxids = beef.transactions.map(&:wtxid)
       beef.sort_transactions!
-      expect(beef.transactions.map(&:txid)).to eq(original_txids)
+      expect(beef.transactions.map(&:wtxid)).to eq(original_wtxids)
     end
 
     it 'sorts reversed transactions into correct order' do
@@ -1295,10 +1295,10 @@ RSpec.describe BSV::Transaction::Beef do
 
     it 'is idempotent on sorted data' do
       beef = described_class.from_hex(beef_set_hex)
-      sorted_txids = beef.transactions.map(&:txid)
+      sorted_wtxids = beef.transactions.map(&:wtxid)
       beef.sort_transactions!
       beef.sort_transactions!
-      expect(beef.transactions.map(&:txid)).to eq(sorted_txids)
+      expect(beef.transactions.map(&:wtxid)).to eq(sorted_wtxids)
     end
   end
 
@@ -1381,34 +1381,34 @@ RSpec.describe BSV::Transaction::Beef do
     it 'upgrades TXID_ONLY to RAW_TX when raw tx is merged' do
       beef = described_class.new
       tx = make_tx
-      txid = tx.txid
+      tx_wtxid = tx.wtxid
 
       beef.transactions << described_class::BeefTx.new(format: described_class::FORMAT_TXID_ONLY, known_wtxid: tx.wtxid)
       expect(beef.transactions.first.format).to eq(described_class::FORMAT_TXID_ONLY)
 
       beef.merge_transaction(tx)
 
-      entry = beef.transactions.find { |bt| bt.txid == txid }
+      entry = beef.transactions.find { |bt| bt.wtxid == tx_wtxid }
       expect(entry.format).to eq(described_class::FORMAT_RAW_TX)
     end
 
     it 'upgrades TXID_ONLY to RAW_TX_AND_BUMP when raw tx + bump merged' do
       beef = described_class.new
       tx = make_tx
-      txid = tx.txid
+      tx_wtxid = tx.wtxid
       tx.merkle_path = make_bump(tx)
 
       beef.transactions << described_class::BeefTx.new(format: described_class::FORMAT_TXID_ONLY, known_wtxid: tx.wtxid)
       beef.merge_transaction(tx)
 
-      entry = beef.transactions.find { |bt| bt.txid == txid }
+      entry = beef.transactions.find { |bt| bt.wtxid == tx_wtxid }
       expect(entry.format).to eq(described_class::FORMAT_RAW_TX_AND_BUMP)
     end
 
     it 'upgrades RAW_TX to RAW_TX_AND_BUMP when a BUMP becomes available via merge_transaction' do
       beef = described_class.new
       tx = make_tx
-      txid = tx.txid
+      tx_wtxid = tx.wtxid
 
       beef.transactions << described_class::BeefTx.new(format: described_class::FORMAT_RAW_TX, transaction: tx)
       expect(beef.transactions.first.format).to eq(described_class::FORMAT_RAW_TX)
@@ -1419,26 +1419,26 @@ RSpec.describe BSV::Transaction::Beef do
 
       beef.merge_transaction(tx_with_bump)
 
-      entry = beef.transactions.find { |bt| bt.txid == txid }
+      entry = beef.transactions.find { |bt| bt.wtxid == tx_wtxid }
       expect(entry.format).to eq(described_class::FORMAT_RAW_TX_AND_BUMP)
     end
 
     it 'upgrades TXID_ONLY to RAW_TX via merge_raw_tx' do
       beef = described_class.new
       tx = make_tx
-      txid = tx.txid
+      tx_wtxid = tx.wtxid
 
       beef.transactions << described_class::BeefTx.new(format: described_class::FORMAT_TXID_ONLY, known_wtxid: tx.wtxid)
       beef.merge_raw_tx(tx.to_binary)
 
-      entry = beef.transactions.find { |bt| bt.txid == txid }
+      entry = beef.transactions.find { |bt| bt.wtxid == tx_wtxid }
       expect(entry.format).to eq(described_class::FORMAT_RAW_TX)
     end
 
     it 'upgrades RAW_TX to RAW_TX_AND_BUMP via merge_raw_tx with bump_index' do
       beef = described_class.new
       tx = make_tx
-      txid = tx.txid
+      tx_wtxid = tx.wtxid
 
       bump = make_bump(tx)
       beef.bumps << bump
@@ -1446,7 +1446,7 @@ RSpec.describe BSV::Transaction::Beef do
       beef.transactions << described_class::BeefTx.new(format: described_class::FORMAT_RAW_TX, transaction: tx)
       beef.merge_raw_tx(tx.to_binary, bump_index: 0)
 
-      entry = beef.transactions.find { |bt| bt.txid == txid }
+      entry = beef.transactions.find { |bt| bt.wtxid == tx_wtxid }
       expect(entry.format).to eq(described_class::FORMAT_RAW_TX_AND_BUMP)
       expect(entry.bump_index).to eq(0)
     end
@@ -1535,7 +1535,7 @@ RSpec.describe BSV::Transaction::Beef do
       tx2, _consumed = BSV::Transaction::Transaction.from_binary_with_offset(binary)
 
       expect(tx2.to_hex).to eq(tx1.to_hex)
-      expect(tx2.txid).to eq(tx1.txid)
+      expect(tx2.wtxid).to eq(tx1.wtxid)
     end
   end
 end

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe BSV::Transaction::Transaction do
       # SHA256d of serialised tx, reversed to display order
       txid = tx.txid_hex
       expect(txid.length).to eq(64)
-      expect(tx.txid.bytesize).to eq(32)
+      expect(tx.wtxid.bytesize).to eq(32)
     end
   end
 
@@ -763,7 +763,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
       result = described_class.from_beef(binary)
       expect(result).not_to be_nil
-      expect(result.txid).to eq(subject.txid)
+      expect(result.wtxid).to eq(subject.wtxid)
     end
 
     it 'wires source_transaction on every input when ancestry is present' do
@@ -799,7 +799,7 @@ RSpec.describe BSV::Transaction::Transaction do
       expect(result.inputs[0].source_transaction).not_to be_nil
       parent_recovered = result.inputs[0].source_transaction
       expect(parent_recovered.inputs[0].source_transaction).not_to be_nil
-      expect(parent_recovered.inputs[0].source_transaction.txid).to eq(grandparent.txid)
+      expect(parent_recovered.inputs[0].source_transaction.wtxid).to eq(grandparent.wtxid)
     end
 
     it 'attaches late-bound BUMPs on FORMAT_RAW_TX ancestors' do
@@ -837,7 +837,7 @@ RSpec.describe BSV::Transaction::Transaction do
       # Sanity: the serialised ancestor must be FORMAT_RAW_TX (has_bump=0).
       # If this fails the spec is no longer exercising the late-bind path.
       reparsed = BSV::Transaction::Beef.from_binary(binary)
-      ancestor_entry = reparsed.transactions.find { |bt| bt.transaction&.txid == ancestor.txid }
+      ancestor_entry = reparsed.transactions.find { |bt| bt.transaction&.wtxid == ancestor.wtxid }
       expect(ancestor_entry.format).to eq(BSV::Transaction::Beef::FORMAT_RAW_TX)
 
       result = described_class.from_beef(binary)
@@ -864,7 +864,7 @@ RSpec.describe BSV::Transaction::Transaction do
 
       result = described_class.from_beef(binary)
       expect(result).not_to be_nil
-      expect(result.txid).to eq(subject.txid)
+      expect(result.wtxid).to eq(subject.wtxid)
       expect(result.inputs.all?(&:source_transaction)).to be true
     end
   end

--- a/gem/bsv-sdk/spec/conformance/beef_spec.rb
+++ b/gem/bsv-sdk/spec/conformance/beef_spec.rb
@@ -106,21 +106,21 @@ RSpec.describe BSV::Transaction::Beef do
   # find_transaction fail and producing a silent cross-SDK divergence.
 
   describe 'TXID_ONLY byte-order consistency (F5.1)' do
-    it 'make_txid_only preserves display-order txid' do
+    it 'make_txid_only preserves wtxid' do
       beef = described_class.from_hex(go_brc62_hex)
       bt = beef.transactions.first
-      display_txid = bt.txid
+      original_wtxid = bt.wtxid
 
       beef.make_txid_only(bt.wtxid)
       txid_only_entry = beef.transactions.find { |entry| entry.format == described_class::FORMAT_TXID_ONLY }
       expect(txid_only_entry).not_to be_nil
-      expect(txid_only_entry.txid).to eq(display_txid)
+      expect(txid_only_entry.wtxid).to eq(original_wtxid)
     end
 
     it 'TXID_ONLY round-trips through V2 serialise/parse' do
       beef = described_class.from_hex(go_brc62_hex)
       first_bt = beef.transactions.first
-      original_txid = first_bt.txid
+      original_wtxid = first_bt.wtxid
 
       beef.make_txid_only(first_bt.wtxid)
       v2_bytes = beef.to_binary(version: described_class::BEEF_V2)
@@ -128,7 +128,7 @@ RSpec.describe BSV::Transaction::Beef do
 
       txid_entry = parsed.transactions.find { |entry| entry.format == described_class::FORMAT_TXID_ONLY }
       expect(txid_entry).not_to be_nil
-      expect(txid_entry.txid).to eq(original_txid)
+      expect(txid_entry.wtxid).to eq(original_wtxid)
     end
 
     it 'TXID_ONLY entries are included in known txids set' do
@@ -168,7 +168,7 @@ RSpec.describe BSV::Transaction::Beef do
       atomic = beef.to_atomic_binary(last_bt.wtxid)
       parsed = described_class.from_binary(atomic)
 
-      expect(parsed.subject_txid).to eq(last_bt.txid)
+      expect(parsed.subject_wtxid).to eq(last_bt.wtxid)
       expect(parsed.transactions.length).to eq(beef.transactions.length)
     end
   end
@@ -220,7 +220,7 @@ RSpec.describe BSV::Transaction::Beef do
 
       # Transaction IDs preserved
       v1.transactions.each_with_index do |bt, i|
-        expect(v2.transactions[i].txid).to eq(bt.txid)
+        expect(v2.transactions[i].wtxid).to eq(bt.wtxid)
       end
     end
   end
@@ -260,7 +260,7 @@ RSpec.describe BSV::Transaction::Beef do
     it 'from_beef returns the subject (last) transaction' do
       tx = BSV::Transaction::Transaction.from_beef_hex(go_beef_set_hex)
       beef = described_class.from_hex(go_beef_set_hex)
-      expect(tx.txid).to eq(beef.transactions.last.txid)
+      expect(tx.wtxid).to eq(beef.transactions.last.wtxid)
     end
 
     it 'to_beef produces valid BEEF that round-trips' do
@@ -268,7 +268,7 @@ RSpec.describe BSV::Transaction::Beef do
       rebuilt_hex = original.to_beef_hex
 
       tx2 = BSV::Transaction::Transaction.from_beef_hex(rebuilt_hex)
-      expect(tx2.txid).to eq(original.txid)
+      expect(tx2.wtxid).to eq(original.wtxid)
     end
   end
 

--- a/gem/bsv-sdk/spec/conformance/beef_spec.rb
+++ b/gem/bsv-sdk/spec/conformance/beef_spec.rb
@@ -101,9 +101,10 @@ RSpec.describe BSV::Transaction::Beef do
   end
 
   # --- F5.1: TXID_ONLY byte-order consistency ---
-  # BeefTx#txid must return display byte order for ALL format types.
-  # Previously, TXID_ONLY entries stored wire-order bytes, making
-  # find_transaction fail and producing a silent cross-SDK divergence.
+  # BeefTx#wtxid must return wire byte order for ALL format types.
+  # Previously, TXID_ONLY entries stored wire-order bytes but the
+  # lookup path expected display-order, causing find_transaction to
+  # fail and producing a silent cross-SDK divergence.
 
   describe 'TXID_ONLY byte-order consistency (F5.1)' do
     it 'make_txid_only preserves wtxid' do


### PR DESCRIPTION
## Summary

- **Fix bug** in `LookupResolver#dedup_key` — was interpolating 32-byte binary txid into a dedup string where hex was intended
- **Remove footgun methods** `Transaction#txid`, `BeefTx#txid`, `Beef#subject_txid` (display-order binary) — a format no external spec requires and no reference SDK exposes
- **Add `validate_dtxid_hex!`** at six trust boundary entry points where external txids enter the SDK without validation

Closes #690

## Detail

The recent wtxid/dtxid rename was a mechanical first pass. A systematic audit of every txid codepath found that `Transaction#txid` (32-byte display-order binary) was structurally indistinguishable from `wtxid` (also 32-byte binary), making it impossible for any runtime validation to catch a mix-up. The only production call site was the lookup resolver bug.

**Removed methods** (breaking):
- `Transaction#txid` — `txid_hex` now inlines `wtxid.reverse.unpack1('H*')`
- `BeefTx#txid` — use `wtxid` (binary) or `dtxid` (hex) instead
- `Beef#subject_txid` — use `subject_wtxid` or `subject_dtxid` instead

**Validated entry points:**
- `BroadcastResponse`, `BroadcastError`, `OverlayBroadcastResult`, `RegisteredDefinition`, `Attest::Response`, `Attest.verify`

**Spec updates:**
- All comparisons migrated from `.txid` to `.wtxid`
- Display assertions migrated to `.dtxid`
- Test fixtures upgraded from short placeholders (`'abc123'`) to valid 64-char hex

## Test plan

- [x] `bundle exec rake` — 5074 examples, 0 failures
- [x] `bundle exec rubocop` — 306 files, no offences

🤖 Generated with [Claude Code](https://claude.com/claude-code)