### PR TITLE
fix(mcp): bump mcp dep to ~> 0.15, adapt spec (#700)

### DIFF
--- a/gem/bsv-sdk/bsv-sdk.gemspec
+++ b/gem/bsv-sdk/bsv-sdk.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'base64'
-  spec.add_dependency 'mcp', '~> 0.12'
+  spec.add_dependency 'mcp', '~> 0.15'
   spec.add_dependency 'secp256k1-native', '>= 0.16'
 end

--- a/gem/bsv-sdk/spec/bsv/mcp/integration_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/mcp/integration_spec.rb
@@ -259,10 +259,14 @@ RSpec.describe 'BSV MCP server — protocol integration' do
   # Error handling — missing required argument
   # ------------------------------------------------------------------
   describe 'tools/call with missing required argument' do
-    it 'returns a JSON-RPC error when the required hex argument is absent' do
+    it 'returns an error when the required hex argument is absent' do
       response = server.handle(rpc('tools/call', { name: 'decode_tx', arguments: {} }, 4))
 
-      expect(response[:error]).to be_a(Hash)
+      # mcp >= 0.15 returns a tool-level error (isError in :result) rather
+      # than a JSON-RPC error (top-level :error key).
+      has_jsonrpc_error = response.key?(:error)
+      has_tool_error = response.dig(:result, :isError) == true
+      expect(has_jsonrpc_error || has_tool_error).to be true
     end
   end
 end


### PR DESCRIPTION
## Summary
- Bumps `mcp` gem dependency from `~> 0.12` to `~> 0.15`
- Adapts missing-argument spec to handle mcp 0.15's tool-level error format (`isError: true`) instead of JSON-RPC error

Closes #700

## Test plan
- [x] Full spec suite passes locally (5074 examples, 0 failures)
- [ ] CI passes on all Ruby versions (2.7–3.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)