### PR TITLE
fix: P1 robustness and security fixes (#703)

### DIFF
--- a/gem/bsv-sdk/lib/bsv/auth/get_verifiable_certificates.rb
+++ b/gem/bsv-sdk/lib/bsv/auth/get_verifiable_certificates.rb
@@ -21,7 +21,9 @@ module BSV
       #   - +:types+ [Hash] type (Base64 string) → array of field names to reveal
       # @param verifier_identity_key [String] the verifier's compressed public key hex
       # @return [Array<VerifiableCertificate>] list of verifiable certificates ready for
-      #   presentation, or +[]+ on any failure
+      #   presentation, or +[]+ when the wallet does not support certificate operations
+      # @raise [StandardError] propagates unexpected errors (network failures, key derivation
+      #   errors, etc.) to the caller — only +UnsupportedActionError+ is swallowed
       def get_verifiable_certificates(wallet, requested_certificates, verifier_identity_key)
         return [] unless wallet.respond_to?(:list_certificates) && wallet.respond_to?(:prove_certificate)
 
@@ -65,11 +67,9 @@ module BSV
             signature: cert[:signature] || cert['signature']
           )
         end
-      rescue StandardError
-        # Auto-fetch is best-effort: wallet may raise UnsupportedActionError,
-        # key derivation errors, or other failures. The peer protocol handles
-        # "no certificates" gracefully — the requesting peer enforces its own
-        # certificate requirements independently.
+      rescue BSV::Wallet::UnsupportedActionError
+        # Wallet does not implement certificate operations (e.g. ProtoWallet).
+        # Return empty — the requesting peer enforces its own requirements independently.
         []
       end
     end

--- a/gem/bsv-sdk/lib/bsv/auth/peer.rb
+++ b/gem/bsv-sdk/lib/bsv/auth/peer.rb
@@ -488,7 +488,7 @@ module BSV
         signature   = fetch!(message, :signature)
 
         # Verify the echoed nonce is one we created
-        raise AuthError, "Nonce verification failed from peer: #{peer_key}" unless Nonce.verify(our_nonce, @wallet)
+        verify_nonce!(our_nonce, context: "initial response from peer: #{peer_key}")
 
         session = @session_manager.get_session(our_nonce)
         raise AuthError, "No pending session for nonce: #{our_nonce.inspect}" unless session
@@ -566,7 +566,7 @@ module BSV
         msg_nonce = fetch!(message, :nonce)
 
         # Verify the echoed nonce is one we created
-        raise AuthError, "Unable to verify nonce for general message from: #{peer_key}" unless Nonce.verify(our_nonce, @wallet)
+        verify_nonce!(our_nonce, context: "general message from: #{peer_key}")
 
         session = @session_manager.get_session(our_nonce)
         raise AuthError, "Session not found for nonce: #{our_nonce.inspect}" unless session
@@ -602,7 +602,7 @@ module BSV
         requested = message[:requested_certificates] || message['requested_certificates']
         signature = fetch!(message, :signature)
 
-        raise AuthError, "Unable to verify nonce for certificate request message from: #{peer_key}" unless Nonce.verify(our_nonce, @wallet)
+        verify_nonce!(our_nonce, context: "certificate request from: #{peer_key}")
 
         session = @session_manager.get_session(our_nonce)
         raise AuthError, "Session not found for nonce: #{our_nonce.inspect}" unless session
@@ -647,7 +647,7 @@ module BSV
         certs     = message[:certificates] || message['certificates'] || []
         signature = fetch!(message, :signature)
 
-        raise AuthError, "Unable to verify nonce for certificate response from: #{peer_key}" unless Nonce.verify(our_nonce, @wallet)
+        verify_nonce!(our_nonce, context: "certificate response from: #{peer_key}")
 
         session = @session_manager.get_session(our_nonce)
         raise AuthError, "Session not found for nonce: #{our_nonce.inspect}" unless session
@@ -771,6 +771,12 @@ module BSV
         return nil if certs.empty?
 
         certs.map { |c| c.respond_to?(:to_h) ? c.to_h : c }
+      end
+
+      def verify_nonce!(nonce, context:)
+        return if Nonce.verify(nonce, @wallet)
+
+        raise AuthError, "Nonce verification failed for #{context}"
       end
 
       def current_time_ms

--- a/gem/bsv-sdk/lib/bsv/auth/session_manager.rb
+++ b/gem/bsv-sdk/lib/bsv/auth/session_manager.rb
@@ -9,9 +9,16 @@ module BSV
     # peer identity key are supported — the most recently updated session
     # is returned when looking up by identity key.
     #
+    # Sessions expire after +default_ttl+ seconds (default: 3600). Pass
+    # +default_ttl: nil+ to disable expiry entirely. Expired sessions are
+    # removed lazily on access; call {#sweep_expired} for proactive cleanup.
+    #
     # Matches the ts-sdk SessionManager dual-index design.
     class SessionManager
-      def initialize
+      # @param default_ttl [Integer, nil] seconds before a session expires;
+      #   +nil+ disables TTL entirely.
+      def initialize(default_ttl: 3600)
+        @default_ttl = default_ttl
         # session_nonce -> PeerSession
         @by_nonce    = {}
         # peer_identity_key -> Set of session_nonces
@@ -50,14 +57,22 @@ module BSV
       #
       # When the identifier is a session nonce, returns that exact session.
       # When the identifier is a peer identity key, returns the most recently
-      # updated session for that peer.
+      # updated non-expired session for that peer.
+      #
+      # Returns +nil+ if the session has expired (and removes it from the store).
       #
       # @param identifier [String]
       # @return [PeerSession, nil]
       def get_session(identifier)
         @mutex.synchronize do
           direct = @by_nonce[identifier]
-          return direct if direct
+          if direct
+            if expired_locked?(direct)
+              remove_session_locked(direct)
+              return nil
+            end
+            return direct
+          end
 
           nonces = @by_identity[identifier]
           return nil if nonces.nil? || nonces.empty?
@@ -66,6 +81,7 @@ module BSV
           nonces.each do |nonce|
             s = @by_nonce[nonce]
             next if s.nil?
+            next if expired_locked?(s)
 
             best = s if best.nil? || (s.last_update || 0) > (best.last_update || 0)
           end
@@ -84,11 +100,41 @@ module BSV
       # @return [Boolean]
       def session?(identifier)
         @mutex.synchronize do
-          return true if @by_nonce.key?(identifier)
+          direct = @by_nonce[identifier]
+          if direct
+            if expired_locked?(direct)
+              remove_session_locked(direct)
+              return false
+            end
+            return true
+          end
 
           nonces = @by_identity[identifier]
-          !nonces.nil? && !nonces.empty?
+          return false if nonces.nil? || nonces.empty?
+
+          nonces.any? do |nonce|
+            s = @by_nonce[nonce]
+            s && !expired_locked?(s)
+          end
         end
+      end
+
+      # Removes all expired sessions from the store.
+      #
+      # Not called automatically — intended for use in long-running servers
+      # that want to proactively reclaim memory.
+      #
+      # @return [Integer] number of sessions removed
+      def sweep_expired
+        removed = 0
+        @mutex.synchronize do
+          expired = @by_nonce.values.select { |s| expired_locked?(s) }
+          expired.each do |s|
+            remove_session_locked(s)
+            removed += 1
+          end
+        end
+        removed
       end
 
       private
@@ -114,6 +160,20 @@ module BSV
 
         nonces.delete(session.session_nonce)
         @by_identity.delete(session.peer_identity_key) if nonces.empty?
+      end
+
+      # Must be called within @mutex.
+      def expired_locked?(session)
+        return false if @default_ttl.nil?
+
+        last = session.last_update
+        return true if last.nil? || last.zero?
+
+        current_time_ms - last > @default_ttl * 1000
+      end
+
+      def current_time_ms
+        (Time.now.to_f * 1000).to_i
       end
     end
   end

--- a/gem/bsv-sdk/lib/bsv/auth/session_manager.rb
+++ b/gem/bsv-sdk/lib/bsv/auth/session_manager.rb
@@ -78,13 +78,19 @@ module BSV
           return nil if nonces.nil? || nonces.empty?
 
           best = nil
+          expired_nonces = []
           nonces.each do |nonce|
             s = @by_nonce[nonce]
             next if s.nil?
-            next if expired_locked?(s)
+
+            if expired_locked?(s)
+              expired_nonces << s
+              next
+            end
 
             best = s if best.nil? || (s.last_update || 0) > (best.last_update || 0)
           end
+          expired_nonces.each { |s| remove_session_locked(s) }
           best
         end
       end
@@ -112,10 +118,20 @@ module BSV
           nonces = @by_identity[identifier]
           return false if nonces.nil? || nonces.empty?
 
-          nonces.any? do |nonce|
+          has_active = false
+          expired_sessions = []
+          nonces.each do |nonce|
             s = @by_nonce[nonce]
-            s && !expired_locked?(s)
+            next if s.nil?
+
+            if expired_locked?(s)
+              expired_sessions << s
+            else
+              has_active = true
+            end
           end
+          expired_sessions.each { |s| remove_session_locked(s) }
+          has_active
         end
       end
 

--- a/gem/bsv-sdk/lib/bsv/wire_format.rb
+++ b/gem/bsv-sdk/lib/bsv/wire_format.rb
@@ -18,6 +18,10 @@ module BSV
   #   BSV::WireFormat.to_wire({ outputs: [{ locking_script: 'abc' }] })
   #   # => { 'outputs' => [{ 'lockingScript' => 'abc' }] }
   module WireFormat
+    # Maximum nesting depth for deep conversions. Prevents stack overflow on
+    # pathologically deep hashes or arrays.
+    MAX_DEPTH = 20
+
     # Well-known snake_case -> camelCase pairs for BRC-100/BRC-103 protocol keys.
     #
     # Acronyms like protocolID, keyID are canonical per the TS SDK (Wallet.interfaces.ts).
@@ -90,10 +94,7 @@ module BSV
     def to_wire(hash)
       raise ArgumentError, 'argument must not be nil' if hash.nil?
 
-      hash.each_with_object({}) do |(k, v), out|
-        camel_key = snake_to_camel(k.to_s)
-        out[camel_key] = deep_convert_value_to_wire(v)
-      end
+      to_wire_at_depth(hash, 0)
     end
 
     # Deeply converts all Hash keys from camelCase strings to snake_case symbols.
@@ -107,10 +108,7 @@ module BSV
     def from_wire(hash)
       raise ArgumentError, 'argument must not be nil' if hash.nil?
 
-      hash.each_with_object({}) do |(k, v), out|
-        snake_key = camel_to_snake(k.to_s).to_sym
-        out[snake_key] = deep_convert_value_from_wire(v)
-      end
+      from_wire_at_depth(hash, 0)
     end
 
     # Converts top-level Hash keys only from snake_case to camelCase strings.
@@ -182,12 +180,35 @@ module BSV
     end
     private_class_method :generic_camel_to_snake
 
+    # Depth-aware inner implementation of to_wire.
+    def to_wire_at_depth(hash, depth)
+      hash.each_with_object({}) do |(k, v), out|
+        camel_key = snake_to_camel(k.to_s)
+        out[camel_key] = deep_convert_value_to_wire(v, depth + 1)
+      end
+    end
+    private_class_method :to_wire_at_depth
+
+    # Depth-aware inner implementation of from_wire.
+    def from_wire_at_depth(hash, depth)
+      hash.each_with_object({}) do |(k, v), out|
+        snake_key = camel_to_snake(k.to_s).to_sym
+        out[snake_key] = deep_convert_value_from_wire(v, depth + 1)
+      end
+    end
+    private_class_method :from_wire_at_depth
+
     # Recursively converts a value destined for the wire (to_wire direction).
-    def deep_convert_value_to_wire(value)
+    # depth is the nesting level of this value (1 = directly inside the root hash).
+    def deep_convert_value_to_wire(value, depth = 0)
       if value.is_a?(Hash)
-        to_wire(value)
+        raise ArgumentError, "WireFormat nesting exceeds maximum depth (#{MAX_DEPTH})" if depth >= MAX_DEPTH
+
+        to_wire_at_depth(value, depth)
       elsif value.is_a?(Array)
-        value.map { |elem| deep_convert_value_to_wire(elem) }
+        raise ArgumentError, "WireFormat nesting exceeds maximum depth (#{MAX_DEPTH})" if depth >= MAX_DEPTH
+
+        value.map { |elem| deep_convert_value_to_wire(elem, depth + 1) }
       else
         value
       end
@@ -195,11 +216,16 @@ module BSV
     private_class_method :deep_convert_value_to_wire
 
     # Recursively converts a value coming from the wire (from_wire direction).
-    def deep_convert_value_from_wire(value)
+    # depth is the nesting level of this value (1 = directly inside the root hash).
+    def deep_convert_value_from_wire(value, depth = 0)
       if value.is_a?(Hash)
-        from_wire(value)
+        raise ArgumentError, "WireFormat nesting exceeds maximum depth (#{MAX_DEPTH})" if depth >= MAX_DEPTH
+
+        from_wire_at_depth(value, depth)
       elsif value.is_a?(Array)
-        value.map { |elem| deep_convert_value_from_wire(elem) }
+        raise ArgumentError, "WireFormat nesting exceeds maximum depth (#{MAX_DEPTH})" if depth >= MAX_DEPTH
+
+        value.map { |elem| deep_convert_value_from_wire(elem, depth + 1) }
       else
         value
       end

--- a/gem/bsv-sdk/spec/bsv/auth/get_verifiable_certificates_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/auth/get_verifiable_certificates_spec.rb
@@ -153,7 +153,38 @@ RSpec.describe 'BSV::Auth.get_verifiable_certificates' do
     end
   end
 
-  context 'when prove_certificate raises an error' do
+  context 'when prove_certificate raises UnsupportedActionError' do
+    let(:wallet) { double('wallet') } # rubocop:disable RSpec/VerifiedDoubles
+
+    before do
+      allow(wallet).to receive(:respond_to?).with(:list_certificates).and_return(true)
+      allow(wallet).to receive(:respond_to?).with(:prove_certificate).and_return(true)
+      allow(wallet).to receive(:list_certificates).and_return({ certificates: [cert_hash_a] })
+      allow(wallet).to receive(:prove_certificate).and_raise(BSV::Wallet::UnsupportedActionError)
+    end
+
+    it 'returns []' do
+      result = BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
+      expect(result).to eq([])
+    end
+  end
+
+  context 'when list_certificates raises UnsupportedActionError' do
+    let(:wallet) { double('wallet') } # rubocop:disable RSpec/VerifiedDoubles
+
+    before do
+      allow(wallet).to receive(:respond_to?).with(:list_certificates).and_return(true)
+      allow(wallet).to receive(:respond_to?).with(:prove_certificate).and_return(true)
+      allow(wallet).to receive(:list_certificates).and_raise(BSV::Wallet::UnsupportedActionError)
+    end
+
+    it 'returns []' do
+      result = BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
+      expect(result).to eq([])
+    end
+  end
+
+  context 'when prove_certificate raises an unexpected error' do
     let(:wallet) { double('wallet') } # rubocop:disable RSpec/VerifiedDoubles
 
     before do
@@ -163,13 +194,14 @@ RSpec.describe 'BSV::Auth.get_verifiable_certificates' do
       allow(wallet).to receive(:prove_certificate).and_raise(RuntimeError, 'protocol mismatch')
     end
 
-    it 'returns [] gracefully' do
-      result = BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
-      expect(result).to eq([])
+    it 'propagates the error to the caller' do
+      expect do
+        BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
+      end.to raise_error(RuntimeError, 'protocol mismatch')
     end
   end
 
-  context 'when list_certificates raises an error' do
+  context 'when list_certificates raises an unexpected error' do
     let(:wallet) { double('wallet') } # rubocop:disable RSpec/VerifiedDoubles
 
     before do
@@ -178,9 +210,27 @@ RSpec.describe 'BSV::Auth.get_verifiable_certificates' do
       allow(wallet).to receive(:list_certificates).and_raise(RuntimeError, 'network error')
     end
 
-    it 'returns [] gracefully' do
-      result = BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
-      expect(result).to eq([])
+    it 'propagates the error to the caller' do
+      expect do
+        BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
+      end.to raise_error(RuntimeError, 'network error')
+    end
+  end
+
+  context 'when prove_certificate raises ArgumentError' do
+    let(:wallet) { double('wallet') } # rubocop:disable RSpec/VerifiedDoubles
+
+    before do
+      allow(wallet).to receive(:respond_to?).with(:list_certificates).and_return(true)
+      allow(wallet).to receive(:respond_to?).with(:prove_certificate).and_return(true)
+      allow(wallet).to receive(:list_certificates).and_return({ certificates: [cert_hash_a] })
+      allow(wallet).to receive(:prove_certificate).and_raise(ArgumentError, 'invalid verifier key')
+    end
+
+    it 'propagates the error to the caller' do
+      expect do
+        BSV::Auth.get_verifiable_certificates(wallet, requested_certificates, verifier_key)
+      end.to raise_error(ArgumentError, 'invalid verifier key')
     end
   end
 

--- a/gem/bsv-sdk/spec/bsv/auth/peer_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/auth/peer_spec.rb
@@ -496,7 +496,7 @@ RSpec.describe BSV::Auth::Peer do
         signature: [0] * 71
       }
       expect { bob.send(:handle_incoming_message, bad_nonce_msg) }
-        .to raise_error(BSV::Auth::AuthError, /Unable to verify nonce/)
+        .to raise_error(BSV::Auth::AuthError, /Nonce verification failed/)
     end
 
     it 'raises AuthError when certificateRequest signature is tampered' do

--- a/gem/bsv-sdk/spec/bsv/auth/session_manager_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/auth/session_manager_spec.rb
@@ -8,10 +8,11 @@ RSpec.describe BSV::Auth::SessionManager do
   let(:session_nonce) { 'nonce-abc' }
   let(:peer_key)      { "02#{'ab' * 32}" }
 
-  def build_session(nonce: session_nonce, peer_identity_key: nil, authenticated: false)
+  def build_session(nonce: session_nonce, peer_identity_key: nil, authenticated: false, last_update: nil)
     s = BSV::Auth::PeerSession.new(session_nonce: nonce)
     s.peer_identity_key = peer_identity_key if peer_identity_key
     s.is_authenticated  = authenticated
+    s.last_update       = last_update unless last_update.nil?
     s
   end
 
@@ -106,11 +107,9 @@ RSpec.describe BSV::Auth::SessionManager do
 
   describe 'multiple sessions per peer identity key' do
     it 'returns the most recently updated session when looking up by identity key' do
-      session_a = build_session(nonce: 'nonce-a', peer_identity_key: peer_key)
-      session_b = build_session(nonce: 'nonce-b', peer_identity_key: peer_key)
-
-      session_a.last_update = 1000
-      session_b.last_update = 2000
+      now_ms    = (Time.now.to_f * 1000).to_i
+      session_a = build_session(nonce: 'nonce-a', peer_identity_key: peer_key, last_update: now_ms - 2000)
+      session_b = build_session(nonce: 'nonce-b', peer_identity_key: peer_key, last_update: now_ms - 1000)
 
       manager.add_session(session_a)
       manager.add_session(session_b)
@@ -128,6 +127,186 @@ RSpec.describe BSV::Auth::SessionManager do
       session = build_session(authenticated: true)
       manager.add_session(session)
       expect(manager.get_session(session_nonce).authenticated?).to be(true)
+    end
+  end
+
+  describe 'TTL expiry' do
+    let(:now_ms) { (Time.now.to_f * 1000).to_i }
+
+    context 'with default TTL (3600s)' do
+      it 'returns a session whose last_update is within the TTL' do
+        session = build_session(last_update: now_ms)
+        manager.add_session(session)
+        expect(manager.get_session(session_nonce)).to equal(session)
+      end
+
+      it 'returns nil for a session past the TTL' do
+        old_ms = now_ms - (3601 * 1000)
+        session = build_session(last_update: old_ms)
+        manager.add_session(session)
+        expect(manager.get_session(session_nonce)).to be_nil
+      end
+
+      it 'removes an expired session from both indexes on get_session' do
+        old_ms = now_ms - (3601 * 1000)
+        session = build_session(last_update: old_ms, peer_identity_key: peer_key)
+        manager.add_session(session)
+
+        manager.get_session(session_nonce)
+
+        expect(manager.get_session(session_nonce)).to be_nil
+        expect(manager.get_session(peer_key)).to be_nil
+      end
+    end
+
+    context 'with session?' do
+      it 'returns false for an expired session (by nonce)' do
+        old_ms = now_ms - (3601 * 1000)
+        session = build_session(last_update: old_ms)
+        manager.add_session(session)
+        expect(manager.session?(session_nonce)).to be(false)
+      end
+
+      it 'returns false for an expired session (by identity key)' do
+        old_ms = now_ms - (3601 * 1000)
+        session = build_session(last_update: old_ms, peer_identity_key: peer_key)
+        manager.add_session(session)
+        expect(manager.session?(peer_key)).to be(false)
+      end
+
+      it 'returns true for a non-expired session' do
+        session = build_session(last_update: now_ms)
+        manager.add_session(session)
+        expect(manager.session?(session_nonce)).to be(true)
+      end
+    end
+
+    context 'with a custom TTL (60s)' do
+      subject(:manager) { described_class.new(default_ttl: 60) }
+
+      it 'returns nil after 61 seconds have elapsed' do
+        old_ms = now_ms - (61 * 1000)
+        session = build_session(last_update: old_ms)
+        manager.add_session(session)
+        expect(manager.get_session(session_nonce)).to be_nil
+      end
+
+      it 'returns the session when it is within 60 seconds' do
+        recent_ms = now_ms - (59 * 1000)
+        session = build_session(last_update: recent_ms)
+        manager.add_session(session)
+        expect(manager.get_session(session_nonce)).to equal(session)
+      end
+    end
+
+    context 'with TTL disabled (default_ttl: nil)' do
+      subject(:manager) { described_class.new(default_ttl: nil) }
+
+      it 'returns a session regardless of age' do
+        old_ms = now_ms - (999_999 * 1000)
+        session = build_session(last_update: old_ms)
+        manager.add_session(session)
+        expect(manager.get_session(session_nonce)).to equal(session)
+      end
+
+      it 'returns true from session? regardless of age' do
+        old_ms = now_ms - (999_999 * 1000)
+        session = build_session(last_update: old_ms)
+        manager.add_session(session)
+        expect(manager.session?(session_nonce)).to be(true)
+      end
+    end
+
+    context 'with last_update: nil' do
+      it 'treats the session as expired' do
+        session = build_session
+        session.last_update = nil
+        manager.add_session(session)
+        expect(manager.get_session(session_nonce)).to be_nil
+      end
+    end
+
+    context 'with last_update: 0' do
+      it 'treats the session as expired' do
+        session = build_session(last_update: 0)
+        manager.add_session(session)
+        expect(manager.get_session(session_nonce)).to be_nil
+      end
+    end
+
+    context 'with mixed expired and active sessions for the same identity key' do
+      it 'skips expired sessions and returns the best non-expired one' do
+        old_ms    = now_ms - (3601 * 1000)
+        recent_ms = now_ms
+
+        expired = build_session(nonce: 'nonce-expired', peer_identity_key: peer_key, last_update: old_ms)
+        active  = build_session(nonce: 'nonce-active',  peer_identity_key: peer_key, last_update: recent_ms)
+
+        manager.add_session(expired)
+        manager.add_session(active)
+
+        expect(manager.get_session(peer_key)).to equal(active)
+      end
+
+      it 'returns nil when all sessions for a peer have expired' do
+        old_ms = now_ms - (3601 * 1000)
+
+        s1 = build_session(nonce: 'nonce-1', peer_identity_key: peer_key, last_update: old_ms)
+        s2 = build_session(nonce: 'nonce-2', peer_identity_key: peer_key, last_update: old_ms)
+
+        manager.add_session(s1)
+        manager.add_session(s2)
+
+        expect(manager.get_session(peer_key)).to be_nil
+      end
+    end
+  end
+
+  describe '#sweep_expired' do
+    let(:now_ms) { (Time.now.to_f * 1000).to_i }
+
+    it 'removes all expired sessions and returns the count' do
+      old_ms = now_ms - (3601 * 1000)
+
+      s1 = build_session(nonce: 'nonce-1', peer_identity_key: peer_key, last_update: old_ms)
+      s2 = build_session(nonce: 'nonce-2', last_update: old_ms)
+      s3 = build_session(nonce: 'nonce-3', last_update: now_ms)
+
+      manager.add_session(s1)
+      manager.add_session(s2)
+      manager.add_session(s3)
+
+      count = manager.sweep_expired
+      expect(count).to eq(2)
+
+      expect(manager.get_session('nonce-1')).to be_nil
+      expect(manager.get_session('nonce-2')).to be_nil
+      expect(manager.get_session('nonce-3')).to equal(s3)
+    end
+
+    it 'returns 0 when no sessions have expired' do
+      manager.add_session(build_session(last_update: now_ms))
+      expect(manager.sweep_expired).to eq(0)
+    end
+
+    it 'returns 0 when the store is empty' do
+      expect(manager.sweep_expired).to eq(0)
+    end
+
+    it 'cleans up identity index entries for swept sessions' do
+      old_ms = now_ms - (3601 * 1000)
+      session = build_session(peer_identity_key: peer_key, last_update: old_ms)
+      manager.add_session(session)
+      manager.sweep_expired
+      expect(manager.get_session(peer_key)).to be_nil
+    end
+
+    it 'does nothing when TTL is disabled' do
+      manager_no_ttl = described_class.new(default_ttl: nil)
+      old_ms = now_ms - (999_999 * 1000)
+      session = build_session(last_update: old_ms)
+      manager_no_ttl.add_session(session)
+      expect(manager_no_ttl.sweep_expired).to eq(0)
     end
   end
 end

--- a/gem/bsv-sdk/spec/bsv/wire_format_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/wire_format_spec.rb
@@ -234,6 +234,88 @@ RSpec.describe BSV::WireFormat do
     end
   end
 
+  describe 'depth limit' do
+    def build_nested_hash(depth)
+      return { key: 'leaf' } if depth == 0
+
+      { key: build_nested_hash(depth - 1) }
+    end
+
+    def build_wire_nested_hash(depth)
+      return { 'key' => 'leaf' } if depth == 0
+
+      { 'key' => build_wire_nested_hash(depth - 1) }
+    end
+
+    def build_nested_array(depth)
+      return ['leaf'] if depth == 0
+
+      [build_nested_array(depth - 1)]
+    end
+
+    it 'exposes MAX_DEPTH constant' do
+      expect(described_class::MAX_DEPTH).to eq(20)
+    end
+
+    describe '.to_wire' do
+      it 'converts a hash nested to depth 19 successfully' do
+        expect { described_class.to_wire(build_nested_hash(19)) }.not_to raise_error
+      end
+
+      it 'raises ArgumentError for a hash nested to depth 20' do
+        expect { described_class.to_wire(build_nested_hash(20)) }
+          .to raise_error(ArgumentError, /WireFormat nesting exceeds maximum depth \(20\)/)
+      end
+
+      it 'raises ArgumentError for arrays nested to depth 20' do
+        # Root hash containing an array nested 20 levels deep
+        input = { key: build_nested_array(20) }
+        expect { described_class.to_wire(input) }
+          .to raise_error(ArgumentError, /WireFormat nesting exceeds maximum depth \(20\)/)
+      end
+
+      it 'raises ArgumentError for mixed hash/array nesting at depth 20' do
+        # Alternating hash and array nesting — each level counts toward the limit
+        nested = 'leaf'
+        20.times { |i| nested = i.odd? ? [nested] : { key: nested } }
+        expect { described_class.to_wire({ root: nested }) }
+          .to raise_error(ArgumentError, /WireFormat nesting exceeds maximum depth \(20\)/)
+      end
+
+      it 'succeeds for a flat hash with many keys' do
+        flat = (1..100).to_h { |i| [:"key_#{i}", i] }
+        expect { described_class.to_wire(flat) }.not_to raise_error
+      end
+
+      it 'includes the depth limit in the error message' do
+        expect { described_class.to_wire(build_nested_hash(20)) }
+          .to raise_error(ArgumentError, /20/)
+      end
+    end
+
+    describe '.from_wire' do
+      it 'converts a hash nested to depth 19 successfully' do
+        expect { described_class.from_wire(build_wire_nested_hash(19)) }.not_to raise_error
+      end
+
+      it 'raises ArgumentError for a hash nested to depth 20' do
+        expect { described_class.from_wire(build_wire_nested_hash(20)) }
+          .to raise_error(ArgumentError, /WireFormat nesting exceeds maximum depth \(20\)/)
+      end
+
+      it 'raises ArgumentError for arrays nested to depth 20' do
+        input = { 'key' => build_nested_array(20) }
+        expect { described_class.from_wire(input) }
+          .to raise_error(ArgumentError, /WireFormat nesting exceeds maximum depth \(20\)/)
+      end
+
+      it 'includes the depth limit in the error message' do
+        expect { described_class.from_wire(build_wire_nested_hash(20)) }
+          .to raise_error(ArgumentError, /20/)
+      end
+    end
+  end
+
   describe 'round-trip' do
     it 'round-trips a representative BRC-100 payload' do
       original = {


### PR DESCRIPTION
## Summary
- Add TTL expiration to SessionManager (default 3600s, configurable) (#707)
- Propagate unexpected errors from certificate fetch instead of silent `[]` (#708)
- Add depth limit (MAX_DEPTH=20) to WireFormat deep conversion (#709)
- Extract `verify_nonce!` helper in Peer, replacing 4 duplicate call sites (#710)

## Test plan
- [x] All auth specs pass (466 examples, 0 failures)
- [x] All wire_format specs pass
- [x] Linter clean (4 files, no offences)
- [x] Acceptance criteria verified

Closes #703
