### PR TITLE
test(wallet): lock binary pubkey contract on reveal_*_linkage wire returns

### DIFF
--- a/gem/bsv-sdk/spec/bsv/wallet/loopback_integration_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/wallet/loopback_integration_spec.rb
@@ -250,6 +250,28 @@ RSpec.describe 'BSV::Wallet loopback integration (WalletWireTransceiver → Wall
       expect(result[:encrypted_linkage_proof]).to be_a(String)
       expect(result[:revelation_time]).to be_a(String)
     end
+
+    # Locks the binary-internal contract per ADR-001 (wtxid/dtxid generalised).
+    # Wire returns 33-byte compressed binary; consumers convert at their JSON boundary.
+    it 'returns prover/verifier/counterparty as 33-byte binary' do
+      result = client.reveal_counterparty_key_linkage(
+        counterparty: other_pubkey,
+        verifier: other_pubkey
+      )
+      %i[prover verifier counterparty].each do |key|
+        expect(result[key]).to be_a(String)
+        expect(result[key].bytesize).to eq(33)
+      end
+    end
+
+    it 'pubkey fields decode to the same hex as ProtoWallet returns directly' do
+      direct = proto.reveal_counterparty_key_linkage(counterparty: other_pubkey, verifier: other_pubkey)
+      wire   = client.reveal_counterparty_key_linkage(counterparty: other_pubkey, verifier: other_pubkey)
+      # Wire layer normalises pubkeys to 33-byte compressed binary; compare as hex
+      %i[prover verifier counterparty].each do |key|
+        expect(wire[key].unpack1('H*')).to eq(direct[key])
+      end
+    end
   end
 
   # -------------------------------------------------------------------------
@@ -268,6 +290,35 @@ RSpec.describe 'BSV::Wallet loopback integration (WalletWireTransceiver → Wall
       )
       expect(result[:encrypted_linkage]).to be_a(String)
       expect(result[:proof_type]).to be_a(Integer)
+    end
+
+    # Locks the binary-internal contract per ADR-001 (wtxid/dtxid generalised).
+    it 'returns prover/verifier/counterparty as 33-byte binary' do
+      result = client.reveal_specific_key_linkage(
+        counterparty: other_pubkey,
+        verifier: other_pubkey,
+        protocol_id: protocol_id,
+        key_id: key_id
+      )
+      %i[prover verifier counterparty].each do |key|
+        expect(result[key]).to be_a(String)
+        expect(result[key].bytesize).to eq(33)
+      end
+    end
+
+    it 'pubkey fields decode to the same hex as ProtoWallet returns directly' do
+      direct = proto.reveal_specific_key_linkage(
+        counterparty: other_pubkey, verifier: other_pubkey,
+        protocol_id: protocol_id, key_id: key_id
+      )
+      wire = client.reveal_specific_key_linkage(
+        counterparty: other_pubkey, verifier: other_pubkey,
+        protocol_id: protocol_id, key_id: key_id
+      )
+      # Wire layer normalises pubkeys to 33-byte compressed binary; compare as hex
+      %i[prover verifier counterparty].each do |key|
+        expect(wire[key].unpack1('H*')).to eq(direct[key])
+      end
     end
   end
 


### PR DESCRIPTION
Closes #804.

## Summary

Adds two assertions per method to the wallet loopback integration spec covering `#reveal_counterparty_key_linkage` and `#reveal_specific_key_linkage`:

1. `prover` / `verifier` / `counterparty` are 33-byte binary strings on the wire (matches the existing `#get_public_key` precedent at `loopback_integration_spec.rb:51-68`).
2. Decoding those binary fields to hex yields the same value that `ProtoWallet` returns directly — locking in the wire's binary form as the canonical post-deserialisation shape, and `ProtoWallet`'s hex form as the consumer-facing equivalent.

## Why

Per ADR-001 (binary-internal representation; hex at boundaries — merged in #813), the wire transceiver is correct to return binary pubkeys; consumers convert to hex at their JSON or human boundary, exactly as they would for `wtxid` → `dtxid_hex`. Without these assertions the contract was implicit, which is what let the audit on HLR #797 misframe it as a bug (#798).

The parity-check form (`wire[key].unpack1('H*') == direct[key]`) survives the future `ProtoWallet` alignment (#812): once `ProtoWallet` also returns binary, the parity check simplifies to direct binary comparison.

## Test plan

- [x] `bundle exec rake` — 5,904 examples, 0 failures, 22 pending (was 5,900; +4 new examples)
- [x] `bundle exec rubocop` — clean
- [x] New tests fail-deliberately if the wire deserialiser is changed to return hex (verified mentally; the binary `bytesize == 33` assertion catches that)