### PR TITLE
feat(network): provider auth and rate limit metadata

### DIFF
--- a/docs/network/examples.md
+++ b/docs/network/examples.md
@@ -232,9 +232,6 @@ gp = BSV::Network::Providers::GorillaPool.default(auth: { bearer: ENV['GP_TOKEN'
 
 # TAAL with a bearer token
 taal = BSV::Network::Providers::TAAL.default(auth: { bearer: ENV['TAAL_TOKEN'] })
-
-# Directly on a facade
-arc = BSV::Network::ARC.default(auth: { bearer: ENV['ARC_TOKEN'] })
 ```
 
 ### Raw API key (no Bearer prefix)
@@ -294,9 +291,9 @@ arc = BSV::Network::ARC.default(api_key: 'my-key')
 arc = BSV::Network::ARC.default(auth: { bearer: 'my-key' })
 ```
 
-For WhatsOnChain, where the protocol sends a bare key (no `Bearer` prefix), use
-`auth: { api_key: 'key' }` rather than the legacy `api_key:` shorthand — the
-legacy form sends a Bearer prefix which WoC does not expect.
+For WhatsOnChain, the protocol sends a bare key (no `Bearer` prefix). Both the
+new `auth: { api_key: 'key' }` form and the legacy `api_key:` shorthand work
+correctly — the factory translates the legacy form automatically.
 
 ## Rate Limit Metadata
 

--- a/docs/network/examples.md
+++ b/docs/network/examples.md
@@ -215,22 +215,117 @@ result = my_tracker.call(:current_height)
 puts result.data  # => 945398
 ```
 
-## API Key Configuration
+## Auth Configuration
 
-API keys are passed through `**opts` on `.default` or directly on constructors:
+The SDK supports three authentication mechanisms via the `auth:` hash. The SDK does not
+read environment variables for credentials — that is a consumer concern. Pass credentials
+in at construction time.
+
+### Bearer token
+
+Use `auth: { bearer: 'token' }` for services that expect `Authorization: Bearer <token>`.
+This is the standard form for GorillaPool ARC and TAAL ARC.
 
 ```ruby
-# Via .default
-arc = BSV::Network::ARC.default(api_key: 'my-key')
-woc = BSV::Network::WhatsOnChain.default(api_key: 'my-woc-key')
+# GorillaPool with a bearer token
+gp = BSV::Network::Providers::GorillaPool.default(auth: { bearer: ENV['GP_TOKEN'] })
 
-# Via provider
-gp = BSV::Network::Providers::GorillaPool.default(api_key: 'my-key')
+# TAAL with a bearer token
+taal = BSV::Network::Providers::TAAL.default(auth: { bearer: ENV['TAAL_TOKEN'] })
 
-# Via constructor
-arc = BSV::Network::ARC.new('https://arc.taal.com', api_key: 'taal-key')
+# Directly on a facade
+arc = BSV::Network::ARC.default(auth: { bearer: ENV['ARC_TOKEN'] })
 ```
 
-The SDK does not read environment variables for API keys — that's a consumer concern.
-Set them however makes sense for your application (ENV vars, Rails credentials,
-config files, etc.) and pass them in at construction time.
+### Raw API key (no Bearer prefix)
+
+Use `auth: { api_key: 'key' }` for services that expect a bare key in the
+`Authorization` header. This is the WhatsOnChain style.
+
+```ruby
+woc = BSV::Network::Providers::WhatsOnChain.default(auth: { api_key: ENV['WOC_KEY'] })
+```
+
+### Custom header
+
+Use `auth: { api_key: 'key', header: 'X-Header-Name' }` when the service expects
+credentials in a non-standard header.
+
+```ruby
+my_provider = BSV::Network::Providers::GorillaPool.default(
+  auth: { api_key: ENV['MY_KEY'], header: 'Api-Key' }
+)
+```
+
+### Auth mechanisms summary
+
+| `auth:` form | Header sent |
+|---|---|
+| `{ bearer: 'token' }` | `Authorization: Bearer token` |
+| `{ api_key: 'key' }` | `Authorization: key` (no prefix) |
+| `{ api_key: 'key', header: 'X-Custom' }` | `X-Custom: key` |
+| `:none` / omitted | No auth header |
+
+### Checking auth status
+
+Providers expose `authenticated?` and `auth` accessors for introspection:
+
+```ruby
+provider = BSV::Network::Providers::WhatsOnChain.mainnet(auth: { api_key: 'my-key' })
+provider.authenticated?   # => true
+provider.auth             # => { api_key: 'my-key' }
+
+public_provider = BSV::Network::Providers::GorillaPool.default
+public_provider.authenticated?  # => false
+public_provider.auth            # => :none
+```
+
+### Migration from `api_key:`
+
+The legacy `api_key:` keyword argument is still supported for backwards compatibility.
+The new `auth:` hash is the preferred form. Both work; `auth:` takes precedence when
+both are supplied.
+
+```ruby
+# Legacy — still works
+arc = BSV::Network::ARC.default(api_key: 'my-key')
+
+# Preferred — explicit about the mechanism
+arc = BSV::Network::ARC.default(auth: { bearer: 'my-key' })
+```
+
+For WhatsOnChain, where the protocol sends a bare key (no `Bearer` prefix), use
+`auth: { api_key: 'key' }` rather than the legacy `api_key:` shorthand — the
+legacy form sends a Bearer prefix which WoC does not expect.
+
+## Rate Limit Metadata
+
+Providers carry a `rate_limit` attribute that declares the requests-per-second limit
+appropriate for the configured credentials. **The SDK does not enforce this limit** —
+it is metadata for the consumer to use in their own rate-limiting logic (e.g. a token
+bucket in an application layer).
+
+```ruby
+# Default rate limit for unauthenticated use
+woc = BSV::Network::Providers::WhatsOnChain.default
+woc.rate_limit   # => 3
+
+# Override for an authenticated tier with higher limits
+woc = BSV::Network::Providers::WhatsOnChain.mainnet(
+  auth: { api_key: ENV['WOC_KEY'] },
+  rate_limit: 25
+)
+woc.rate_limit   # => 25
+
+# TAAL: nil because it depends on subscription tier
+taal = BSV::Network::Providers::TAAL.default
+taal.rate_limit  # => nil
+```
+
+Default rate limits per provider (unauthenticated tier):
+
+| Provider | `DEFAULT_RATE_LIMIT` |
+|----------|---------------------|
+| `WhatsOnChain` | 3 req/s |
+| `GorillaPool` | 3 req/s |
+| `TAAL` | `nil` (depends on subscription) |

--- a/docs/network/overview.md
+++ b/docs/network/overview.md
@@ -55,6 +55,41 @@ Each provider composes protocol instances with concrete URLs and credentials. Wh
 call `.default`, you get a ready-to-use provider pointed at the mainnet endpoints.
 Pass `testnet: true` for testnet.
 
+#### Auth and Rate Limit Metadata
+
+Providers carry `auth` and `rate_limit` as metadata — they describe what credentials
+the provider is configured with and what request rate is appropriate. The SDK does not
+enforce rate limiting itself; that is a consumer concern.
+
+```ruby
+provider = BSV::Network::Providers::WhatsOnChain.mainnet(
+  auth: { api_key: 'my-key' },
+  rate_limit: 10
+)
+
+provider.authenticated?   # => true
+provider.auth             # => { api_key: 'my-key' }
+provider.rate_limit       # => 10
+```
+
+Without credentials:
+
+```ruby
+provider = BSV::Network::Providers::GorillaPool.default
+provider.authenticated?   # => false
+provider.auth             # => :none
+provider.rate_limit       # => 3  (GorillaPool default)
+```
+
+The `rate_limit` value is requests per second. Each provider factory sets a
+`DEFAULT_RATE_LIMIT` constant for unauthenticated use:
+
+| Provider | `DEFAULT_RATE_LIMIT` | Notes |
+|----------|---------------------|-------|
+| `WhatsOnChain` | 3 | Public tier limit |
+| `GorillaPool` | 3 | Public tier limit |
+| `TAAL` | `nil` | Depends on subscription tier |
+
 ## SDK Facades
 
 For convenience, the SDK provides facade classes that preserve the familiar API from

--- a/docs/sdk/network.md
+++ b/docs/sdk/network.md
@@ -29,9 +29,22 @@ arc = BSV::Network::ARC.default(testnet: true)
 
 ### Custom Endpoint
 
-Point at any ARC-compatible endpoint:
+Point at any ARC-compatible endpoint. Use `auth:` to specify the authentication mechanism:
 
 ```ruby
+# Bearer token (default for GorillaPool and TAAL ARC)
+arc = BSV::Network::ARC.new(
+  'https://my-arc-server.example.com',
+  auth: { bearer: 'my-api-key' }
+)
+
+# Raw API key in Authorization header (no Bearer prefix)
+arc = BSV::Network::ARC.new(
+  'https://my-arc-server.example.com',
+  auth: { api_key: 'my-api-key' }
+)
+
+# The legacy api_key: shorthand is still supported and sends Bearer
 arc = BSV::Network::ARC.new(
   'https://my-arc-server.example.com',
   api_key: 'my-api-key'
@@ -214,7 +227,7 @@ Environment variables:
 |----------|---------|-------------|
 | `BSV_NETWORK` | `main` | Network: `main` or `test` |
 | `BSV_ARC_URL` | GorillaPool | Custom ARC endpoint URL |
-| `BSV_ARC_API_KEY` | *(none)* | ARC API key for authenticated access |
+| `BSV_ARC_API_KEY` | *(none)* | ARC API key — passed as `auth: { bearer: value }` |
 
 See the **[MCP Server Guide](../general/mcp.md)** for full setup instructions, testnet configuration, and example workflows.
 

--- a/gem/bsv-sdk/lib/bsv/network/protocol.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocol.rb
@@ -103,14 +103,21 @@ module BSV
       @endpoints     = {}
       @subscriptions = {}
 
-      attr_reader :base_url, :api_key, :network, :http_client
+      attr_reader :base_url, :api_key, :auth, :network, :http_client
 
       # @param base_url    [String] base URL, may contain +{network}+ placeholder
-      # @param api_key     [String, nil] API key for authenticated requests
+      # @param api_key     [String, nil] legacy API key — sends +Authorization: Bearer <key>+
+      # @param auth        [Hash, Symbol, nil] auth config hash; takes precedence over +api_key:+.
+      #   Supported forms:
+      #   - +{ bearer: 'token' }+ → +Authorization: Bearer token+
+      #   - +{ api_key: 'key' }+ → +Authorization: key+ (no Bearer prefix, WoC style)
+      #   - +{ api_key: 'key', header: 'X-Custom' }+ → +X-Custom: key+
+      #   - +:none+ or +nil+ → no auth header
       # @param network     [String, Symbol, nil] network name (e.g. 'main', 'test')
       # @param http_client [Object, nil] injectable HTTP client (used in Task 3)
-      def initialize(base_url:, api_key: nil, network: nil, http_client: nil)
+      def initialize(base_url:, api_key: nil, auth: nil, network: nil, http_client: nil)
         @api_key     = api_key
+        @auth        = auth
         @network     = network
         @http_client = http_client
         @base_url    = build_base_url(base_url, network)
@@ -228,6 +235,14 @@ module BSV
 
       # Builds a Net::HTTP request for the given method, URI, and optional body.
       #
+      # Auth header dispatch (in priority order):
+      # 1. +auth:+ config hash takes precedence over the legacy +api_key:+ shorthand.
+      # 2. +{ bearer: 'token' }+ → +Authorization: Bearer token+
+      # 3. +{ api_key: 'key', header: 'X-Custom' }+ → +X-Custom: key+
+      # 4. +{ api_key: 'key' }+ → +Authorization: key+ (no Bearer prefix)
+      # 5. +auth: :none+ or no auth at all → no Authorization header set
+      # 6. Legacy +api_key:+ (no auth: provided) → +Authorization: Bearer api_key+
+      #
       # @param http_method [Symbol] +:get+ or +:post+
       # @param uri   [URI]
       # @param body  [String, nil] raw body for POST requests
@@ -240,12 +255,33 @@ module BSV
           else raise ArgumentError, "unsupported HTTP method: #{http_method}"
           end
 
-        request['Authorization'] = "Bearer #{@api_key}" if @api_key
+        apply_auth(request)
+
         if body && request.respond_to?(:body=)
           request.body = body
           request.content_type = 'application/json' unless request.content_type
         end
         request
+      end
+
+      # Applies the auth header to the request based on the +auth:+ config or
+      # the legacy +api_key:+ shorthand.
+      #
+      # @param request [Net::HTTPRequest]
+      def apply_auth(request)
+        # auth: config takes precedence over legacy api_key:
+        if @auth && @auth != :none
+          auth = @auth
+          if auth[:bearer]
+            request['Authorization'] = "Bearer #{auth[:bearer]}"
+          elsif auth[:api_key]
+            header = auth[:header] || 'Authorization'
+            request[header] = auth[:api_key]
+          end
+        elsif @api_key && @auth.nil?
+          # Legacy shorthand: api_key: without auth: sends Bearer
+          request['Authorization'] = "Bearer #{@api_key}"
+        end
       end
 
       # Executes the request via the injectable client or +Net::HTTP.start+.

--- a/gem/bsv-sdk/lib/bsv/network/protocol.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocol.rb
@@ -117,7 +117,7 @@ module BSV
       # @param http_client [Object, nil] injectable HTTP client (used in Task 3)
       def initialize(base_url:, api_key: nil, auth: nil, network: nil, http_client: nil)
         @api_key     = api_key
-        @auth        = auth
+        @auth        = normalise_auth(auth)
         @network     = network
         @http_client = http_client
         @base_url    = build_base_url(base_url, network)
@@ -270,7 +270,7 @@ module BSV
       # @param request [Net::HTTPRequest]
       def apply_auth(request)
         # auth: config takes precedence over legacy api_key:
-        if @auth && @auth != :none
+        if @auth != :none
           auth = @auth
           if auth[:bearer]
             request['Authorization'] = "Bearer #{auth[:bearer]}"
@@ -278,10 +278,24 @@ module BSV
             header = auth[:header] || 'Authorization'
             request[header] = auth[:api_key]
           end
-        elsif @api_key && @auth.nil?
+        elsif @api_key
           # Legacy shorthand: api_key: without auth: sends Bearer
           request['Authorization'] = "Bearer #{@api_key}"
         end
+      end
+
+      # Normalises the +auth+ argument so that +nil+ and empty hashes are
+      # stored as +:none+, giving a single canonical sentinel value for
+      # "no authentication".
+      #
+      # @param auth [Hash, Symbol, nil]
+      # @return [Hash, Symbol]
+      def normalise_auth(auth)
+        return :none if auth.nil?
+        return :none if auth == :none
+        return :none if auth.is_a?(Hash) && (auth.empty? || (auth[:bearer].nil? && auth[:api_key].nil?))
+
+        auth
       end
 
       # Executes the request via the injectable client or +Net::HTTP.start+.

--- a/gem/bsv-sdk/lib/bsv/network/protocols/arc.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/arc.rb
@@ -45,16 +45,17 @@ module BSV
         endpoint :health,         :get,  '/v1/health',      response: :json
 
         # @param base_url      [String]      ARC base URL (may contain {network})
-        # @param api_key       [String, nil] optional bearer token
+        # @param api_key       [String, nil] legacy bearer token shorthand — use +auth:+ for new code
+        # @param auth          [Hash, Symbol, nil] auth config; takes precedence over +api_key:+
         # @param network       [String, nil] network name for base URL interpolation
         # @param deployment_id [String, nil] deployment identifier for the
         #   XDeployment-ID header; defaults to a per-instance random hex value
         # @param callback_url  [String, nil] optional X-CallbackUrl header value
         # @param callback_token [String, nil] optional X-CallbackToken header value
         # @param http_client   [#request, nil] injectable HTTP client for testing
-        def initialize(base_url:, api_key: nil, network: nil, deployment_id: nil,
+        def initialize(base_url:, api_key: nil, auth: nil, network: nil, deployment_id: nil,
                        callback_url: nil, callback_token: nil, http_client: nil)
-          super(base_url: base_url, api_key: api_key, network: network, http_client: http_client)
+          super(base_url: base_url, api_key: api_key, auth: auth, network: network, http_client: http_client)
           @deployment_id  = deployment_id || "bsv-ruby-sdk-#{SecureRandom.hex(8)}"
           @callback_url   = callback_url
           @callback_token = callback_token

--- a/gem/bsv-sdk/lib/bsv/network/protocols/chaintracks.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/chaintracks.rb
@@ -28,9 +28,10 @@ module BSV
                  response: ->(body) { JSON.parse(body)['height'] }
 
         # @param base_url    [String] base URL for the Chaintracks API
-        # @param api_key     [String, nil] optional Bearer API key
+        # @param api_key     [String, nil] legacy Bearer API key shorthand — use +auth:+ for new code
+        # @param auth        [Hash, Symbol, nil] auth config; takes precedence over +api_key:+
         # @param http_client [Object, nil] injectable HTTP client for testing
-        def initialize(base_url:, api_key: nil, http_client: nil)
+        def initialize(base_url:, api_key: nil, auth: nil, http_client: nil)
           super
         end
       end

--- a/gem/bsv-sdk/lib/bsv/network/protocols/jungle_bus.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/jungle_bus.rb
@@ -38,9 +38,10 @@ module BSV
         endpoint :get_block_headers, :get, '/v1/block_header/list/{height}', response: :json_array
 
         # @param base_url    [String] base URL for the JungleBus API
-        # @param api_key     [String, nil] optional API key
+        # @param api_key     [String, nil] legacy API key shorthand — use +auth:+ for new code
+        # @param auth        [Hash, Symbol, nil] auth config; takes precedence over +api_key:+
         # @param http_client [Object, nil] injectable HTTP client for testing
-        def initialize(base_url:, api_key: nil, http_client: nil)
+        def initialize(base_url:, api_key: nil, auth: nil, http_client: nil)
           super
         end
       end

--- a/gem/bsv-sdk/lib/bsv/network/protocols/ordinals.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/ordinals.rb
@@ -21,9 +21,10 @@ module BSV
         endpoint :get_merkle_path, :get, '/api/tx/{txid}/proof', response: :json
 
         # @param base_url    [String] base URL for the Ordinals API
-        # @param api_key     [String, nil] optional Bearer API key
+        # @param api_key     [String, nil] legacy Bearer API key shorthand — use +auth:+ for new code
+        # @param auth        [Hash, Symbol, nil] auth config; takes precedence over +api_key:+
         # @param http_client [Object, nil] injectable HTTP client for testing
-        def initialize(base_url:, api_key: nil, http_client: nil)
+        def initialize(base_url:, api_key: nil, auth: nil, http_client: nil)
           super
         end
       end

--- a/gem/bsv-sdk/lib/bsv/network/protocols/taal_binary.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/taal_binary.rb
@@ -8,7 +8,7 @@ module BSV
       #
       # TAAL quirks handled here:
       # - Content-Type is +application/octet-stream+ (not JSON)
-      # - Authorization header uses the API key directly with no "Bearer" prefix
+      # - Authorization header is applied via the standard +apply_auth+ mechanism
       # - A response containing +txn-already-known+ in the error field is treated
       #   as success (the transaction is already in the mempool — idempotent)
       #
@@ -16,12 +16,23 @@ module BSV
       #
       #   protocol = BSV::Network::Protocols::TAALBinary.new(
       #     base_url: 'https://api.taal.com',
-      #     api_key: 'mainnet_your_key_here'
+      #     auth: { api_key: 'mainnet_your_key_here' }
       #   )
       #   result = protocol.call(:broadcast, tx)
       #   puts result.data[:txid] if result.success?
       class TAALBinary < BSV::Network::Protocol
         endpoint :broadcast, :post, '/api/v1/broadcast', response: :json
+
+        # @param base_url    [String] base URL for the TAAL binary API
+        # @param api_key     [String, nil] legacy API key shorthand (no Bearer prefix) — use +auth:+ for new code
+        # @param auth        [Hash, Symbol, nil] auth config; takes precedence over +api_key:+
+        # @param http_client [Object, nil] injectable HTTP client for testing
+        def initialize(base_url:, api_key: nil, auth: nil, http_client: nil)
+          # Translate legacy api_key: to auth: { api_key: } so the base class sends
+          # the raw key without a Bearer prefix, matching TAAL's expected auth format.
+          resolved_auth = auth || (api_key ? { api_key: api_key } : nil)
+          super(base_url: base_url, auth: resolved_auth, http_client: http_client)
+        end
 
         private
 
@@ -35,8 +46,8 @@ module BSV
 
           uri     = URI("#{@base_url}/api/v1/broadcast")
           request = Net::HTTP::Post.new(uri)
-          request['Content-Type']  = 'application/octet-stream'
-          request['Authorization'] = @api_key if @api_key
+          request['Content-Type'] = 'application/octet-stream'
+          apply_auth(request)
 
           request.body = body
 

--- a/gem/bsv-sdk/lib/bsv/network/protocols/woc_rest.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/woc_rest.rb
@@ -121,25 +121,23 @@ module BSV
 
         # @param base_url    [String] base URL for the WoC API; may contain
         #   +{network}+ which will be interpolated with the resolved network name
-        # @param network  [Symbol, String] :main, :mainnet, :test, :testnet, :stn
-        # @param api_key  [String, nil]    optional Bearer API key
+        # @param network     [Symbol, String] :main, :mainnet, :test, :testnet, :stn
+        # @param api_key     [String, nil] legacy API key — sends +Authorization: key+
+        #   (no Bearer prefix, matching WoC's expected auth format)
+        # @param auth        [Hash, Symbol, nil] auth config hash forwarded to Protocol;
+        #   when provided, takes precedence over +api_key:+
         # @param http_client [Object, nil] injectable HTTP client for testing
-        def initialize(base_url:, network: :main, api_key: nil, http_client: nil)
+        def initialize(base_url:, network: :main, api_key: nil, auth: nil, http_client: nil)
           @network_name = resolve_network(network)
+          # Translate legacy api_key: to auth: { api_key: } so the base class sends
+          # the raw key without a Bearer prefix, matching WoC's expected auth format.
+          resolved_auth = auth || (api_key ? { api_key: api_key } : nil)
           super(
             base_url: base_url,
-            api_key: api_key,
+            auth: resolved_auth,
             network: @network_name,
             http_client: http_client
           )
-        end
-
-        # WoC expects a raw Authorization header (no Bearer prefix).
-        # Override the base class which adds "Bearer ".
-        def build_request(http_method, uri, body)
-          request = super
-          request['Authorization'] = @api_key if @api_key
-          request
         end
 
         private

--- a/gem/bsv-sdk/lib/bsv/network/provider.rb
+++ b/gem/bsv-sdk/lib/bsv/network/provider.rb
@@ -119,24 +119,6 @@ module BSV
       end
       alias inspect to_s
 
-      private
-
-      # Normalises the +auth+ argument so that +nil+ and empty hashes are
-      # stored as +:none+, giving a single canonical sentinel value for
-      # "no authentication".
-      #
-      # @param auth [Hash, Symbol, nil]
-      # @return [Hash, Symbol]
-      def normalise_auth(auth)
-        return :none if auth.nil?
-        return :none if auth == :none
-        return :none if auth.is_a?(Hash) && auth.empty?
-
-        auth
-      end
-
-      public
-
       # Dispatches a command to the first-registered protocol that serves it.
       #
       # @param command_name [Symbol, String] command to invoke
@@ -150,6 +132,22 @@ module BSV
         raise ArgumentError, "#{@name} does not provide command :#{sym}" unless instance
 
         instance.call(sym, *args, **kwargs)
+      end
+
+      private
+
+      # Normalises the +auth+ argument so that +nil+ and empty hashes are
+      # stored as +:none+, giving a single canonical sentinel value for
+      # "no authentication".
+      #
+      # @param auth [Hash, Symbol, nil]
+      # @return [Hash, Symbol]
+      def normalise_auth(auth)
+        return :none if auth.nil?
+        return :none if auth == :none
+        return :none if auth.is_a?(Hash) && (auth.empty? || (auth[:bearer].nil? && auth[:api_key].nil?))
+
+        auth
       end
     end
   end

--- a/gem/bsv-sdk/lib/bsv/network/provider.rb
+++ b/gem/bsv-sdk/lib/bsv/network/provider.rb
@@ -22,15 +22,28 @@ module BSV
     #   result = gorillapool.call(:broadcast, tx)
     #   result.success?  # => true
     class Provider
-      attr_reader :name
+      attr_reader :name, :auth, :rate_limit
 
-      # @param name  [String] human-readable provider name (e.g. 'GorillaPool')
-      # @param block [Proc]   optional configuration block — yields +self+
-      def initialize(name, &block)
+      # @param name       [String]        human-readable provider name (e.g. 'GorillaPool')
+      # @param auth       [Hash, Symbol]  authentication config or +:none+ (default: +:none+).
+      #                                   An empty hash or +nil+ is treated as +:none+.
+      # @param rate_limit [Numeric, nil]  maximum requests per second (+nil+ = unlimited)
+      # @param block      [Proc]          optional configuration block — yields +self+
+      def initialize(name, auth: :none, rate_limit: nil, &block)
         @name           = name
+        @auth           = normalise_auth(auth)
+        @rate_limit     = rate_limit
         @protocols      = []
         @command_index  = {}
         block&.call(self)
+      end
+
+      # Returns +true+ when the provider is configured with authentication
+      # credentials (i.e. +auth+ is not +:none+ and not an empty hash).
+      #
+      # @return [Boolean]
+      def authenticated?
+        @auth != :none
       end
 
       # Registers a protocol class with the provider.
@@ -100,9 +113,29 @@ module BSV
       # @return [String]
       def to_s
         protocol_summary = @protocols.map { |p| p.class.name&.split('::')&.last || p.class.to_s }.join(', ')
-        "#<#{self.class} name=#{@name.inspect} protocols=[#{protocol_summary}]>"
+        auth_status      = authenticated? ? 'authenticated' : 'unauthenticated'
+        rate_part        = @rate_limit.nil? ? '' : " rate_limit=#{@rate_limit}"
+        "#<#{self.class} name=#{@name.inspect} auth=#{auth_status}#{rate_part} protocols=[#{protocol_summary}]>"
       end
       alias inspect to_s
+
+      private
+
+      # Normalises the +auth+ argument so that +nil+ and empty hashes are
+      # stored as +:none+, giving a single canonical sentinel value for
+      # "no authentication".
+      #
+      # @param auth [Hash, Symbol, nil]
+      # @return [Hash, Symbol]
+      def normalise_auth(auth)
+        return :none if auth.nil?
+        return :none if auth == :none
+        return :none if auth.is_a?(Hash) && auth.empty?
+
+        auth
+      end
+
+      public
 
       # Dispatches a command to the first-registered protocol that serves it.
       #

--- a/gem/bsv-sdk/lib/bsv/network/providers/gorilla_pool.rb
+++ b/gem/bsv-sdk/lib/bsv/network/providers/gorilla_pool.rb
@@ -14,49 +14,68 @@ module BSV
       # - Ordinals at +https://ordinals.gorillapool.io+
       # - JungleBus at +https://junglebus.gorillapool.io+
       #
-      # Testnet provides ARC only at +https://testnet.arcade.gorillapool.io+.
+      # Testnet provides ARC and Chaintracks at +https://testnet.arcade.gorillapool.io+.
       #
       # == Example
       #
       #   provider = BSV::Network::Providers::GorillaPool.mainnet
       #   provider.call(:broadcast, tx)
       #
-      #   provider = BSV::Network::Providers::GorillaPool.testnet(api_key: 'my-key')
+      #   provider = BSV::Network::Providers::GorillaPool.mainnet(auth: { bearer: 'token' })
       #   provider.call(:broadcast, tx)
+      #
+      #   # Legacy api_key: shorthand — still supported
+      #   provider = BSV::Network::Providers::GorillaPool.testnet(api_key: 'my-key')
       class GorillaPool
+        # Default requests-per-second limit for unauthenticated use.
+        DEFAULT_RATE_LIMIT = 3
+
         # Returns a mainnet Provider configured with ARC, Chaintracks, Ordinals, and JungleBus.
         #
-        # @param opts [Hash] keyword arguments forwarded to each protocol constructor
+        # Auth is forwarded to all four protocols so each can authenticate independently.
+        #
+        # @param auth       [Hash, Symbol, nil] auth config forwarded to Provider and all protocols
+        # @param rate_limit [Numeric, nil] requests per second; defaults to +DEFAULT_RATE_LIMIT+
+        # @param opts       [Hash] keyword arguments forwarded to each protocol constructor
         # @return [Provider]
-        def self.mainnet(**opts)
-          common = opts.slice(:api_key, :http_client)
-          Provider.new('GorillaPool') do |p|
-            p.protocol Protocols::ARC,         base_url: 'https://arcade.gorillapool.io', **opts
+        def self.mainnet(auth: nil, rate_limit: DEFAULT_RATE_LIMIT, **opts)
+          resolved_auth = auth || (opts[:api_key] ? { bearer: opts[:api_key] } : :none)
+          common = opts.slice(:api_key, :http_client).merge(auth: auth)
+          Provider.new('GorillaPool', auth: resolved_auth, rate_limit: rate_limit) do |p|
+            p.protocol Protocols::ARC,         base_url: 'https://arcade.gorillapool.io', auth: auth, **opts
             p.protocol Protocols::Chaintracks, base_url: 'https://arcade.gorillapool.io', **common
             p.protocol Protocols::Ordinals,    base_url: 'https://ordinals.gorillapool.io', **common
-            p.protocol Protocols::JungleBus, base_url: 'https://junglebus.gorillapool.io', **common
+            p.protocol Protocols::JungleBus,   base_url: 'https://junglebus.gorillapool.io', **common
           end
         end
 
         # Returns a testnet Provider configured with ARC and Chaintracks.
         #
-        # @param opts [Hash] keyword arguments forwarded to each protocol constructor
+        # Auth is forwarded to both protocols.
+        #
+        # @param auth       [Hash, Symbol, nil] auth config forwarded to Provider and all protocols
+        # @param rate_limit [Numeric, nil] requests per second; defaults to +DEFAULT_RATE_LIMIT+
+        # @param opts       [Hash] keyword arguments forwarded to each protocol constructor
         # @return [Provider]
-        def self.testnet(**opts)
-          common = opts.slice(:api_key, :http_client)
-          Provider.new('GorillaPool') do |p|
-            p.protocol Protocols::ARC,         base_url: 'https://testnet.arcade.gorillapool.io', **opts
+        def self.testnet(auth: nil, rate_limit: DEFAULT_RATE_LIMIT, **opts)
+          resolved_auth = auth || (opts[:api_key] ? { bearer: opts[:api_key] } : :none)
+          common = opts.slice(:api_key, :http_client).merge(auth: auth)
+          Provider.new('GorillaPool', auth: resolved_auth, rate_limit: rate_limit) do |p|
+            p.protocol Protocols::ARC,         base_url: 'https://testnet.arcade.gorillapool.io', auth: auth, **opts
             p.protocol Protocols::Chaintracks, base_url: 'https://testnet.arcade.gorillapool.io', **common
           end
         end
 
         # Returns a mainnet or testnet Provider depending on the +testnet:+ flag.
         #
-        # @param testnet [Boolean] when true, returns the testnet Provider
-        # @param opts    [Hash]    keyword arguments forwarded to each protocol constructor
+        # @param testnet    [Boolean] when true, returns the testnet Provider
+        # @param auth       [Hash, Symbol, nil] auth config forwarded to Provider and all protocols
+        # @param rate_limit [Numeric, nil] requests per second; defaults to +DEFAULT_RATE_LIMIT+
+        # @param opts       [Hash] keyword arguments forwarded to each protocol constructor
         # @return [Provider]
-        def self.default(testnet: false, **opts)
-          testnet ? testnet(**opts) : mainnet(**opts)
+        def self.default(testnet: false, auth: nil, rate_limit: DEFAULT_RATE_LIMIT, **opts)
+          kwargs = { auth: auth, rate_limit: rate_limit, **opts }
+          testnet ? testnet(**kwargs) : mainnet(**kwargs)
         end
       end
     end

--- a/gem/bsv-sdk/lib/bsv/network/providers/taal.rb
+++ b/gem/bsv-sdk/lib/bsv/network/providers/taal.rb
@@ -14,42 +14,63 @@ module BSV
       # To use TAALBinary directly, call +provider.protocol_for(:broadcast)+ on the
       # TAALBinary instance via +provider.protocols.last+, or build a custom Provider.
       #
+      # TAAL requires an API key for production use. The default rate limit is +nil+
+      # (unconstrained) because the effective limit depends on the subscription tier.
+      #
       # There is no TAAL testnet default — TAAL does not publish a supported testnet ARC URL.
       #
       # == Example
       #
-      #   provider = BSV::Network::Providers::TAAL.mainnet(api_key: 'mainnet_...')
+      #   provider = BSV::Network::Providers::TAAL.mainnet(auth: { api_key: 'mainnet_...' })
       #   provider.call(:broadcast, tx)
+      #
+      #   # Legacy api_key: shorthand — still supported
+      #   provider = BSV::Network::Providers::TAAL.mainnet(api_key: 'mainnet_...')
       class TAAL
+        # Default requests-per-second limit.
+        # +nil+ because the effective limit depends on the TAAL subscription tier.
+        DEFAULT_RATE_LIMIT = nil
+
         # Returns a mainnet Provider configured with ARC and TAALBinary.
         #
-        # @param opts [Hash] keyword arguments forwarded to each protocol constructor
+        # Both protocols receive the same auth credentials.
+        #
+        # @param auth       [Hash, Symbol, nil] auth config forwarded to Provider and all protocols
+        # @param rate_limit [Numeric, nil] requests per second; defaults to +DEFAULT_RATE_LIMIT+ (nil)
+        # @param opts       [Hash] keyword arguments forwarded to each protocol constructor
         # @return [Provider]
-        def self.mainnet(**opts)
-          common = opts.slice(:api_key, :http_client)
-          Provider.new('TAAL') do |p|
-            p.protocol Protocols::ARC, base_url: 'https://arc.taal.com', **opts
-            p.protocol Protocols::TAALBinary, base_url: 'https://api.taal.com', **common
+        def self.mainnet(auth: nil, rate_limit: DEFAULT_RATE_LIMIT, **opts)
+          resolved_auth = auth || (opts[:api_key] ? { bearer: opts[:api_key] } : :none)
+          common = opts.slice(:api_key, :http_client).merge(auth: auth)
+          Provider.new('TAAL', auth: resolved_auth, rate_limit: rate_limit) do |p|
+            p.protocol Protocols::ARC,        base_url: 'https://arc.taal.com',  auth: auth, **opts
+            p.protocol Protocols::TAALBinary, base_url: 'https://api.taal.com',  **common
           end
         end
 
         # Returns a testnet Provider configured with ARC only.
         #
-        # @param opts [Hash] keyword arguments forwarded to each protocol constructor
+        # @param auth       [Hash, Symbol, nil] auth config forwarded to Provider and ARC protocol
+        # @param rate_limit [Numeric, nil] requests per second; defaults to +DEFAULT_RATE_LIMIT+ (nil)
+        # @param opts       [Hash] keyword arguments forwarded to the ARC protocol constructor
         # @return [Provider]
-        def self.testnet(**opts)
-          Provider.new('TAAL') do |p|
-            p.protocol Protocols::ARC, base_url: 'https://arc-test.taal.com', **opts
+        def self.testnet(auth: nil, rate_limit: DEFAULT_RATE_LIMIT, **opts)
+          resolved_auth = auth || (opts[:api_key] ? { bearer: opts[:api_key] } : :none)
+          Provider.new('TAAL', auth: resolved_auth, rate_limit: rate_limit) do |p|
+            p.protocol Protocols::ARC, base_url: 'https://arc-test.taal.com', auth: auth, **opts
           end
         end
 
         # Returns a mainnet or testnet Provider depending on the +testnet:+ flag.
         #
-        # @param testnet [Boolean] when true, returns the testnet Provider
-        # @param opts    [Hash]    keyword arguments forwarded to each protocol constructor
+        # @param testnet    [Boolean] when true, returns the testnet Provider
+        # @param auth       [Hash, Symbol, nil] auth config forwarded to Provider and all protocols
+        # @param rate_limit [Numeric, nil] requests per second; defaults to +DEFAULT_RATE_LIMIT+ (nil)
+        # @param opts       [Hash] keyword arguments forwarded to each protocol constructor
         # @return [Provider]
-        def self.default(testnet: false, **opts)
-          testnet ? testnet(**opts) : mainnet(**opts)
+        def self.default(testnet: false, auth: nil, rate_limit: DEFAULT_RATE_LIMIT, **opts)
+          kwargs = { auth: auth, rate_limit: rate_limit, **opts }
+          testnet ? testnet(**kwargs) : mainnet(**kwargs)
         end
       end
     end

--- a/gem/bsv-sdk/lib/bsv/network/providers/taal.rb
+++ b/gem/bsv-sdk/lib/bsv/network/providers/taal.rb
@@ -21,7 +21,7 @@ module BSV
       #
       # == Example
       #
-      #   provider = BSV::Network::Providers::TAAL.mainnet(auth: { api_key: 'mainnet_...' })
+      #   provider = BSV::Network::Providers::TAAL.mainnet(auth: { bearer: 'mainnet_...' })
       #   provider.call(:broadcast, tx)
       #
       #   # Legacy api_key: shorthand — still supported
@@ -33,7 +33,9 @@ module BSV
 
         # Returns a mainnet Provider configured with ARC and TAALBinary.
         #
-        # Both protocols receive the same auth credentials.
+        # Auth is forwarded to both protocols. ARC uses Bearer tokens;
+        # TAALBinary uses raw API keys. Each protocol's constructor handles
+        # the translation appropriate to its endpoint.
         #
         # @param auth       [Hash, Symbol, nil] auth config forwarded to Provider and all protocols
         # @param rate_limit [Numeric, nil] requests per second; defaults to +DEFAULT_RATE_LIMIT+ (nil)

--- a/gem/bsv-sdk/lib/bsv/network/providers/whats_on_chain.rb
+++ b/gem/bsv-sdk/lib/bsv/network/providers/whats_on_chain.rb
@@ -15,55 +15,76 @@ module BSV
       #   provider = BSV::Network::Providers::WhatsOnChain.mainnet
       #   provider.call(:get_tx, 'abc123...')
       #
-      #   provider = BSV::Network::Providers::WhatsOnChain.testnet(api_key: 'my-key')
+      #   provider = BSV::Network::Providers::WhatsOnChain.mainnet(auth: { api_key: 'my-key' })
       #   provider.call(:broadcast, tx)
+      #
+      #   # Legacy api_key: shorthand — still supported
+      #   provider = BSV::Network::Providers::WhatsOnChain.testnet(api_key: 'my-key')
       class WhatsOnChain
+        # Default requests-per-second limit for unauthenticated use.
+        DEFAULT_RATE_LIMIT = 3
+
         # Returns a mainnet Provider configured with WoCREST.
         #
-        # @param opts [Hash] keyword arguments forwarded to each protocol constructor
+        # @param auth       [Hash, Symbol, nil] auth config forwarded to Provider and WoCREST protocol
+        # @param rate_limit [Numeric, nil] requests per second; defaults to +DEFAULT_RATE_LIMIT+
+        # @param opts       [Hash] keyword arguments forwarded to the WoCREST protocol constructor
         # @return [Provider]
-        def self.mainnet(**opts)
-          Provider.new('WhatsOnChain') do |p|
-            p.protocol Protocols::WoCREST, base_url: 'https://api.whatsonchain.com/v1/bsv/main', **opts
+        def self.mainnet(auth: nil, rate_limit: DEFAULT_RATE_LIMIT, **opts)
+          resolved_auth = auth || (opts[:api_key] ? { api_key: opts[:api_key] } : :none)
+          Provider.new('WhatsOnChain', auth: resolved_auth, rate_limit: rate_limit) do |p|
+            p.protocol Protocols::WoCREST, base_url: 'https://api.whatsonchain.com/v1/bsv/main',
+                                           auth: auth, **opts
           end
         end
 
         # Returns a testnet Provider configured with WoCREST.
         #
-        # @param opts [Hash] keyword arguments forwarded to each protocol constructor
+        # @param auth       [Hash, Symbol, nil] auth config forwarded to Provider and WoCREST protocol
+        # @param rate_limit [Numeric, nil] requests per second; defaults to +DEFAULT_RATE_LIMIT+
+        # @param opts       [Hash] keyword arguments forwarded to the WoCREST protocol constructor
         # @return [Provider]
-        def self.testnet(**opts)
-          Provider.new('WhatsOnChain') do |p|
-            p.protocol Protocols::WoCREST, base_url: 'https://api.whatsonchain.com/v1/bsv/test', **opts
+        def self.testnet(auth: nil, rate_limit: DEFAULT_RATE_LIMIT, **opts)
+          resolved_auth = auth || (opts[:api_key] ? { api_key: opts[:api_key] } : :none)
+          Provider.new('WhatsOnChain', auth: resolved_auth, rate_limit: rate_limit) do |p|
+            p.protocol Protocols::WoCREST, base_url: 'https://api.whatsonchain.com/v1/bsv/test',
+                                           auth: auth, **opts
           end
         end
 
         # Returns a Provider for the BSV Scaling Test Network (STN).
         #
-        # @param opts [Hash] keyword arguments forwarded to each protocol constructor
+        # @param auth       [Hash, Symbol, nil] auth config forwarded to Provider and WoCREST protocol
+        # @param rate_limit [Numeric, nil] requests per second; defaults to +DEFAULT_RATE_LIMIT+
+        # @param opts       [Hash] keyword arguments forwarded to the WoCREST protocol constructor
         # @return [Provider]
-        def self.stn(**opts)
-          Provider.new('WhatsOnChain') do |p|
-            p.protocol Protocols::WoCREST, base_url: 'https://api.whatsonchain.com/v1/bsv/stn', **opts
+        def self.stn(auth: nil, rate_limit: DEFAULT_RATE_LIMIT, **opts)
+          resolved_auth = auth || (opts[:api_key] ? { api_key: opts[:api_key] } : :none)
+          Provider.new('WhatsOnChain', auth: resolved_auth, rate_limit: rate_limit) do |p|
+            p.protocol Protocols::WoCREST, base_url: 'https://api.whatsonchain.com/v1/bsv/stn',
+                                           auth: auth, **opts
           end
         end
 
         # Returns a Provider for the given network.
         #
-        # @param testnet [Boolean] when true, returns the testnet Provider
-        # @param network [Symbol, nil] explicit network (:main, :test, :stn) — overrides +testnet:+
-        # @param opts [Hash] keyword arguments forwarded to each protocol constructor
+        # @param testnet    [Boolean] when true, returns the testnet Provider
+        # @param network    [Symbol, nil] explicit network (:main, :test, :stn) — overrides +testnet:+
+        # @param auth       [Hash, Symbol, nil] auth config forwarded to Provider and WoCREST protocol
+        # @param rate_limit [Numeric, nil] requests per second; defaults to +DEFAULT_RATE_LIMIT+
+        # @param opts       [Hash] keyword arguments forwarded to the WoCREST protocol constructor
         # @return [Provider]
-        def self.default(testnet: false, network: nil, **opts)
+        def self.default(testnet: false, network: nil, auth: nil, rate_limit: DEFAULT_RATE_LIMIT, **opts)
+          kwargs = { auth: auth, rate_limit: rate_limit, **opts }
           if network
             case network.to_sym
-            when :main, :mainnet then mainnet(**opts)
-            when :test, :testnet then testnet(**opts)
-            when :stn then stn(**opts)
+            when :main, :mainnet then mainnet(**kwargs)
+            when :test, :testnet then testnet(**kwargs)
+            when :stn then stn(**kwargs)
             else raise ArgumentError, "unknown network: #{network}"
             end
           else
-            testnet ? testnet(**opts) : mainnet(**opts)
+            testnet ? testnet(**kwargs) : mainnet(**kwargs)
           end
         end
       end

--- a/gem/bsv-sdk/spec/bsv/network/auth_integration_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/auth_integration_spec.rb
@@ -1,0 +1,437 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/DescribeClass
+
+require 'spec_helper'
+
+# Minimal fake HTTP response — mimics Net::HTTPResponse.
+AuthIntegrationFakeResponse = Struct.new(:code, :body)
+
+# Injectable HTTP client that records the last request, returns a canned response.
+# Used to inspect auth headers set by the full factory → Provider → Protocol stack.
+class AuthIntegrationFakeHttpClient
+  attr_reader :last_request
+
+  def initialize(response)
+    @response = response
+  end
+
+  def request(_uri, req)
+    @last_request = req
+    @response
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Builds a fake HTTP client that returns a minimal successful ARC JSON response
+# and records the request for header inspection.
+def arc_fake_http
+  body = '{"txid":"deadbeef","txStatus":"MINED"}'
+  AuthIntegrationFakeHttpClient.new(AuthIntegrationFakeResponse.new('200', body))
+end
+
+# Builds a fake HTTP client that returns a minimal successful WoC broadcast response.
+def woc_fake_http
+  AuthIntegrationFakeHttpClient.new(AuthIntegrationFakeResponse.new('200', 'ok'))
+end
+
+# Builds a fake HTTP client returning a minimal TAAL binary broadcast response.
+def taal_binary_fake_http
+  body = '{"txid":"cafebeef"}'
+  AuthIntegrationFakeHttpClient.new(AuthIntegrationFakeResponse.new('200', body))
+end
+
+# Minimal transaction double that satisfies ARC's escape-hatch broadcast.
+def dummy_tx
+  tx = double('tx') # rubocop:disable RSpec/VerifiedDoubles
+  allow(tx).to receive_messages(to_ef_hex: 'deadbeef', to_binary: "\xde\xad")
+  allow(tx).to receive(:respond_to?).and_return(false)
+  allow(tx).to receive(:respond_to?).with(:to_binary).and_return(true)
+  tx
+end
+
+# ---------------------------------------------------------------------------
+# Integration specs
+# ---------------------------------------------------------------------------
+
+RSpec.describe 'Provider auth mechanisms — end-to-end integration' do
+  # ── Scenario 1: WoC with auth: { api_key: } ─────────────────────────────────
+  #
+  # WoCREST sends the raw key with no Bearer prefix (WoC style).
+
+  describe 'WhatsOnChain with auth: { api_key: }' do
+    let(:woc_provider) do
+      BSV::Network::Providers::WhatsOnChain.mainnet(
+        auth: { api_key: 'woc-secret' },
+        http_client: woc_fake_http
+      )
+    end
+
+    it 'provider.auth is the api_key hash' do
+      expect(woc_provider.auth).to eq({ api_key: 'woc-secret' })
+    end
+
+    it 'provider.authenticated? is true' do
+      expect(woc_provider.authenticated?).to be(true)
+    end
+
+    it 'protocol receives auth: { api_key: }' do
+      expect(woc_provider.protocols[0].auth).to eq({ api_key: 'woc-secret' })
+    end
+
+    it 'HTTP request has Authorization: woc-secret (no Bearer prefix)' do
+      # Trigger a broadcast call so the HTTP client records the request.
+      # WoCREST broadcast sends the raw tx hex in the body.
+      http = woc_fake_http
+      p = BSV::Network::Providers::WhatsOnChain.mainnet(
+        auth: { api_key: 'woc-secret' },
+        http_client: http
+      )
+      p.call(:broadcast, body: 'rawhex')
+      expect(http.last_request['Authorization']).to eq('woc-secret')
+    end
+
+    it 'Authorization header does not include Bearer prefix' do
+      http = woc_fake_http
+      p = BSV::Network::Providers::WhatsOnChain.mainnet(
+        auth: { api_key: 'woc-secret' },
+        http_client: http
+      )
+      p.call(:broadcast, body: 'rawhex')
+      expect(http.last_request['Authorization']).not_to start_with('Bearer')
+    end
+  end
+
+  # ── Scenario 2: GorillaPool ARC with auth: { bearer: } ─────────────────────
+  #
+  # GorillaPool ARC uses Bearer token auth.
+
+  describe 'GorillaPool with auth: { bearer: }' do
+    it 'provider.auth is the bearer hash' do
+      p = BSV::Network::Providers::GorillaPool.mainnet(
+        auth: { bearer: 'gp-bearer-token' },
+        http_client: arc_fake_http
+      )
+      expect(p.auth).to eq({ bearer: 'gp-bearer-token' })
+    end
+
+    it 'provider.authenticated? is true' do
+      p = BSV::Network::Providers::GorillaPool.mainnet(
+        auth: { bearer: 'gp-bearer-token' },
+        http_client: arc_fake_http
+      )
+      expect(p.authenticated?).to be(true)
+    end
+
+    it 'ARC protocol receives auth: { bearer: }' do
+      p = BSV::Network::Providers::GorillaPool.mainnet(
+        auth: { bearer: 'gp-bearer-token' },
+        http_client: arc_fake_http
+      )
+      arc = p.protocols.find { |pr| pr.is_a?(BSV::Network::Protocols::ARC) }
+      expect(arc.auth).to eq({ bearer: 'gp-bearer-token' })
+    end
+
+    it 'HTTP request has Authorization: Bearer gp-bearer-token' do
+      http = arc_fake_http
+      p = BSV::Network::Providers::GorillaPool.mainnet(
+        auth: { bearer: 'gp-bearer-token' },
+        http_client: http
+      )
+      tx = dummy_tx
+      p.call(:broadcast, tx)
+      expect(http.last_request['Authorization']).to eq('Bearer gp-bearer-token')
+    end
+  end
+
+  # ── Scenario 3: GorillaPool ARC with custom header auth ─────────────────────
+  #
+  # Custom header: auth: { api_key: 'key', header: 'Api-Key' } → Api-Key: key
+
+  describe 'GorillaPool with auth: { api_key:, header: }' do
+    it 'HTTP request has Api-Key: key header' do
+      http = arc_fake_http
+      p = BSV::Network::Providers::GorillaPool.mainnet(
+        auth: { api_key: 'gp-key', header: 'Api-Key' },
+        http_client: http
+      )
+      tx = dummy_tx
+      p.call(:broadcast, tx)
+      expect(http.last_request['Api-Key']).to eq('gp-key')
+    end
+
+    it 'Authorization header is absent when custom header is used' do
+      http = arc_fake_http
+      p = BSV::Network::Providers::GorillaPool.mainnet(
+        auth: { api_key: 'gp-key', header: 'Api-Key' },
+        http_client: http
+      )
+      tx = dummy_tx
+      p.call(:broadcast, tx)
+      expect(http.last_request['Authorization']).to be_nil
+    end
+  end
+
+  # ── Scenario 4: TAAL ARC with auth: { bearer: } ─────────────────────────────
+  #
+  # TAAL ARC broadcast uses Bearer token via ARC (first-registered wins).
+
+  describe 'TAAL with auth: { bearer: }' do
+    it 'provider.auth is the bearer hash' do
+      p = BSV::Network::Providers::TAAL.mainnet(
+        auth: { bearer: 'taal-bearer-token' },
+        http_client: arc_fake_http
+      )
+      expect(p.auth).to eq({ bearer: 'taal-bearer-token' })
+    end
+
+    it 'HTTP request has Authorization: Bearer taal-bearer-token' do
+      http = arc_fake_http
+      p = BSV::Network::Providers::TAAL.mainnet(
+        auth: { bearer: 'taal-bearer-token' },
+        http_client: http
+      )
+      tx = dummy_tx
+      p.call(:broadcast, tx)
+      expect(http.last_request['Authorization']).to eq('Bearer taal-bearer-token')
+    end
+  end
+
+  # ── Scenario 5: TAALBinary with auth: { api_key: } (escape hatch) ───────────
+  #
+  # TAALBinary translates api_key: to auth: { api_key: } (no Bearer prefix)
+  # and sets the raw key on the Authorization header.
+
+  describe 'TAALBinary with auth: { api_key: }' do
+    it 'Authorization header has raw key (no Bearer)' do
+      http = taal_binary_fake_http
+      tb = BSV::Network::Protocols::TAALBinary.new(
+        base_url: 'https://api.taal.com',
+        auth: { api_key: 'mainnet_rawkey' },
+        http_client: http
+      )
+      tb.call(:broadcast, "\x00")
+      expect(http.last_request['Authorization']).to eq('mainnet_rawkey')
+    end
+
+    it 'Authorization header has no Bearer prefix' do
+      http = taal_binary_fake_http
+      tb = BSV::Network::Protocols::TAALBinary.new(
+        base_url: 'https://api.taal.com',
+        auth: { api_key: 'mainnet_rawkey' },
+        http_client: http
+      )
+      tb.call(:broadcast, "\x00")
+      expect(http.last_request['Authorization']).not_to start_with('Bearer')
+    end
+  end
+
+  # ── Scenario 6: Unauthenticated provider ────────────────────────────────────
+  #
+  # No auth kwargs → auth: :none → no Authorization header on any request.
+
+  describe 'unauthenticated provider (no auth supplied)' do
+    it 'GorillaPool provider.auth is :none' do
+      p = BSV::Network::Providers::GorillaPool.mainnet(http_client: arc_fake_http)
+      expect(p.auth).to eq(:none)
+    end
+
+    it 'GorillaPool provider.authenticated? is false' do
+      p = BSV::Network::Providers::GorillaPool.mainnet(http_client: arc_fake_http)
+      expect(p.authenticated?).to be(false)
+    end
+
+    it 'GorillaPool HTTP request has no Authorization header' do
+      http = arc_fake_http
+      p = BSV::Network::Providers::GorillaPool.mainnet(http_client: http)
+      tx = dummy_tx
+      p.call(:broadcast, tx)
+      expect(http.last_request['Authorization']).to be_nil
+    end
+
+    it 'WhatsOnChain provider.auth is :none' do
+      p = BSV::Network::Providers::WhatsOnChain.mainnet(http_client: woc_fake_http)
+      expect(p.auth).to eq(:none)
+    end
+
+    it 'WhatsOnChain HTTP request has no Authorization header' do
+      http = woc_fake_http
+      p = BSV::Network::Providers::WhatsOnChain.mainnet(http_client: http)
+      p.call(:broadcast, body: 'rawhex')
+      expect(http.last_request['Authorization']).to be_nil
+    end
+
+    it 'TAAL provider.auth is :none' do
+      p = BSV::Network::Providers::TAAL.mainnet(http_client: arc_fake_http)
+      expect(p.auth).to eq(:none)
+    end
+  end
+
+  # ── Scenario 7: Provider metadata readback ──────────────────────────────────
+  #
+  # Verify auth, rate_limit, and authenticated? surface the correct values
+  # from each factory.
+
+  describe 'provider metadata readback' do
+    describe 'WhatsOnChain' do
+      it 'provider.rate_limit defaults to DEFAULT_RATE_LIMIT' do
+        p = BSV::Network::Providers::WhatsOnChain.mainnet(http_client: woc_fake_http)
+        expect(p.rate_limit).to eq(BSV::Network::Providers::WhatsOnChain::DEFAULT_RATE_LIMIT)
+      end
+
+      it 'provider.rate_limit reflects supplied rate_limit' do
+        p = BSV::Network::Providers::WhatsOnChain.mainnet(rate_limit: 20, http_client: woc_fake_http)
+        expect(p.rate_limit).to eq(20)
+      end
+
+      it 'provider.authenticated? is false with no auth' do
+        p = BSV::Network::Providers::WhatsOnChain.mainnet(http_client: woc_fake_http)
+        expect(p.authenticated?).to be(false)
+      end
+
+      it 'provider.authenticated? is true with auth: hash' do
+        p = BSV::Network::Providers::WhatsOnChain.mainnet(auth: { api_key: 'k' }, http_client: woc_fake_http)
+        expect(p.authenticated?).to be(true)
+      end
+    end
+
+    describe 'GorillaPool' do
+      it 'provider.rate_limit defaults to DEFAULT_RATE_LIMIT' do
+        p = BSV::Network::Providers::GorillaPool.mainnet(http_client: arc_fake_http)
+        expect(p.rate_limit).to eq(BSV::Network::Providers::GorillaPool::DEFAULT_RATE_LIMIT)
+      end
+
+      it 'provider.rate_limit reflects supplied rate_limit' do
+        p = BSV::Network::Providers::GorillaPool.mainnet(rate_limit: 50, http_client: arc_fake_http)
+        expect(p.rate_limit).to eq(50)
+      end
+
+      it 'provider.authenticated? is true with bearer auth' do
+        p = BSV::Network::Providers::GorillaPool.mainnet(auth: { bearer: 'tok' }, http_client: arc_fake_http)
+        expect(p.authenticated?).to be(true)
+      end
+    end
+
+    describe 'TAAL' do
+      it 'provider.rate_limit is nil by default' do
+        p = BSV::Network::Providers::TAAL.mainnet(http_client: arc_fake_http)
+        expect(p.rate_limit).to be_nil
+      end
+
+      it 'provider.rate_limit reflects supplied rate_limit' do
+        p = BSV::Network::Providers::TAAL.mainnet(rate_limit: 25, http_client: arc_fake_http)
+        expect(p.rate_limit).to eq(25)
+      end
+
+      it 'provider.authenticated? is true with api_key auth' do
+        p = BSV::Network::Providers::TAAL.mainnet(auth: { api_key: 'taal-k' }, http_client: arc_fake_http)
+        expect(p.authenticated?).to be(true)
+      end
+    end
+  end
+
+  # ── Scenario 8: Legacy api_key: path end-to-end ─────────────────────────────
+  #
+  # Legacy api_key: kwarg still works through the full factory → protocol →
+  # HTTP request stack. Each factory translates it differently:
+  # - WoC: api_key: → auth: { api_key: } → Authorization: key (no Bearer)
+  # - GorillaPool: api_key: → auth: { bearer: } → Authorization: Bearer key
+  # - TAAL ARC: api_key: → legacy path → Authorization: Bearer key
+  # - TAAL TAALBinary: api_key: → auth: { api_key: } → Authorization: key
+
+  describe 'legacy api_key: path' do
+    it 'WhatsOnChain — HTTP request has Authorization: key (no Bearer)' do
+      http = woc_fake_http
+      p = BSV::Network::Providers::WhatsOnChain.mainnet(api_key: 'legacy-woc-key', http_client: http)
+      p.call(:broadcast, body: 'rawhex')
+      expect(http.last_request['Authorization']).to eq('legacy-woc-key')
+    end
+
+    it 'WhatsOnChain — provider.authenticated? is true' do
+      p = BSV::Network::Providers::WhatsOnChain.mainnet(api_key: 'legacy-woc-key', http_client: woc_fake_http)
+      expect(p.authenticated?).to be(true)
+    end
+
+    it 'GorillaPool — HTTP request has Authorization: Bearer key' do
+      http = arc_fake_http
+      p = BSV::Network::Providers::GorillaPool.mainnet(api_key: 'legacy-gp-key', http_client: http)
+      tx = dummy_tx
+      p.call(:broadcast, tx)
+      expect(http.last_request['Authorization']).to eq('Bearer legacy-gp-key')
+    end
+
+    it 'GorillaPool — provider.authenticated? is true' do
+      p = BSV::Network::Providers::GorillaPool.mainnet(api_key: 'legacy-gp-key', http_client: arc_fake_http)
+      expect(p.authenticated?).to be(true)
+    end
+
+    it 'TAAL ARC — HTTP request has Authorization: Bearer key' do
+      http = arc_fake_http
+      p = BSV::Network::Providers::TAAL.mainnet(api_key: 'legacy-taal-key', http_client: http)
+      tx = dummy_tx
+      p.call(:broadcast, tx)
+      expect(http.last_request['Authorization']).to eq('Bearer legacy-taal-key')
+    end
+
+    it 'TAAL — provider.authenticated? is true' do
+      p = BSV::Network::Providers::TAAL.mainnet(api_key: 'legacy-taal-key', http_client: arc_fake_http)
+      expect(p.authenticated?).to be(true)
+    end
+  end
+
+  # ── Edge cases ───────────────────────────────────────────────────────────────
+
+  describe 'edge cases' do
+    it 'auth: nil is normalised to :none on provider' do
+      p = BSV::Network::Providers::WhatsOnChain.mainnet(auth: nil, http_client: woc_fake_http)
+      expect(p.auth).to eq(:none)
+    end
+
+    it 'auth: {} is normalised to :none on provider' do
+      p = BSV::Network::Providers::WhatsOnChain.mainnet(auth: {}, http_client: woc_fake_http)
+      expect(p.auth).to eq(:none)
+    end
+
+    it 'auth: nil — provider.authenticated? is false' do
+      p = BSV::Network::Providers::GorillaPool.mainnet(auth: nil, http_client: arc_fake_http)
+      expect(p.authenticated?).to be(false)
+    end
+
+    it 'auth: {} — provider.authenticated? is false' do
+      p = BSV::Network::Providers::GorillaPool.mainnet(auth: {}, http_client: arc_fake_http)
+      expect(p.authenticated?).to be(false)
+    end
+
+    it 'auth: nil — no Authorization header in HTTP request' do
+      http = arc_fake_http
+      p = BSV::Network::Providers::GorillaPool.mainnet(auth: nil, http_client: http)
+      tx = dummy_tx
+      p.call(:broadcast, tx)
+      expect(http.last_request['Authorization']).to be_nil
+    end
+
+    it 'auth: {} — no Authorization header in HTTP request' do
+      http = arc_fake_http
+      p = BSV::Network::Providers::GorillaPool.mainnet(auth: {}, http_client: http)
+      tx = dummy_tx
+      p.call(:broadcast, tx)
+      expect(http.last_request['Authorization']).to be_nil
+    end
+
+    it 'auth: takes precedence over api_key: in WhatsOnChain' do
+      http = woc_fake_http
+      p = BSV::Network::Providers::WhatsOnChain.mainnet(
+        auth: { api_key: 'explicit-key' },
+        api_key: 'legacy-key',
+        http_client: http
+      )
+      p.call(:broadcast, body: 'rawhex')
+      expect(http.last_request['Authorization']).to eq('explicit-key')
+    end
+  end
+end
+
+# rubocop:enable RSpec/DescribeClass

--- a/gem/bsv-sdk/spec/bsv/network/protocol_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocol_spec.rb
@@ -397,7 +397,7 @@ RSpec.describe 'BSV::Network::Protocol' do
   end
 
   describe '#default_call — Authorization header' do
-    it 'sends Authorization: Bearer header when api_key is set' do
+    it 'sends Authorization: Bearer header when api_key is set (legacy shorthand)' do
       http     = ProtocolSpecFakeHttpClient.new(ok_response)
       instance = test_protocol_class.new(
         base_url: 'https://api.example.com',
@@ -413,6 +413,67 @@ RSpec.describe 'BSV::Network::Protocol' do
       instance = test_protocol_class.new(base_url: 'https://api.example.com', http_client: http)
       instance.default_call(:get_raw)
       expect(http.last_request['Authorization']).to be_nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Generic auth dispatch
+  # ---------------------------------------------------------------------------
+
+  def make_auth_instance(auth_opts)
+    http = ProtocolSpecFakeHttpClient.new(ok_response)
+    instance = test_protocol_class.new(base_url: 'https://api.example.com', http_client: http, **auth_opts)
+    [instance, http]
+  end
+
+  describe '#default_call — generic auth dispatch' do
+    it 'auth: { bearer: token } sends Authorization: Bearer token' do
+      instance, http = make_auth_instance(auth: { bearer: 'my-token' })
+      instance.default_call(:get_raw)
+      expect(http.last_request['Authorization']).to eq('Bearer my-token')
+    end
+
+    it 'auth: { api_key: key } sends Authorization: key (no Bearer prefix)' do
+      instance, http = make_auth_instance(auth: { api_key: 'raw-key' })
+      instance.default_call(:get_raw)
+      expect(http.last_request['Authorization']).to eq('raw-key')
+    end
+
+    it 'auth: { api_key: key, header: X-Custom } sends X-Custom: key' do
+      instance, http = make_auth_instance(auth: { api_key: 'raw-key', header: 'X-Custom' })
+      instance.default_call(:get_raw)
+      expect(http.last_request['X-Custom']).to eq('raw-key')
+      expect(http.last_request['Authorization']).to be_nil
+    end
+
+    it 'auth: :none sends no Authorization header' do
+      instance, http = make_auth_instance(auth: :none)
+      instance.default_call(:get_raw)
+      expect(http.last_request['Authorization']).to be_nil
+    end
+
+    it 'no auth options sends no Authorization header' do
+      instance, http = make_auth_instance({})
+      instance.default_call(:get_raw)
+      expect(http.last_request['Authorization']).to be_nil
+    end
+
+    it 'auth: takes precedence over api_key: when both are provided' do
+      http = ProtocolSpecFakeHttpClient.new(ok_response)
+      instance = test_protocol_class.new(
+        base_url: 'https://api.example.com',
+        api_key: 'legacy-key',
+        auth: { bearer: 'auth-token' },
+        http_client: http
+      )
+      instance.default_call(:get_raw)
+      expect(http.last_request['Authorization']).to eq('Bearer auth-token')
+    end
+
+    it 'auth: { bearer: empty } sends Authorization: Bearer with empty value' do
+      instance, http = make_auth_instance(auth: { bearer: '' })
+      instance.default_call(:get_raw)
+      expect(http.last_request['Authorization']).to eq('Bearer ')
     end
   end
 end

--- a/gem/bsv-sdk/spec/bsv/network/protocols/woc_rest_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/woc_rest_spec.rb
@@ -2372,7 +2372,7 @@ RSpec.describe BSV::Network::Protocols::WoCREST do # rubocop:disable RSpec/SpecF
   # ---------------------------------------------------------------------------
 
   describe 'API key authentication' do
-    it 'sends Bearer auth header when api_key is provided' do
+    it 'sends raw api_key as Authorization header (no Bearer prefix) when api_key is provided' do
       http_client = fake(200, '{"blocks":800000}')
       protocol = described_class.new(base_url: 'https://api.whatsonchain.com/v1/bsv/main', network: :main, api_key: 'my-woc-key', http_client: http_client)
 

--- a/gem/bsv-sdk/spec/bsv/network/provider_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/provider_spec.rb
@@ -33,6 +33,84 @@ RSpec.describe 'BSV::Network::Provider' do
       p = provider.new('Test') { |pr| yielded = pr }
       expect(yielded).to be(p)
     end
+
+    it 'defaults auth to :none' do
+      p = provider.new('X')
+      expect(p.auth).to eq(:none)
+    end
+
+    it 'defaults rate_limit to nil' do
+      p = provider.new('X')
+      expect(p.rate_limit).to be_nil
+    end
+  end
+
+  # ── #auth / #rate_limit / #authenticated? ─────────────────────────────────────
+
+  describe '#auth' do
+    it 'stores an api_key auth hash' do
+      p = provider.new('X', auth: { api_key: 'k' })
+      expect(p.auth).to eq({ api_key: 'k' })
+    end
+
+    it 'stores a bearer auth hash' do
+      p = provider.new('X', auth: { bearer: 'token' })
+      expect(p.auth).to eq({ bearer: 'token' })
+    end
+
+    it 'normalises nil to :none' do
+      p = provider.new('X', auth: nil)
+      expect(p.auth).to eq(:none)
+    end
+
+    it 'normalises empty hash to :none' do
+      p = provider.new('X', auth: {})
+      expect(p.auth).to eq(:none)
+    end
+  end
+
+  describe '#rate_limit' do
+    it 'stores the supplied rate limit' do
+      p = provider.new('X', rate_limit: 10)
+      expect(p.rate_limit).to eq(10)
+    end
+
+    it 'accepts rate_limit: 0 as a valid value' do
+      p = provider.new('X', rate_limit: 0)
+      expect(p.rate_limit).to eq(0)
+    end
+
+    it 'defaults to nil when not supplied' do
+      p = provider.new('X')
+      expect(p.rate_limit).to be_nil
+    end
+  end
+
+  describe '#authenticated?' do
+    it 'returns false when auth is :none (default)' do
+      p = provider.new('X')
+      expect(p.authenticated?).to be(false)
+    end
+
+    it 'returns true when auth is an api_key hash' do
+      p = provider.new('X', auth: { api_key: 'x' })
+      expect(p.authenticated?).to be(true)
+    end
+
+    it 'returns true when auth is a bearer hash' do
+      p = provider.new('X', auth: { bearer: 'token' })
+      expect(p.authenticated?).to be(true)
+    end
+
+    it 'returns false when auth is an empty hash' do
+      p = provider.new('X', auth: {})
+      expect(p.authenticated?).to be(false)
+    end
+
+    it 'returns false when auth is nil' do
+      p = provider.new('X', auth: nil)
+      expect(p.authenticated?).to be(false)
+    end
   end
 
   # ── Block DSL ─────────────────────────────────────────────────────────────────
@@ -362,6 +440,26 @@ RSpec.describe 'BSV::Network::Provider' do
     it 'shows an empty protocols list when no protocols are registered' do
       p = provider.new('Empty')
       expect(p.to_s).to include('protocols=[]')
+    end
+
+    it 'shows auth=unauthenticated when no auth is configured' do
+      p = provider.new('Test')
+      expect(p.to_s).to include('auth=unauthenticated')
+    end
+
+    it 'shows auth=authenticated when an auth hash is supplied' do
+      p = provider.new('Test', auth: { api_key: 'k' })
+      expect(p.to_s).to include('auth=authenticated')
+    end
+
+    it 'omits rate_limit from output when nil' do
+      p = provider.new('Test')
+      expect(p.to_s).not_to include('rate_limit')
+    end
+
+    it 'includes rate_limit in output when set' do
+      p = provider.new('Test', rate_limit: 10)
+      expect(p.to_s).to include('rate_limit=10')
     end
   end
 

--- a/gem/bsv-sdk/spec/bsv/network/providers/defaults_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/providers/defaults_spec.rb
@@ -242,10 +242,14 @@ RSpec.describe 'BSV::Network::Providers defaults' do
       expect(provider.protocols[1].base_url).to eq('https://api.taal.com')
     end
 
-    it 'forwards api_key to both protocols' do
+    it 'forwards api_key to ARC protocol' do
       p = BSV::Network::Providers::TAAL.mainnet(api_key: 'taal-key', http_client: http_client)
       expect(p.protocols[0].api_key).to eq('taal-key')
-      expect(p.protocols[1].api_key).to eq('taal-key')
+    end
+
+    it 'translates api_key to auth: { api_key: } for TAALBinary (no Bearer prefix)' do
+      p = BSV::Network::Providers::TAAL.mainnet(api_key: 'taal-key', http_client: http_client)
+      expect(p.protocols[1].auth).to eq({ api_key: 'taal-key' })
     end
   end
 
@@ -266,6 +270,169 @@ RSpec.describe 'BSV::Network::Providers defaults' do
 
     it 'sets ARC base_url to arc-test.taal.com' do
       expect(provider.protocols[0].base_url).to eq('https://arc-test.taal.com')
+    end
+  end
+  # ── Auth and rate_limit wiring ────────────────────────────────────────────────
+
+  describe 'DEFAULT_RATE_LIMIT constants' do
+    it 'WhatsOnChain::DEFAULT_RATE_LIMIT is 3' do
+      expect(BSV::Network::Providers::WhatsOnChain::DEFAULT_RATE_LIMIT).to eq(3)
+    end
+
+    it 'GorillaPool::DEFAULT_RATE_LIMIT is 3' do
+      expect(BSV::Network::Providers::GorillaPool::DEFAULT_RATE_LIMIT).to eq(3)
+    end
+
+    it 'TAAL::DEFAULT_RATE_LIMIT is nil (tier-dependent)' do
+      expect(BSV::Network::Providers::TAAL::DEFAULT_RATE_LIMIT).to be_nil
+    end
+  end
+
+  describe 'WhatsOnChain — auth and rate_limit' do
+    it 'provider.auth is :none when no auth supplied' do
+      p = BSV::Network::Providers::WhatsOnChain.mainnet(http_client: http_client)
+      expect(p.auth).to eq(:none)
+    end
+
+    it 'provider.rate_limit is DEFAULT_RATE_LIMIT when no rate_limit supplied' do
+      p = BSV::Network::Providers::WhatsOnChain.mainnet(http_client: http_client)
+      expect(p.rate_limit).to eq(BSV::Network::Providers::WhatsOnChain::DEFAULT_RATE_LIMIT)
+    end
+
+    it 'provider.auth reflects auth: hash' do
+      p = BSV::Network::Providers::WhatsOnChain.mainnet(auth: { api_key: 'k' }, http_client: http_client)
+      expect(p.auth).to eq({ api_key: 'k' })
+    end
+
+    it 'provider.authenticated? is true when auth: hash supplied' do
+      p = BSV::Network::Providers::WhatsOnChain.mainnet(auth: { api_key: 'k' }, http_client: http_client)
+      expect(p.authenticated?).to be(true)
+    end
+
+    it 'protocol receives auth: hash' do
+      p = BSV::Network::Providers::WhatsOnChain.mainnet(auth: { api_key: 'k' }, http_client: http_client)
+      expect(p.protocols[0].auth).to eq({ api_key: 'k' })
+    end
+
+    it 'rate_limit: override replaces default' do
+      p = BSV::Network::Providers::WhatsOnChain.mainnet(rate_limit: 10, http_client: http_client)
+      expect(p.rate_limit).to eq(10)
+    end
+
+    it 'auth: takes precedence over api_key:' do
+      p = BSV::Network::Providers::WhatsOnChain.mainnet(
+        auth: { api_key: 'explicit' }, api_key: 'legacy', http_client: http_client
+      )
+      expect(p.protocols[0].auth).to eq({ api_key: 'explicit' })
+    end
+
+    it 'legacy api_key: populates provider auth metadata' do
+      p = BSV::Network::Providers::WhatsOnChain.mainnet(api_key: 'legacy-key', http_client: http_client)
+      expect(p.auth).to eq({ api_key: 'legacy-key' })
+      expect(p.authenticated?).to be(true)
+    end
+  end
+
+  describe 'GorillaPool — auth and rate_limit' do
+    it 'provider.auth is :none when no auth supplied' do
+      p = BSV::Network::Providers::GorillaPool.mainnet(http_client: http_client)
+      expect(p.auth).to eq(:none)
+    end
+
+    it 'provider.rate_limit is DEFAULT_RATE_LIMIT when no rate_limit supplied' do
+      p = BSV::Network::Providers::GorillaPool.mainnet(http_client: http_client)
+      expect(p.rate_limit).to eq(BSV::Network::Providers::GorillaPool::DEFAULT_RATE_LIMIT)
+    end
+
+    it 'provider.auth reflects auth: hash' do
+      p = BSV::Network::Providers::GorillaPool.mainnet(auth: { bearer: 'tok' }, http_client: http_client)
+      expect(p.auth).to eq({ bearer: 'tok' })
+    end
+
+    it 'provider.authenticated? is true when auth: supplied' do
+      p = BSV::Network::Providers::GorillaPool.mainnet(auth: { bearer: 'tok' }, http_client: http_client)
+      expect(p.authenticated?).to be(true)
+    end
+
+    it 'forwards auth: to ARC protocol' do
+      p = BSV::Network::Providers::GorillaPool.mainnet(auth: { bearer: 'tok' }, http_client: http_client)
+      expect(p.protocols[0].auth).to eq({ bearer: 'tok' })
+    end
+
+    it 'forwards auth: to Chaintracks protocol' do
+      p = BSV::Network::Providers::GorillaPool.mainnet(auth: { bearer: 'tok' }, http_client: http_client)
+      expect(p.protocols[1].auth).to eq({ bearer: 'tok' })
+    end
+
+    it 'forwards auth: to Ordinals protocol' do
+      p = BSV::Network::Providers::GorillaPool.mainnet(auth: { bearer: 'tok' }, http_client: http_client)
+      expect(p.protocols[2].auth).to eq({ bearer: 'tok' })
+    end
+
+    it 'forwards auth: to JungleBus protocol' do
+      p = BSV::Network::Providers::GorillaPool.mainnet(auth: { bearer: 'tok' }, http_client: http_client)
+      expect(p.protocols[3].auth).to eq({ bearer: 'tok' })
+    end
+
+    it 'rate_limit: override replaces default' do
+      p = BSV::Network::Providers::GorillaPool.mainnet(rate_limit: 50, http_client: http_client)
+      expect(p.rate_limit).to eq(50)
+    end
+
+    it 'legacy api_key: populates provider auth metadata as bearer' do
+      p = BSV::Network::Providers::GorillaPool.mainnet(api_key: 'gp-key', http_client: http_client)
+      expect(p.auth).to eq({ bearer: 'gp-key' })
+      expect(p.authenticated?).to be(true)
+    end
+
+    it 'testnet forwards auth: to all protocols' do
+      p = BSV::Network::Providers::GorillaPool.testnet(auth: { bearer: 'tok' }, http_client: http_client)
+      p.protocols.each do |proto|
+        expect(proto.auth).to eq({ bearer: 'tok' })
+      end
+    end
+  end
+
+  describe 'TAAL — auth and rate_limit' do
+    it 'provider.auth is :none when no auth supplied' do
+      p = BSV::Network::Providers::TAAL.mainnet(http_client: http_client)
+      expect(p.auth).to eq(:none)
+    end
+
+    it 'provider.rate_limit is nil (DEFAULT_RATE_LIMIT) when no rate_limit supplied' do
+      p = BSV::Network::Providers::TAAL.mainnet(http_client: http_client)
+      expect(p.rate_limit).to be_nil
+    end
+
+    it 'provider.auth reflects auth: hash' do
+      p = BSV::Network::Providers::TAAL.mainnet(auth: { api_key: 'taal-k' }, http_client: http_client)
+      expect(p.auth).to eq({ api_key: 'taal-k' })
+    end
+
+    it 'provider.authenticated? is true when auth: supplied' do
+      p = BSV::Network::Providers::TAAL.mainnet(auth: { api_key: 'taal-k' }, http_client: http_client)
+      expect(p.authenticated?).to be(true)
+    end
+
+    it 'forwards auth: to ARC protocol' do
+      p = BSV::Network::Providers::TAAL.mainnet(auth: { api_key: 'taal-k' }, http_client: http_client)
+      expect(p.protocols[0].auth).to eq({ api_key: 'taal-k' })
+    end
+
+    it 'forwards auth: to TAALBinary protocol' do
+      p = BSV::Network::Providers::TAAL.mainnet(auth: { api_key: 'taal-k' }, http_client: http_client)
+      expect(p.protocols[1].auth).to eq({ api_key: 'taal-k' })
+    end
+
+    it 'rate_limit: override replaces default' do
+      p = BSV::Network::Providers::TAAL.mainnet(rate_limit: 25, http_client: http_client)
+      expect(p.rate_limit).to eq(25)
+    end
+
+    it 'legacy api_key: populates provider auth metadata as bearer' do
+      p = BSV::Network::Providers::TAAL.mainnet(api_key: 'taal-key', http_client: http_client)
+      expect(p.auth).to eq({ bearer: 'taal-key' })
+      expect(p.authenticated?).to be(true)
     end
   end
 end

--- a/gem/bsv-sdk/spec/bsv/network/providers/defaults_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/providers/defaults_spec.rb
@@ -136,9 +136,9 @@ RSpec.describe 'BSV::Network::Providers defaults' do
       expect(provider.protocols[0].base_url).to eq('https://api.whatsonchain.com/v1/bsv/main')
     end
 
-    it 'forwards api_key to WoCREST protocol' do
+    it 'forwards api_key to WoCREST protocol as auth: { api_key: }' do
       p = BSV::Network::Providers::WhatsOnChain.mainnet(api_key: 'woc-key', http_client: http_client)
-      expect(p.protocols[0].api_key).to eq('woc-key')
+      expect(p.protocols[0].auth).to eq({ api_key: 'woc-key' })
     end
   end
 


### PR DESCRIPTION
## Summary
- Provider base class gains `auth:` and `rate_limit:` attributes with `authenticated?` accessor
- Generic auth dispatch in Protocol `build_request` — supports Bearer tokens, API keys, and custom headers
- WoCREST's ad-hoc `build_request` override replaced by generic handling
- All provider factories (WhatsOnChain, GorillaPool, TAAL) accept `auth:` and `rate_limit:` kwargs with sensible defaults
- 44 end-to-end integration specs covering all auth mechanisms
- Documentation updated across network overview, examples, and SDK guide

## Test plan
- [x] All 5258 examples pass (0 failures)
- [x] RuboCop clean (328 files, no offences)
- [x] Acceptance criteria verified against implementation
- [x] Backwards compatible — legacy `api_key:` kwarg still works

Closes #718
