### PR TITLE
fix(script): add length/size to Stack (#752)

### DIFF
--- a/gem/bsv-sdk/lib/bsv/script/interpreter/stack.rb
+++ b/gem/bsv-sdk/lib/bsv/script/interpreter/stack.rb
@@ -98,10 +98,8 @@ module BSV
         @items.length
       end
 
-      def length
-        @items.length
-      end
-      alias size length
+      alias length depth
+      alias size depth
 
       def empty?
         @items.empty?

--- a/gem/bsv-sdk/lib/bsv/script/interpreter/stack.rb
+++ b/gem/bsv-sdk/lib/bsv/script/interpreter/stack.rb
@@ -98,6 +98,11 @@ module BSV
         @items.length
       end
 
+      def length
+        @items.length
+      end
+      alias size length
+
       def empty?
         @items.empty?
       end


### PR DESCRIPTION
## Summary

- Adds `length` and `size` methods to `BSV::Script::Stack`, fixing `NoMethodError` when the interpreter logs at DEBUG level
- `Stack` already had `depth` (Forth convention) but lacked the standard Ruby collection methods the interpreter expected

Closes #752

## Test plan

- [x] All 59 existing stack specs pass
- [ ] Verify `tx.verify_input` with `BSV.logger.level = Logger::DEBUG` no longer raises

🤖 Generated with [Claude Code](https://claude.com/claude-code)