### PR TITLE
feat(network)!: canonical block-header response across protocols (#791)

### DIFF
--- a/gem/bsv-sdk/CHANGELOG.md
+++ b/gem/bsv-sdk/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to the `bsv-sdk` gem are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this gem adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.23.0 — 2026-06-03
+
+### Changed (breaking)
+- **Canonical block-header response shape across protocols.** `Protocols::JungleBus`,
+  `Protocols::Chaintracks`, and `Protocols::WoCREST` now emit the merkle root as
+  `'merkle_root'` (lowercase snake_case) in their `:get_block_header` and
+  `:get_block_headers` responses, replacing the upstream-specific names
+  (`'merkleroot'` for JungleBus/WoCREST, `'merkleRoot'` for Chaintracks). Consumers
+  reading the raw field directly from `provider.call(:get_block_header).data` must
+  migrate to the canonical key. Wire protocols stay honest about other fields;
+  only the merkle-root key is renamed. No shim. (#791)
+- `WoCREST#:valid_root` now reads the normalised `merkle_root` key internally
+  (no behaviour change — same comparison output).
+- `BSV::Transaction::ChainTracker#valid_root_for_height?` reads
+  `result.data['merkle_root']` directly; the previous private
+  `normalise_merkle_root` helper is removed. Subclass-override pattern unchanged.
+
+### Note
+- This is the "Pattern A" normalisation from #791 — push cosmetic field-name
+  divergence down into the wire-protocol classes where the data is semantically
+  identical across upstreams. Pattern B (broadcast / get_tx_status with
+  structurally divergent shapes) stays at the consumer layer and is not part of
+  this release.
+
 ## 0.22.0 — 2026-05-30
 
 ### Added

--- a/gem/bsv-sdk/lib/bsv/network/protocols/chaintracks.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/chaintracks.rb
@@ -21,7 +21,7 @@ module BSV
       #   result.data  # => 800000
       #
       #   result = ct.call(:get_block_header, 800_000)
-      #   result.data  # => { 'hash' => '...', 'height' => 800000, 'merkleRoot' => '...' }
+      #   result.data  # => { 'hash' => '...', 'height' => 800000, 'merkle_root' => '...' }
       #
       # @note No public Chaintracks instance is hosted by major providers — GorillaPool
       #   serves chain data via JungleBus instead. For general chain-tracking against
@@ -39,6 +39,26 @@ module BSV
         # @param http_client [Object, nil] injectable HTTP client for testing
         def initialize(base_url:, api_key: nil, auth: nil, http_client: nil)
           super
+        end
+
+        private
+
+        # Block-header escape hatch: normalises Chaintracks's +merkleRoot+ field
+        # to the canonical +merkle_root+ key. See issue #791 for the cross-protocol
+        # rationale.
+        def call_get_block_header(*args, **kwargs)
+          response = default_call(:get_block_header, *args, **kwargs)
+          return response unless response.http_success?
+
+          response.with(data: normalize_block_header(response.data))
+        end
+
+        def normalize_block_header(data)
+          return data unless data.is_a?(Hash) && data.key?('merkleRoot')
+
+          data = data.dup
+          data['merkle_root'] = data.delete('merkleRoot')
+          data
         end
       end
     end

--- a/gem/bsv-sdk/lib/bsv/network/protocols/chaintracks.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/chaintracks.rb
@@ -46,8 +46,8 @@ module BSV
         # Block-header escape hatch: normalises Chaintracks's +merkleRoot+ field
         # to the canonical +merkle_root+ key. See issue #791 for the cross-protocol
         # rationale.
-        def call_get_block_header(*args, **kwargs)
-          response = default_call(:get_block_header, *args, **kwargs)
+        def call_get_block_header(*, **)
+          response = default_call(:get_block_header, *, **)
           return response unless response.http_success?
 
           response.with(data: normalize_block_header(response.data))

--- a/gem/bsv-sdk/lib/bsv/network/protocols/jungle_bus.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/jungle_bus.rb
@@ -52,6 +52,34 @@ module BSV
         def initialize(base_url:, api_key: nil, auth: nil, http_client: nil)
           super
         end
+
+        private
+
+        # Block-header escape hatch: normalises JungleBus's +merkleroot+ field
+        # to the canonical +merkle_root+ key. See issue #791 for the cross-protocol
+        # rationale.
+        def call_get_block_header(height, **)
+          response = default_call(:get_block_header, height)
+          return response unless response.http_success?
+
+          response.with(data: normalize_block_header(response.data))
+        end
+
+        def call_get_block_headers(height, **)
+          response = default_call(:get_block_headers, height)
+          return response unless response.http_success?
+          return response unless response.data.is_a?(Array)
+
+          response.with(data: response.data.map { |h| normalize_block_header(h) })
+        end
+
+        def normalize_block_header(data)
+          return data unless data.is_a?(Hash) && data.key?('merkleroot')
+
+          data = data.dup
+          data['merkle_root'] = data.delete('merkleroot')
+          data
+        end
       end
     end
   end

--- a/gem/bsv-sdk/lib/bsv/network/protocols/jungle_bus.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/jungle_bus.rb
@@ -58,15 +58,15 @@ module BSV
         # Block-header escape hatch: normalises JungleBus's +merkleroot+ field
         # to the canonical +merkle_root+ key. See issue #791 for the cross-protocol
         # rationale.
-        def call_get_block_header(*args, **kwargs)
-          response = default_call(:get_block_header, *args, **kwargs)
+        def call_get_block_header(*, **)
+          response = default_call(:get_block_header, *, **)
           return response unless response.http_success?
 
           response.with(data: normalize_block_header(response.data))
         end
 
-        def call_get_block_headers(*args, **kwargs)
-          response = default_call(:get_block_headers, *args, **kwargs)
+        def call_get_block_headers(*, **)
+          response = default_call(:get_block_headers, *, **)
           return response unless response.http_success?
           return response unless response.data.is_a?(Array)
 

--- a/gem/bsv-sdk/lib/bsv/network/protocols/jungle_bus.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/jungle_bus.rb
@@ -58,15 +58,15 @@ module BSV
         # Block-header escape hatch: normalises JungleBus's +merkleroot+ field
         # to the canonical +merkle_root+ key. See issue #791 for the cross-protocol
         # rationale.
-        def call_get_block_header(height, **)
-          response = default_call(:get_block_header, height)
+        def call_get_block_header(*args, **kwargs)
+          response = default_call(:get_block_header, *args, **kwargs)
           return response unless response.http_success?
 
           response.with(data: normalize_block_header(response.data))
         end
 
-        def call_get_block_headers(height, **)
-          response = default_call(:get_block_headers, height)
+        def call_get_block_headers(*args, **kwargs)
+          response = default_call(:get_block_headers, *args, **kwargs)
           return response unless response.http_success?
           return response unless response.data.is_a?(Array)
 

--- a/gem/bsv-sdk/lib/bsv/network/protocols/woc_rest.rb
+++ b/gem/bsv-sdk/lib/bsv/network/protocols/woc_rest.rb
@@ -373,8 +373,35 @@ module BSV
           result = default_call(:valid_root, height)
           return result unless result.http_success?
 
-          actual = result.data['merkleroot']
+          data = normalize_block_header(result.data)
+          actual = data['merkle_root']
           result.with(data: actual.to_s.downcase == root.to_s.downcase)
+        end
+
+        # Block-header escape hatch: normalises WoCREST's +merkleroot+ field
+        # to the canonical +merkle_root+ key. See issue #791 for the cross-protocol
+        # rationale.
+        def call_get_block_header(*, **)
+          response = default_call(:get_block_header, *, **)
+          return response unless response.http_success?
+
+          response.with(data: normalize_block_header(response.data))
+        end
+
+        def call_get_block_headers(*, **)
+          response = default_call(:get_block_headers, *, **)
+          return response unless response.http_success?
+          return response unless response.data.is_a?(Array)
+
+          response.with(data: response.data.map { |h| normalize_block_header(h) })
+        end
+
+        def normalize_block_header(data)
+          return data unless data.is_a?(Hash) && data.key?('merkleroot')
+
+          data = data.dup
+          data['merkle_root'] = data.delete('merkleroot')
+          data
         end
       end
     end

--- a/gem/bsv-sdk/lib/bsv/transaction/chain_tracker.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/chain_tracker.rb
@@ -70,8 +70,10 @@ module BSV
       # Verify that a merkle root is valid for the given block height.
       #
       # Dispatches +:get_block_header+ to the configured provider. Returns +false+
-      # on 404 (block not found). Normalises the merkle root field name from any
-      # of +merkleroot+, +merkleRoot+, or +merkle_root+.
+      # on 404 (block not found). Relies on the wire-protocol classes
+      # (+Protocols::ARC+, +Protocols::JungleBus+, etc.) to emit the canonical
+      # +merkle_root+ key — see issue #791 / PR for the Pattern A normalisation
+      # that absorbed the previous field-name shim.
       #
       # @param root [String] merkle root as a hex string
       # @param height [Integer] block height
@@ -85,7 +87,7 @@ module BSV
         return false if result.http_not_found?
         raise result.error_message.to_s unless result.http_success?
 
-        actual = normalise_merkle_root(result.data)
+        actual = result.data.is_a?(Hash) ? result.data['merkle_root'] : nil
         return false unless actual
 
         actual.casecmp(root).zero?
@@ -107,16 +109,6 @@ module BSV
         raise result.error_message.to_s
       end
 
-      private
-
-      # Field-name diversity belongs at the Protocols::* layer; this is a
-      # transitional shim until the wire protocols return canonical shapes.
-      # See #791.
-      def normalise_merkle_root(body)
-        return nil unless body.is_a?(Hash)
-
-        body['merkleroot'] || body['merkleRoot'] || body['merkle_root']
-      end
     end
   end
 end

--- a/gem/bsv-sdk/lib/bsv/transaction/chain_tracker.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/chain_tracker.rb
@@ -108,7 +108,6 @@ module BSV
 
         raise result.error_message.to_s
       end
-
     end
   end
 end

--- a/gem/bsv-sdk/lib/bsv/transaction/chain_tracker.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/chain_tracker.rb
@@ -70,10 +70,11 @@ module BSV
       # Verify that a merkle root is valid for the given block height.
       #
       # Dispatches +:get_block_header+ to the configured provider. Returns +false+
-      # on 404 (block not found). Relies on the wire-protocol classes
-      # (+Protocols::ARC+, +Protocols::JungleBus+, etc.) to emit the canonical
-      # +merkle_root+ key — see issue #791 / PR for the Pattern A normalisation
-      # that absorbed the previous field-name shim.
+      # on 404 (block not found). Relies on the wire-protocol classes that expose
+      # +:get_block_header+ (+Protocols::JungleBus+, +Protocols::Chaintracks+,
+      # +Protocols::WoCREST+) to emit the canonical +merkle_root+ key — see
+      # issue #791 for the Pattern A normalisation that absorbed the previous
+      # field-name shim.
       #
       # @param root [String] merkle root as a hex string
       # @param height [Integer] block height

--- a/gem/bsv-sdk/lib/bsv/version.rb
+++ b/gem/bsv-sdk/lib/bsv/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BSV
-  VERSION = '0.22.0'
+  VERSION = '0.23.0'
 end

--- a/gem/bsv-sdk/spec/bsv/network/protocols/chaintracks_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/chaintracks_spec.rb
@@ -34,15 +34,16 @@ RSpec.describe BSV::Network::Protocols::Chaintracks do
 
   describe ':get_block_header' do
     let(:header_body) do
-      { 'hash' => 'abc123', 'height' => 800_000, 'merkleroot' => 'def456' }.to_json
+      { 'hash' => 'abc123', 'height' => 800_000, 'merkleRoot' => 'def456' }.to_json
     end
 
-    it 'returns parsed JSON on success' do
+    it 'returns parsed JSON on success with merkleRoot normalised to merkle_root' do
       instance, _http = make_instance(200, header_body)
       result = instance.call(:get_block_header, height: 800_000)
 
       expect(result).to be_http_success
-      expect(result.data).to eq({ 'hash' => 'abc123', 'height' => 800_000, 'merkleroot' => 'def456' })
+      expect(result.data).to eq({ 'hash' => 'abc123', 'height' => 800_000, 'merkle_root' => 'def456' })
+      expect(result.data).not_to have_key('merkleRoot')
     end
 
     it 'builds the correct URL' do

--- a/gem/bsv-sdk/spec/bsv/network/protocols/jungle_bus_integration_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/jungle_bus_integration_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'JungleBus integration', :integration do # rubocop:disable RSpec/
       expect(result.data).to be_a(Hash)
       expect(result.data['hash']).to eq(fork_block_hash)
       expect(result.data['height']).to eq(fork_block_height)
-      expect(result.data['merkleroot']).to be_a(String)
+      expect(result.data['merkle_root']).to be_a(String)
     else
       expect(result).to be_http_not_found.or(satisfy { |r| !r.http_success? })
     end

--- a/gem/bsv-sdk/spec/bsv/network/protocols/jungle_bus_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/jungle_bus_spec.rb
@@ -192,6 +192,16 @@ RSpec.describe BSV::Network::Protocols::JungleBus do
       expect(result.data['hash']).to start_with('0000000000')
     end
 
+    it 'normalises merkleroot to canonical merkle_root key' do
+      http_client = fake(200, header_json)
+      proto = described_class.new(base_url: 'https://junglebus.gorillapool.io', http_client: http_client)
+
+      result = proto.call(:get_block_header, 556_767)
+
+      expect(result.data['merkle_root']).to eq('da2b9eb7e8a3619734a17b55c47bdd6fd855b0afa9c7e14e3a164a279e51bba9')
+      expect(result.data).not_to have_key('merkleroot')
+    end
+
     it 'sends GET to /v1/block_header/get/{height}' do
       http_client = fake(200, header_json)
       proto = described_class.new(base_url: 'https://junglebus.gorillapool.io', http_client: http_client)
@@ -218,9 +228,19 @@ RSpec.describe BSV::Network::Protocols::JungleBus do
   describe '#call(:get_block_headers)' do
     let(:headers_json) do
       [
-        { 'hash' => 'abc', 'height' => 948_120, 'time' => 1_778_184_660 },
-        { 'hash' => 'def', 'height' => 948_121, 'time' => 1_778_185_691 }
+        { 'hash' => 'abc', 'height' => 948_120, 'time' => 1_778_184_660, 'merkleroot' => 'aaa' },
+        { 'hash' => 'def', 'height' => 948_121, 'time' => 1_778_185_691, 'merkleroot' => 'bbb' }
       ].to_json
+    end
+
+    it 'normalises merkleroot on each header in the array' do
+      http_client = fake(200, headers_json)
+      proto = described_class.new(base_url: 'https://junglebus.gorillapool.io', http_client: http_client)
+
+      result = proto.call(:get_block_headers, 948_120)
+
+      expect(result.data.map { |h| h['merkle_root'] }).to eq(%w[aaa bbb])
+      expect(result.data).to all(satisfy { |h| !h.key?('merkleroot') })
     end
 
     it 'returns an array of block headers' do

--- a/gem/bsv-sdk/spec/bsv/network/protocols/woc_rest_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/woc_rest_spec.rb
@@ -212,6 +212,16 @@ RSpec.describe BSV::Network::Protocols::WoCREST do # rubocop:disable RSpec/SpecF
       expect(result.data['height']).to eq(800_000)
     end
 
+    it 'normalises merkleroot to canonical merkle_root key' do
+      http_client = fake(200, header_json)
+      protocol = described_class.new(base_url: 'https://api.whatsonchain.com/v1/bsv/main', network: :main, http_client: http_client)
+
+      result = protocol.call(:get_block_header, 800_000)
+
+      expect(result.data['merkle_root']).to eq('deadbeef00000000' * 4)
+      expect(result.data).not_to have_key('merkleroot')
+    end
+
     it 'sends GET to /block/{height}/header' do
       http_client = fake(200, header_json)
       protocol = described_class.new(base_url: 'https://api.whatsonchain.com/v1/bsv/main', network: :main, http_client: http_client)
@@ -928,6 +938,16 @@ RSpec.describe BSV::Network::Protocols::WoCREST do # rubocop:disable RSpec/SpecF
       expect(result.data).to be_an(Array)
       expect(result.data.length).to eq(2)
       expect(result.data[0]['height']).to eq(800_000)
+    end
+
+    it 'normalises merkleroot on each header in the array' do
+      http_client = fake(200, headers_json)
+      protocol = described_class.new(base_url: 'https://api.whatsonchain.com/v1/bsv/main', network: :main, http_client: http_client)
+
+      result = protocol.call(:get_block_headers)
+
+      expect(result.data.map { |h| h['merkle_root'] }).to eq(%w[dead beef])
+      expect(result.data).to all(satisfy { |h| !h.key?('merkleroot') })
     end
 
     it 'sends GET to /block/headers' do

--- a/gem/bsv-sdk/spec/bsv/transaction/chain_tracker_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/chain_tracker_spec.rb
@@ -71,29 +71,25 @@ RSpec.describe BSV::Transaction::ChainTracker do
         allow(provider).to receive(:call).with(:get_block_header, anything).and_return(response)
       end
 
-      it 'returns true when root matches (lowercase field name)' do
-        stub_header('merkleroot' => 'abc')
-        expect(tracker.valid_root_for_height?('ABC', 800_000)).to be true
-      end
-
-      it 'returns true when root matches (camelCase field name)' do
-        stub_header('merkleRoot' => 'abc')
-        expect(tracker.valid_root_for_height?('ABC', 800_000)).to be true
-      end
-
-      it 'returns true when root matches (snake_case field name)' do
+      it 'returns true when root matches canonical merkle_root key' do
         stub_header('merkle_root' => 'abc')
         expect(tracker.valid_root_for_height?('ABC', 800_000)).to be true
       end
 
       it 'returns true when root matches with identical casing' do
-        stub_header('merkleroot' => 'abc123')
+        stub_header('merkle_root' => 'abc123')
         expect(tracker.valid_root_for_height?('abc123', 800_000)).to be true
       end
 
       it 'returns false when root does not match' do
-        stub_header('merkleroot' => 'abc')
+        stub_header('merkle_root' => 'abc')
         expect(tracker.valid_root_for_height?('zzz', 800_000)).to be false
+      end
+
+      it 'returns false when given a raw (un-normalised) merkleroot key' do
+        # Wire protocols are expected to normalise; the porcelain trusts canonical only.
+        stub_header('merkleroot' => 'abc')
+        expect(tracker.valid_root_for_height?('abc', 800_000)).to be false
       end
 
       it 'returns false on 404' do

--- a/gem/bsv-sdk/spec/integration/chaintracks_cloudflare_spec.rb
+++ b/gem/bsv-sdk/spec/integration/chaintracks_cloudflare_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe 'Custom Provider: chaintracks-cloudflare', :chaintracks_live do
   # -------------------------------------------------------------------
   # Define a custom Protocol subclass using the DSL — this is the code
   # under test, exercising endpoint declaration and response handlers.
+  #
+  # Note: this is an ad-hoc protocol class, NOT BSV::Network::Protocols::Chaintracks.
+  # The custom lambda response handlers do no key normalisation, so reads of
+  # `data['merkleRoot']` below use the raw upstream key — not the canonical
+  # `merkle_root` produced by Protocols::Chaintracks (see #791).
   # -------------------------------------------------------------------
 
   let(:protocol_class) do


### PR DESCRIPTION
Closes #791.

## Summary

Pushes the `merkleroot`/`merkleRoot` field-name normalisation down from the `ChainTracker` porcelain into the wire-protocol classes themselves. All three protocols exposing `:get_block_header` (JungleBus, Chaintracks, WoCREST) now emit the canonical `'merkle_root'` (lowercase snake_case) key, replacing their upstream-specific names. The porcelain shim deletes.

This is the **Pattern A** normalisation from #791 — pushed-down because the data is semantically identical across upstreams, only the field name differs. Pattern B (broadcast / get_tx_status with structurally divergent shapes) is explicitly out of scope and stays at the consumer layer.

## What changed

- `Protocols::JungleBus`: escape hatches for `:get_block_header` and `:get_block_headers` rename `merkleroot` → `merkle_root`
- `Protocols::Chaintracks`: escape hatch for `:get_block_header` renames `merkleRoot` → `merkle_root`
- `Protocols::WoCREST`: escape hatches for `:get_block_header` and `:get_block_headers` rename `merkleroot` → `merkle_root`; existing `:valid_root` updated to read the canonical key after normalisation (no behaviour change)
- `BSV::Transaction::ChainTracker#valid_root_for_height?` now reads `result.data['merkle_root']` directly; private `normalise_merkle_root` helper removed
- CHANGELOG: 0.22.0 → 0.23.0

## Breaking change

Direct consumers reading `result.data['merkleroot']` or `result.data['merkleRoot']` from any of the three protocols must migrate to `result.data['merkle_root']`. Grep confirms zero affected readers in lib/ — the only previous internal readers were the now-removed `ChainTracker` shim and WoCREST's own `call_valid_root` (updated). bsv-wallet has a parallel shim that gracefully absorbs the canonical name (its `||` chain includes `merkle_root` as a fallback); they can simplify on next uptake.

## Test plan

- [x] All specs pass (`bundle exec rake spec:sdk` — 5895 examples, 0 failures, 22 pre-existing pending)
- [x] Linter clean (`bundle exec rubocop` — 386 files, no offences)
- [x] Per-protocol unit specs assert canonical `merkle_root` key present, raw key absent
- [x] `ChainTracker#valid_root_for_height?` works against the new canonical shape
- [x] Acceptance criteria from #791 verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)