### PR TITLE
fix: guard against nil source_satoshis in sighash

### DIFF
--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -439,6 +439,17 @@ module BSV
         raise ArgumentError, 'only SIGHASH_FORKID types are supported' unless sighash_type & Sighash::FORK_ID != 0
 
         input = @inputs[input_index]
+
+        if input.source_satoshis.nil?
+          raise ArgumentError,
+                "input #{input_index} has nil source_satoshis — set before computing sighash"
+        end
+
+        unless subscript || input.source_locking_script
+          raise ArgumentError,
+                "input #{input_index} has nil source_locking_script — set before computing sighash"
+        end
+
         base_type = sighash_type & Sighash::MASK
         anyone = sighash_type.anybits?(Sighash::ANYONE_CAN_PAY)
 

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -439,6 +439,7 @@ module BSV
         raise ArgumentError, 'only SIGHASH_FORKID types are supported' unless sighash_type & Sighash::FORK_ID != 0
 
         input = @inputs[input_index]
+        raise ArgumentError, "no input at index #{input_index}" if input.nil?
 
         if input.source_satoshis.nil?
           raise ArgumentError,

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction.rb
@@ -441,14 +441,25 @@ module BSV
         input = @inputs[input_index]
         raise ArgumentError, "no input at index #{input_index}" if input.nil?
 
+        # Resolve source data from wired source_transaction when not explicitly set.
+        if input.source_transaction
+          source_output = input.source_transaction.outputs[input.prev_tx_out_index]
+          if source_output
+            input.source_satoshis       ||= source_output.satoshis
+            input.source_locking_script ||= source_output.locking_script
+          end
+        end
+
         if input.source_satoshis.nil?
           raise ArgumentError,
-                "input #{input_index} has nil source_satoshis — set before computing sighash"
+                "input #{input_index} has nil source_satoshis — " \
+                'set it or wire source_transaction before computing sighash'
         end
 
         unless subscript || input.source_locking_script
           raise ArgumentError,
-                "input #{input_index} has nil source_locking_script — set before computing sighash"
+                "input #{input_index} has nil source_locking_script — " \
+                'set it or wire source_transaction before computing sighash'
         end
 
         base_type = sighash_type & Sighash::MASK

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
@@ -436,6 +436,17 @@ RSpec.describe BSV::Transaction::Transaction do
         ArgumentError, /input 0 has nil source_locking_script/
       )
     end
+
+    it 'raises ArgumentError when input_index is out of bounds' do
+      private_key = BSV::Primitives::PrivateKey.generate
+
+      tx = described_class.new
+      # No inputs added
+
+      expect { tx.sign(0, private_key) }.to raise_error(
+        ArgumentError, /no input at index 0/
+      )
+    end
   end
 
   describe 'UnlockingScriptTemplate integration' do

--- a/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/transaction_spec.rb
@@ -388,6 +388,54 @@ RSpec.describe BSV::Transaction::Transaction do
         expect(input.unlocking_script).not_to be_nil
       end
     end
+
+    it 'raises ArgumentError when input has nil source_satoshis' do
+      private_key = BSV::Primitives::PrivateKey.generate
+      pubkey_hash = private_key.public_key.hash160
+      locking_script = BSV::Script::Script.p2pkh_lock(pubkey_hash)
+
+      tx = described_class.new
+      input = BSV::Transaction::TransactionInput.new(
+        prev_wtxid: "\x01".b * 32,
+        prev_tx_out_index: 0
+      )
+      # source_satoshis intentionally not set
+      input.source_locking_script = locking_script
+      tx.add_input(input)
+
+      tx.add_output(BSV::Transaction::TransactionOutput.new(
+                      satoshis: 90_000,
+                      locking_script: locking_script
+                    ))
+
+      expect { tx.sign(0, private_key) }.to raise_error(
+        ArgumentError, /input 0 has nil source_satoshis/
+      )
+    end
+
+    it 'raises ArgumentError when input has nil source_locking_script' do
+      private_key = BSV::Primitives::PrivateKey.generate
+      pubkey_hash = private_key.public_key.hash160
+      locking_script = BSV::Script::Script.p2pkh_lock(pubkey_hash)
+
+      tx = described_class.new
+      input = BSV::Transaction::TransactionInput.new(
+        prev_wtxid: "\x01".b * 32,
+        prev_tx_out_index: 0
+      )
+      input.source_satoshis = 100_000
+      # source_locking_script intentionally not set
+      tx.add_input(input)
+
+      tx.add_output(BSV::Transaction::TransactionOutput.new(
+                      satoshis: 90_000,
+                      locking_script: locking_script
+                    ))
+
+      expect { tx.sign(0, private_key) }.to raise_error(
+        ArgumentError, /input 0 has nil source_locking_script/
+      )
+    end
   end
 
   describe 'UnlockingScriptTemplate integration' do


### PR DESCRIPTION
## Summary

- Adds fail-fast guard clauses in `sighash_preimage` that raise `ArgumentError` with a clear message when `source_satoshis` or `source_locking_script` is nil on the input being signed
- Guards are in `sighash_preimage` (not just `sign`) so all callers are protected — direct `sighash` calls and template-based signing via `sign_all`
- Previously, nil `source_satoshis` produced a cryptic `TypeError: no implicit conversion of nil into Integer` deep in `pack('Q<')`

## Test plan

- [x] All 52 transaction specs pass
- [x] 2 new specs cover nil `source_satoshis` and nil `source_locking_script`
- [x] Linter clean

Closes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)