### PR TITLE
feat(transaction)!: rename Transaction class to Tx (#795)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -115,7 +115,7 @@ Metrics/ClassLength:
   Exclude:
     - 'gem/bsv-sdk/lib/bsv/primitives/**/*'
     - 'gem/bsv-sdk/lib/bsv/script/**/*'
-    - 'gem/bsv-sdk/lib/bsv/transaction/transaction.rb'
+    - 'gem/bsv-sdk/lib/bsv/transaction/tx.rb'
     - 'gem/bsv-sdk/lib/bsv/transaction/merkle_path.rb'
     - 'gem/bsv-sdk/lib/bsv/transaction/beef.rb'
     - 'gem/bsv-sdk/lib/bsv/network/**/*'

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ pubkey_hash = priv_key.public_key.hash160
 locking_script = BSV::Script::Script.p2pkh_lock(pubkey_hash)
 
 # Create a transaction spending a UTXO
-tx = BSV::Transaction::Transaction.new
+tx = BSV::Transaction::Tx.new
 
 # Add an input referencing a previous transaction output
 input = BSV::Transaction::TransactionInput.new(

--- a/docs/general/naming-conventions.md
+++ b/docs/general/naming-conventions.md
@@ -85,7 +85,7 @@ For generating new instances (not from data), use `new` or `generate`:
 
 ```ruby
 BSV::Primitives::PrivateKey.generate      # random new key
-BSV::Transaction::Tx.new          # empty transaction
+BSV::Transaction::Tx.new                  # empty transaction
 ```
 
 ### 7. Options objects become keyword arguments

--- a/docs/general/naming-conventions.md
+++ b/docs/general/naming-conventions.md
@@ -85,7 +85,7 @@ For generating new instances (not from data), use `new` or `generate`:
 
 ```ruby
 BSV::Primitives::PrivateKey.generate      # random new key
-BSV::Transaction::Transaction.new          # empty transaction
+BSV::Transaction::Tx.new          # empty transaction
 ```
 
 ### 7. Options objects become keyword arguments

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -66,7 +66,7 @@ pubkey_hash = private_key.public_key.hash160
 locking_script = BSV::Script::Script.p2pkh_lock(pubkey_hash)
 
 # Create the transaction
-tx = BSV::Transaction::Transaction.new
+tx = BSV::Transaction::Tx.new
 
 # Add an input (referencing a previous UTXO)
 input = BSV::Transaction::TransactionInput.new(
@@ -106,7 +106,7 @@ puts response.txid  # display-order hex (ARC API boundary)
 For transactions with multiple inputs, use unlocking script templates. This lets `sign_all` handle each input automatically:
 
 ```ruby
-tx = BSV::Transaction::Transaction.new
+tx = BSV::Transaction::Tx.new
 
 # Create inputs with templates
 input = BSV::Transaction::TransactionInput.new(

--- a/docs/guides/wtxid-dtxid.md
+++ b/docs/guides/wtxid-dtxid.md
@@ -29,7 +29,7 @@ This SDK eliminates the ambiguity by making the byte order explicit in every nam
 ### Examples
 
 ```ruby
-tx = BSV::Transaction::Transaction.from_hex(raw_hex)
+tx = BSV::Transaction::Tx.from_hex(raw_hex)
 
 # Wire order — for computation, storage, binary protocols
 tx.wtxid            # => 32-byte binary string

--- a/docs/sdk/transaction.md
+++ b/docs/sdk/transaction.md
@@ -44,7 +44,7 @@ data_output = BSV::Transaction::TransactionOutput.new(
 ### Assembling
 
 ```ruby
-tx = BSV::Transaction::Transaction.new
+tx = BSV::Transaction::Tx.new
 tx.add_input(input)
 tx.add_output(output)
 tx.add_output(data_output)
@@ -126,11 +126,11 @@ binary = tx.to_binary  # raw transaction bytes
 ### Parsing
 
 ```ruby
-tx = BSV::Transaction::Transaction.from_hex('0100000001...')
-tx = BSV::Transaction::Transaction.from_binary(raw_bytes)
+tx = BSV::Transaction::Tx.from_hex('0100000001...')
+tx = BSV::Transaction::Tx.from_binary(raw_bytes)
 
 # Parse with offset tracking (for embedded transactions)
-tx, bytes_consumed = BSV::Transaction::Transaction.from_binary_with_offset(data, offset)
+tx, bytes_consumed = BSV::Transaction::Tx.from_binary_with_offset(data, offset)
 ```
 
 ### Transaction ID
@@ -195,7 +195,7 @@ BEEF automatically wires source transactions: inputs that reference other transa
 `Transaction.from_beef` returns the subject transaction with full ancestry wired, including late-bound BUMP attachment for ancestors stored as raw transactions alongside a separately-bundled merkle proof:
 
 ```ruby
-tx = BSV::Transaction::Transaction.from_beef(beef_bytes)
+tx = BSV::Transaction::Tx.from_beef(beef_bytes)
 
 # Source data is derived from the wired ancestry — no need to set
 # source_satoshis or source_locking_script explicitly.
@@ -283,7 +283,7 @@ sender_lock = BSV::Script::Script.p2pkh_lock(sender.public_key.hash160)
 recipient_lock = BSV::Script::Script.p2pkh_lock(recipient.public_key.hash160)
 
 # Build
-tx = BSV::Transaction::Transaction.new
+tx = BSV::Transaction::Tx.new
 
 input = BSV::Transaction::TransactionInput.new(
   prev_wtxid: BSV::Transaction::TransactionInput.wtxid_from_hex(utxo_txid),

--- a/docs/testing/testnet.md
+++ b/docs/testing/testnet.md
@@ -53,7 +53,7 @@ the status response contains the expected status.
 
 ```ruby
 # The core flow, simplified
-tx = BSV::Transaction::Transaction.new
+tx = BSV::Transaction::Tx.new
 tx.add_input(input)
 tx.add_output(payment)
 tx.add_output(change)

--- a/gem/bsv-attest/spec/bsv/attest_spec.rb
+++ b/gem/bsv-attest/spec/bsv/attest_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe BSV::Attest do
       digest = BSV::Primitives::Digest.sha256(data_to_attest)
       script = BSV::Script::Script.op_return(digest)
       output = BSV::Transaction::TransactionOutput.new(satoshis: 0, locking_script: script)
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       tx.add_output(output)
 
       Class.new do
@@ -163,7 +163,7 @@ RSpec.describe BSV::Attest do
       prefix = 'ATTEST'.b
       script = BSV::Script::Script.op_return(prefix, digest)
       output = BSV::Transaction::TransactionOutput.new(satoshis: 0, locking_script: script)
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       tx.add_output(output)
 
       provider = Class.new do

--- a/gem/bsv-sdk/README.md
+++ b/gem/bsv-sdk/README.md
@@ -86,7 +86,7 @@ pubkey_hash = priv_key.public_key.hash160
 locking_script = BSV::Script::Script.p2pkh_lock(pubkey_hash)
 
 # Create a transaction spending a UTXO
-tx = BSV::Transaction::Transaction.new
+tx = BSV::Transaction::Tx.new
 
 # Add an input referencing a previous transaction output
 input = BSV::Transaction::TransactionInput.new(

--- a/gem/bsv-sdk/lib/bsv/identity/client.rb
+++ b/gem/bsv-sdk/lib/bsv/identity/client.rb
@@ -169,7 +169,7 @@ module BSV
 
         raise 'Public reveal failed: failed to create action!' if create_result[:tx].nil?
 
-        tx = BSV::Transaction::Transaction.from_beef(create_result[:tx])
+        tx = BSV::Transaction::Tx.from_beef(create_result[:tx])
         broadcaster_for_action.broadcast(tx)
       end
 
@@ -232,7 +232,7 @@ module BSV
         raise 'Revoke failed: failed to create signable transaction' if create_result[:signable_transaction].nil?
 
         signable = create_result[:signable_transaction]
-        partial_tx = BSV::Transaction::Transaction.from_beef(signable[:tx])
+        partial_tx = BSV::Transaction::Tx.from_beef(signable[:tx])
 
         # Unlock via PushDrop
         template = BSV::Script::PushDropTemplate.new(wallet: @wallet, originator: @originator)
@@ -255,7 +255,7 @@ module BSV
 
         raise 'Revoke failed: failed to sign transaction' if sign_result[:tx].nil?
 
-        signed_tx = BSV::Transaction::Transaction.from_beef(sign_result[:tx])
+        signed_tx = BSV::Transaction::Tx.from_beef(sign_result[:tx])
         broadcaster_for_action.broadcast(signed_tx)
       end
 

--- a/gem/bsv-sdk/lib/bsv/mcp/tools/broadcast_p2pkh.rb
+++ b/gem/bsv-sdk/lib/bsv/mcp/tools/broadcast_p2pkh.rb
@@ -150,7 +150,7 @@ module BSV
         # Build, fee-compute, and sign the transaction.
         # @api private
         def self.build_transaction(selected_utxos, satoshis, to_address, sender_address, private_key)
-          tx = BSV::Transaction::Transaction.new
+          tx = BSV::Transaction::Tx.new
 
           # Wire inputs with EF metadata (source_satoshis + source_locking_script)
           selected_utxos.each do |utxo|

--- a/gem/bsv-sdk/lib/bsv/mcp/tools/decode_tx.rb
+++ b/gem/bsv-sdk/lib/bsv/mcp/tools/decode_tx.rb
@@ -48,7 +48,7 @@ module BSV
         )
 
         def self.call(hex:, **)
-          tx = BSV::Transaction::Transaction.from_hex(hex)
+          tx = BSV::Transaction::Tx.from_hex(hex)
           result = Helpers.transaction_to_h(tx)
 
           ::MCP::Tool::Response.new(

--- a/gem/bsv-sdk/lib/bsv/mcp/tools/fetch_tx.rb
+++ b/gem/bsv-sdk/lib/bsv/mcp/tools/fetch_tx.rb
@@ -59,7 +59,7 @@ module BSV
             return Helpers.error_response(msg)
           end
 
-          tx = BSV::Transaction::Transaction.from_hex(fetch_result.data)
+          tx = BSV::Transaction::Tx.from_hex(fetch_result.data)
 
           result = {
             hex: tx.to_hex,

--- a/gem/bsv-sdk/lib/bsv/mcp/tools/helpers.rb
+++ b/gem/bsv-sdk/lib/bsv/mcp/tools/helpers.rb
@@ -21,7 +21,7 @@ module BSV
 
         # Convert a Transaction to a hash suitable for JSON responses.
         #
-        # @param tx [BSV::Transaction::Transaction]
+        # @param tx [BSV::Transaction::Tx]
         # @return [Hash]
         def self.transaction_to_h(tx)
           {

--- a/gem/bsv-sdk/lib/bsv/overlay/admin_token_template.rb
+++ b/gem/bsv-sdk/lib/bsv/overlay/admin_token_template.rb
@@ -80,7 +80,7 @@ module BSV
         # Computes the BIP-143 sighash (SIGHASH_ALL|FORK_ID) and signs it
         # using the wallet's derived key for the protocol.
         #
-        # @param tx [BSV::Transaction::Transaction] the spending transaction
+        # @param tx [BSV::Transaction::Tx] the spending transaction
         # @param input_index [Integer] which input to sign
         # @return [BSV::Script::Script] the unlocking script
         def sign(tx, input_index)
@@ -101,7 +101,7 @@ module BSV
 
         # Estimated byte length of the unlocking script.
         #
-        # @param _tx [BSV::Transaction::Transaction] unused
+        # @param _tx [BSV::Transaction::Tx] unused
         # @param _input_index [Integer] unused
         # @return [Integer]
         def estimated_length(_tx, _input_index)

--- a/gem/bsv-sdk/lib/bsv/overlay/topic_broadcaster.rb
+++ b/gem/bsv-sdk/lib/bsv/overlay/topic_broadcaster.rb
@@ -74,7 +74,7 @@ module BSV
 
       # Broadcast a transaction to all interested overlay hosts.
       #
-      # @param tx [BSV::Transaction::Transaction] the transaction to broadcast
+      # @param tx [BSV::Transaction::Tx] the transaction to broadcast
       # @return [OverlayBroadcastResult]
       def broadcast(tx)
         beef = serialise_beef(tx)

--- a/gem/bsv-sdk/lib/bsv/registry/client.rb
+++ b/gem/bsv-sdk/lib/bsv/registry/client.rb
@@ -81,7 +81,7 @@ module BSV
 
         raise "Register failed: could not create #{definition_type} registration transaction" if create_result[:tx].nil?
 
-        tx = BSV::Transaction::Transaction.from_beef(normalise_beef(create_result[:tx]))
+        tx = BSV::Transaction::Tx.from_beef(normalise_beef(create_result[:tx]))
         broadcaster_for(definition_type).broadcast(tx)
       end
 
@@ -465,7 +465,7 @@ module BSV
       # @return [BSV::Overlay::OverlayBroadcastResult]
       def sign_and_broadcast(definition_type, create_result)
         signable   = create_result[:signable_transaction]
-        partial_tx = BSV::Transaction::Transaction.from_beef(normalise_beef(signable[:tx]))
+        partial_tx = BSV::Transaction::Tx.from_beef(normalise_beef(signable[:tx]))
 
         template = BSV::Script::PushDropTemplate.new(wallet: @wallet, originator: @originator)
         unlocker = template.unlock(
@@ -488,7 +488,7 @@ module BSV
 
         raise 'Revoke failed: could not sign transaction' if sign_result[:tx].nil?
 
-        signed_tx = BSV::Transaction::Transaction.from_beef(normalise_beef(sign_result[:tx]))
+        signed_tx = BSV::Transaction::Tx.from_beef(normalise_beef(sign_result[:tx]))
         broadcaster_for(definition_type).broadcast(signed_tx)
       end
 

--- a/gem/bsv-sdk/lib/bsv/script/interpreter/interpreter.rb
+++ b/gem/bsv-sdk/lib/bsv/script/interpreter/interpreter.rb
@@ -70,7 +70,7 @@ module BSV
 
       # Verify a transaction input by evaluating its scripts.
       #
-      # @param tx [Transaction::Transaction] the transaction being verified
+      # @param tx [Transaction::Tx] the transaction being verified
       # @param input_index [Integer] the input index within the transaction
       # @param unlock_script [Script] the input's unlocking script
       # @param lock_script [Script] the previous output's locking script

--- a/gem/bsv-sdk/lib/bsv/script/push_drop_template.rb
+++ b/gem/bsv-sdk/lib/bsv/script/push_drop_template.rb
@@ -93,7 +93,7 @@ module BSV
         # the wallet's derived key, then returns a P2PKH unlock wrapped in a
         # PushDrop unlock (which is a pass-through).
         #
-        # @param tx [BSV::Transaction::Transaction] the spending transaction
+        # @param tx [BSV::Transaction::Tx] the spending transaction
         # @param input_index [Integer] which input to sign
         # @return [BSV::Script::Script] the unlocking script
         def sign(tx, input_index)
@@ -125,7 +125,7 @@ module BSV
 
         # Estimated byte length of the unlocking script.
         #
-        # @param _tx [BSV::Transaction::Transaction] unused
+        # @param _tx [BSV::Transaction::Tx] unused
         # @param _input_index [Integer] unused
         # @return [Integer]
         def estimated_length(_tx, _input_index)

--- a/gem/bsv-sdk/lib/bsv/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction.rb
@@ -3,7 +3,7 @@
 module BSV
   # Transaction building, signing, serialisation, and verification.
   #
-  # Provides the {Transaction::Transaction} class for constructing and signing
+  # Provides the {Transaction::Tx} class for constructing and signing
   # transactions, {Transaction::Beef} for BEEF (BRC-62/95/96) serialisation,
   # {Transaction::MerklePath} for BRC-74 merkle proofs, and
   # {Transaction::Sighash} constants for BIP-143 sighash computation.
@@ -21,6 +21,6 @@ module BSV
     autoload :Beef,                     'bsv/transaction/beef'
     autoload :UnlockingScriptTemplate,  'bsv/transaction/unlocking_script_template'
     autoload :P2PKH,                    'bsv/transaction/p2pkh'
-    autoload :Transaction,              'bsv/transaction/transaction'
+    autoload :Tx,                       'bsv/transaction/tx'
   end
 end

--- a/gem/bsv-sdk/lib/bsv/transaction/beef.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef.rb
@@ -72,10 +72,10 @@ module BSV
 
       # A BEEF entry containing a raw transaction without a merkle proof.
       class RawTxEntry < BeefTx
-        # @return [Transaction] the transaction
+        # @return [Tx] the transaction
         attr_reader :transaction
 
-        # @param transaction [Transaction] the transaction
+        # @param transaction [Tx] the transaction
         # @raise [ArgumentError] if transaction is nil
         def initialize(transaction:)
           raise ArgumentError, 'RawTxEntry requires a transaction' if transaction.nil?
@@ -97,13 +97,13 @@ module BSV
 
       # A BEEF entry containing a raw transaction with an associated BUMP index.
       class ProvenTxEntry < BeefTx
-        # @return [Transaction] the transaction
+        # @return [Tx] the transaction
         attr_reader :transaction
 
         # @return [Integer] index into the BEEF bumps array
         attr_reader :bump_index
 
-        # @param transaction [Transaction] the transaction
+        # @param transaction [Tx] the transaction
         # @param bump_index [Integer] index into the bumps array
         # @raise [ArgumentError] if transaction or bump_index is nil
         def initialize(transaction:, bump_index:)
@@ -320,7 +320,7 @@ module BSV
       # Find a transaction in the bundle by its wire-order transaction ID.
       #
       # @param wtxid [String] 32-byte wire-order wtxid
-      # @return [Transaction, nil] the matching transaction, or nil
+      # @return [Tx, nil] the matching transaction, or nil
       def find_transaction(wtxid)
         BSV::Primitives::Hex.validate_wtxid!(wtxid, name: 'wtxid')
         BSV.logger&.debug { "[Beef] find_transaction: #{wtxid.reverse.unpack1('H*')} in #{@transactions.length} entries" }
@@ -353,7 +353,7 @@ module BSV
       # Find a transaction with all source_transactions wired for signing.
       #
       # @param wtxid [String] 32-byte wire-order wtxid
-      # @return [Transaction, nil] the transaction with wired inputs, or nil
+      # @return [Tx, nil] the transaction with wired inputs, or nil
       def find_transaction_for_signing(wtxid)
         BSV::Primitives::Hex.validate_wtxid!(wtxid, name: 'wtxid')
         tx = find_transaction(wtxid)
@@ -367,7 +367,7 @@ module BSV
       # and merkle paths) for atomic proof validation.
       #
       # @param wtxid [String] 32-byte wire-order wtxid
-      # @return [Transaction, nil] the transaction with full proof tree, or nil
+      # @return [Tx, nil] the transaction with full proof tree, or nil
       def find_atomic_transaction(wtxid)
         BSV::Primitives::Hex.validate_wtxid!(wtxid, name: 'wtxid')
         tx = find_transaction(wtxid)
@@ -440,7 +440,7 @@ module BSV
       # (same txid) are upgraded if a stronger format is now available (F5.7):
       # TXID_ONLY → RAW_TX or RAW_TX_AND_BUMP; RAW_TX → RAW_TX_AND_BUMP.
       #
-      # @param tx [Transaction] the transaction to merge
+      # @param tx [Tx] the transaction to merge
       # @return [BeefTx] the (possibly existing or upgraded) BeefTx entry
       def merge_transaction(tx)
         wtxid = tx.wtxid
@@ -479,7 +479,7 @@ module BSV
       # @param bump_index [Integer, nil] optional BUMP index
       # @return [BeefTx] the new or upgraded BeefTx entry
       def merge_raw_tx(raw_bytes, bump_index: nil)
-        tx = Transaction.from_binary(raw_bytes)
+        tx = Tx.from_binary(raw_bytes)
 
         if bump_index
           unless bump_index.is_a?(Integer) && bump_index >= 0 && bump_index < @bumps.length
@@ -740,7 +740,7 @@ module BSV
             case format
             when FORMAT_TXID_ONLY
               # Wire stores txid in internal (little-endian / wire) byte order;
-              # store as-is in known_wtxid so it matches Transaction#wtxid.
+              # store as-is in known_wtxid so it matches Tx#wtxid.
               raise ArgumentError, 'truncated BEEF: not enough bytes for TXID_ONLY entry' if offset + 32 > data.bytesize
 
               known_wtxid = data.byteslice(offset, 32)
@@ -749,12 +749,12 @@ module BSV
             when FORMAT_RAW_TX_AND_BUMP
               bump_index, vi_size = VarInt.decode(data, offset)
               offset += vi_size
-              tx, consumed = Transaction.from_binary_with_offset(data, offset)
+              tx, consumed = Tx.from_binary_with_offset(data, offset)
               offset += consumed
               tx.merkle_path = beef.bumps[bump_index] if bump_index < beef.bumps.length
               beef.transactions << ProvenTxEntry.new(transaction: tx, bump_index: bump_index)
             when FORMAT_RAW_TX
-              tx, consumed = Transaction.from_binary_with_offset(data, offset)
+              tx, consumed = Tx.from_binary_with_offset(data, offset)
               offset += consumed
               beef.transactions << RawTxEntry.new(transaction: tx)
             end
@@ -768,7 +768,7 @@ module BSV
           offset += vi_size
 
           num_txs.times do
-            tx, consumed = Transaction.from_binary_with_offset(data, offset)
+            tx, consumed = Tx.from_binary_with_offset(data, offset)
             offset += consumed
 
             has_bump = data.getbyte(offset)
@@ -821,7 +821,7 @@ module BSV
       #   RAW_TX    → RAW_TX_AND_BUMP (if bump now available)
       #
       # @param existing [BeefTx] the current entry in @transactions
-      # @param tx [Transaction, nil] the raw transaction (may be nil for TXID_ONLY → TXID_ONLY)
+      # @param tx [Tx, nil] the raw transaction (may be nil for TXID_ONLY → TXID_ONLY)
       # @param bump_index [Integer, nil] a BUMP index already validated against @bumps
       # @return [BeefTx, nil] the upgraded entry, or nil when no upgrade is needed
       def upgrade_beef_tx(existing, tx, bump_index: nil)

--- a/gem/bsv-sdk/lib/bsv/transaction/chain_tracker.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/chain_tracker.rb
@@ -4,7 +4,7 @@ module BSV
   module Transaction
     # Duck type for block header lookups used by the SDK's verify methods.
     #
-    # {Beef#verify}, {MerklePath#verify}, and {Transaction#verify} define
+    # {Beef#verify}, {MerklePath#verify}, and {Tx#verify} define
     # what a valid structure *is* — they walk trees, check proofs, and
     # compare roots. But they have no data source of their own. The
     # chain tracker is the data source: an object the consumer provides

--- a/gem/bsv-sdk/lib/bsv/transaction/fee_model.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/fee_model.rb
@@ -17,7 +17,7 @@ module BSV
     class FeeModel
       # Compute the fee for a transaction.
       #
-      # @param transaction [Transaction] the transaction to compute the fee for
+      # @param transaction [Tx] the transaction to compute the fee for
       # @return [Integer] the fee in satoshis
       # @raise [NotImplementedError] if not overridden by a subclass
       def compute_fee(_transaction)

--- a/gem/bsv-sdk/lib/bsv/transaction/fee_models/live_policy.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/fee_models/live_policy.rb
@@ -66,7 +66,7 @@ module BSV
 
         # Compute the fee for a transaction using the latest ARC rate.
         #
-        # @param transaction [Transaction] the transaction to compute the fee for
+        # @param transaction [Tx] the transaction to compute the fee for
         # @return [Integer] the fee in satoshis
         def compute_fee(transaction)
           rate = current_rate

--- a/gem/bsv-sdk/lib/bsv/transaction/fee_models/satoshis_per_kilobyte.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/fee_models/satoshis_per_kilobyte.rb
@@ -23,7 +23,7 @@ module BSV
 
         # Compute the fee for a transaction based on its estimated size.
         #
-        # @param transaction [Transaction] the transaction to compute the fee for
+        # @param transaction [Tx] the transaction to compute the fee for
         # @return [Integer] the fee in satoshis
         def compute_fee(transaction)
           size = transaction.estimated_size

--- a/gem/bsv-sdk/lib/bsv/transaction/merkle_path.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/merkle_path.rb
@@ -450,7 +450,7 @@ module BSV
       # that the extracted path computes the same merkle root as the
       # source.
       #
-      # The primary use case is +Transaction#to_beef+: when a BUMP loaded
+      # The primary use case is +Tx#to_beef+: when a BUMP loaded
       # from a proof store carries +txid: true+ flags for transactions
       # that are not part of the current BEEF bundle, extracting only the
       # bundled txids strips the phantom flags (and the now-unneeded

--- a/gem/bsv-sdk/lib/bsv/transaction/p2pkh.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/p2pkh.rb
@@ -24,7 +24,7 @@ module BSV
 
       # Generate the P2PKH unlocking script for the given input.
       #
-      # @param tx [Transaction] the transaction being signed
+      # @param tx [Tx] the transaction being signed
       # @param input_index [Integer] the input index to sign
       # @return [Script::Script] the unlocking script (signature + pubkey)
       def sign(tx, input_index)

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction_input.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction_input.rb
@@ -26,7 +26,7 @@ module BSV
       # @return [Script::Script, nil] locking script of the source output (needed for sighash)
       attr_accessor :source_locking_script
 
-      # @return [Transaction, nil] the full source transaction (for BEEF wiring)
+      # @return [Tx, nil] the full source transaction (for BEEF wiring)
       attr_accessor :source_transaction
 
       # @return [UnlockingScriptTemplate, nil] template for deferred signing

--- a/gem/bsv-sdk/lib/bsv/transaction/tx.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/tx.rb
@@ -10,12 +10,12 @@ module BSV
     # estimation.
     #
     # @example Build, sign, and serialise a transaction
-    #   tx = BSV::Transaction::Transaction.new
+    #   tx = BSV::Transaction::Tx.new
     #   tx.add_input(input)
     #   tx.add_output(output)
     #   tx.sign(0, private_key)
     #   tx.to_hex #=> "0100000001..."
-    class Transaction
+    class Tx
       # Estimated size of an unsigned P2PKH input in bytes.
       UNSIGNED_P2PKH_INPUT_SIZE = 148
 
@@ -144,7 +144,7 @@ module BSV
       # Deserialise a transaction from binary data.
       #
       # @param data [String] raw binary transaction
-      # @return [Transaction] the parsed transaction
+      # @return [Tx] the parsed transaction
       def self.from_binary(data)
         raise ArgumentError, "truncated transaction: need at least 10 bytes, got #{data.bytesize}" if data.bytesize < 10
 
@@ -182,7 +182,7 @@ module BSV
       # Deserialise a transaction from a hex string.
       #
       # @param hex [String] hex-encoded transaction
-      # @return [Transaction] the parsed transaction
+      # @return [Tx] the parsed transaction
       def self.from_hex(hex)
         from_binary(BSV::Primitives::Hex.decode(hex, name: 'transaction hex'))
       end
@@ -190,7 +190,7 @@ module BSV
       # Deserialise a transaction from Extended Format (BRC-30) binary data.
       #
       # @param data [String] raw EF binary
-      # @return [Transaction] the parsed transaction with source data on inputs
+      # @return [Tx] the parsed transaction with source data on inputs
       # @raise [ArgumentError] if the EF marker is invalid
       def self.from_ef(data)
         raise ArgumentError, "truncated EF transaction: need at least 10 bytes, got #{data.bytesize}" if data.bytesize < 10
@@ -250,7 +250,7 @@ module BSV
       # Deserialise a transaction from an Extended Format hex string.
       #
       # @param hex [String] hex-encoded EF transaction
-      # @return [Transaction] the parsed transaction with source data on inputs
+      # @return [Tx] the parsed transaction with source data on inputs
       def self.from_ef_hex(hex)
         from_ef(BSV::Primitives::Hex.decode(hex, name: 'EF transaction hex'))
       end
@@ -260,7 +260,7 @@ module BSV
       #
       # @param data [String] binary data containing the transaction
       # @param offset [Integer] byte offset to start reading from
-      # @return [Array(Transaction, Integer)] the transaction and bytes consumed
+      # @return [Array(Tx, Integer)] the transaction and bytes consumed
       def self.from_binary_with_offset(data, offset = 0)
         if data.bytesize < offset + 10
           raise ArgumentError, "truncated transaction: need at least 10 bytes at offset #{offset}, got #{data.bytesize - offset}"
@@ -331,7 +331,7 @@ module BSV
         bump_index_by_height = build_beef_bumps(beef, ancestors)
         BSV.logger&.debug do
           proven = ancestors.count(&:merkle_path)
-          "[Transaction] BEEF: #{ancestors.length} ancestors, #{proven} proven " \
+          "[Tx] BEEF: #{ancestors.length} ancestors, #{proven} proven " \
             "across #{bump_index_by_height.length} block heights"
         end
 
@@ -370,7 +370,7 @@ module BSV
       # +wire_source_transactions+ pass in +Beef.from_binary+.
       #
       # @param data [String] raw BEEF binary
-      # @return [Transaction, nil] the subject transaction with ancestry wired,
+      # @return [Tx, nil] the subject transaction with ancestry wired,
       #   or nil if the BEEF is empty or contains no raw transaction entries
       def self.from_beef(data)
         beef = Beef.from_binary(data)
@@ -384,7 +384,7 @@ module BSV
       # Parse a BEEF hex string and return the subject transaction.
       #
       # @param hex [String] hex-encoded BEEF
-      # @return [Transaction, nil] the subject transaction with ancestry wired,
+      # @return [Tx, nil] the subject transaction with ancestry wired,
       #   or nil if the BEEF is empty or contains no raw transaction entries
       def self.from_beef_hex(hex)
         from_beef(BSV::Primitives::Hex.decode(hex, name: 'BEEF hex'))
@@ -400,7 +400,7 @@ module BSV
       # @return [String] 32-byte transaction ID in wire byte order
       def wtxid
         id = BSV::Primitives::Digest.sha256d(to_binary)
-        BSV.logger&.debug { "[Transaction] wtxid computed (dtxid=#{id.reverse.unpack1('H*')})" }
+        BSV.logger&.debug { "[Tx] wtxid computed (dtxid=#{id.reverse.unpack1('H*')})" }
         id
       end
 
@@ -729,7 +729,7 @@ module BSV
       # @return [Integer] estimated fee in satoshis (rounded up)
       def estimated_fee(satoshis_per_byte: 0.1)
         unless self.class.instance_variable_get(:@_estimated_fee_warned)
-          warn '[DEPRECATION] BSV::Transaction::Transaction#estimated_fee is deprecated. ' \
+          warn '[DEPRECATION] BSV::Transaction::Tx#estimated_fee is deprecated. ' \
                'Use BSV::Transaction::FeeModels::SatoshisPerKilobyte.new.compute_fee(tx) instead.', uplevel: 1
           self.class.instance_variable_set(:@_estimated_fee_warned, true)
         end
@@ -913,12 +913,12 @@ module BSV
 
         if tx.merkle_path
           BSV.logger&.debug do
-            "[Transaction] ancestor: #{tx.dtxid_hex} proven at height #{tx.merkle_path.block_height} (leaf stop)"
+            "[Tx] ancestor: #{tx.dtxid_hex} proven at height #{tx.merkle_path.block_height} (leaf stop)"
           end
         else
           tx.inputs.each_with_index do |input, idx|
             unless input.source_transaction
-              BSV.logger&.debug { "[Transaction] ancestor: #{tx.dtxid_hex} input #{idx} has no source_transaction (skipped)" }
+              BSV.logger&.debug { "[Tx] ancestor: #{tx.dtxid_hex} input #{idx} has no source_transaction (skipped)" }
               next
             end
 

--- a/gem/bsv-sdk/lib/bsv/transaction/unlocking_script_template.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/unlocking_script_template.rb
@@ -14,7 +14,7 @@ module BSV
     class UnlockingScriptTemplate
       # Generate the unlocking script for a transaction input.
       #
-      # @param _tx [Transaction] the transaction being signed
+      # @param _tx [Tx] the transaction being signed
       # @param _input_index [Integer] the input index to sign
       # @return [Script::Script] the generated unlocking script
       # @raise [NotImplementedError] if not overridden by a subclass
@@ -24,7 +24,7 @@ module BSV
 
       # Estimate the unlocking script length in bytes (for fee estimation).
       #
-      # @param _tx [Transaction] the transaction
+      # @param _tx [Tx] the transaction
       # @param _input_index [Integer] the input index
       # @return [Integer] estimated script length in bytes
       # @raise [NotImplementedError] if not overridden by a subclass

--- a/gem/bsv-sdk/spec/bsv/identity/client_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/identity/client_spec.rb
@@ -228,8 +228,8 @@ RSpec.describe 'BSV::Identity::Client' do
         prove_certificate: { keyring_for_verifier: keyring },
         create_action: { tx: beef_bytes, txid: 'ab' * 32 }
       )
-      allow(BSV::Transaction::Transaction).to receive(:from_beef)
-        .and_return(instance_double(BSV::Transaction::Transaction, txid_hex: 'ab' * 32))
+      allow(BSV::Transaction::Tx).to receive(:from_beef)
+        .and_return(instance_double(BSV::Transaction::Tx, txid_hex: 'ab' * 32))
       allow(broadcaster).to receive(:broadcast).and_return(broadcast_result)
     end
 
@@ -321,7 +321,7 @@ RSpec.describe 'BSV::Identity::Client' do
 
     # Minimal BEEF-like stub: just needs to respond to .transactions.last.transaction
     let(:mock_output) { instance_double(BSV::Transaction::TransactionOutput) }
-    let(:inner_tx) { instance_double(BSV::Transaction::Transaction, txid_hex: 'deadbeef01', outputs: [mock_output]) }
+    let(:inner_tx) { instance_double(BSV::Transaction::Tx, txid_hex: 'deadbeef01', outputs: [mock_output]) }
     let(:beef_tx) { instance_double(BSV::Transaction::Beef::RawTxEntry, transaction: inner_tx) }
     let(:beef_obj) { instance_double(BSV::Transaction::Beef, transactions: [beef_tx]) }
     let(:beef_bytes) { 'fake_beef' }
@@ -329,8 +329,8 @@ RSpec.describe 'BSV::Identity::Client' do
     let(:output) { { 'beef' => beef_bytes, 'outputIndex' => 0 } }
     let(:answer) { BSV::Overlay::LookupAnswer.new(type: 'output-list', outputs: [output]) }
 
-    let(:partial_tx) { instance_double(BSV::Transaction::Transaction) }
-    let(:signed_tx) { instance_double(BSV::Transaction::Transaction) }
+    let(:partial_tx) { instance_double(BSV::Transaction::Tx) }
+    let(:signed_tx) { instance_double(BSV::Transaction::Tx) }
     let(:mock_script) { instance_double(BSV::Script::Script, to_hex: '00' * 107) }
     let(:mock_unlocker) { instance_double(BSV::Script::PushDropTemplate::Unlocker, sign: mock_script) }
     let(:mock_template) { instance_double(BSV::Script::PushDropTemplate, unlock: mock_unlocker) }
@@ -351,9 +351,9 @@ RSpec.describe 'BSV::Identity::Client' do
         end
       end
 
-      allow(BSV::Transaction::Transaction).to receive(:from_beef).with(beef_bytes).and_return(partial_tx)
+      allow(BSV::Transaction::Tx).to receive(:from_beef).with(beef_bytes).and_return(partial_tx)
       allow(wallet).to receive(:sign_action).and_return({ tx: 'signed_beef', txid: 'de' * 32 })
-      allow(BSV::Transaction::Transaction).to receive(:from_beef).with('signed_beef').and_return(signed_tx)
+      allow(BSV::Transaction::Tx).to receive(:from_beef).with('signed_beef').and_return(signed_tx)
       allow(broadcaster).to receive(:broadcast).and_return(broadcast_result)
     end
 

--- a/gem/bsv-sdk/spec/bsv/mcp/integration_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/mcp/integration_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe 'BSV MCP server — protocol integration' do
         '00000000'
     end
 
-    # Verified by parsing with BSV::Transaction::Transaction.from_hex.
+    # Verified by parsing with BSV::Transaction::Tx.from_hex.
     let(:expected_txid) { '45200ad773a26a07189cb2390853f608ff7237e092fe182aa896ea0a013dc2eb' }
 
     let(:call_request) do

--- a/gem/bsv-sdk/spec/bsv/network/protocols/arc_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/arc_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe BSV::Network::Protocols::ARC do
   end
 
   def make_tx(ef_hex: nil, hex: 'deadbeef')
-    tx = instance_double(BSV::Transaction::Transaction)
+    tx = instance_double(BSV::Transaction::Tx)
     if ef_hex
       allow(tx).to receive(:to_ef_hex).and_return(ef_hex)
     else

--- a/gem/bsv-sdk/spec/bsv/network/protocols/arcade_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/arcade_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe BSV::Network::Protocols::Arcade do
   end
 
   def make_tx(ef_hex: nil, hex: 'deadbeef')
-    tx = instance_double(BSV::Transaction::Transaction)
+    tx = instance_double(BSV::Transaction::Tx)
     if ef_hex
       allow(tx).to receive(:to_ef_hex).and_return(ef_hex)
     else

--- a/gem/bsv-sdk/spec/bsv/network/protocols/broadcast_integration_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/network/protocols/broadcast_integration_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Live broadcast', :integration do # rubocop:disable RSpec/Describ
 
     output = BSV::Transaction::TransactionOutput.new(satoshis: change, locking_script: lock_script)
 
-    t = BSV::Transaction::Transaction.new
+    t = BSV::Transaction::Tx.new
     t.add_input(input)
     t.add_output(output)
     t.sign_all(private_key)

--- a/gem/bsv-sdk/spec/bsv/overlay/admin_token_template_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/overlay/admin_token_template_spec.rb
@@ -298,7 +298,7 @@ RSpec.describe BSV::Overlay::AdminTokenTemplate do
       satoshis = 1_000
 
       # Source transaction: contains the locked output.
-      source_tx = BSV::Transaction::Transaction.new
+      source_tx = BSV::Transaction::Tx.new
       dummy_input = BSV::Transaction::TransactionInput.new(
         prev_wtxid: "\x00" * 32,
         prev_tx_out_index: 0
@@ -312,7 +312,7 @@ RSpec.describe BSV::Overlay::AdminTokenTemplate do
       )
 
       # Spending transaction: spends the locked output.
-      spend_tx = BSV::Transaction::Transaction.new
+      spend_tx = BSV::Transaction::Tx.new
       spend_input = BSV::Transaction::TransactionInput.new(
         prev_wtxid: source_tx.wtxid,
         prev_tx_out_index: 0,

--- a/gem/bsv-sdk/spec/bsv/overlay/lookup_resolver_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/overlay/lookup_resolver_spec.rb
@@ -31,7 +31,7 @@ module LookupResolverSpecHelpers
   def slap_beef(domain:, service:)
     script = slap_script(domain: domain, service: service)
     tx_out = BSV::Transaction::TransactionOutput.new(satoshis: 1, locking_script: script)
-    tx     = BSV::Transaction::Transaction.new
+    tx     = BSV::Transaction::Tx.new
     tx.add_output(tx_out)
     beef = BSV::Transaction::Beef.new
     beef.merge_transaction(tx)
@@ -43,7 +43,7 @@ module LookupResolverSpecHelpers
   def plain_beef
     script = dummy_lock_script
     tx_out = BSV::Transaction::TransactionOutput.new(satoshis: 1, locking_script: script)
-    tx     = BSV::Transaction::Transaction.new
+    tx     = BSV::Transaction::Tx.new
     tx.add_output(tx_out)
     beef = BSV::Transaction::Beef.new
     beef.merge_transaction(tx)
@@ -202,7 +202,7 @@ RSpec.describe 'BSV::Overlay::LookupResolver' do
         BSV::Script::Script.p2pkh_lock(("\x00" * 20).b)
       )
       tx_out = BSV::Transaction::TransactionOutput.new(satoshis: 1, locking_script: ship_script_val)
-      tx     = BSV::Transaction::Transaction.new
+      tx     = BSV::Transaction::Tx.new
       tx.add_output(tx_out)
       beef = BSV::Transaction::Beef.new
       beef.merge_transaction(tx)

--- a/gem/bsv-sdk/spec/bsv/overlay/topic_broadcaster_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/overlay/topic_broadcaster_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe BSV::Overlay::TopicBroadcaster do
   let(:mock_txid) { "#{'aabbcc' * 10}aabb" }
 
   let(:mock_tx) do
-    tx = instance_double(BSV::Transaction::Transaction)
+    tx = instance_double(BSV::Transaction::Tx)
     allow(tx).to receive_messages(to_beef: "\xbe\xef\x01", txid_hex: mock_txid)
     tx
   end

--- a/gem/bsv-sdk/spec/bsv/registry/client_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/registry/client_spec.rb
@@ -67,8 +67,8 @@ RSpec.describe 'BSV::Registry::Client' do
     before do
       allow(BSV::Script::PushDropTemplate).to receive(:new).and_return(mock_template)
       allow(wallet).to receive(:create_action).and_return({ tx: REGISTRY_SPEC_BEEF_BYTES })
-      allow(BSV::Transaction::Transaction).to receive(:from_beef)
-        .and_return(instance_double(BSV::Transaction::Transaction, txid_hex: REGISTRY_SPEC_TXID))
+      allow(BSV::Transaction::Tx).to receive(:from_beef)
+        .and_return(instance_double(BSV::Transaction::Tx, txid_hex: REGISTRY_SPEC_TXID))
       allow(broadcaster).to receive(:broadcast).and_return(broadcast_result)
     end
 
@@ -177,8 +177,8 @@ RSpec.describe 'BSV::Registry::Client' do
     before do
       allow(BSV::Script::PushDropTemplate).to receive(:new).and_return(mock_template)
       allow(wallet).to receive(:create_action).and_return({ tx: REGISTRY_SPEC_BEEF_BYTES })
-      allow(BSV::Transaction::Transaction).to receive(:from_beef)
-        .and_return(instance_double(BSV::Transaction::Transaction, txid_hex: REGISTRY_SPEC_TXID))
+      allow(BSV::Transaction::Tx).to receive(:from_beef)
+        .and_return(instance_double(BSV::Transaction::Tx, txid_hex: REGISTRY_SPEC_TXID))
       allow(broadcaster).to receive(:broadcast).and_return(broadcast_result)
     end
 
@@ -254,7 +254,7 @@ RSpec.describe 'BSV::Registry::Client' do
         locking_script: mock_locking_script,
         satoshis: 1
       )
-      instance_double(BSV::Transaction::Transaction,
+      instance_double(BSV::Transaction::Tx,
                       txid_hex: REGISTRY_SPEC_TXID,
                       outputs: [tx_output])
     end
@@ -423,7 +423,7 @@ RSpec.describe 'BSV::Registry::Client' do
     end
 
     let(:mock_tx) do
-      instance_double(BSV::Transaction::Transaction,
+      instance_double(BSV::Transaction::Tx,
                       txid_hex: REGISTRY_SPEC_TXID,
                       outputs: [mock_tx_output])
     end
@@ -533,17 +533,17 @@ RSpec.describe 'BSV::Registry::Client' do
       )
     end
 
-    let(:partial_tx) { instance_double(BSV::Transaction::Transaction) }
-    let(:signed_tx)  { instance_double(BSV::Transaction::Transaction) }
+    let(:partial_tx) { instance_double(BSV::Transaction::Tx) }
+    let(:signed_tx)  { instance_double(BSV::Transaction::Tx) }
     let(:mock_unlock_script) { instance_double(BSV::Script::Script, to_hex: '00' * 107) }
     let(:mock_unlocker) { instance_double(BSV::Script::PushDropTemplate::Unlocker, sign: mock_unlock_script) }
     let(:mock_template_revoke) { instance_double(BSV::Script::PushDropTemplate, unlock: mock_unlocker) }
 
     before do
       allow(BSV::Script::PushDropTemplate).to receive(:new).and_return(mock_template_revoke)
-      allow(BSV::Transaction::Transaction).to receive(:from_beef).with(REGISTRY_SPEC_BEEF_BYTES).and_return(partial_tx)
+      allow(BSV::Transaction::Tx).to receive(:from_beef).with(REGISTRY_SPEC_BEEF_BYTES).and_return(partial_tx)
       allow(wallet).to receive_messages(create_action: { signable_transaction: { tx: REGISTRY_SPEC_BEEF_BYTES, reference: 'REF456' } }, sign_action: { tx: 'signed_beef' })
-      allow(BSV::Transaction::Transaction).to receive(:from_beef).with('signed_beef').and_return(signed_tx)
+      allow(BSV::Transaction::Tx).to receive(:from_beef).with('signed_beef').and_return(signed_tx)
       allow(broadcaster).to receive(:broadcast).and_return(broadcast_result)
     end
 
@@ -636,8 +636,8 @@ RSpec.describe 'BSV::Registry::Client' do
       )
     end
 
-    let(:partial_tx) { instance_double(BSV::Transaction::Transaction) }
-    let(:signed_tx)  { instance_double(BSV::Transaction::Transaction) }
+    let(:partial_tx) { instance_double(BSV::Transaction::Tx) }
+    let(:signed_tx)  { instance_double(BSV::Transaction::Tx) }
     let(:mock_unlock_script) { instance_double(BSV::Script::Script, to_hex: '00' * 107) }
     let(:mock_unlocker) { instance_double(BSV::Script::PushDropTemplate::Unlocker, sign: mock_unlock_script) }
     let(:mock_template_update) { instance_double(BSV::Script::PushDropTemplate, lock: mock_script, unlock: mock_unlocker) }
@@ -653,9 +653,9 @@ RSpec.describe 'BSV::Registry::Client' do
         end
       end
 
-      allow(BSV::Transaction::Transaction).to receive(:from_beef).with(REGISTRY_SPEC_BEEF_BYTES).and_return(partial_tx)
+      allow(BSV::Transaction::Tx).to receive(:from_beef).with(REGISTRY_SPEC_BEEF_BYTES).and_return(partial_tx)
       allow(wallet).to receive(:sign_action).and_return({ tx: 'signed_beef' })
-      allow(BSV::Transaction::Transaction).to receive(:from_beef).with('signed_beef').and_return(signed_tx)
+      allow(BSV::Transaction::Tx).to receive(:from_beef).with('signed_beef').and_return(signed_tx)
       allow(broadcaster).to receive(:broadcast).and_return(broadcast_result)
     end
 

--- a/gem/bsv-sdk/spec/bsv/script/interpreter/hardening_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/script/interpreter/hardening_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe 'A6 Interpreter Hardening' do
       pub = priv.public_key
       lock_script = BSV::Script::Script.p2pk_lock(pub.compressed)
 
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       input = BSV::Transaction::TransactionInput.new(
         prev_wtxid: "\x00" * 32,
         prev_tx_out_index: 0

--- a/gem/bsv-sdk/spec/bsv/script/interpreter/interpreter_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/script/interpreter/interpreter_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe BSV::Script::Interpreter do
     end
   end
 
-  describe 'Transaction#verify_input' do
+  describe 'Tx#verify_input' do
     it 'verifies a P2PKH input' do
       ctx = build_p2pkh_tx
       expect(ctx[:tx].verify_input(0)).to be true

--- a/gem/bsv-sdk/spec/bsv/script/interpreter/interpreter_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/script/interpreter/interpreter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe BSV::Script::Interpreter do
     pub = priv.public_key
     lock_script = BSV::Script::Script.p2pkh_lock(pub.hash160)
 
-    tx = BSV::Transaction::Transaction.new
+    tx = BSV::Transaction::Tx.new
     input = BSV::Transaction::TransactionInput.new(
       prev_wtxid: "\x00" * 32,
       prev_tx_out_index: 0
@@ -38,7 +38,7 @@ RSpec.describe BSV::Script::Interpreter do
     pub = priv.public_key
     lock_script = BSV::Script::Script.p2pk_lock(pub.compressed)
 
-    tx = BSV::Transaction::Transaction.new
+    tx = BSV::Transaction::Tx.new
     input = BSV::Transaction::TransactionInput.new(
       prev_wtxid: "\x00" * 32,
       prev_tx_out_index: 0
@@ -65,7 +65,7 @@ RSpec.describe BSV::Script::Interpreter do
     pubkeys = keys.map { |k| k.public_key.compressed }
     lock_script = BSV::Script::Script.p2ms_lock(2, pubkeys)
 
-    tx = BSV::Transaction::Transaction.new
+    tx = BSV::Transaction::Tx.new
     input = BSV::Transaction::TransactionInput.new(
       prev_wtxid: "\x00" * 32,
       prev_tx_out_index: 0
@@ -267,7 +267,7 @@ RSpec.describe BSV::Script::Interpreter do
         "OP_IF #{pub.to_hex} OP_CHECKSIG OP_ELSE OP_0 OP_ENDIF"
       )
 
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       input = BSV::Transaction::TransactionInput.new(prev_wtxid: "\x00" * 32, prev_tx_out_index: 0)
       input.source_locking_script = lock_script
       input.source_satoshis = 100_000
@@ -300,7 +300,7 @@ RSpec.describe BSV::Script::Interpreter do
         "OP_IF #{pub.to_hex} OP_CHECKSIG OP_ELSE OP_0 OP_ENDIF"
       )
 
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       input = BSV::Transaction::TransactionInput.new(prev_wtxid: "\x00" * 32, prev_tx_out_index: 0)
       input.source_locking_script = lock_script
       input.source_satoshis = 100_000

--- a/gem/bsv-sdk/spec/bsv/script/interpreter/operations/chronicle_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/script/interpreter/operations/chronicle_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Chronicle opcodes' do
   # OP_VER / OP_VERIF / OP_VERNOTIF scripts need no signatures — the transaction
   # just needs inputs and outputs to satisfy the Transaction structure.
   def build_ver_tx(version:)
-    tx = BSV::Transaction::Transaction.new(version: version)
+    tx = BSV::Transaction::Tx.new(version: version)
     input = BSV::Transaction::TransactionInput.new(
       prev_wtxid: "\x00" * 32,
       prev_tx_out_index: 0

--- a/gem/bsv-sdk/spec/bsv/script/interpreter/operations/crypto_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/script/interpreter/operations/crypto_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe BSV::Script::Interpreter do
     pub = priv.public_key
     lock_script = BSV::Script::Script.p2pkh_lock(pub.hash160)
 
-    tx = BSV::Transaction::Transaction.new
+    tx = BSV::Transaction::Tx.new
     input = BSV::Transaction::TransactionInput.new(
       prev_wtxid: "\x00" * 32,
       prev_tx_out_index: 0
@@ -43,7 +43,7 @@ RSpec.describe BSV::Script::Interpreter do
     pub = priv.public_key
     lock_script = BSV::Script::Script.p2pk_lock(pub.compressed)
 
-    tx = BSV::Transaction::Transaction.new
+    tx = BSV::Transaction::Tx.new
     input = BSV::Transaction::TransactionInput.new(
       prev_wtxid: "\x00" * 32,
       prev_tx_out_index: 0
@@ -184,7 +184,7 @@ RSpec.describe BSV::Script::Interpreter do
       # Lock: <pubkey> CHECKSIGVERIFY OP_1
       lock_script = BSV::Script::Script.from_asm("#{pub.to_hex} OP_CHECKSIGVERIFY OP_1")
 
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       input = BSV::Transaction::TransactionInput.new(prev_wtxid: "\x00" * 32, prev_tx_out_index: 0)
       input.source_locking_script = lock_script
       input.source_satoshis = 100_000
@@ -219,7 +219,7 @@ RSpec.describe BSV::Script::Interpreter do
       lock_script = BSV::Script::Script.p2ms_lock(1,
                                                   [pub1.compressed, pub2.compressed])
 
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       input = BSV::Transaction::TransactionInput.new(
         prev_wtxid: "\x00" * 32, prev_tx_out_index: 0
       )
@@ -257,7 +257,7 @@ RSpec.describe BSV::Script::Interpreter do
       lock_script = BSV::Script::Script.p2ms_lock(2,
                                                   [pub1.compressed, pub2.compressed])
 
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       input = BSV::Transaction::TransactionInput.new(
         prev_wtxid: "\x00" * 32, prev_tx_out_index: 0
       )
@@ -295,7 +295,7 @@ RSpec.describe BSV::Script::Interpreter do
       lock_script = BSV::Script::Script.p2ms_lock(2,
                                                   [pub1.compressed, pub2.compressed])
 
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       input = BSV::Transaction::TransactionInput.new(
         prev_wtxid: "\x00" * 32, prev_tx_out_index: 0
       )
@@ -333,7 +333,7 @@ RSpec.describe BSV::Script::Interpreter do
       pub = priv.public_key
       lock_script = BSV::Script::Script.p2ms_lock(1, [pub.compressed])
 
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       input = BSV::Transaction::TransactionInput.new(prev_wtxid: "\x00" * 32, prev_tx_out_index: 0)
       input.source_locking_script = lock_script
       input.source_satoshis = 100_000

--- a/gem/bsv-sdk/spec/bsv/script/push_drop_template_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/script/push_drop_template_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe 'BSV::Script::PushDropTemplate' do
   # Sets +source_locking_script+ and +source_satoshis+ on the input so the
   # sighash computation has everything it needs.
   def build_spending_tx(lock_script, satoshis:)
-    tx = BSV::Transaction::Transaction.new
+    tx = BSV::Transaction::Tx.new
     input = BSV::Transaction::TransactionInput.new(
       prev_wtxid: "\x00" * 32,
       prev_tx_out_index: 0

--- a/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
@@ -1475,7 +1475,7 @@ RSpec.describe BSV::Transaction::Beef do
     end
   end
 
-  describe 'Transaction.from_binary_with_offset' do
+  describe 'Tx.from_binary_with_offset' do
     it 'returns correct bytes consumed' do
       hex = '010000000193a35408b6068499e0d5abd799d3e827d9bfe70c9b75ebe209c91d2507232651' \
             '0000000000ffffffff02404b4c00000000001976a91404ff367be719efa79d76e4416ffb07' \

--- a/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe BSV::Transaction::Beef do
 
     it 'parses transactions with expected structure' do
       beef.transactions.each do |beef_tx|
-        expect(beef_tx.transaction).to be_a(BSV::Transaction::Transaction)
+        expect(beef_tx.transaction).to be_a(BSV::Transaction::Tx)
         expect(beef_tx.transaction.inputs).not_to be_empty
         expect(beef_tx.transaction.outputs).not_to be_empty
       end
@@ -329,12 +329,12 @@ RSpec.describe BSV::Transaction::Beef do
     end
   end
 
-  describe 'Transaction.from_beef / Transaction#to_beef' do
-    it 'round-trips Transaction.from_beef through the V2 vector' do
+  describe 'Tx.from_beef / Tx#to_beef' do
+    it 'round-trips Tx.from_beef through the V2 vector' do
       beef_data = [beef_set_hex].pack('H*')
-      tx = BSV::Transaction::Transaction.from_beef(beef_data)
+      tx = BSV::Transaction::Tx.from_beef(beef_data)
 
-      expect(tx).to be_a(BSV::Transaction::Transaction)
+      expect(tx).to be_a(BSV::Transaction::Tx)
       # Subject tx is the last one in the bundle
       beef = described_class.from_hex(beef_set_hex)
       expected_wtxid = beef.transactions.last.transaction.wtxid
@@ -342,19 +342,19 @@ RSpec.describe BSV::Transaction::Beef do
     end
 
     it 'round-trips via from_beef_hex' do
-      tx = BSV::Transaction::Transaction.from_beef_hex(beef_set_hex)
-      expect(tx).to be_a(BSV::Transaction::Transaction)
+      tx = BSV::Transaction::Tx.from_beef_hex(beef_set_hex)
+      expect(tx).to be_a(BSV::Transaction::Tx)
     end
 
     it 'wires source transactions on the returned transaction' do
-      tx = BSV::Transaction::Transaction.from_beef_hex(beef_set_hex)
+      tx = BSV::Transaction::Tx.from_beef_hex(beef_set_hex)
       wired = tx.inputs.select(&:source_transaction)
       expect(wired).not_to be_empty
     end
 
     it 'builds a BEEF from a transaction with ancestry' do
       # Parse the BEEF to get a transaction with wired sources
-      tx = BSV::Transaction::Transaction.from_beef_hex(beef_set_hex)
+      tx = BSV::Transaction::Tx.from_beef_hex(beef_set_hex)
 
       # Rebuild BEEF from that transaction
       beef_binary = tx.to_beef
@@ -371,7 +371,7 @@ RSpec.describe BSV::Transaction::Beef do
     end
 
     it 'to_beef_hex returns a hex string' do
-      tx = BSV::Transaction::Transaction.from_beef_hex(beef_set_hex)
+      tx = BSV::Transaction::Tx.from_beef_hex(beef_set_hex)
       hex = tx.to_beef_hex
       expect(hex).to match(/\A[0-9a-f]+\z/)
       expect([hex].pack('H*').byteslice(0, 4).unpack1('V')).to eq(BSV::Transaction::Beef::BEEF_V1)
@@ -383,7 +383,7 @@ RSpec.describe BSV::Transaction::Beef do
       lock = BSV::Script::Script.p2pkh_lock(priv.public_key.hash160)
       pe = BSV::Transaction::MerklePath::PathElement
 
-      ancestor_a = BSV::Transaction::Transaction.new
+      ancestor_a = BSV::Transaction::Tx.new
       ancestor_a.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 5000, locking_script: lock))
       ancestor_a.merkle_path = BSV::Transaction::MerklePath.new(
         block_height: 800_000,
@@ -391,7 +391,7 @@ RSpec.describe BSV::Transaction::Beef do
                 pe.new(offset: 1, hash: ['aa' * 32].pack('H*'))]]
       )
 
-      ancestor_b = BSV::Transaction::Transaction.new(version: 2)
+      ancestor_b = BSV::Transaction::Tx.new(version: 2)
       ancestor_b.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 3000, locking_script: lock))
       ancestor_b.merkle_path = BSV::Transaction::MerklePath.new(
         block_height: 800_000,
@@ -400,7 +400,7 @@ RSpec.describe BSV::Transaction::Beef do
       )
 
       # Build a child spending both
-      child = BSV::Transaction::Transaction.new
+      child = BSV::Transaction::Tx.new
       input_a = BSV::Transaction::TransactionInput.new(prev_wtxid: ancestor_a.wtxid, prev_tx_out_index: 0)
       input_a.source_transaction = ancestor_a
       input_a.source_satoshis = 5000
@@ -446,7 +446,7 @@ RSpec.describe BSV::Transaction::Beef do
     # Build a synthetic 4-leaf merkle tree so two single-leaf BUMPs for
     # different leaves can share the same merkle root and collapse under
     # merge_bump. The txid-flagged leaves use the real txids of the
-    # synthetic transactions below so that Transaction#to_beef's extract
+    # synthetic transactions below so that Tx#to_beef's extract
     # pass finds them.
     let(:mp_class) { BSV::Transaction::MerklePath }
     let(:pe) { mp_class::PathElement }
@@ -454,12 +454,12 @@ RSpec.describe BSV::Transaction::Beef do
 
     # Proven ancestors at offsets 1 and 2 of the synthetic 4-leaf block.
     let(:tx_a) do
-      t = BSV::Transaction::Transaction.new
+      t = BSV::Transaction::Tx.new
       t.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 100, locking_script: lock))
       t
     end
     let(:tx_b) do
-      t = BSV::Transaction::Transaction.new(version: 2)
+      t = BSV::Transaction::Tx.new(version: 2)
       t.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 200, locking_script: lock))
       t
     end
@@ -505,7 +505,7 @@ RSpec.describe BSV::Transaction::Beef do
       tx_a.merkle_path = path_a
       tx_b.merkle_path = path_b
 
-      child = BSV::Transaction::Transaction.new
+      child = BSV::Transaction::Tx.new
       input_a = BSV::Transaction::TransactionInput.new(prev_wtxid: tx_a.wtxid, prev_tx_out_index: 0)
       input_a.source_transaction = tx_a
       child.add_input(input_a)
@@ -577,7 +577,7 @@ RSpec.describe BSV::Transaction::Beef do
       expect(parsed.bumps.length).to eq(1)
     end
 
-    it 'serialises exactly one BUMP via Transaction#to_beef' do
+    it 'serialises exactly one BUMP via Tx#to_beef' do
       child = attach_paths_and_build_child
 
       parsed = described_class.from_binary(child.to_beef)
@@ -593,10 +593,10 @@ RSpec.describe BSV::Transaction::Beef do
   # resulting stored BUMP entry in LocalProofStore carries txid-flagged leaves
   # for every txid in the original compound — including ones unrelated to
   # the tx being stored. When a subsequent tx spends those UTXOs and calls
-  # Transaction#to_beef, the phantom flags were previously propagated into
+  # Tx#to_beef, the phantom flags were previously propagated into
   # the emitted BEEF, which ARC rejects.
   #
-  # The fix is in Transaction#to_beef (which now groups ancestors by block,
+  # The fix is in Tx#to_beef (which now groups ancestors by block,
   # combines their merkle paths, and calls MerklePath#extract with the bundle
   # txids to produce clean BUMPs) backed by MerklePath#extract and #trim.
   describe 'phantom txid leaves in to_beef (issue #302)' do
@@ -607,7 +607,7 @@ RSpec.describe BSV::Transaction::Beef do
 
       # The real proven ancestor — sits at offset 0 in the block merkle tree.
       let(:tx_real) do
-        t = BSV::Transaction::Transaction.new
+        t = BSV::Transaction::Tx.new
         t.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 500, locking_script: lock))
         t
       end
@@ -649,7 +649,7 @@ RSpec.describe BSV::Transaction::Beef do
       let(:child) do
         tx_real.merkle_path = contaminated_bump
 
-        c = BSV::Transaction::Transaction.new
+        c = BSV::Transaction::Tx.new
         input = BSV::Transaction::TransactionInput.new(prev_wtxid: tx_real.wtxid, prev_tx_out_index: 0)
         input.source_transaction = tx_real
         c.add_input(input)
@@ -811,7 +811,7 @@ RSpec.describe BSV::Transaction::Beef do
       beef = described_class.from_hex(beef_set_hex)
       last_tx = beef.transactions.last.transaction
       found = beef.find_transaction_for_signing(last_tx.wtxid)
-      expect(found).to be_a(BSV::Transaction::Transaction)
+      expect(found).to be_a(BSV::Transaction::Tx)
       expect(found.wtxid).to eq(last_tx.wtxid)
     end
 
@@ -826,7 +826,7 @@ RSpec.describe BSV::Transaction::Beef do
       beef = described_class.from_hex(beef_set_hex)
       last_tx = beef.transactions.last.transaction
       found = beef.find_atomic_transaction(last_tx.wtxid)
-      expect(found).to be_a(BSV::Transaction::Transaction)
+      expect(found).to be_a(BSV::Transaction::Tx)
       expect(found.wtxid).to eq(last_tx.wtxid)
     end
   end
@@ -906,21 +906,21 @@ RSpec.describe BSV::Transaction::Beef do
 
   describe 'BeefTx initialisation invariants' do
     it 'raises when ProvenTxEntry is constructed without a bump_index' do
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       expect do
         described_class::ProvenTxEntry.new(transaction: tx, bump_index: nil)
       end.to raise_error(ArgumentError, /ProvenTxEntry requires a bump_index/)
     end
 
     it 'accepts ProvenTxEntry with a bump_index' do
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       expect do
         described_class::ProvenTxEntry.new(transaction: tx, bump_index: 0)
       end.not_to raise_error
     end
 
     it 'accepts RawTxEntry without a bump_index' do
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       expect do
         described_class::RawTxEntry.new(transaction: tx)
       end.not_to raise_error
@@ -1010,7 +1010,7 @@ RSpec.describe BSV::Transaction::Beef do
       # a bump_index that doesn't exist in @bumps.
       source = described_class.from_hex(brc62_hex)
       bogus_entry = described_class::ProvenTxEntry.new(
-        transaction: BSV::Transaction::Transaction.new(version: 99), # unique txid
+        transaction: BSV::Transaction::Tx.new(version: 99), # unique txid
         bump_index: source.bumps.length + 42
       )
       source.transactions << bogus_entry
@@ -1056,7 +1056,7 @@ RSpec.describe BSV::Transaction::Beef do
     it 'returns false when an unproven transaction has missing ancestors' do
       # Create a BEEF with a raw tx (no BUMP) whose input references a txid not in the bundle
       beef = described_class.new
-      tx = BSV::Transaction::Transaction.from_hex(
+      tx = BSV::Transaction::Tx.from_hex(
         '010000000193a35408b6068499e0d5abd799d3e827d9bfe70c9b75ebe209c91d25072326510000000000ffffffff' \
         '02404b4c00000000001976a91404ff367be719efa79d76e4416ffb072cd53b208888acde94a905000000001976a914' \
         '04d03f746652cfcb6cb55119ab473a045137d26588ac00000000'
@@ -1156,7 +1156,7 @@ RSpec.describe BSV::Transaction::Beef do
     it 'returns false when a FORMAT_RAW_TX_AND_BUMP entry has no BUMP' do
       # Construct a BeefTx that claims RAW_TX_AND_BUMP but the bumps array is empty
       beef = described_class.new
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 100, locking_script: BSV::Script::Script.new))
       # Add a real BUMP (from the brc62 vector) so BeefTx construction succeeds,
       # but the BUMP won't contain the fresh tx's txid — compute_root will raise.
@@ -1185,7 +1185,7 @@ RSpec.describe BSV::Transaction::Beef do
 
     it 'returns false for a structurally invalid bundle' do
       bad_beef = described_class.new
-      tx = BSV::Transaction::Transaction.from_hex(
+      tx = BSV::Transaction::Tx.from_hex(
         '010000000193a35408b6068499e0d5abd799d3e827d9bfe70c9b75ebe209c91d25072326510000000000ffffffff' \
         '02404b4c00000000001976a91404ff367be719efa79d76e4416ffb072cd53b208888acde94a905000000001976a914' \
         '04d03f746652cfcb6cb55119ab473a045137d26588ac00000000'
@@ -1240,8 +1240,8 @@ RSpec.describe BSV::Transaction::Beef do
       input_a = instance_double(BSV::Transaction::TransactionInput, prev_wtxid: wtxid_b)
       input_b = instance_double(BSV::Transaction::TransactionInput, prev_wtxid: wtxid_a)
 
-      tx_a = instance_double(BSV::Transaction::Transaction, wtxid: wtxid_a, inputs: [input_a])
-      tx_b = instance_double(BSV::Transaction::Transaction, wtxid: wtxid_b, inputs: [input_b])
+      tx_a = instance_double(BSV::Transaction::Tx, wtxid: wtxid_a, inputs: [input_a])
+      tx_b = instance_double(BSV::Transaction::Tx, wtxid: wtxid_b, inputs: [input_b])
 
       beef = described_class.new
       beef.transactions << described_class::RawTxEntry.new(transaction: tx_a)
@@ -1289,7 +1289,7 @@ RSpec.describe BSV::Transaction::Beef do
 
     it 'upgrades existing FORMAT_RAW_TX entries to FORMAT_RAW_TX_AND_BUMP when BUMP arrives' do
       beef = described_class.new
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 500, locking_script: BSV::Script::Script.new))
 
       # Add as raw tx first
@@ -1331,7 +1331,7 @@ RSpec.describe BSV::Transaction::Beef do
     let(:lock) { BSV::Script::Script.new }
 
     def make_tx
-      t = BSV::Transaction::Transaction.new
+      t = BSV::Transaction::Tx.new
       t.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 100, locking_script: lock))
       t
     end
@@ -1426,7 +1426,7 @@ RSpec.describe BSV::Transaction::Beef do
 
     it 'finds a BUMP via @bumps when there is no transaction-table entry' do
       beef = described_class.new
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 100, locking_script: BSV::Script::Script.new))
 
       sibling = BSV::Primitives::Digest.sha256('sibling')
@@ -1485,7 +1485,7 @@ RSpec.describe BSV::Transaction::Beef do
       trailing = "\xFF".b * 10
       data = binary + trailing
 
-      tx, consumed = BSV::Transaction::Transaction.from_binary_with_offset(data)
+      tx, consumed = BSV::Transaction::Tx.from_binary_with_offset(data)
       expect(consumed).to eq(binary.bytesize)
       expect(tx.inputs.length).to eq(1)
       expect(tx.outputs.length).to eq(2)
@@ -1498,8 +1498,8 @@ RSpec.describe BSV::Transaction::Beef do
             'd26588ac00000000'
       binary = [hex].pack('H*')
 
-      tx1 = BSV::Transaction::Transaction.from_binary(binary)
-      tx2, _consumed = BSV::Transaction::Transaction.from_binary_with_offset(binary)
+      tx1 = BSV::Transaction::Tx.from_binary(binary)
+      tx2, _consumed = BSV::Transaction::Tx.from_binary_with_offset(binary)
 
       expect(tx2.to_hex).to eq(tx1.to_hex)
       expect(tx2.wtxid).to eq(tx1.wtxid)

--- a/gem/bsv-sdk/spec/bsv/transaction/benford_distribution_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/benford_distribution_spec.rb
@@ -40,7 +40,7 @@ BENFORD_CHI_SQUARED_CRITICAL_P01 = 20.09
 
 RSpec.describe 'Benford change distribution — statistical validation' do # rubocop:disable RSpec/DescribeClass
   # Expose the private helper via a thin wrapper so we can test it directly.
-  let(:tx_class) { BSV::Transaction::Transaction }
+  let(:tx_class) { BSV::Transaction::Tx }
 
   def benford_number(min, max, rng = nil)
     allow(Random).to(receive(:rand).and_wrap_original { |_m, *args| rng.rand(*args) }) if rng

--- a/gem/bsv-sdk/spec/bsv/transaction/benford_number/lookup_table_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/benford_number/lookup_table_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe BSV::Transaction::Transaction do
+RSpec.describe BSV::Transaction::Tx do
   describe '#benford_number(min, max)' do
     def ts_sdk_reference_benford_number_scaler(min, max, rnd)
       # from: src/transaction/Transaction.ts private benfordNumber (min: number, max: number): number

--- a/gem/bsv-sdk/spec/bsv/transaction/fee_model_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/fee_model_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BSV::Transaction::FeeModel do
 
   describe '#compute_fee' do
     it 'raises NotImplementedError' do
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       expect { model.compute_fee(tx) }
         .to raise_error(NotImplementedError, /compute_fee must be implemented/)
     end

--- a/gem/bsv-sdk/spec/bsv/transaction/fee_models/satoshis_per_kilobyte_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/fee_models/satoshis_per_kilobyte_spec.rb
@@ -5,35 +5,35 @@ require 'spec_helper'
 RSpec.describe BSV::Transaction::FeeModels::SatoshisPerKilobyte do
   describe '#compute_fee' do
     it 'computes fee for a 1 KB transaction at default rate' do
-      tx = instance_double(BSV::Transaction::Transaction, estimated_size: 1000)
+      tx = instance_double(BSV::Transaction::Tx, estimated_size: 1000)
       model = described_class.new
 
       expect(model.compute_fee(tx)).to eq(100) # 1000/1000 * 100
     end
 
     it 'computes fee for a 250 byte transaction at default rate' do
-      tx = instance_double(BSV::Transaction::Transaction, estimated_size: 250)
+      tx = instance_double(BSV::Transaction::Tx, estimated_size: 250)
       model = described_class.new
 
       expect(model.compute_fee(tx)).to eq(25) # ceil(250/1000 * 100) = 25
     end
 
     it 'computes fee with custom rate' do
-      tx = instance_double(BSV::Transaction::Transaction, estimated_size: 500)
+      tx = instance_double(BSV::Transaction::Tx, estimated_size: 500)
       model = described_class.new(value: 100)
 
       expect(model.compute_fee(tx)).to eq(50) # 500/1000 * 100 = 50
     end
 
     it 'rounds up to ensure minimum 1 satoshi fee' do
-      tx = instance_double(BSV::Transaction::Transaction, estimated_size: 1)
+      tx = instance_double(BSV::Transaction::Tx, estimated_size: 1)
       model = described_class.new(value: 1)
 
       expect(model.compute_fee(tx)).to eq(1) # ceil(1/1000 * 1) = ceil(0.001) = 1
     end
 
     it 'computes correct fee for large transaction' do
-      tx = instance_double(BSV::Transaction::Transaction, estimated_size: 10_000)
+      tx = instance_double(BSV::Transaction::Tx, estimated_size: 10_000)
       model = described_class.new(value: 50)
 
       expect(model.compute_fee(tx)).to eq(500) # 10000/1000 * 50 = 500

--- a/gem/bsv-sdk/spec/bsv/transaction/live_policy_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/live_policy_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe BSV::Transaction::FeeModels::LivePolicy do
 
   describe '#compute_fee' do
     it 'computes fee using the live rate' do
-      tx = instance_double(BSV::Transaction::Transaction, estimated_size: 250)
+      tx = instance_double(BSV::Transaction::Tx, estimated_size: 250)
       fee = model.compute_fee(tx)
       # 250 / 1000 * 50 = 12.5, ceil = 13
       expect(fee).to eq(13)

--- a/gem/bsv-sdk/spec/bsv/transaction/p2pkh_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/p2pkh_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe BSV::Transaction::P2PKH do
   let(:locking_script) { BSV::Script::Script.p2pkh_lock(pubkey_hash) }
 
   let(:tx) do
-    tx = BSV::Transaction::Transaction.new
+    tx = BSV::Transaction::Tx.new
     input = BSV::Transaction::TransactionInput.new(
       prev_wtxid: "\x01".b * 32,
       prev_tx_out_index: 0
@@ -39,9 +39,9 @@ RSpec.describe BSV::Transaction::P2PKH do
       expect(chunks[1].data.bytesize).to eq(33)
     end
 
-    it 'produces the same result as Transaction#sign' do
+    it 'produces the same result as Tx#sign' do
       # Sign with direct method
-      direct_tx = BSV::Transaction::Transaction.new
+      direct_tx = BSV::Transaction::Tx.new
       input1 = BSV::Transaction::TransactionInput.new(
         prev_wtxid: "\x01".b * 32,
         prev_tx_out_index: 0

--- a/gem/bsv-sdk/spec/bsv/transaction/sighash_vectors_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/sighash_vectors_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Sighash vectors (TS SDK)' do
       raw_tx_hex, script_hex, input_index, hash_type, expected_hex = vec
 
       begin
-        tx = BSV::Transaction::Transaction.from_hex(raw_tx_hex)
+        tx = BSV::Transaction::Tx.from_hex(raw_tx_hex)
         subscript = BSV::Script::Script.from_hex(script_hex)
 
         # TS SDK vectors assume source_satoshis = 0 for sighash computation

--- a/gem/bsv-sdk/spec/bsv/transaction/truncated_parsing_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/truncated_parsing_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'truncated binary parsing' do # rubocop:disable RSpec/DescribeCla
     end
   end
 
-  describe BSV::Transaction::Transaction do
+  describe BSV::Transaction::Tx do
     describe '.from_binary' do
       it 'raises on empty data' do
         expect { described_class.from_binary(''.b) }.to raise_error(ArgumentError, /truncated transaction/)

--- a/gem/bsv-sdk/spec/bsv/transaction/tx_ef_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/tx_ef_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe BSV::Transaction::Transaction do
+RSpec.describe BSV::Transaction::Tx do
   describe 'Extended Format (EF) serialisation' do
     # Go SDK test vector — a signed P2PKH transaction with 1 input, 1 output
     let(:go_sdk_ef_hex) do

--- a/gem/bsv-sdk/spec/bsv/transaction/tx_fee_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/tx_fee_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe BSV::Transaction::Transaction do
+RSpec.describe BSV::Transaction::Tx do
   describe '#fee' do
     let(:priv) { BSV::Primitives::PrivateKey.generate }
     let(:lock_script) { BSV::Script::Script.p2pkh_lock(priv.public_key.hash160) }

--- a/gem/bsv-sdk/spec/bsv/transaction/tx_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/tx_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe BSV::Transaction::Transaction do
+RSpec.describe BSV::Transaction::Tx do
   # Go SDK test vector: 1 input, 2 outputs
   let(:vector1_hex) do
     '010000000193a35408b6068499e0d5abd799d3e827d9bfe70c9b75ebe209c91d2507232651' \
@@ -780,7 +780,7 @@ RSpec.describe BSV::Transaction::Transaction do
     #
     # PathElement hashes must be in wire byte order (MerklePath serialisation).
     def proven_tx(satoshis: 1000, block_height: 800_000, offset: 0)
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: satoshis, locking_script: lock))
       sibling_hash = BSV::Primitives::Digest.sha256("sibling_#{offset}") # 32 raw bytes
       tx.merkle_path = BSV::Transaction::MerklePath.new(

--- a/gem/bsv-sdk/spec/bsv/transaction/tx_vectors_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/tx_vectors_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Transaction serialisation vectors (TS SDK)' do
         next unless tx_hex.is_a?(String) && tx_hex.length > 10
 
         begin
-          tx = BSV::Transaction::Transaction.from_hex(tx_hex)
+          tx = BSV::Transaction::Tx.from_hex(tx_hex)
           round_tripped = tx.to_hex
 
           if round_tripped == tx_hex
@@ -65,7 +65,7 @@ RSpec.describe 'Transaction serialisation vectors (TS SDK)' do
         next unless tx_hex.is_a?(String) && tx_hex.length > 10
 
         begin
-          tx = BSV::Transaction::Transaction.from_hex(tx_hex)
+          tx = BSV::Transaction::Tx.from_hex(tx_hex)
           txid = tx.txid_hex
 
           # txid should be 64 hex chars (32 bytes)

--- a/gem/bsv-sdk/spec/bsv/transaction/tx_verify_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/tx_verify_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe BSV::Transaction::Transaction do
+RSpec.describe BSV::Transaction::Tx do
   describe '#verify' do
     let(:priv) { BSV::Primitives::PrivateKey.generate }
     let(:pub) { priv.public_key }

--- a/gem/bsv-sdk/spec/conformance/beef_spec.rb
+++ b/gem/bsv-sdk/spec/conformance/beef_spec.rb
@@ -259,16 +259,16 @@ RSpec.describe BSV::Transaction::Beef do
 
   describe 'Transaction.from_beef / Transaction#to_beef' do
     it 'from_beef returns the subject (last) transaction' do
-      tx = BSV::Transaction::Transaction.from_beef_hex(go_beef_set_hex)
+      tx = BSV::Transaction::Tx.from_beef_hex(go_beef_set_hex)
       beef = described_class.from_hex(go_beef_set_hex)
       expect(tx.wtxid).to eq(beef.transactions.last.wtxid)
     end
 
     it 'to_beef produces valid BEEF that round-trips' do
-      original = BSV::Transaction::Transaction.from_beef_hex(go_beef_set_hex)
+      original = BSV::Transaction::Tx.from_beef_hex(go_beef_set_hex)
       rebuilt_hex = original.to_beef_hex
 
-      tx2 = BSV::Transaction::Transaction.from_beef_hex(rebuilt_hex)
+      tx2 = BSV::Transaction::Tx.from_beef_hex(rebuilt_hex)
       expect(tx2.wtxid).to eq(original.wtxid)
     end
   end

--- a/gem/bsv-sdk/spec/conformance/beef_spec.rb
+++ b/gem/bsv-sdk/spec/conformance/beef_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe BSV::Transaction::Beef do
 
   # --- Transaction convenience method conformance ---
 
-  describe 'Transaction.from_beef / Transaction#to_beef' do
+  describe 'Tx.from_beef / Tx#to_beef' do
     it 'from_beef returns the subject (last) transaction' do
       tx = BSV::Transaction::Tx.from_beef_hex(go_beef_set_hex)
       beef = described_class.from_hex(go_beef_set_hex)

--- a/gem/bsv-sdk/spec/conformance/fee_model_spec.rb
+++ b/gem/bsv-sdk/spec/conformance/fee_model_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe BSV::Transaction::FeeModels::SatoshisPerKilobyte do # rubocop:dis
       { size: 374, rate: 50, expected: 19, desc: 'typical 1-in-2-out P2PKH at 50 sat/kB' }
     ].each do |v|
       it "computes #{v[:expected]} sat for #{v[:desc]}" do
-        tx = instance_double(BSV::Transaction::Transaction, estimated_size: v[:size])
+        tx = instance_double(BSV::Transaction::Tx, estimated_size: v[:size])
         model = described_class.new(value: v[:rate])
 
         fee = model.compute_fee(tx)
@@ -45,7 +45,7 @@ RSpec.describe BSV::Transaction::FeeModels::SatoshisPerKilobyte do # rubocop:dis
   end
 
   it 'returns an Integer' do
-    tx = instance_double(BSV::Transaction::Transaction, estimated_size: 250)
+    tx = instance_double(BSV::Transaction::Tx, estimated_size: 250)
     expect(described_class.new.compute_fee(tx)).to be_an(Integer)
   end
 
@@ -54,7 +54,7 @@ RSpec.describe BSV::Transaction::FeeModels::SatoshisPerKilobyte do # rubocop:dis
   end
 end
 
-RSpec.describe BSV::Transaction::Transaction do
+RSpec.describe BSV::Transaction::Tx do
   describe '#fee conformance' do
     let(:priv) { BSV::Primitives::PrivateKey.generate }
     let(:lock_script) { BSV::Script::Script.p2pkh_lock(priv.public_key.hash160) }

--- a/gem/bsv-sdk/spec/conformance/sighash_bip143_spec.rb
+++ b/gem/bsv-sdk/spec/conformance/sighash_bip143_spec.rb
@@ -15,7 +15,7 @@ require 'spec_helper'
 #
 #   1. The vectors are Bitcoin Core BIP-143 vectors; their hashType values
 #      are 32-bit signed integers that only sometimes include the FORKID bit
-#      (0x40). `BSV::Transaction::Transaction#sighash_preimage` correctly
+#      (0x40). `BSV::Transaction::Tx#sighash_preimage` correctly
 #      raises `ArgumentError` for non-FORKID hashTypes, matching BSV
 #      consensus (all BSV sighashes must set FORKID post-UAHF).
 #

--- a/gem/bsv-sdk/spec/conformance/spv_verify_beef_spec.rb
+++ b/gem/bsv-sdk/spec/conformance/spv_verify_beef_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 require 'base64'
 
-# Protocol conformance: BEEF-based SPV verification (Transaction#verify)
+# Protocol conformance: BEEF-based SPV verification (Tx#verify)
 #
 # Parses real BEEF bundles from the reference SDK test vectors and runs
-# Transaction#verify against them. This validates end-to-end cross-SDK
+# Tx#verify against them. This validates end-to-end cross-SDK
 # conformance for SPV verification using actual BEEF-encoded data rather
 # than hand-built mocked transactions.
 #

--- a/gem/bsv-sdk/spec/conformance/spv_verify_beef_spec.rb
+++ b/gem/bsv-sdk/spec/conformance/spv_verify_beef_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'BEEF-based SPV verification conformance' do
   # --- Happy-path verification with always-true chain tracker ---
 
   describe 'BRC62Hex (V1 BEEF)' do
-    subject(:tx) { BSV::Transaction::Transaction.from_beef_hex(brc62_hex) }
+    subject(:tx) { BSV::Transaction::Tx.from_beef_hex(brc62_hex) }
 
     it 'parses successfully and verifies with always-true chain tracker' do
       expect(tx.verify(chain_tracker: always_true_tracker)).to be true
@@ -56,7 +56,7 @@ RSpec.describe 'BEEF-based SPV verification conformance' do
   describe 'BEEF base64 (V1 multi-transaction BEEF)' do
     subject(:tx) do
       data = Base64.strict_decode64(beef_base64)
-      BSV::Transaction::Transaction.from_beef(data)
+      BSV::Transaction::Tx.from_beef(data)
     end
 
     it 'parses successfully and verifies with always-true chain tracker' do
@@ -65,7 +65,7 @@ RSpec.describe 'BEEF-based SPV verification conformance' do
   end
 
   describe 'BEEFSet (V2 BEEF)' do
-    subject(:tx) { BSV::Transaction::Transaction.from_beef_hex(beef_set_hex) }
+    subject(:tx) { BSV::Transaction::Tx.from_beef_hex(beef_set_hex) }
 
     it 'parses successfully and verifies with always-true chain tracker' do
       expect(tx.verify(chain_tracker: always_true_tracker)).to be true
@@ -73,7 +73,7 @@ RSpec.describe 'BEEF-based SPV verification conformance' do
   end
 
   describe 'Issue96BeefHex (V1 BEEF — regression for "no leaves at height: 1")' do
-    subject(:tx) { BSV::Transaction::Transaction.from_beef_hex(issue96_hex) }
+    subject(:tx) { BSV::Transaction::Tx.from_beef_hex(issue96_hex) }
 
     it 'parses successfully and verifies with always-true chain tracker' do
       expect(tx.verify(chain_tracker: always_true_tracker)).to be true
@@ -83,7 +83,7 @@ RSpec.describe 'BEEF-based SPV verification conformance' do
   # --- Fee model integration (Go SDK: TestSPVVerifyWithSufficientFee / TestSPVVerifyWithInsufficientFee) ---
 
   describe 'fee model integration using BRC62Hex' do
-    subject(:tx) { BSV::Transaction::Transaction.from_beef_hex(brc62_hex) }
+    subject(:tx) { BSV::Transaction::Tx.from_beef_hex(brc62_hex) }
 
     it 'verifies when fee model rate is low (passes)' do
       # 1 sat/kB is effectively zero — any real transaction fee will exceed this
@@ -106,7 +106,7 @@ RSpec.describe 'BEEF-based SPV verification conformance' do
 
   describe 'corrupt merkle proof' do
     it 'raises VerificationError(:invalid_merkle_proof) when a BUMP hash is flipped' do
-      tx = BSV::Transaction::Transaction.from_beef_hex(brc62_hex)
+      tx = BSV::Transaction::Tx.from_beef_hex(brc62_hex)
 
       # Find a mined ancestor (one that has a merkle_path attached)
       mined_tx = nil
@@ -177,7 +177,7 @@ RSpec.describe 'BEEF-based SPV verification conformance' do
       )
 
       # Re-parse a fresh copy so the source_locking_script population is clean
-      tx2 = BSV::Transaction::Transaction.from_beef_hex(brc62_hex)
+      tx2 = BSV::Transaction::Tx.from_beef_hex(brc62_hex)
       mined_tx2 = nil
       queue2 = [tx2]
       visited2 = {}
@@ -208,7 +208,7 @@ RSpec.describe 'BEEF-based SPV verification conformance' do
 
   describe 'tampered subject transaction' do
     it 'fails verification when an output amount is modified' do
-      tx = BSV::Transaction::Transaction.from_beef_hex(brc62_hex)
+      tx = BSV::Transaction::Tx.from_beef_hex(brc62_hex)
 
       # Corrupt the subject transaction's first output satoshi value.
       # This will cause the output ≤ input check or script verification to fail,

--- a/gem/bsv-sdk/spec/conformance/spv_verify_spec.rb
+++ b/gem/bsv-sdk/spec/conformance/spv_verify_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-# Protocol conformance: SPV verification (Transaction#verify)
+# Protocol conformance: SPV verification (Tx#verify)
 #
 # Cross-validates the Ruby SDK's SPV verification against the patterns
 # used by all three reference SDKs.

--- a/gem/bsv-sdk/spec/conformance/spv_verify_spec.rb
+++ b/gem/bsv-sdk/spec/conformance/spv_verify_spec.rb
@@ -12,7 +12,7 @@ require 'spec_helper'
 #   Go SDK:  spv/verify.go (Verify function)
 #   Python:  transaction.py (verify method, lines 405-457)
 
-RSpec.describe BSV::Transaction::Transaction do # rubocop:disable RSpec/MultipleDescribes
+RSpec.describe BSV::Transaction::Tx do # rubocop:disable RSpec/MultipleDescribes
   describe 'SPV verify conformance' do
     let(:priv) { BSV::Primitives::PrivateKey.generate }
     let(:pub) { priv.public_key }
@@ -212,7 +212,7 @@ RSpec.describe BSV::Transaction::FeeModel do
     let(:chain_tracker) { instance_double(BSV::Transaction::ChainTracker) }
 
     it 'SatoshisPerKilobyte integrates with verify' do
-      source_tx = BSV::Transaction::Transaction.new
+      source_tx = BSV::Transaction::Tx.new
       input = BSV::Transaction::TransactionInput.new(
         prev_wtxid: BSV::Primitives::Digest.sha256d('fee-test'),
         prev_tx_out_index: 0
@@ -229,7 +229,7 @@ RSpec.describe BSV::Transaction::FeeModel do
                                               block_height: 800_000,
                                               verify: true)
 
-      tx = BSV::Transaction::Transaction.new
+      tx = BSV::Transaction::Tx.new
       spend_input = BSV::Transaction::TransactionInput.new(
         prev_wtxid: source_tx.wtxid,
         prev_tx_out_index: 0

--- a/gem/bsv-sdk/spec/integration/testnet_spec.rb
+++ b/gem/bsv-sdk/spec/integration/testnet_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Testnet integration', :testnet do
   end
 
   def build_and_sign(inputs, outputs)
-    tx = BSV::Transaction::Transaction.new
+    tx = BSV::Transaction::Tx.new
     inputs.each { |i| tx.add_input(i) }
     outputs.each { |o| tx.add_output(o) }
     tx.sign_all(@private_key)
@@ -160,7 +160,7 @@ RSpec.describe 'Testnet integration', :testnet do
 
       expect(fetched_hex).to eq(original_hex)
 
-      parsed = BSV::Transaction::Transaction.from_hex(fetched_hex)
+      parsed = BSV::Transaction::Tx.from_hex(fetched_hex)
       expect(parsed.txid_hex).to eq(original_txid)
       expect(parsed.to_hex).to eq(original_hex)
     end


### PR DESCRIPTION
Closes #795.

## Summary

Renames `BSV::Transaction::Transaction` → `BSV::Transaction::Tx`. Class only; module `BSV::Transaction` and peer classes (`TransactionInput`, `TransactionOutput`, `ChainTracker`, `Beef`, etc.) unchanged.

The class doubling was awkward at call sites and stylistically out of step with the module's peer classes (descriptive names within the namespace, not redundant repetitions).

```ruby
# Before                              # After
BSV::Transaction::Transaction.new    BSV::Transaction::Tx.new
tx.is_a?(BSV::Transaction::Transaction)   tx.is_a?(BSV::Transaction::Tx)
```

## What changed

- **Files**: `transaction/transaction.rb` → `tx.rb`; `transaction_spec.rb` / `transaction_ef_spec.rb` / `transaction_fee_spec.rb` / `transaction_vectors_spec.rb` / `transaction_verify_spec.rb` → `tx_*_spec.rb`
- **Class definition**: `class Transaction` → `class Tx` (inside `module Transaction`)
- **Autoload entry** in `lib/bsv/transaction.rb` updated
- **~140 in-repo references** updated mechanically across SDK lib + spec + bsv-attest + docs
- **Bare `Transaction.from_binary` / `from_binary_with_offset` calls in `beef.rb`** (4 sites) updated to `Tx.*` — these were mandatory because bare `Transaction` inside the module now resolves to the module itself, not the class
- **YARD type tags** `@return [Transaction]` / `{Transaction#method}` updated to `Tx`
- **`.rubocop.yml`** `Metrics/ClassLength` exclusion path updated for the rename

## What is NOT changed

- The `BSV::Transaction` module itself
- `TransactionInput`, `TransactionOutput` class names
- Other classes in the module: `ChainTracker`, `Beef`, `FeeModel`, `MerklePath`, `Sighash`, `VarInt`, etc.
- Compat alias — pre-1.0 clean break per `feedback_no_compat_shims`

## Why this specifically and not `BSV::Tx::Transaction`

Considered during planning. Rejected: ~3× larger scope (770 vs 225 references), forces a `lib/bsv/transaction/` → `lib/bsv/tx/` directory rename, creates cascading inconsistencies (`BSV::Tx::TransactionInput` reads worse than `BSV::Transaction::TransactionInput`).

## Downstream

bsv-wallet has ~89 references — separate PR after this releases. Their `bsv-sdk` gemspec floor is currently unconstrained, so they can stage migration.

## Phase 0 verification (completed before this PR)

- No `Tx` collision in `BSV::Transaction::*` or anywhere in SDK / attest
- No bare `Tx` identifier in lib that would shadow on `include BSV::Transaction`
- No JSON conformance vectors reference the class name as a string
- No external subclasses of `Transaction`

## Test plan
- [x] All specs pass (`bundle exec rake spec:sdk` — 5900 examples, 0 failures, 22 pre-existing pending)
- [x] Linter clean (`bundle exec rubocop` — 405 files, no offences)
- [x] `BSV::Transaction::Tx` resolves at load time
- [x] No remaining `BSV::Transaction::Transaction` literals in tracked files
- [x] Atomic single commit (no broken intermediate states)