### PR TITLE
feat: read-only ecosystem clients — StorageDownloader, GlobalKVStore, Registry typed resolves, Historian

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -125,6 +125,7 @@ Metrics/ClassLength:
     - 'gem/bsv-sdk/lib/bsv/identity/**/*'
     - 'gem/bsv-sdk/lib/bsv/registry/**/*'
     - 'gem/bsv-sdk/lib/bsv/mcp/**/*'
+    - 'gem/bsv-sdk/lib/bsv/kv_store/**/*'
 
 Metrics/ParameterLists:
   Exclude:
@@ -137,6 +138,7 @@ Metrics/ParameterLists:
     - 'gem/bsv-sdk/lib/bsv/identity/**/*'
     - 'gem/bsv-sdk/lib/bsv/registry/**/*'
     - 'gem/bsv-sdk/lib/bsv/auth/**/*'
+    - 'gem/*/spec/**/*'
 
 # The interpreter condition stack uses :true/:false symbols intentionally
 # (matching the Go SDK pattern) to distinguish from boolean values.
@@ -176,6 +178,7 @@ RSpec/MultipleExpectations:
     - 'gem/bsv-sdk/spec/bsv/registry/**/*'
     - 'gem/bsv-sdk/spec/bsv/mcp/**/*'
     - 'gem/bsv-sdk/spec/bsv/storage/**/*'
+    - 'gem/bsv-sdk/spec/bsv/kv_store/**/*'
     - 'gem/*/spec/support/**/*'
     - 'gem/bsv-sdk/spec/integration/**/*'
     - 'gem/bsv-sdk/spec/conformance/**/*'
@@ -193,6 +196,7 @@ RSpec/MultipleMemoizedHelpers:
     - 'gem/bsv-sdk/spec/bsv/network/**/*'
     - 'gem/bsv-sdk/spec/bsv/wallet/**/*'
     - 'gem/bsv-sdk/spec/bsv/storage/**/*'
+    - 'gem/bsv-sdk/spec/bsv/kv_store/**/*'
     - 'gem/bsv-sdk/spec/conformance/**/*'
     - 'gem/*/spec/support/**/*'
 
@@ -211,6 +215,7 @@ RSpec/ExampleLength:
     - 'gem/bsv-sdk/spec/bsv/registry/**/*'
     - 'gem/bsv-sdk/spec/bsv/mcp/**/*'
     - 'gem/bsv-sdk/spec/bsv/storage/**/*'
+    - 'gem/bsv-sdk/spec/bsv/kv_store/**/*'
     - 'gem/*/spec/support/**/*'
     - 'gem/bsv-sdk/spec/integration/**/*'
     - 'gem/bsv-sdk/spec/conformance/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -175,6 +175,7 @@ RSpec/MultipleExpectations:
     - 'gem/bsv-sdk/spec/bsv/identity/**/*'
     - 'gem/bsv-sdk/spec/bsv/registry/**/*'
     - 'gem/bsv-sdk/spec/bsv/mcp/**/*'
+    - 'gem/bsv-sdk/spec/bsv/storage/**/*'
     - 'gem/*/spec/support/**/*'
     - 'gem/bsv-sdk/spec/integration/**/*'
     - 'gem/bsv-sdk/spec/conformance/**/*'
@@ -191,6 +192,7 @@ RSpec/MultipleMemoizedHelpers:
     - 'gem/bsv-sdk/spec/bsv/mcp/**/*'
     - 'gem/bsv-sdk/spec/bsv/network/**/*'
     - 'gem/bsv-sdk/spec/bsv/wallet/**/*'
+    - 'gem/bsv-sdk/spec/bsv/storage/**/*'
     - 'gem/bsv-sdk/spec/conformance/**/*'
     - 'gem/*/spec/support/**/*'
 
@@ -208,6 +210,7 @@ RSpec/ExampleLength:
     - 'gem/bsv-sdk/spec/bsv/identity/**/*'
     - 'gem/bsv-sdk/spec/bsv/registry/**/*'
     - 'gem/bsv-sdk/spec/bsv/mcp/**/*'
+    - 'gem/bsv-sdk/spec/bsv/storage/**/*'
     - 'gem/*/spec/support/**/*'
     - 'gem/bsv-sdk/spec/integration/**/*'
     - 'gem/bsv-sdk/spec/conformance/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -138,7 +138,7 @@ Metrics/ParameterLists:
     - 'gem/bsv-sdk/lib/bsv/identity/**/*'
     - 'gem/bsv-sdk/lib/bsv/registry/**/*'
     - 'gem/bsv-sdk/lib/bsv/auth/**/*'
-    - 'gem/*/spec/**/*'
+    - 'gem/bsv-sdk/spec/bsv/kv_store/**/*'
 
 # The interpreter condition stack uses :true/:false symbols intentionally
 # (matching the Go SDK pattern) to distinguish from boolean values.

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,17 @@ Higher-level overlay clients for working with on-chain services:
 - **[KVStore](sdk/kvstore.md)** — read from the global key-value store overlay
 - **[Ecosystem Clients](sdk/ecosystem-clients.md)** — Registry typed resolves, Overlay Historian
 
+## Overlay services
+
+End-user facing explanations of the overlay protocols the SDK supports,
+including how each one fits with the `bsv-wallet` write paths:
+
+- **[Overlay services overview](overlays.md)** — what overlays are, BRC-22/24 architecture, SDK vs wallet split
+- **[UHRP Storage](overlays/uhrp-storage.md)** — content-addressed file storage (BRC-26)
+- **[Historian](overlays/historian.md)** — walk on-chain state through transaction ancestry
+- **[KVStore](overlays/kvstore.md)** — overlay-backed signed key-value entries
+- **[Registries](overlays/registries.md)** — typed basket / protocol / certificate definitions
+
 ## Companion gems
 
 - **[bsv-wallet](gems/wallet.md)** — BRC-100 wallet interface with `BSV::Wallet::Client`, storage adapters, and broadcast queue

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,14 @@ The SDK is organised into three top-level modules:
 - **[Script](sdk/script.md)** — script parsing, opcodes, templates, interpreter
 - **[Transaction](sdk/transaction.md)** — building, signing, BEEF serialisation, merkle proofs
 
+## Ecosystem Clients
+
+Higher-level overlay clients for working with on-chain services:
+
+- **[Storage](sdk/storage.md)** — UHRP URL utilities and content download with hash verification
+- **[KVStore](sdk/kvstore.md)** — read from the global key-value store overlay
+- **[Ecosystem Clients](sdk/ecosystem-clients.md)** — Registry typed resolves, Overlay Historian
+
 ## Companion gems
 
 - **[bsv-wallet](gems/wallet.md)** — BRC-100 wallet interface with `BSV::Wallet::Client`, storage adapters, and broadcast queue

--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -1,0 +1,110 @@
+# Overlay services
+
+Overlay services are application protocols that live *on top of* the base BSV
+network. They don't change Bitcoin — they index a slice of it, agreeing on a
+common interpretation of certain UTXOs and providing a lookup API for clients.
+
+If you've used the SDK's `Storage::Downloader` or `KVStore::Global`, you've
+already used an overlay service.
+
+## The problem they solve
+
+The base BSV protocol broadcasts transactions and proves them with merkle
+roots. It doesn't help you ask questions like:
+
+- "Which UTXOs advertise the file with this SHA-256 hash?"
+- "What's the current value of this key for this controller?"
+- "Where can I download `uhrp://XUT6Pq…`?"
+
+Answering those needs a higher layer that watches transactions, tags the
+relevant outputs, and lets clients query by application-meaningful keys.
+That higher layer is an overlay service.
+
+## How an overlay works
+
+An overlay node runs two complementary services:
+
+1. A **topic manager** ([BRC-22](https://hub.bsvblockchain.org/brc/overlays/0022))
+   accepts transactions submitted by any participant, decides which outputs
+   are admissible into one or more *topics*, and tracks them. Topics are
+   strings like `tm_kvstore` or `tm_uhrp` — see
+   [BRC-87](https://hub.bsvblockchain.org/brc/overlays/0087) for the naming
+   convention.
+
+2. A **lookup service** ([BRC-24](https://hub.bsvblockchain.org/brc/overlays/0024))
+   indexes the admitted outputs and exposes a query API. Lookup providers
+   are also strings: `ls_kvstore`, `ls_uhrp`, etc.
+
+Submission is `POST /submit`; query is `POST /lookup`. Both endpoints are
+authenticated with [BRC-31](https://hub.bsvblockchain.org/brc/peer-to-peer/0031)
+identity signatures, and may be monetised with
+[BRC-41](https://hub.bsvblockchain.org/brc/payments/0041) micropayments.
+
+Nodes that host the same topics gossip transactions to each other so the
+overlay state stays consistent across the network. The discovery protocol
+for finding nodes that host a given topic is
+[BRC-23 CHIP](https://hub.bsvblockchain.org/brc/overlays/0023) — also known
+as SHIP/SLAP in
+[BRC-88](https://hub.bsvblockchain.org/brc/overlays/0088).
+
+## Topic ⇄ lookup-service pairing
+
+In practice, every overlay you'll use ships a `tm_*` topic manager and an
+`ls_*` lookup service:
+
+| Application | Topic | Lookup service | BRC |
+|---|---|---|---|
+| Content addressing (UHRP) | `tm_uhrp` | `ls_uhrp` | [BRC-26](https://hub.bsvblockchain.org/brc/overlays/0026) |
+| Global key-value store | `tm_kvstore` | `ls_kvstore` | TS SDK reference |
+| Registry definitions | `tm_basketmap` / `tm_protomap` / `tm_certmap` | `ls_basketmap` / `ls_protomap` / `ls_certmap` | [BRC-86](https://hub.bsvblockchain.org/brc/wallet/0086) |
+| Identity certificates | `tm_users` | `ls_users` | BRC-52 |
+
+The Ruby SDK's `BSV::Overlay::LookupResolver` is a single client that
+multiplexes across any of these by passing the lookup-service identifier in
+each query.
+
+## SDK vs wallet — the read/write split
+
+The `bsv-sdk` gem ships the **read paths** for the overlays above. Reading
+is pure consumption: no UTXOs spent, no signatures over private keys, no
+payment flow. A read client only needs an HTTP transport and a parser.
+
+The **write paths** live in the [`bsv-wallet`](../gems/wallet.md) gem
+because creating an advertisement, registering a definition, or setting
+a KV entry requires:
+
+- Spending a UTXO to fund the new output, which needs a wallet.
+- Signing the output with the wallet's identity key.
+- Optionally paying a BRC-41 micropayment to the overlay node.
+
+The split keeps consumer apps light. A read-only viewer or aggregator can
+depend on `bsv-sdk` alone; only apps that publish to an overlay also need
+`bsv-wallet`.
+
+## What this section covers
+
+The pages below walk through each overlay the SDK supports today,
+explaining what the protocol is, what the SDK provides, and where the
+wallet picks up for writes.
+
+- **[UHRP Storage](overlays/uhrp-storage.md)** — content-addressed file storage
+  ([BRC-26](https://hub.bsvblockchain.org/brc/overlays/0026))
+- **[Historian](overlays/historian.md)** — walk the history of any
+  application-level state through its transaction ancestry
+- **[KVStore](overlays/kvstore.md)** — read overlay-backed signed key-value
+  entries
+- **[Registries](overlays/registries.md)** — resolve named baskets, protocols,
+  and certificate types
+  ([BRC-86](https://hub.bsvblockchain.org/brc/wallet/0086))
+
+## Further reading
+
+- BSV Academy: [Essentials of Overlay Services](https://hub.bsvblockchain.org/higher-learning/bsv-academy/bsv-network-topology/essentials-of-overlay-services)
+- BRC overlay specs: [22](https://hub.bsvblockchain.org/brc/overlays/0022),
+  [24](https://hub.bsvblockchain.org/brc/overlays/0024),
+  [26](https://hub.bsvblockchain.org/brc/overlays/0026),
+  [87](https://hub.bsvblockchain.org/brc/overlays/0087),
+  [88](https://hub.bsvblockchain.org/brc/overlays/0088)
+- Reference SDKs: [TypeScript](https://github.com/bitcoin-sv/ts-sdk),
+  [Go](https://github.com/bitcoin-sv/go-sdk),
+  [Python](https://github.com/bitcoin-sv/py-sdk)

--- a/docs/overlays/historian.md
+++ b/docs/overlays/historian.md
@@ -51,12 +51,14 @@ defensive reasons.
 ```ruby
 require 'bsv-sdk'
 
-# Match outputs that have an OP_RETURN with the marker 'note:' and
-# return whatever follows as the value.
+# Match outputs that have an OP_RETURN containing a 'note:' push and
+# return whatever follows as the value. Script#op_return_data returns
+# Array<String> — one element per push — so iterate.
 NoteInterpreter = ->(tx, idx, _ctx) {
-  out = tx.outputs[idx]
-  data = out.locking_script.op_return_data
-  data&.start_with?('note:') ? data.slice(5..) : nil
+  out    = tx.outputs[idx]
+  pushes = out.locking_script.op_return_data
+  marker = pushes&.find { |p| p.start_with?('note:') }
+  marker&.slice(5..)
 }
 
 historian = BSV::Overlay::Historian.new(NoteInterpreter)
@@ -76,7 +78,7 @@ audit reports), pass any `[]/[]=`-responder as a cache:
 
 ```ruby
 historian = BSV::Overlay::Historian.new(
-  KVStore::Interpreter,
+  BSV::KVStore::Interpreter,
   history_cache: {},
   interpreter_version: 'v1'
 )

--- a/docs/overlays/historian.md
+++ b/docs/overlays/historian.md
@@ -1,0 +1,128 @@
+# Historian
+
+`BSV::Overlay::Historian` is a generic walker over a transaction's input
+ancestry. Given a starting transaction and a callable that knows how to
+interpret one output, it returns the chronological sequence of all the
+interpreter's values across the whole back-history.
+
+It isn't itself an overlay — it's a tool you use to make sense of state
+that overlays surface.
+
+## Why it exists
+
+Many overlay-backed application states are *mutable*: a KVStore key has a
+current value but also a history of prior values; an identity certificate
+may be re-issued; a registry definition can be updated. Each change is a
+new transaction that spends the previous state UTXO.
+
+So the *current* state is a single UTXO, but the *history* is the chain of
+UTXOs you can walk by following each transaction's inputs back through
+their source transactions.
+
+Historian is the generic walker for that chain. It doesn't know what a
+KVStore entry looks like or what an identity certificate is — that
+knowledge lives in an *interpreter*. Historian just walks; the
+interpreter decodes.
+
+## The interpreter contract
+
+An interpreter is any callable matching:
+
+```ruby
+interpreter.call(tx, output_index, ctx) #=> value or nil
+```
+
+- `tx` is a `BSV::Transaction::Tx`.
+- `output_index` is the output Historian is asking about.
+- `ctx` is whatever you passed to `build_history` — usually a hash like
+  `{ key: 'foo', protocol_id: [1, 'kvstore'] }`.
+- Return the typed value if this output matches your interest, or `nil` to
+  skip it.
+
+`nil` is the *only* skip signal: `false`, `""`, and `0` are all valid
+history entries and will be included.
+
+Anything you raise inside the interpreter is silently caught by Historian
+and treated as a skip — your interpreter should never need to rescue for
+defensive reasons.
+
+## Getting started — a tiny interpreter
+
+```ruby
+require 'bsv-sdk'
+
+# Match outputs that have an OP_RETURN with the marker 'note:' and
+# return whatever follows as the value.
+NoteInterpreter = ->(tx, idx, _ctx) {
+  out = tx.outputs[idx]
+  data = out.locking_script.op_return_data
+  data&.start_with?('note:') ? data.slice(5..) : nil
+}
+
+historian = BSV::Overlay::Historian.new(NoteInterpreter)
+notes     = historian.build_history(some_tx)
+# => ["first note", "second note", "third note"]   # oldest first
+```
+
+The same interpreter pattern is used internally by `KVStore::Global` when
+you call `get(query, history: true)` — it walks the history of a key
+through `KVStore::Interpreter`. See
+[`docs/overlays/kvstore.md`](kvstore.md) for that path.
+
+## Caching
+
+For applications that repeatedly walk the same long history (UI rendering,
+audit reports), pass any `[]/[]=`-responder as a cache:
+
+```ruby
+historian = BSV::Overlay::Historian.new(
+  KVStore::Interpreter,
+  history_cache: {},
+  interpreter_version: 'v1'
+)
+
+historian.build_history(tx, ctx)  # cold — walks ancestry
+historian.build_history(tx, ctx)  # hot — returns cached duplicate
+```
+
+The cache key is `"#{interpreter_version}|#{dtxid_hex}|#{ctx_key}"`. Bump
+`interpreter_version` to invalidate the cache when your interpreter
+changes meaning. `ctx_key` defaults to `context.to_s`; pass a
+`ctx_key_fn:` callable if your context doesn't serialise sensibly that
+way.
+
+Cached arrays are stored frozen; each retrieval returns a `dup` so
+consumer mutation can't poison the cache.
+
+## When *not* to use Historian
+
+Historian walks `input.source_transaction` — so your starting transaction
+must have its input ancestry populated (typically via BEEF). If you only
+have a TXID, you can't walk anything: fetch the ancestry first via your
+chain tracker or overlay.
+
+It's also strictly sequential: a 500-deep history walks 500 transactions
+serially. For very deep ancestries, consider caching incremental results
+or building a domain-specific index over the overlay's lookup service
+instead.
+
+## Edge cases worth knowing
+
+- **Cycles.** Historian tracks a visited set keyed by `wtxid` (binary).
+  Pathological inputs that try to point back at an ancestor are visited
+  once and then ignored.
+- **Missing source transactions.** Inputs without `source_transaction`
+  populated are skipped silently (debug-logged if you pass `debug: true`).
+- **Interpreter exceptions.** Per-output rescue inside `traverse` — your
+  interpreter can throw anything, and traversal continues.
+- **Deep stacks.** Ancestry is walked recursively, so the practical limit
+  is Ruby's stack depth. We follow the TS reference here; converting to
+  an iterative worklist is a future enhancement if real-world ancestries
+  ever hit that wall.
+
+## References
+
+- TypeScript: [`Historian.ts`](https://github.com/bitcoin-sv/ts-sdk/blob/master/src/overlay-tools/Historian.ts)
+- Python: [`bsv/overlay_tools/historian.py`](https://github.com/bitcoin-sv/py-sdk/blob/master/bsv/overlay_tools/historian.py)
+- [SDK reference: Ecosystem Clients](../sdk/ecosystem-clients.md)
+- [KVStore overlay](kvstore.md) — the most common Historian consumer

--- a/docs/overlays/kvstore.md
+++ b/docs/overlays/kvstore.md
@@ -1,0 +1,147 @@
+# KVStore
+
+The KVStore overlay is a signed key-value store backed by overlay-tracked
+PushDrop UTXOs. Each entry is owned by a *controller* (a public key), tagged
+with a *protocol ID*, and signed — so readers can verify both who set the
+value and which application namespace it belongs to.
+
+The SDK's `BSV::KVStore::Global` is the **read client**. The matching
+write client (set, remove, double-spend retry) lives in `bsv-wallet`.
+
+## Why it exists
+
+Apps need cross-device, cross-app shared state on top of BSV without
+running their own database — a username profile, a preference value, a
+public configuration setting. Plain transactions can carry data but offer
+no read API; a separate database breaks the "self-contained on BSV"
+property apps want.
+
+KVStore solves this by:
+
+1. **Storing the entry as a PushDrop UTXO.** Fields encode the protocol ID,
+   the key, the value, the controller pubkey, optional tags, and a
+   signature over them all.
+2. **Tracking the UTXO on the `tm_kvstore` topic.** Setting a new value
+   spends the previous UTXO, so the overlay always knows which UTXO is the
+   current entry for a given controller/key/protocol triple.
+3. **Exposing reads through `ls_kvstore`.** Clients query by any
+   combination of key, controller, protocol ID, or tags.
+
+## What the SDK provides
+
+### `BSV::KVStore::Global` — the read client
+
+`#get(query)` always returns `Array<KVStore::Entry>` — even for
+single-result selectors. Use `.first` if you expect one result.
+
+```ruby
+require 'bsv-sdk'
+
+kv = BSV::KVStore::Global.new(network_preset: :mainnet)
+
+# Look up by key alone — may return multiple controllers' entries
+entries = kv.get({ key: 'display_name' })
+
+# Narrow by controller pubkey hex
+entries = kv.get({
+  key:        'display_name',
+  controller: '02a1b2c3...'
+})
+
+# Filter by protocol namespace
+entries = kv.get({
+  key:         'theme',
+  protocol_id: [1, 'my-app-prefs']
+})
+
+# Inspect an entry
+entry = entries.first
+entry.key         # => "display_name"
+entry.value       # => "Alice"
+entry.controller  # => "02a1b2c3..."
+entry.protocol_id # => [1, "babbage-profile"]
+entry.tags        # => nil  (or an array on 6-field tokens)
+```
+
+At least one of `key`, `controller`, `protocol_id`, or non-empty `tags`
+must be present — otherwise the call raises `ArgumentError`.
+
+### Including the source token
+
+Pass `include_token: true` to populate the underlying BEEF, dtxid, and
+output index. Useful if you want to spend the entry from a wallet:
+
+```ruby
+entry = kv.get({ key: 'foo' }, include_token: true).first
+entry.token.dtxid         # => display-order txid hex
+entry.token.output_index  # => 0
+entry.token.beef          # => BEEF object — verifiable, embeddable
+entry.token.satoshis      # => 1
+```
+
+### Including history
+
+Pass `history: true` and Historian walks the UTXO's ancestry, decoding each
+previous version of the entry:
+
+```ruby
+entry = kv.get({ key: 'theme' }, history: true).first
+entry.value    # => "dark"          (current)
+entry.history  # => ["system", "light", "dark"]  (oldest first)
+```
+
+Internally this is `Overlay::Historian.new(KVStore::Interpreter).build_history`.
+See [Historian](historian.md) for the underlying mechanic.
+
+### `BSV::KVStore::Interpreter` — the decoder
+
+`Interpreter.call(tx, output_index, ctx)` is the Historian callable for
+KVStore PushDrop tokens. You normally don't call it directly — `Global`
+wires it up — but it's exposed in case you want to plug it into your own
+walker. The contract:
+
+- Returns the UTF-8 value String on match.
+- Returns `nil` for any mismatch, malformed field, signature failure, or
+  encoding error.
+- Never raises.
+
+## Signature verification
+
+Every entry returned by `Global#get` has been verified against the
+controller's pubkey using `BSV::Wallet::ProtoWallet.verify_signature` —
+the standard BRC-100 verification path. Entries that fail verification
+are silently dropped, matching the TS SDK contract.
+
+If you need stricter behaviour — e.g. logging dropped entries — pass your
+own `proto_wallet:` to the `Global` constructor.
+
+## What the wallet provides
+
+[`bsv-wallet`](../gems/wallet.md) ships `LocalKVStore` for **writes**:
+`#set`, `#remove`, optimistic double-spend retry, and a key-locking layer
+so concurrent writers from the same wallet don't race against each other.
+
+The split is the same as everywhere else: reading needs only the public
+overlay query; writing needs a wallet to fund the new UTXO and sign it.
+
+## Edge cases worth knowing
+
+- **Field-count compatibility.** Two on-the-wire formats are accepted:
+  5-field legacy (no tags) and 6-field current (with tags). Anything else
+  is silently skipped.
+- **Selector validation.** Empty strings don't count as a selector. Pass
+  `key: ''` and you'll get an `ArgumentError`.
+- **No "single entry" overload.** Some other SDKs let you call
+  `get(controller, key)` and get either an entry or `nil`. The Ruby SDK
+  always returns Array — use `.first`.
+- **Camel-case is handled.** The Ruby query takes snake_case keys
+  (`protocol_id`, `tag_query_mode`). They're translated to the overlay's
+  expected camelCase (`protocolID`, `tagQueryMode`) at the boundary.
+
+## References
+
+- TypeScript: [`GlobalKVStore.ts`](https://github.com/bitcoin-sv/ts-sdk/blob/master/src/kvstore/GlobalKVStore.ts) (canonical reference)
+- [SDK reference: KVStore](../sdk/kvstore.md)
+- [Historian overlay](historian.md) — used for the `history: true` path
+- [BRC-100](https://hub.bsvblockchain.org/brc/wallet/0100) — wallet
+  interface (`verify_signature`, `ProtoWallet`)

--- a/docs/overlays/registries.md
+++ b/docs/overlays/registries.md
@@ -63,19 +63,21 @@ certs = client.resolve_certificate(type: 'identity-v1')
 ```
 
 Each method returns `Array<BSV::Registry::RegisteredDefinition>`. A
-definition exposes the registry operator's pubkey, the parsed
-type-specific data, and the underlying token info so you can verify
-authenticity:
+definition exposes the type-specific data via `definition_data`, plus
+on-chain fields (`txid`, `output_index`, `satoshis`, `locking_script`,
+`beef`) so you can verify authenticity:
 
 ```ruby
 basket = baskets.first
-basket.definition.basket_id        # => "ordinals"
-basket.definition.name             # => "Ordinals"
-basket.definition.icon_url         # => "https://example.com/ord.png"
-basket.definition.description      # => "..."
-basket.registry_operator           # => pubkey hex of the publisher
-basket.token.satoshis              # => 1
-basket.token.dtxid_hex             # => display-order txid
+basket.definition_data.basket_id           # => "ordinals"
+basket.definition_data.name                # => "Ordinals"
+basket.definition_data.icon_url            # => "https://example.com/ord.png"
+basket.definition_data.description         # => "..."
+basket.definition_data.registry_operator   # => pubkey hex of the publisher
+basket.satoshis                            # => 1
+basket.txid                                # => display-order txid
+basket.output_index                        # => 0
+basket.beef                                # => BSV::Transaction::Beef (verifiable, embeddable)
 ```
 
 ### Trust model — filter by operator

--- a/docs/overlays/registries.md
+++ b/docs/overlays/registries.md
@@ -1,0 +1,147 @@
+# Registries
+
+The registry overlay maps human-readable names to canonical on-chain
+definitions for three kinds of thing:
+
+- **Baskets** — wallet output groupings (think "asset categories").
+- **Protocols** — application protocol IDs used across BRC-43-aware wallets.
+- **Certificate types** — schemas for BRC-52 identity certificates.
+
+Each definition is a PushDrop UTXO signed by the *registry operator* —
+typically the entity who owns the namespace. Anyone can publish a
+definition; clients decide which operators they trust by passing
+`registry_operators` filters in their queries.
+
+The SDK ships the **read paths** (`resolve_basket`, `resolve_protocol`,
+`resolve_certificate`). Publishing, updating, and revoking definitions
+need a wallet and live in `bsv-wallet`.
+
+## Why it exists
+
+Wallets and apps need to talk about the same things by name:
+
+- "Show me everything in the *ordinals* basket."
+- "I'm signing with the *p2p messaging* protocol."
+- "Verify this *identity profile* certificate."
+
+Without a registry, every app invents its own ID and the wallet UI can't
+tell `ordinals` from `ordinals-v2` from `ordinalz`. The registry overlay
+gives each name a verifiable canonical definition — title, description,
+icon URL, documentation link — so wallet UIs can show consistent metadata
+across apps and the user can audit what they're consenting to.
+
+## The three overlays
+
+Each definition type runs on its own topic/lookup-service pair:
+
+| Type | Topic | Lookup service | BRC-43 protocol ID |
+|---|---|---|---|
+| Basket | `tm_basketmap` | `ls_basketmap` | `[1, 'basketmap']` |
+| Protocol | `tm_protomap` | `ls_protomap` | `[1, 'protomap']` |
+| Certificate | `tm_certmap` | `ls_certmap` | `[1, 'certmap']` |
+
+Naming follows [BRC-87](https://hub.bsvblockchain.org/brc/overlays/0087)'s
+convention. Splitting the three types across separate overlays means a
+node can choose to index only the kinds it cares about.
+
+## What the SDK provides
+
+```ruby
+require 'bsv-sdk'
+
+# Resolver-only construction — read paths don't need a wallet
+client = BSV::Registry::Client.new(wallet: nil)
+
+# Resolve baskets by id, name, or both
+baskets = client.resolve_basket(basket_id: 'ordinals')
+
+# Resolve protocols (BRC-43 [security_level, name] format)
+protocols = client.resolve_protocol(protocol_id: [1, 'p2p messaging'])
+
+# Resolve certificate types
+certs = client.resolve_certificate(type: 'identity-v1')
+```
+
+Each method returns `Array<BSV::Registry::RegisteredDefinition>`. A
+definition exposes the registry operator's pubkey, the parsed
+type-specific data, and the underlying token info so you can verify
+authenticity:
+
+```ruby
+basket = baskets.first
+basket.definition.basket_id        # => "ordinals"
+basket.definition.name             # => "Ordinals"
+basket.definition.icon_url         # => "https://example.com/ord.png"
+basket.definition.description      # => "..."
+basket.registry_operator           # => pubkey hex of the publisher
+basket.token.satoshis              # => 1
+basket.token.dtxid_hex             # => display-order txid
+```
+
+### Trust model — filter by operator
+
+The overlay returns *every* definition matching your query, regardless of
+who published it. If you only trust certain operators, filter the
+results client-side or pass `registry_operators:` so the overlay
+pre-filters:
+
+```ruby
+client.resolve_basket(
+  basket_id: 'ordinals',
+  registry_operators: ['02a1b2c3...', '03d4e5f6...']
+)
+```
+
+The Ruby SDK pre-existed before this PR; `resolve_basket`/`_protocol`/
+`_certificate` are new thin wrappers around the existing
+`resolve(type, query)` that match the typed API in other SDKs.
+
+See [SDK reference: Ecosystem Clients](../sdk/ecosystem-clients.md) for
+the full method surface.
+
+## What the wallet provides
+
+`Registry::Client` accepts a `wallet:` because its **write paths** are
+on the same class:
+
+- `register_definition(type, data)` — publish a new definition (broadcast
+  to the corresponding `tm_*` topic).
+- `update_definition(...)` — spend the existing UTXO and publish a new
+  version.
+- `revoke_definition(...)` — spend the UTXO to take the definition out of
+  circulation.
+- `list_own_registry_entries(type)` — query the wallet for definitions
+  *this* identity has published.
+
+Those methods need a BRC-100 wallet because they create-and-sign new
+transactions. The Ruby SDK's `Client` requires one for those — pass any
+BRC-100-compatible wallet (typically `bsv-wallet`'s `Wallet::Client`).
+
+If you're only reading, you can pass `wallet: nil` and use only the
+typed resolve methods. The constructor accepts it.
+
+## Edge cases worth knowing
+
+- **Multiple definitions can share a name.** The overlay doesn't dedupe.
+  If two operators both register `basket_id: 'ordinals'`, you'll get two
+  results and have to choose based on who you trust.
+- **Empty queries are valid.** `client.resolve_basket()` returns every
+  basket definition the overlay knows about. Useful for discovery; bad
+  for performance unless you intend to scan.
+- **Updates don't dedupe in history.** `update_definition` spends the old
+  UTXO and creates a new one — readers see only the new state, but the
+  history is walkable through Historian if you want to display
+  provenance.
+- **Revocation is a spend.** A revoked definition simply doesn't appear
+  in lookup responses (the underlying UTXO is spent and no longer
+  topical).
+
+## References
+
+- [BRC-87](https://hub.bsvblockchain.org/brc/overlays/0087) — overlay
+  naming convention (where the `tm_*` / `ls_*` names come from)
+- [BRC-43](https://hub.bsvblockchain.org/brc/key-derivation/0043) —
+  protocol ID format (`[security_level, name]`)
+- Go: [`registry/methods.go`](https://github.com/bitcoin-sv/go-sdk/blob/master/registry/methods.go)
+- Python: [`bsv/registry/client.py`](https://github.com/bitcoin-sv/py-sdk/blob/master/bsv/registry/client.py)
+- [SDK reference: Ecosystem Clients](../sdk/ecosystem-clients.md)

--- a/docs/overlays/uhrp-storage.md
+++ b/docs/overlays/uhrp-storage.md
@@ -1,0 +1,132 @@
+# UHRP Storage
+
+UHRP — the **Universal Hash Resource Protocol**
+([BRC-26](https://hub.bsvblockchain.org/brc/overlays/0026)) — is a
+content-addressed file-storage layer for BSV.
+
+Each file has a self-verifying URL of the form
+`XUT6PqWb3GP3LR7dmBMCJwZ3oo5g1iGCF3CrpzyuJCemkGu1WGoq` — a Base58Check
+encoding of the SHA-256 hash of the content with a two-byte
+`0xCE 0x00` version prefix. Anyone who knows the URL can request the file,
+fetch it from any willing host, and verify it's the right bytes by
+recomputing the hash.
+
+## Why it exists
+
+Centralised storage has a single point of failure: if the host disappears
+or pulls the file, the link is dead. UHRP turns that on its head:
+
+1. **Anyone can host.** A host advertises that it has the file by publishing
+   a UTXO whose locking script contains the file's SHA-256 hash, the URL it
+   will serve from, and an expiry timestamp.
+2. **Anyone can find a host.** A reader queries the `ls_uhrp` lookup service
+   with a UHRP URL and gets back a list of currently-advertised host URLs.
+3. **The content is self-verifying.** The reader downloads from any host
+   and SHA-256s the body. If the hash matches, the content is correct —
+   the host is untrusted.
+4. **Hosts can be paid to stay online.** The advertisement UTXO can be
+   funded by the publisher, multiplying the hosts as a hedge against any
+   single host going offline.
+
+This is what makes UHRP useful for content the network has to keep
+available — long-term archives, software updates, signed certificates —
+without trusting any one server.
+
+## What the SDK provides
+
+The `bsv-sdk` gem ships the **read path**: URL helpers and a downloader.
+
+### `BSV::Storage::Utils` — URL encode/decode
+
+```ruby
+require 'bsv-sdk'
+
+# Encode 32 raw bytes as a UHRP URL
+data = File.binread('document.pdf')
+url  = BSV::Storage::Utils.get_url_for_file(data)
+# => "XUT7mGMrAbG3EWJz..."
+
+# Decode a URL back to its 32-byte SHA-256 hash
+hash = BSV::Storage::Utils.get_hash_from_url(url)
+
+# Validate (never raises)
+BSV::Storage::Utils.valid_url?(url)         # => true
+BSV::Storage::Utils.valid_url?('not-a-url') # => false
+```
+
+URLs are accepted with or without the `uhrp:` or `uhrp://` scheme prefix.
+The `web+uhrp://` variant is deliberately not normalised — we follow the TS
+SDK contract here so URLs round-trip identically across SDKs.
+
+### `BSV::Storage::Downloader` — resolve and fetch
+
+```ruby
+require 'bsv-sdk'
+
+dl = BSV::Storage::Downloader.new(network_preset: :mainnet)
+
+# What hosts currently advertise this file?
+urls = dl.resolve('uhrp://XUT7mGMrAbG3EWJz...')
+# => ["https://nanostore.example/cdn/abc...", "https://archive.example/uhrp/xyz..."]
+
+# Download and verify
+result = dl.download('uhrp://XUT7mGMrAbG3EWJz...')
+result.data       # => binary file content (already SHA-256 verified)
+result.mime_type  # => "application/pdf"
+```
+
+The downloader queries `ls_uhrp`, decodes each PushDrop output to extract
+the host URL and expiry, drops expired advertisements, and then walks the
+host list until one returns bytes that match the URL's hash. 4xx and 5xx
+responses are treated as failed hosts and the next URL is tried — there
+is no special handling for 401/402/403 in v1.
+
+See [SDK reference: Storage](../sdk/storage.md) for the full method
+surface.
+
+## What the wallet provides
+
+Publishing to UHRP — creating the host-advertisement UTXOs — lives in
+[`bsv-wallet`](../gems/wallet.md). A `StorageUploader` there takes a file
+and a target host, signs the advertisement, pays the satoshi cost, and
+submits to the `tm_uhrp` topic on behalf of the wallet's identity.
+
+The split matches the SDK/wallet boundary: reading needs no key material or
+funding; publishing needs both.
+
+## Reference implementations and infrastructure
+
+The canonical UHRP storage server reference is
+[bsv-blockchain/storage-server](https://github.com/bsv-blockchain/storage-server)
+(archived in May 2026 in favour of the ts-stack monorepo). It implements:
+
+- Upload endpoints that accept file content plus a hosting commitment.
+- A notifier that broadcasts the advertisement to the overlay.
+- Billing for hosting duration.
+
+Public UHRP overlay nodes are reachable through the default
+`BSV::Overlay::LookupResolver` — you don't need to know specific host
+URLs in normal SDK usage.
+
+## Edge cases worth knowing
+
+- **Privacy of host URLs.** The downloader follows whatever URLs the
+  overlay returns, including non-HTTPS or private-IP hosts. The SHA-256
+  verification means the returned bytes can't be tampered with, but the
+  DNS resolution and TCP attempt itself can leak. For wallet apps running
+  on user devices, consider filtering URLs before fetching (the SDK
+  doesn't filter by design — that policy belongs at the integration
+  layer).
+- **Redirects are not followed.** Net::HTTP's default is preserved. A 302
+  is treated as a failed host. Hosts that need to redirect should serve
+  directly.
+- **Expired advertisements are silently dropped.** No exception, no log
+  line — the host simply doesn't appear in `resolve`'s result.
+
+## References
+
+- [BRC-26](https://hub.bsvblockchain.org/brc/overlays/0026) — UHRP specification
+- [bsv-blockchain/storage-server](https://github.com/bsv-blockchain/storage-server) — reference server
+- TypeScript: [`StorageDownloader.ts`](https://github.com/bitcoin-sv/ts-sdk/blob/master/src/storage/StorageDownloader.ts)
+- Python: [`bsv/storage/downloader.py`](https://github.com/bitcoin-sv/py-sdk/blob/master/bsv/storage/downloader.py)
+- [SDK reference: Storage](../sdk/storage.md)

--- a/docs/sdk/ecosystem-clients.md
+++ b/docs/sdk/ecosystem-clients.md
@@ -1,0 +1,84 @@
+# Ecosystem Clients
+
+The SDK ships several overlay-aware client modules that work alongside `BSV::Registry::Client`
+to query and interact with protocol-specific overlay services: the Registry for discovering
+known baskets, protocols, and certificate types; the Historian for reconstructing the history
+of any PushDrop token; the KVStore for reading the global key-value store; and the Storage
+downloader for fetching UHRP-addressed content.
+
+For full details, see the individual pages:
+
+- [Storage (Utils + Downloader)](storage.md)
+- [KVStore (Global + Interpreter)](kvstore.md)
+- [Registry Client](network.md#registry) *(typed resolves are covered below)*
+
+## Registry::Client — typed resolves
+
+`BSV::Registry::Client` provides three convenience methods that correspond to the Go SDK's
+`ResolveBasket`, `ResolveProtocol`, and `ResolveCertificate`:
+
+```ruby
+require 'bsv-sdk'
+
+client = BSV::Registry::Client.new(wallet: my_wallet)
+
+# Resolve basket definitions
+baskets = client.resolve_basket(basket_id: 'tokens.1sat')
+baskets.first.definition_data.name          # => "1Sat Ordinals"
+baskets.first.definition_data.icon_url      # => "https://..."
+
+# Resolve protocol definitions — protocol_id is a two-element BRC-43 array
+protocols = client.resolve_protocol(protocol_id: [1, 'my-app'])
+protocols.first.definition_data.description # => "Stores my application state"
+
+# Resolve certificate type definitions
+certs = client.resolve_certificate(name: 'Age Verification')
+certs.first.definition_data.type            # => Base64 certificate type identifier
+
+# No-argument form — returns all registered definitions of that type
+all_baskets = client.resolve_basket
+```
+
+**Contract notes:**
+
+- All three methods return `Array<RegisteredDefinition>`. An empty array means no matching
+  definitions were found.
+- `resolve_basket` / `resolve_protocol` / `resolve_certificate` are thin wrappers around
+  `resolve(definition_type, query)` — use the lower-level method when you need to pass
+  `registry_operators:` to filter by operator public key.
+- Outputs that fail BEEF parsing or PushDrop decoding are silently skipped.
+
+## Overlay::Historian
+
+`Historian` traverses a transaction's input ancestry and returns a chronological list of
+values decoded by an interpreter callable. It is protocol-agnostic — any callable that
+accepts `(tx, output_index, ctx)` and returns a value or `nil` works.
+
+```ruby
+require 'bsv-sdk'
+
+# Custom interpreter: extract OP_RETURN payloads from a specific app prefix
+my_interpreter = ->(tx, output_index, _ctx) do
+  script = tx.outputs[output_index]&.locking_script
+  return nil unless script&.op_return?
+
+  items = script.op_return_data
+  return nil unless items&.first == 'myapp'.b
+
+  items[1]&.force_encoding('UTF-8')
+end
+
+historian = BSV::Overlay::Historian.new(my_interpreter)
+history   = historian.build_history(tx)
+# => ["first-value", "second-value", "current-value"]  (oldest → newest)
+```
+
+**Contract notes:**
+
+- Inputs must have `source_transaction` populated for traversal to follow ancestors.
+  Use `BSV::Transaction::Beef` to load a fully-linked transaction graph.
+- Each transaction is visited at most once; cycles are safe.
+- `false`, `""`, and `0` are valid history entries and are included. Only `nil` is excluded.
+- Pass `history_cache:` (any Hash-like object) to cache results across calls.
+  Cache keys have the form `"#{interpreter_version}|#{dtxid_hex}|#{ctx_key}"`.
+- Pass `debug: true` to emit traversal logging via `BSV.logger`.

--- a/docs/sdk/ecosystem-clients.md
+++ b/docs/sdk/ecosystem-clients.md
@@ -10,7 +10,7 @@ For full details, see the individual pages:
 
 - [Storage (Utils + Downloader)](storage.md)
 - [KVStore (Global + Interpreter)](kvstore.md)
-- [Registry Client](network.md#registry) *(typed resolves are covered below)*
+- [Registry Client](../overlays/registries.md) *(typed resolves are covered below)*
 
 ## Registry::Client — typed resolves
 

--- a/docs/sdk/kvstore.md
+++ b/docs/sdk/kvstore.md
@@ -1,0 +1,62 @@
+# KVStore
+
+`BSV::KVStore::Global` is a read-only client for the global KVStore overlay service.
+It queries the `ls_kvstore` lookup service, decodes and verifies PushDrop tokens, and
+returns typed `Entry` objects. Set and remove operations require wallet writes and live
+in the `bsv-wallet` gem.
+
+## Querying entries
+
+```ruby
+require 'bsv-sdk'
+
+kv = BSV::KVStore::Global.new(network_preset: :mainnet)
+
+# Look up by key + protocol
+entries = kv.get(
+  key: 'user-preference',
+  protocol_id: [1, 'my-app']
+)
+entry = entries.first
+entry.key          # => "user-preference"
+entry.value        # => "dark-mode"
+entry.controller   # => "03a1b2c3..." (compressed pubkey hex)
+entry.protocol_id  # => [1, "my-app"]
+entry.tags         # => ["ui", "prefs"] or nil for old-format tokens
+
+# Look up by controller (all keys belonging to an identity)
+kv.get(controller: '03a1b2c3...')
+
+# Look up by tags
+kv.get(tags: ['ui'], tag_query_mode: 'any')
+
+# Include the raw BEEF token for on-chain verification
+entries = kv.get({ key: 'user-preference', protocol_id: [1, 'my-app'] }, include_token: true)
+entries.first.token.dtxid        # => display-order txid hex
+entries.first.token.output_index # => 0
+```
+
+**Contract notes:**
+
+- `get` requires at least one selector (`key`, `controller`, `protocol_id`, or a non-empty
+  `tags` array); it raises `ArgumentError` without one.
+- `get` always returns an `Array`; use `.first` when you expect a single result.
+- Outputs that fail BEEF parsing, field-count validation, or signature verification are
+  silently skipped — the array may be shorter than the raw lookup result.
+- Pass `lookup_resolver:` to inject a custom `BSV::Overlay::LookupResolver` for testing
+  or pointing at a local network.
+
+## KVStore::Interpreter (advanced)
+
+`KVStore::Interpreter` implements the Historian interpreter contract and is used internally
+by `Global` when `history: true` is passed to `get`. You can also use it directly with
+`BSV::Overlay::Historian` to walk the ancestry of any KVStore-bearing transaction:
+
+```ruby
+historian = BSV::Overlay::Historian.new(BSV::KVStore::Interpreter)
+history   = historian.build_history(tx, { key: 'user-preference', protocol_id: [1, 'my-app'] })
+# => ["initial-value", "updated-value", "dark-mode"]  (oldest → newest)
+```
+
+The interpreter never raises — it returns `nil` for any output that does not match the
+given `key` and `protocol_id`.

--- a/docs/sdk/storage.md
+++ b/docs/sdk/storage.md
@@ -1,0 +1,67 @@
+# Storage
+
+The `BSV::Storage` module provides utilities for working with UHRP (Unified Hash Resource
+Protocol), the content-addressed storage standard used by BSV overlay services.
+
+## Storage::Utils
+
+`Storage::Utils` encodes and decodes UHRP URLs. A UHRP URL is a Base58Check string whose
+payload contains the SHA-256 hash of the content, making each URL self-verifying and
+stable across storage providers.
+
+```ruby
+require 'bsv-sdk'
+
+# Generate a UHRP URL from file content
+data = File.binread('document.pdf')
+url  = BSV::Storage::Utils.get_url_for_file(data)
+# => "XUT7mGMrAbG3EWJz..."
+
+# Round-trip: decode the hash back from the URL
+hash = BSV::Storage::Utils.get_hash_from_url(url)
+# => 32-byte binary SHA-256 digest
+
+# Validate a URL (returns false rather than raising)
+BSV::Storage::Utils.valid_url?(url)         # => true
+BSV::Storage::Utils.valid_url?('not-a-url') # => false
+
+# Normalise a URL that includes the uhrp: scheme or // authority prefix
+normalised = BSV::Storage::Utils.normalize_url('uhrp://XUT7mGMrAbG3EWJz...')
+```
+
+**Contract notes:**
+
+- `get_url_for_file` computes SHA-256 internally — pass raw binary, not hex.
+- `get_hash_from_url` accepts `uhrp:` and `uhrp://` prefixes; `web+uhrp://` is not
+  stripped (follows the TS SDK; Python diverges here).
+- `valid_url?` never raises — use it as a guard before `get_hash_from_url`.
+
+## Storage::Downloader
+
+`Downloader` resolves a UHRP URL to a list of HTTP(S) hosts via the `ls_uhrp` overlay
+lookup service, then fetches the content and verifies its SHA-256 hash.
+
+```ruby
+require 'bsv-sdk'
+
+downloader = BSV::Storage::Downloader.new(network_preset: :mainnet)
+
+# Resolve only — returns an Array of download URLs without fetching content
+urls = downloader.resolve('XUT7mGMrAbG3EWJz...')
+# => ["https://staging-nanostore.babbage.systems/cdn/..."]
+
+# Full download — verifies hash, returns DownloadResult
+result = downloader.download('XUT7mGMrAbG3EWJz...')
+result.data       # => binary String (file content)
+result.mime_type  # => "application/pdf"
+```
+
+**Contract notes:**
+
+- Any 4xx/5xx response, empty body, or network exception causes that host to be skipped;
+  the next host in the list is tried automatically.
+- `download` raises `BSV::Storage::DownloadError` if all hosts fail or the UHRP lookup
+  returns no entries.
+- HTTP redirects are not followed in v1.
+- Pass `http_client:` to inject a test double that responds to `.call(url)` and returns
+  an object with `#code`, `#body`, and `#[]` (header access).

--- a/gem/bsv-sdk/lib/bsv-sdk.rb
+++ b/gem/bsv-sdk/lib/bsv-sdk.rb
@@ -26,6 +26,7 @@ module BSV
   autoload :Identity,    'bsv/identity'
   autoload :Registry,    'bsv/registry'
   autoload :MCP,         'bsv/mcp'
+  autoload :Storage,     'bsv/storage'
 
   # Wallet is loaded eagerly to avoid load-path shadowing when bsv-wallet is
   # also in the bundle (bsv-wallet/lib/bsv/wallet.rb would otherwise win).

--- a/gem/bsv-sdk/lib/bsv-sdk.rb
+++ b/gem/bsv-sdk/lib/bsv-sdk.rb
@@ -27,6 +27,7 @@ module BSV
   autoload :Registry,    'bsv/registry'
   autoload :MCP,         'bsv/mcp'
   autoload :Storage,     'bsv/storage'
+  autoload :KVStore,     'bsv/kv_store'
 
   # Wallet is loaded eagerly to avoid load-path shadowing when bsv-wallet is
   # also in the bundle (bsv-wallet/lib/bsv/wallet.rb would otherwise win).

--- a/gem/bsv-sdk/lib/bsv/kv_store.rb
+++ b/gem/bsv-sdk/lib/bsv/kv_store.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module BSV
+  module KVStore
+    autoload :Interpreter, 'bsv/kv_store/interpreter'
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/kv_store.rb
+++ b/gem/bsv-sdk/lib/bsv/kv_store.rb
@@ -3,5 +3,8 @@
 module BSV
   module KVStore
     autoload :Interpreter, 'bsv/kv_store/interpreter'
+    autoload :Entry,       'bsv/kv_store/entry'
+    autoload :Token,       'bsv/kv_store/token'
+    autoload :Global,      'bsv/kv_store/global'
   end
 end

--- a/gem/bsv-sdk/lib/bsv/kv_store/entry.rb
+++ b/gem/bsv-sdk/lib/bsv/kv_store/entry.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module BSV
+  module KVStore
+    # An immutable KVStore entry returned from {Global#get}.
+    #
+    # +token+ is populated only when +include_token: true+ is passed to +#get+.
+    # +history+ is populated only when +history: true+ is passed to +#get+.
+    Entry = Data.define(:key, :value, :controller, :protocol_id, :tags, :token, :history) do
+      def initialize(key:, value:, controller:, protocol_id:, tags:, token: nil, history: nil)
+        super
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/kv_store/global.rb
+++ b/gem/bsv-sdk/lib/bsv/kv_store/global.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module BSV
+  module KVStore
+    # Read-only client for the global KVStore overlay service.
+    #
+    # Queries the +ls_kvstore+ lookup service via a {BSV::Overlay::LookupResolver},
+    # decodes PushDrop tokens (5-field legacy and 6-field current formats), verifies
+    # the token signature, and returns typed {Entry} objects.
+    #
+    # Set/remove operations require wallet writes and are out of scope — those live
+    # in the +bsv-wallet+ gem.
+    #
+    # == Selector requirement
+    #
+    # {#get} raises +ArgumentError+ unless at least one of +key+, +controller+,
+    # +protocol_id+, or a non-empty +tags+ array is supplied in the query.
+    #
+    # == Always returns Array
+    #
+    # {#get} always returns +Array<Entry>+, even for single-result selectors such
+    # as +key + controller+. Callers that expect at most one result should use
+    # +.first+.
+    #
+    # == Silent skipping
+    #
+    # Outputs that fail BEEF parsing, PushDrop decoding, field-count validation, or
+    # signature verification are silently skipped (matching the TS SDK contract).
+    class Global
+      # @param network_preset [Symbol] :mainnet, :testnet, or :local
+      # @param lookup_resolver [BSV::Overlay::LookupResolver, nil] injectable resolver
+      # @param service_name [String] lookup service identifier
+      def initialize(network_preset: :mainnet, lookup_resolver: nil, service_name: 'ls_kvstore')
+        @lookup_resolver = lookup_resolver || BSV::Overlay::LookupResolver.new(network_preset: network_preset)
+        @service_name = service_name
+        @proto_wallet = BSV::Wallet::ProtoWallet.new('anyone')
+      end
+
+      # Query the overlay for KVStore entries.
+      #
+      # @param query [Hash] selector: +:key+, +:controller+, +:protocol_id+, +:tags+,
+      #   +:tag_query_mode+. At least one of the first four must be present.
+      # @param include_token [Boolean] populate {Token} on each entry when true
+      # @param history [Boolean] populate history via {BSV::Overlay::Historian} when true
+      # @return [Array<Entry>] matching entries (empty array when nothing matches)
+      # @raise [ArgumentError] if no selector is provided
+      def get(query, include_token: false, history: false)
+        validate_selector!(query)
+
+        question = BSV::Overlay::LookupQuestion.new(
+          service: @service_name,
+          query: camelise(query)
+        )
+
+        answer = @lookup_resolver.query(question)
+        return [] unless answer.type == 'output-list'
+
+        answer.outputs.filter_map do |output|
+          build_entry(output, include_token: include_token, history: history)
+        rescue StandardError
+          nil
+        end
+      end
+
+      private
+
+      # ---- Selector validation ----
+
+      def validate_selector!(query)
+        has_key        = query[:key].is_a?(String)        && !query[:key].empty?
+        has_controller = query[:controller].is_a?(String) && !query[:controller].empty?
+        has_protocol   = query[:protocol_id].is_a?(Array) && query[:protocol_id].length == 2
+        has_tags       = query[:tags].is_a?(Array)        && !query[:tags].empty?
+
+        return if has_key || has_controller || has_protocol || has_tags
+
+        raise ArgumentError,
+              'At least one selector required (key, controller, protocol_id, or non-empty tags)'
+      end
+
+      # ---- Entry construction ----
+
+      def build_entry(output, include_token:, history:)
+        beef_data    = output['beef'] || output[:beef]
+        output_index = (output['outputIndex'] || output[:output_index] || 0).to_i
+
+        beef = parse_beef!(beef_data)
+        beef_tx = beef.transactions.last
+        raise 'No transaction in BEEF' if beef_tx.nil? || beef_tx.is_a?(BSV::Transaction::Beef::TxidOnlyEntry)
+
+        tx     = beef_tx.transaction
+        txout  = tx.outputs[output_index]
+        raise 'outputIndex out of range' if txout.nil?
+
+        locking_script = txout.locking_script
+        raise 'No locking script' unless locking_script&.pushdrop?
+
+        raw_fields = locking_script.pushdrop_fields
+        raise 'Not a PushDrop script' unless raw_fields
+
+        field_count = raw_fields.length
+        raise "Unexpected field count: #{field_count}" unless [5, 6].include?(field_count)
+
+        # Separate data fields from trailing signature field
+        data_fields = raw_fields[0...-1]
+        sig_bytes   = raw_fields.last
+
+        # Decode common fields (indices match kvProtocol in TS SDK)
+        protocol_id = decode_protocol_id!(data_fields[0])
+        key         = decode_utf8!(data_fields[1])
+        value       = decode_utf8!(data_fields[2])
+        controller  = data_fields[3].unpack1('H*')
+
+        # New format (6 fields) has tags at index 4; old format (5 fields) has no tags field
+        tags = if field_count == 6
+                 begin
+                   JSON.parse(decode_utf8!(data_fields[4]))
+                 rescue StandardError
+                   nil
+                 end
+               end
+
+        verify_signature!(data_fields, sig_bytes, protocol_id, key, controller)
+
+        token = if include_token
+                  Token.new(
+                    dtxid: tx.dtxid_hex,
+                    output_index: output_index,
+                    beef: beef,
+                    satoshis: txout.satoshis || 0
+                  )
+                end
+
+        entry_history = if history
+                          BSV::Overlay::Historian
+                            .new(BSV::KVStore::Interpreter)
+                            .build_history(tx, { key: key, protocol_id: protocol_id })
+                        end
+
+        Entry.new(
+          key: key,
+          value: value,
+          controller: controller,
+          protocol_id: protocol_id,
+          tags: tags,
+          token: token,
+          history: entry_history
+        )
+      end
+
+      # ---- Field decoding helpers ----
+
+      def parse_beef!(beef_data)
+        case beef_data
+        when String
+          BSV::Transaction::Beef.from_binary(beef_data)
+        when Array
+          BSV::Transaction::Beef.from_binary(beef_data.pack('C*'))
+        else
+          raise 'Missing or unsupported BEEF data'
+        end
+      end
+
+      def decode_utf8!(bytes)
+        raise 'Nil field' if bytes.nil?
+
+        str = bytes.force_encoding(Encoding::UTF_8)
+        raise 'Invalid UTF-8' unless str.valid_encoding?
+
+        str
+      end
+
+      def decode_protocol_id!(bytes)
+        JSON.parse(decode_utf8!(bytes))
+      end
+
+      # ---- Signature verification ----
+
+      def verify_signature!(data_fields, sig_bytes, protocol_id, key, controller)
+        data = data_fields.reduce(''.b) { |acc, f| acc + f }.unpack('C*')
+        sig  = sig_bytes.unpack('C*')
+
+        @proto_wallet.verify_signature(
+          data: data,
+          signature: sig,
+          protocol_id: protocol_id,
+          key_id: key,
+          counterparty: controller
+        )
+      end
+
+      # ---- Query key camelisation ----
+
+      def camelise(query)
+        query.transform_keys do |k|
+          case k
+          when :protocol_id    then :protocolID
+          when :tag_query_mode then :tagQueryMode
+          else k
+          end
+        end
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/kv_store/global.rb
+++ b/gem/bsv-sdk/lib/bsv/kv_store/global.rb
@@ -85,6 +85,7 @@ module BSV
       def build_entry(output, include_token:, history:)
         beef_data    = output['beef'] || output[:beef]
         output_index = (output['outputIndex'] || output[:output_index] || 0).to_i
+        raise 'Negative outputIndex' if output_index.negative?
 
         beef = parse_beef!(beef_data)
         beef_tx = beef.transactions.last

--- a/gem/bsv-sdk/lib/bsv/kv_store/global.rb
+++ b/gem/bsv-sdk/lib/bsv/kv_store/global.rb
@@ -32,10 +32,13 @@ module BSV
       # @param network_preset [Symbol] :mainnet, :testnet, or :local
       # @param lookup_resolver [BSV::Overlay::LookupResolver, nil] injectable resolver
       # @param service_name [String] lookup service identifier
-      def initialize(network_preset: :mainnet, lookup_resolver: nil, service_name: 'ls_kvstore')
+      # @param proto_wallet [BSV::Wallet::ProtoWallet, nil] injectable wallet used for
+      #   signature verification; defaults to +ProtoWallet.new('anyone')+. Tests can
+      #   substitute a double to avoid +allow_any_instance_of+.
+      def initialize(network_preset: :mainnet, lookup_resolver: nil, service_name: 'ls_kvstore', proto_wallet: nil)
         @lookup_resolver = lookup_resolver || BSV::Overlay::LookupResolver.new(network_preset: network_preset)
         @service_name = service_name
-        @proto_wallet = BSV::Wallet::ProtoWallet.new('anyone')
+        @proto_wallet = proto_wallet || BSV::Wallet::ProtoWallet.new('anyone')
       end
 
       # Query the overlay for KVStore entries.

--- a/gem/bsv-sdk/lib/bsv/kv_store/global.rb
+++ b/gem/bsv-sdk/lib/bsv/kv_store/global.rb
@@ -72,6 +72,8 @@ module BSV
       # ---- Selector validation ----
 
       def validate_selector!(query)
+        raise ArgumentError, 'query must be a Hash' unless query.is_a?(Hash)
+
         has_key        = query[:key].is_a?(String)        && !query[:key].empty?
         has_controller = query[:controller].is_a?(String) && !query[:controller].empty?
         has_protocol   = query[:protocol_id].is_a?(Array) && query[:protocol_id].length == 2
@@ -183,12 +185,9 @@ module BSV
       # ---- Signature verification ----
 
       def verify_signature!(data_fields, sig_bytes, protocol_id, key, controller)
-        data = data_fields.reduce(''.b) { |acc, f| acc + f }.unpack('C*')
-        sig  = sig_bytes.unpack('C*')
-
         @proto_wallet.verify_signature(
-          data: data,
-          signature: sig,
+          data: data_fields.join.bytes,
+          signature: sig_bytes.bytes,
           protocol_id: protocol_id,
           key_id: key,
           counterparty: controller

--- a/gem/bsv-sdk/lib/bsv/kv_store/interpreter.rb
+++ b/gem/bsv-sdk/lib/bsv/kv_store/interpreter.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module BSV
+  module KVStore
+    # Historian interpreter for KVStore PushDrop tokens.
+    #
+    # Decodes a PushDrop locking script from the specified output, validates it
+    # has the expected field count (5 old format / 6 new format), and filters by
+    # +ctx[:key]+ and +ctx[:protocol_id]+.
+    #
+    # Returns the value as a UTF-8 string, or +nil+ for any non-match or error.
+    # Never raises.
+    #
+    # Field layout (old format — 5 fields):
+    #   [0] protocolID (JSON-encoded array)
+    #   [1] key
+    #   [2] value
+    #   [3] controller
+    #   [4] signature
+    #
+    # Field layout (new format — 6 fields):
+    #   [0] protocolID (JSON-encoded array)
+    #   [1] key
+    #   [2] value
+    #   [3] controller
+    #   [4] tags
+    #   [5] signature
+    module Interpreter
+      PROTOCOL_ID    = 0
+      KEY            = 1
+      VALUE          = 2
+      CONTROLLER     = 3
+      TAGS_NEW       = 4
+      SIGNATURE_OLD  = 4
+      SIGNATURE_NEW  = 5
+
+      KV_PROTOCOL_FIELDS_OLD = 5
+      KV_PROTOCOL_FIELDS_NEW = 6
+
+      # Decode the KVStore token at +output_index+ in +tx+.
+      #
+      # Implements the Historian interpreter contract:
+      # +interpreter.call(tx, output_index, ctx)+ → String or nil.
+      #
+      # @param tx [BSV::Transaction::Tx, nil] the transaction to inspect
+      # @param output_index [Integer] index into +tx.outputs+
+      # @param ctx [Hash, nil] must contain +:key+ (String) and +:protocol_id+ (Array)
+      # @return [String, nil] the decoded UTF-8 value, or nil on any mismatch/error
+      def self.call(tx, output_index, ctx)
+        return nil if tx.nil?
+        return nil if ctx.nil? || ctx[:key].nil?
+
+        output = tx.outputs[output_index]
+        return nil if output.nil?
+
+        locking_script = output.locking_script
+        return nil if locking_script.nil?
+
+        return nil unless locking_script.pushdrop?
+
+        fields = locking_script.pushdrop_fields
+        return nil unless fields
+
+        field_count = fields.length
+        return nil unless [KV_PROTOCOL_FIELDS_OLD, KV_PROTOCOL_FIELDS_NEW].include?(field_count)
+
+        protocol_id_bytes = fields[PROTOCOL_ID]
+        return nil if protocol_id_bytes.nil?
+
+        begin
+          protocol_id_str = protocol_id_bytes.force_encoding(Encoding::UTF_8)
+          return nil unless protocol_id_str.valid_encoding?
+
+          parsed_protocol_id = JSON.parse(protocol_id_str)
+          return nil unless parsed_protocol_id == ctx[:protocol_id]
+        rescue JSON::ParserError
+          return nil
+        end
+
+        key_bytes = fields[KEY]
+        return nil if key_bytes.nil?
+
+        begin
+          key_str = key_bytes.force_encoding(Encoding::UTF_8)
+          return nil unless key_str.valid_encoding?
+          return nil unless key_str == ctx[:key]
+        rescue StandardError
+          return nil
+        end
+
+        begin
+          value_bytes = fields[VALUE]
+          return nil if value_bytes.nil?
+
+          value_str = value_bytes.force_encoding(Encoding::UTF_8)
+          return nil unless value_str.valid_encoding?
+
+          value_str
+        rescue StandardError
+          nil
+        end
+      rescue StandardError
+        nil
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/kv_store/token.rb
+++ b/gem/bsv-sdk/lib/bsv/kv_store/token.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module BSV
+  module KVStore
+    # Transaction output reference for a KVStore token.
+    #
+    # Populated when +include_token: true+ is passed to {Global#get}.
+    Token = Data.define(:dtxid, :output_index, :beef, :satoshis)
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/overlay.rb
+++ b/gem/bsv-sdk/lib/bsv/overlay.rb
@@ -25,5 +25,6 @@ module BSV
     autoload :HTTPSBroadcastFacilitator,  'bsv/overlay/broadcast_facilitator'
     autoload :TopicBroadcaster,           'bsv/overlay/topic_broadcaster'
     autoload :SHIPBroadcaster,            'bsv/overlay/topic_broadcaster'
+    autoload :Historian,                  'bsv/overlay/historian'
   end
 end

--- a/gem/bsv-sdk/lib/bsv/overlay/historian.rb
+++ b/gem/bsv-sdk/lib/bsv/overlay/historian.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module BSV
+  module Overlay
+    # Builds a chronological history (oldest → newest) of typed values by traversing
+    # a transaction's input ancestry and interpreting each output with a provided interpreter.
+    #
+    # The interpreter contract is: +interpreter.call(tx, output_index, ctx)+, returning the
+    # typed value or +nil+. Any callable responding to +:call+ is accepted (lambda, proc,
+    # method, or object).
+    #
+    # Traversal follows +input.source_transaction+ references recursively. Callers must
+    # supply transactions whose inputs have +source_transaction+ populated.
+    #
+    # == Cycle safety
+    #
+    # Each transaction is visited at most once, tracked by its +wtxid+ (wire-order binary).
+    #
+    # == Value semantics
+    #
+    # Only +nil+ is excluded. Falsy non-nil values (+false+, +""+, +0+) are valid history
+    # entries and are included in the result.
+    #
+    # == Caching
+    #
+    # An optional +history_cache+ (any +[]/[]=+ responder) caches complete history results.
+    # Cache keys have the form: <tt>"#{interpreter_version}|#{dtxid_hex}|#{ctx_key}"</tt>.
+    # Cached arrays are stored frozen; each retrieval returns a +dup+ to protect the cache.
+    #
+    # == Note
+    #
+    # The Ruby Historian is synchronous. There is no async/await semantics.
+    class Historian
+      # @param interpreter       [#call]     callable: +call(tx, output_index, ctx) → value|nil+
+      # @param debug             [Boolean]   enable debug logging via +BSV.logger+
+      # @param history_cache     [Hash, nil] optional cache store (+[]/[]=+ responder)
+      # @param interpreter_version [String]  version tag for cache key invalidation
+      # @param ctx_key_fn        [#call, nil] serialises context to a string cache key
+      def initialize(interpreter, debug: false, history_cache: nil, interpreter_version: 'v1', ctx_key_fn: nil)
+        @interpreter = interpreter
+        @debug = debug
+        @history_cache = history_cache
+        @interpreter_version = interpreter_version
+        @ctx_key_fn = ctx_key_fn
+      end
+
+      # Traverses input ancestry from +start_transaction+ and returns all interpreted
+      # values in chronological order (oldest first).
+      #
+      # @param start_transaction [BSV::Transaction::Tx]
+      # @param context           [Object, nil] forwarded verbatim to the interpreter
+      # @return [Array] interpreted values, oldest first
+      def build_history(start_transaction, context = nil)
+        if @history_cache
+          key = cache_key(start_transaction, context)
+          cached = @history_cache[key]
+          unless cached.nil?
+            BSV.logger&.debug { "[Historian] History cache hit: #{key}" } if @debug
+            return cached.dup
+          end
+        end
+
+        history = []
+        visited = {}
+
+        traverse(start_transaction, context, history, visited)
+
+        result = history.reverse
+
+        if @history_cache
+          key ||= cache_key(start_transaction, context)
+          @history_cache[key] = result.dup.freeze
+          BSV.logger&.debug { "[Historian] History cached: #{key}" } if @debug
+        end
+
+        result
+      end
+
+      private
+
+      def cache_key(tx, context)
+        ctx_key = @ctx_key_fn ? @ctx_key_fn.call(context) : context.to_s
+        "#{@interpreter_version}|#{tx.dtxid_hex}|#{ctx_key}"
+      end
+
+      def traverse(tx, context, history, visited)
+        id = tx.wtxid
+
+        if visited.key?(id)
+          BSV.logger&.debug { "[Historian] Skipping already visited transaction: #{tx.dtxid_hex}" } if @debug
+          return
+        end
+
+        visited[id] = true
+
+        BSV.logger&.debug { "[Historian] Processing transaction: #{tx.dtxid_hex}" } if @debug
+
+        tx.outputs.each_with_index do |_output, index|
+          value = @interpreter.call(tx, index, context)
+          unless value.nil?
+            history << value
+            BSV.logger&.debug { "[Historian] Added value to history: #{value.inspect}" } if @debug
+          end
+        rescue StandardError => e
+          BSV.logger&.debug { "[Historian] Failed to interpret output #{index}: #{e.message}" } if @debug
+        end
+
+        tx.inputs.each do |input|
+          if input.source_transaction
+            traverse(input.source_transaction, context, history, visited)
+          elsif @debug
+            BSV.logger&.debug { '[Historian] Input missing sourceTransaction, skipping' }
+          end
+        end
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/registry/client.rb
+++ b/gem/bsv-sdk/lib/bsv/registry/client.rb
@@ -112,6 +112,48 @@ module BSV
         end
       end
 
+      # Resolves basket registry definitions.
+      #
+      # Thin wrapper around {#resolve} for cross-SDK parity with the Go SDK's
+      # +ResolveBasket+ method.
+      #
+      # @param query [Hash] optional filter criteria:
+      #   - +:basket_id+ [String] exact basket identifier
+      #   - +:name+ [String] human-readable basket name
+      #   - +:registry_operators+ [Array<String>] operator public key hexes
+      # @return [Array<RegisteredDefinition>] matching registered basket definitions
+      def resolve_basket(query = {})
+        resolve(DefinitionType::BASKET, query)
+      end
+
+      # Resolves protocol registry definitions.
+      #
+      # Thin wrapper around {#resolve} for cross-SDK parity with the Go SDK's
+      # +ResolveProtocol+ method.
+      #
+      # @param query [Hash] optional filter criteria:
+      #   - +:name+ [String] human-readable protocol name
+      #   - +:protocol_id+ [Array] BRC-43 two-element protocol ID, e.g. +[1, 'protomap']+
+      #   - +:registry_operators+ [Array<String>] operator public key hexes
+      # @return [Array<RegisteredDefinition>] matching registered protocol definitions
+      def resolve_protocol(query = {})
+        resolve(DefinitionType::PROTOCOL, query)
+      end
+
+      # Resolves certificate type registry definitions.
+      #
+      # Thin wrapper around {#resolve} for cross-SDK parity with the Go SDK's
+      # +ResolveCertificate+ method.
+      #
+      # @param query [Hash] optional filter criteria:
+      #   - +:type+ [String] Base64-encoded certificate type identifier
+      #   - +:name+ [String] human-readable certificate type name
+      #   - +:registry_operators+ [Array<String>] operator public key hexes
+      # @return [Array<RegisteredDefinition>] matching registered certificate type definitions
+      def resolve_certificate(query = {})
+        resolve(DefinitionType::CERTIFICATE, query)
+      end
+
       # Lists the registry operator's own published definitions for the given type.
       #
       # Queries the wallet for spendable outputs in the appropriate basket,

--- a/gem/bsv-sdk/lib/bsv/storage.rb
+++ b/gem/bsv-sdk/lib/bsv/storage.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module BSV
+  # Storage module for UHRP (Unified Hash Resource Protocol) URL encoding,
+  # decoding, and validation helpers.
+  #
+  # UHRP enables content-addressed storage on BSV: a SHA-256 hash of a file
+  # is Base58Check-encoded with the `\xCE\x00` prefix to produce a stable,
+  # self-verifying URL.
+  module Storage
+    autoload :Utils, 'bsv/storage/utils'
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/storage.rb
+++ b/gem/bsv-sdk/lib/bsv/storage.rb
@@ -8,6 +8,9 @@ module BSV
   # is Base58Check-encoded with the `\xCE\x00` prefix to produce a stable,
   # self-verifying URL.
   module Storage
-    autoload :Utils, 'bsv/storage/utils'
+    autoload :Utils,          'bsv/storage/utils'
+    autoload :DownloadResult, 'bsv/storage/downloader'
+    autoload :Downloader,     'bsv/storage/downloader'
+    autoload :DownloadError,  'bsv/storage/errors'
   end
 end

--- a/gem/bsv-sdk/lib/bsv/storage/downloader.rb
+++ b/gem/bsv-sdk/lib/bsv/storage/downloader.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'openssl'
+require 'uri'
+
+module BSV
+  module Storage
+    # Result returned by {Downloader#download}.
+    DownloadResult = Data.define(:data, :mime_type)
+
+    # Downloads UHRP-addressed content from distributed storage hosts.
+    #
+    # Resolution: queries the +ls_uhrp+ lookup service via a {BSV::Overlay::LookupResolver},
+    # decodes each PushDrop output to extract the host URL (field[2]) and expiry timestamp
+    # (field[3], varint). Expired entries are silently dropped.
+    #
+    # Download: fetches each resolved URL in turn. Any HTTP 4xx/5xx, empty body, or
+    # network exception is treated as a failed host and the next URL is tried. This
+    # matches the TS SDK contract — no special treatment of 401/402/403.
+    #
+    # HTTP redirects are not followed (Net::HTTP default). This is intentional in v1.
+    #
+    # Download URLs are taken directly from the overlay; no private-IP filter is applied
+    # here. (The LookupResolver applies SSRF filtering to SLAP-discovered *infrastructure*
+    # hosts — content URLs are end-user data and are not subject to the same filter.)
+    class Downloader
+      # @param network_preset   [Symbol]                         :mainnet, :testnet, or :local
+      # @param lookup_resolver  [BSV::Overlay::LookupResolver]   injectable resolver (nil = default)
+      # @param http_client      [#call, nil]                     injectable HTTP client for testing.
+      #   Must respond to +.call(url_string)+ and return an object exposing +#code+ (Integer),
+      #   +#body+ (binary String), and +#[](header_name)+ for header access.
+      #   Default: a thin {Net::HTTP.get_response} wrapper.
+      # @param timeout          [Integer]                        per-request timeout in seconds
+      def initialize(network_preset: :mainnet, lookup_resolver: nil, http_client: nil, timeout: 30)
+        @lookup_resolver = lookup_resolver || BSV::Overlay::LookupResolver.new(network_preset: network_preset)
+        @http_client     = http_client
+        @timeout         = timeout
+      end
+
+      # Resolve a UHRP URL to a list of HTTP(S) download URLs.
+      #
+      # Queries the +ls_uhrp+ lookup service, decodes each PushDrop output,
+      # drops expired entries, and returns the remaining URLs.
+      #
+      # @param uhrp_url [String] UHRP URL (with or without +uhrp://+ prefix)
+      # @return [Array<String>] resolved HTTP(S) download URLs
+      # @raise [BSV::Storage::DownloadError] if the lookup answer is not an output-list
+      def resolve(uhrp_url)
+        question = BSV::Overlay::LookupQuestion.new(
+          service: 'ls_uhrp',
+          query: { 'uhrpUrl' => uhrp_url }
+        )
+        answer = @lookup_resolver.query(question)
+        raise DownloadError, 'Lookup answer must be an output list' unless answer.type == 'output-list'
+
+        current_time = Time.now.to_i
+        urls = []
+
+        answer.outputs.each do |output|
+          url = decode_output_url(output, current_time)
+          urls << url if url
+        end
+
+        urls
+      end
+
+      # Download the content addressed by +uhrp_url+.
+      #
+      # Validates the URL, resolves it to a list of hosts, then attempts each
+      # host in order. Verifies the SHA-256 hash of the downloaded body against
+      # the hash embedded in the UHRP URL. Returns on the first successful match.
+      #
+      # @param uhrp_url [String] UHRP URL
+      # @return [BSV::Storage::DownloadResult] downloaded data and MIME type
+      # @raise [ArgumentError] if the URL is not a valid UHRP URL
+      # @raise [BSV::Storage::DownloadError] if no host yields content matching the hash
+      def download(uhrp_url)
+        raise ArgumentError, 'Invalid parameter UHRP url' unless BSV::Storage::Utils.valid_url?(uhrp_url)
+
+        urls = resolve(uhrp_url)
+        raise DownloadError, 'No one currently hosts this file!' if urls.empty?
+
+        expected_hash = BSV::Storage::Utils.get_hash_from_url(uhrp_url)
+
+        urls.each do |url|
+          result = attempt_download(url, expected_hash)
+          return result if result
+        end
+
+        raise DownloadError, "Unable to download content from #{uhrp_url}"
+      end
+
+      private
+
+      def decode_output_url(output, current_time)
+        beef_data    = output['beef'] || output[:beef]
+        output_index = (output['outputIndex'] || output[:output_index] || 0).to_i
+        return nil if beef_data.nil?
+
+        beef   = parse_beef(beef_data)
+        return nil unless beef
+
+        beef_tx = beef.transactions.last
+        return nil if beef_tx.nil? || beef_tx.is_a?(BSV::Transaction::Beef::TxidOnlyEntry)
+
+        txout = beef_tx.transaction.outputs[output_index]
+        return nil unless txout
+
+        fields = txout.locking_script.pushdrop_fields
+        return nil if fields.nil? || fields.length < 4
+
+        expiry, = BSV::Transaction::VarInt.decode(fields[3])
+        return nil if expiry < current_time
+
+        fields[2].force_encoding('UTF-8')
+      rescue StandardError
+        nil
+      end
+
+      def parse_beef(beef_data)
+        case beef_data
+        when String
+          BSV::Transaction::Beef.from_binary(beef_data)
+        when Array
+          BSV::Transaction::Beef.from_binary(beef_data.pack('C*'))
+        end
+      rescue StandardError
+        nil
+      end
+
+      def attempt_download(url, expected_hash)
+        response = fetch(url)
+        return nil if response.nil?
+
+        code = response.code.to_i
+        return nil if code >= 400
+
+        body = response.body.to_s
+        return nil if body.empty?
+
+        actual_hash = OpenSSL::Digest::SHA256.digest(body)
+        return nil unless actual_hash == expected_hash
+
+        DownloadResult.new(data: body, mime_type: response['Content-Type'])
+      rescue StandardError
+        nil
+      end
+
+      def fetch(url)
+        if @http_client
+          @http_client.call(url)
+        else
+          uri = URI(url)
+          Net::HTTP.start(
+            uri.hostname,
+            uri.port,
+            use_ssl: uri.scheme == 'https',
+            open_timeout: @timeout,
+            read_timeout: @timeout
+          ) { |http| http.request(Net::HTTP::Get.new(uri)) }
+        end
+      rescue StandardError
+        nil
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/storage/downloader.rb
+++ b/gem/bsv-sdk/lib/bsv/storage/downloader.rb
@@ -49,7 +49,7 @@ module BSV
       def resolve(uhrp_url)
         question = BSV::Overlay::LookupQuestion.new(
           service: 'ls_uhrp',
-          query: { 'uhrpUrl' => uhrp_url }
+          query: { 'uhrpUrl' => BSV::Storage::Utils.normalize_url(uhrp_url) }
         )
         answer = @lookup_resolver.query(question)
         raise DownloadError, 'Lookup answer must be an output list' unless answer.type == 'output-list'
@@ -138,7 +138,9 @@ module BSV
         return nil if response.nil?
 
         code = response.code.to_i
-        return nil if code >= 400
+        # 3xx is treated as a failed host: redirects are intentionally not followed in v1,
+        # so a 302 body is never the content we want.
+        return nil if code >= 300
 
         body = response.body.to_s
         return nil if body.empty?

--- a/gem/bsv-sdk/lib/bsv/storage/downloader.rb
+++ b/gem/bsv-sdk/lib/bsv/storage/downloader.rb
@@ -114,7 +114,10 @@ module BSV
         expiry, = BSV::Transaction::VarInt.decode(fields[3])
         return nil if expiry < current_time
 
-        fields[2].force_encoding('UTF-8')
+        url = fields[2].force_encoding('UTF-8')
+        return nil unless url.valid_encoding?
+
+        url
       rescue StandardError
         nil
       end

--- a/gem/bsv-sdk/lib/bsv/storage/downloader.rb
+++ b/gem/bsv-sdk/lib/bsv/storage/downloader.rb
@@ -97,6 +97,7 @@ module BSV
         beef_data    = output['beef'] || output[:beef]
         output_index = (output['outputIndex'] || output[:output_index] || 0).to_i
         return nil if beef_data.nil?
+        return nil if output_index.negative?
 
         beef   = parse_beef(beef_data)
         return nil unless beef

--- a/gem/bsv-sdk/lib/bsv/storage/errors.rb
+++ b/gem/bsv-sdk/lib/bsv/storage/errors.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module BSV
+  module Storage
+    # Raised when a UHRP file cannot be downloaded from any available host.
+    class DownloadError < StandardError; end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/storage/utils.rb
+++ b/gem/bsv-sdk/lib/bsv/storage/utils.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'openssl'
+
+module BSV
+  module Storage
+    # Helpers for encoding and decoding UHRP (Unified Hash Resource Protocol) URLs.
+    #
+    # A UHRP URL is a Base58Check string with a two-byte `\xCE\x00` prefix prepended
+    # to the SHA-256 hash of the content. This makes each URL self-verifying and
+    # stable across storage providers.
+    #
+    # == URL normalisation
+    #
+    # `normalize_url` strips the `uhrp:` scheme (case-insensitive) and the optional
+    # `//` authority prefix, matching the TS SDK contract exactly. The `web+uhrp://`
+    # variant used by some browser extension manifests is *not* normalised here — that
+    # diverges from the TS reference (Python normalises it; we follow TS).
+    module Utils
+      # Two-byte UHRP version prefix: 0xCE 0x00.
+      UHRP_PREFIX = "\xCE\x00".b.freeze
+
+      module_function
+
+      # Encode a 32-byte binary SHA-256 hash as a UHRP URL.
+      #
+      # @param hash [String] 32-byte binary string (SHA-256 hash)
+      # @return [String] Base58Check-encoded UHRP URL
+      # @raise [ArgumentError] if hash is not exactly 32 bytes
+      def get_url_for_hash(hash)
+        raise ArgumentError, 'Hash length must be 32 bytes (sha256)' unless hash.bytesize == 32
+
+        BSV::Primitives::Base58.check_encode(hash.b, prefix: UHRP_PREFIX)
+      end
+
+      # Compute the SHA-256 hash of +data+ and encode it as a UHRP URL.
+      #
+      # @param data [String] binary file content
+      # @return [String] Base58Check-encoded UHRP URL
+      def get_url_for_file(data)
+        hash = OpenSSL::Digest::SHA256.digest(data.b)
+        get_url_for_hash(hash)
+      end
+
+      # Decode a UHRP URL and return the 32-byte binary SHA-256 hash.
+      #
+      # Accepts URLs with or without the `uhrp:` scheme and optional `//` authority.
+      #
+      # @param url [String] UHRP URL (with or without `uhrp:` prefix)
+      # @return [String] 32-byte binary SHA-256 hash
+      # @raise [ArgumentError] if the URL is empty, has a bad prefix, or has wrong length
+      # @raise [BSV::Primitives::Base58::ChecksumError] if the Base58Check checksum fails
+      def get_hash_from_url(url)
+        raise ArgumentError, 'URL must not be empty' if url.empty?
+
+        normalised = normalize_url(url)
+        result = BSV::Primitives::Base58.check_decode(normalised, prefix_length: 2)
+        raise ArgumentError, 'Bad prefix' unless result[:prefix] == UHRP_PREFIX
+        raise ArgumentError, 'Invalid length!' unless result[:data].bytesize == 32
+
+        result[:data]
+      end
+
+      # Strip the `uhrp:` scheme (case-insensitive) and optional `//` from a URL.
+      #
+      # Follows the TS SDK contract: only `uhrp:` and `uhrp://` are normalised.
+      # `web+uhrp://` is deliberately not stripped (TS does not strip it; Python does).
+      #
+      # @param url [String] URL to normalise
+      # @return [String] normalised URL
+      def normalize_url(url)
+        url = url.slice(5..) if url.downcase.start_with?('uhrp:')
+        url = url.slice(2..) if url.start_with?('//')
+        url
+      end
+
+      # Return +true+ if +url+ is a syntactically valid UHRP URL.
+      #
+      # @param url [String] URL to validate
+      # @return [Boolean]
+      def valid_url?(url)
+        get_hash_from_url(url)
+        true
+      rescue ArgumentError, BSV::Primitives::Base58::ChecksumError
+        false
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/storage/utils.rb
+++ b/gem/bsv-sdk/lib/bsv/storage/utils.rb
@@ -48,9 +48,10 @@ module BSV
       #
       # @param url [String] UHRP URL (with or without `uhrp:` prefix)
       # @return [String] 32-byte binary SHA-256 hash
-      # @raise [ArgumentError] if the URL is empty, has a bad prefix, or has wrong length
+      # @raise [ArgumentError] if the URL is not a String, empty, has a bad prefix, or has wrong length
       # @raise [BSV::Primitives::Base58::ChecksumError] if the Base58Check checksum fails
       def get_hash_from_url(url)
+        raise ArgumentError, 'URL must be a String' unless url.is_a?(String)
         raise ArgumentError, 'URL must not be empty' if url.empty?
 
         normalised = normalize_url(url)

--- a/gem/bsv-sdk/spec/bsv/kv_store/global_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/kv_store/global_spec.rb
@@ -206,6 +206,24 @@ RSpec.describe BSV::KVStore::Global do
       end
     end
 
+    context 'with a negative outputIndex (untrusted overlay response)' do
+      before do
+        good_script   = raw_old_format_script
+        good_output   = overlay_output(locking_script: good_script)
+        negative      = good_output.merge('outputIndex' => -1)
+        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature).and_return({ valid: true }) # rubocop:disable RSpec/AnyInstance
+        allow(resolver).to receive(:query).and_return(
+          lookup_answer([negative, good_output])
+        )
+      end
+
+      it 'silently skips the entry rather than reading the wrong output via negative indexing' do
+        entries = global.get({ key: 'my-key' })
+        expect(entries.length).to eq(1)
+        expect(entries.first.key).to eq('my-key')
+      end
+    end
+
     context 'with signature verification failing on one output' do
       let(:good_script) { raw_old_format_script(key: 'good') }
       let(:bad_script)  { raw_old_format_script(key: 'bad') }

--- a/gem/bsv-sdk/spec/bsv/kv_store/global_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/kv_store/global_spec.rb
@@ -1,0 +1,398 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-sdk'
+require 'json'
+
+GLOBAL_TEST_PROTOCOL_ID = [1, 'kvstore'].freeze
+GLOBAL_TEST_PUBKEY_HASH = ("\x00" * 20).b
+
+RSpec.describe BSV::KVStore::Global do
+  # ---- Helpers ----
+
+  def dummy_p2pkh
+    BSV::Script::Script.p2pkh_lock(GLOBAL_TEST_PUBKEY_HASH)
+  end
+
+  def pushdrop_script(fields)
+    BSV::Script::Script.pushdrop_lock(fields, dummy_p2pkh, lock_position: :before)
+  end
+
+  # Build a raw old-format PushDrop script (5 fields: no real signature)
+  def raw_old_format_script(protocol_id: GLOBAL_TEST_PROTOCOL_ID, key: 'my-key',
+                            value: 'hello', controller_hex: ('aa' * 33),
+                            signature: 'fake-sig')
+    pushdrop_script([
+                      JSON.generate(protocol_id).b,
+                      key.b,
+                      value.b,
+                      [controller_hex].pack('H*').b,
+                      signature.b
+                    ])
+  end
+
+  # Build a raw new-format PushDrop script (6 fields: with tags, no real signature)
+  def raw_new_format_script(protocol_id: GLOBAL_TEST_PROTOCOL_ID, key: 'my-key',
+                            value: 'hello', controller_hex: ('aa' * 33),
+                            tags: ['tag1'], signature: 'fake-sig')
+    pushdrop_script([
+                      JSON.generate(protocol_id).b,
+                      key.b,
+                      value.b,
+                      [controller_hex].pack('H*').b,
+                      JSON.generate(tags).b,
+                      signature.b
+                    ])
+  end
+
+  # Create a minimal BEEF wrapping a single tx with the given locking script
+  def beef_with_script(locking_script, satoshis: 1000)
+    tx = BSV::Transaction::Tx.new
+    tx.add_output(BSV::Transaction::TransactionOutput.new(
+                    satoshis: satoshis,
+                    locking_script: locking_script
+                  ))
+    beef = BSV::Transaction::Beef.new
+    beef.transactions << BSV::Transaction::Beef::RawTxEntry.new(transaction: tx)
+    beef.to_binary
+  end
+
+  # Build a synthetic output hash as the overlay would return it
+  def overlay_output(locking_script:, satoshis: 1000, output_index: 0)
+    {
+      'beef' => beef_with_script(locking_script, satoshis: satoshis),
+      'outputIndex' => output_index
+    }
+  end
+
+  def lookup_answer(outputs)
+    BSV::Overlay::LookupAnswer.new(type: 'output-list', outputs: outputs)
+  end
+
+  def empty_answer
+    BSV::Overlay::LookupAnswer.new(type: 'output-list', outputs: [])
+  end
+
+  # ---- Shared setup ----
+
+  let(:resolver) { instance_double(BSV::Overlay::LookupResolver) }
+  let(:global) { described_class.new(lookup_resolver: resolver) }
+
+  # ---- #get: selector validation ----
+
+  describe '#get' do
+    context 'with no selector' do
+      it 'raises ArgumentError when query is empty' do
+        expect { global.get({}) }.to raise_error(ArgumentError, /selector/)
+      end
+
+      it 'raises ArgumentError when key is an empty string' do
+        expect { global.get({ key: '' }) }.to raise_error(ArgumentError, /selector/)
+      end
+
+      it 'raises ArgumentError when controller is an empty string' do
+        expect { global.get({ controller: '' }) }.to raise_error(ArgumentError, /selector/)
+      end
+
+      it 'raises ArgumentError when protocol_id has wrong arity' do
+        expect { global.get({ protocol_id: [1] }) }.to raise_error(ArgumentError, /selector/)
+      end
+
+      it 'raises ArgumentError when tags is an empty array' do
+        expect { global.get({ tags: [] }) }.to raise_error(ArgumentError, /selector/)
+      end
+    end
+
+    context 'with only key' do
+      let(:controller_hex) { 'aa' * 33 }
+      let(:key)            { 'my-key' }
+      let(:value)          { 'my-value' }
+
+      before do
+        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature).and_return({ valid: true }) # rubocop:disable RSpec/AnyInstance
+        allow(resolver).to receive(:query).and_return(
+          lookup_answer([
+                          overlay_output(locking_script: raw_old_format_script(
+                            key: key, value: value, controller_hex: controller_hex
+                          ))
+                        ])
+        )
+      end
+
+      it 'issues a query to the resolver with the key' do
+        captured = nil
+        allow(resolver).to receive(:query) { |q|
+          captured = q
+          empty_answer
+        }
+        global.get({ key: key })
+        expect(captured.service).to eq('ls_kvstore')
+        expect(captured.query[:key]).to eq(key)
+      end
+
+      it 'returns an array of matching entries' do
+        entries = global.get({ key: key })
+        expect(entries).to be_an(Array)
+        expect(entries.length).to eq(1)
+        expect(entries.first.key).to eq(key)
+        expect(entries.first.value).to eq(value)
+      end
+    end
+
+    context 'with key + controller' do
+      let(:controller_hex) { 'bb' * 33 }
+
+      before do
+        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature).and_return({ valid: true }) # rubocop:disable RSpec/AnyInstance
+        allow(resolver).to receive(:query).and_return(
+          lookup_answer([
+                          overlay_output(locking_script: raw_old_format_script(
+                            key: 'k', value: 'v', controller_hex: controller_hex
+                          ))
+                        ])
+        )
+      end
+
+      it 'returns an Array (not a single entry)' do
+        result = global.get({ key: 'k', controller: controller_hex })
+        expect(result).to be_an(Array)
+        expect(result.length).to eq(1)
+      end
+
+      it 'returns empty Array when resolver returns no outputs' do
+        allow(resolver).to receive(:query).and_return(empty_answer)
+        result = global.get({ key: 'k', controller: controller_hex })
+        expect(result).to eq([])
+      end
+    end
+
+    context 'when resolver returns no outputs' do
+      before do
+        allow(resolver).to receive(:query).and_return(empty_answer)
+      end
+
+      it 'returns an empty array' do
+        expect(global.get({ key: 'k' })).to eq([])
+      end
+    end
+
+    context 'when resolver returns a non-output-list answer' do
+      before do
+        allow(resolver).to receive(:query).and_return(
+          BSV::Overlay::LookupAnswer.new(type: 'freeform', outputs: [])
+        )
+      end
+
+      it 'returns an empty array' do
+        expect(global.get({ key: 'k' })).to eq([])
+      end
+    end
+
+    context 'with malformed BEEF on one output' do
+      before do
+        bad_output  = { 'beef' => 'not-valid-beef', 'outputIndex' => 0 }
+        good_script = raw_old_format_script
+        good_output = overlay_output(locking_script: good_script)
+        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature).and_return({ valid: true }) # rubocop:disable RSpec/AnyInstance
+        allow(resolver).to receive(:query).and_return(
+          lookup_answer([bad_output, good_output])
+        )
+      end
+
+      it 'silently skips the malformed output and returns the good one' do
+        entries = global.get({ key: 'my-key' })
+        expect(entries.length).to eq(1)
+        expect(entries.first.key).to eq('my-key')
+      end
+    end
+
+    context 'with signature verification failing on one output' do
+      let(:good_script) { raw_old_format_script(key: 'good') }
+      let(:bad_script)  { raw_old_format_script(key: 'bad') }
+
+      before do
+        allow(resolver).to receive(:query).and_return(
+          lookup_answer([
+                          overlay_output(locking_script: bad_script),
+                          overlay_output(locking_script: good_script)
+                        ])
+        )
+
+        call_count = 0
+        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature) do # rubocop:disable RSpec/AnyInstance
+          call_count += 1
+          raise BSV::Wallet::InvalidSignatureError if call_count == 1
+
+          { valid: true }
+        end
+      end
+
+      it 'skips the output with failed verification' do
+        entries = global.get({ key: 'good' })
+        expect(entries.length).to eq(1)
+        expect(entries.first.key).to eq('good')
+      end
+    end
+
+    context 'with include_token: true' do
+      let(:satoshis) { 5000 }
+
+      before do
+        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature).and_return({ valid: true }) # rubocop:disable RSpec/AnyInstance
+        allow(resolver).to receive(:query).and_return(
+          lookup_answer([
+                          overlay_output(
+                            locking_script: raw_old_format_script,
+                            satoshis: satoshis
+                          )
+                        ])
+        )
+      end
+
+      it 'populates the token field on each entry' do
+        entries = global.get({ key: 'my-key' }, include_token: true)
+        expect(entries.length).to eq(1)
+        token = entries.first.token
+        expect(token).to be_a(BSV::KVStore::Token)
+        expect(token.output_index).to eq(0)
+        expect(token.satoshis).to eq(satoshis)
+        expect(token.dtxid).to be_a(String)
+        expect(token.dtxid.length).to eq(64)
+        expect(token.beef).to be_a(BSV::Transaction::Beef)
+      end
+
+      it 'does not populate token when include_token is false (default)' do
+        entries = global.get({ key: 'my-key' })
+        expect(entries.first.token).to be_nil
+      end
+    end
+
+    context 'with history: true' do
+      before do
+        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature).and_return({ valid: true }) # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(BSV::Overlay::Historian).to receive(:build_history).and_return(['old-value']) # rubocop:disable RSpec/AnyInstance
+        allow(resolver).to receive(:query).and_return(
+          lookup_answer([overlay_output(locking_script: raw_old_format_script)])
+        )
+      end
+
+      it 'populates the history field via Historian' do
+        entries = global.get({ key: 'my-key' }, history: true)
+        expect(entries.length).to eq(1)
+        expect(entries.first.history).to eq(['old-value'])
+      end
+
+      it 'does not populate history when history is false (default)' do
+        allow_any_instance_of(BSV::Overlay::Historian).to receive(:build_history).and_call_original # rubocop:disable RSpec/AnyInstance
+        entries = global.get({ key: 'my-key' })
+        expect(entries.first.history).to be_nil
+      end
+    end
+
+    context 'with old 5-field format' do
+      let(:controller_hex) { 'cc' * 33 }
+
+      before do
+        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature).and_return({ valid: true }) # rubocop:disable RSpec/AnyInstance
+        allow(resolver).to receive(:query).and_return(
+          lookup_answer([
+                          overlay_output(locking_script: raw_old_format_script(
+                            key: 'k1', value: 'v1', controller_hex: controller_hex
+                          ))
+                        ])
+        )
+      end
+
+      it 'decodes key, value, controller correctly' do
+        entries = global.get({ key: 'k1' })
+        expect(entries.length).to eq(1)
+        entry = entries.first
+        expect(entry.key).to eq('k1')
+        expect(entry.value).to eq('v1')
+        expect(entry.controller).to eq(controller_hex)
+        expect(entry.tags).to be_nil
+        expect(entry.protocol_id).to eq(GLOBAL_TEST_PROTOCOL_ID)
+      end
+    end
+
+    context 'with new 6-field format' do
+      let(:controller_hex) { 'dd' * 33 }
+      let(:tags) { %w[alpha beta] }
+
+      before do
+        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature).and_return({ valid: true }) # rubocop:disable RSpec/AnyInstance
+        allow(resolver).to receive(:query).and_return(
+          lookup_answer([
+                          overlay_output(locking_script: raw_new_format_script(
+                            key: 'k2', value: 'v2', controller_hex: controller_hex, tags: tags
+                          ))
+                        ])
+        )
+      end
+
+      it 'decodes key, value, controller, and tags correctly' do
+        entries = global.get({ key: 'k2' })
+        expect(entries.length).to eq(1)
+        entry = entries.first
+        expect(entry.key).to eq('k2')
+        expect(entry.value).to eq('v2')
+        expect(entry.controller).to eq(controller_hex)
+        expect(entry.tags).to eq(tags)
+      end
+    end
+
+    context 'with a script having wrong field count' do
+      before do
+        # 4 fields — neither 5 nor 6
+        bad_script = pushdrop_script([
+                                       JSON.generate(GLOBAL_TEST_PROTOCOL_ID).b,
+                                       'key'.b,
+                                       'value'.b,
+                                       'sig'.b
+                                     ])
+        allow(resolver).to receive(:query).and_return(
+          lookup_answer([overlay_output(locking_script: bad_script)])
+        )
+      end
+
+      it 'silently skips the output and returns empty array' do
+        expect(global.get({ key: 'key' })).to eq([])
+      end
+    end
+
+    context 'when camelising query keys' do
+      before do
+        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature).and_return({ valid: true }) # rubocop:disable RSpec/AnyInstance
+        allow(resolver).to receive(:query).and_return(empty_answer)
+      end
+
+      it 'converts protocol_id to protocolID in the query' do
+        captured = nil
+        allow(resolver).to receive(:query) { |q|
+          captured = q
+          empty_answer
+        }
+        global.get({ protocol_id: GLOBAL_TEST_PROTOCOL_ID })
+        expect(captured.query[:protocolID]).to eq(GLOBAL_TEST_PROTOCOL_ID)
+        expect(captured.query.key?(:protocol_id)).to be(false)
+      end
+
+      it 'converts tag_query_mode to tagQueryMode in the query' do
+        captured = nil
+        allow(resolver).to receive(:query) { |q|
+          captured = q
+          empty_answer
+        }
+        global.get({ tags: ['t'], tag_query_mode: 'all' })
+        expect(captured.query[:tagQueryMode]).to eq('all')
+        expect(captured.query.key?(:tag_query_mode)).to be(false)
+      end
+    end
+
+    context 'with default resolver construction' do
+      it 'instantiates without error when no resolver is supplied' do
+        expect { described_class.new(network_preset: :local) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/kv_store/global_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/kv_store/global_spec.rb
@@ -82,6 +82,16 @@ RSpec.describe BSV::KVStore::Global do
   # ---- #get: selector validation ----
 
   describe '#get' do
+    context 'with a non-Hash query' do
+      it 'raises ArgumentError on nil' do
+        expect { global.get(nil) }.to raise_error(ArgumentError, /query must be a Hash/)
+      end
+
+      it 'raises ArgumentError on a String query' do
+        expect { global.get('key=foo') }.to raise_error(ArgumentError, /query must be a Hash/)
+      end
+    end
+
     context 'with no selector' do
       it 'raises ArgumentError when query is empty' do
         expect { global.get({}) }.to raise_error(ArgumentError, /selector/)

--- a/gem/bsv-sdk/spec/bsv/kv_store/global_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/kv_store/global_spec.rb
@@ -76,7 +76,8 @@ RSpec.describe BSV::KVStore::Global do
   # ---- Shared setup ----
 
   let(:resolver) { instance_double(BSV::Overlay::LookupResolver) }
-  let(:global) { described_class.new(lookup_resolver: resolver) }
+  let(:proto_wallet) { instance_double(BSV::Wallet::ProtoWallet) }
+  let(:global) { described_class.new(lookup_resolver: resolver, proto_wallet: proto_wallet) }
 
   # ---- #get: selector validation ----
 
@@ -109,7 +110,7 @@ RSpec.describe BSV::KVStore::Global do
       let(:value)          { 'my-value' }
 
       before do
-        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature).and_return({ valid: true }) # rubocop:disable RSpec/AnyInstance
+        allow(proto_wallet).to receive(:verify_signature).and_return({ valid: true })
         allow(resolver).to receive(:query).and_return(
           lookup_answer([
                           overlay_output(locking_script: raw_old_format_script(
@@ -143,7 +144,7 @@ RSpec.describe BSV::KVStore::Global do
       let(:controller_hex) { 'bb' * 33 }
 
       before do
-        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature).and_return({ valid: true }) # rubocop:disable RSpec/AnyInstance
+        allow(proto_wallet).to receive(:verify_signature).and_return({ valid: true })
         allow(resolver).to receive(:query).and_return(
           lookup_answer([
                           overlay_output(locking_script: raw_old_format_script(
@@ -193,7 +194,7 @@ RSpec.describe BSV::KVStore::Global do
         bad_output  = { 'beef' => 'not-valid-beef', 'outputIndex' => 0 }
         good_script = raw_old_format_script
         good_output = overlay_output(locking_script: good_script)
-        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature).and_return({ valid: true }) # rubocop:disable RSpec/AnyInstance
+        allow(proto_wallet).to receive(:verify_signature).and_return({ valid: true })
         allow(resolver).to receive(:query).and_return(
           lookup_answer([bad_output, good_output])
         )
@@ -211,7 +212,7 @@ RSpec.describe BSV::KVStore::Global do
         good_script   = raw_old_format_script
         good_output   = overlay_output(locking_script: good_script)
         negative      = good_output.merge('outputIndex' => -1)
-        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature).and_return({ valid: true }) # rubocop:disable RSpec/AnyInstance
+        allow(proto_wallet).to receive(:verify_signature).and_return({ valid: true })
         allow(resolver).to receive(:query).and_return(
           lookup_answer([negative, good_output])
         )
@@ -237,7 +238,7 @@ RSpec.describe BSV::KVStore::Global do
         )
 
         call_count = 0
-        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature) do # rubocop:disable RSpec/AnyInstance
+        allow(proto_wallet).to receive(:verify_signature) do
           call_count += 1
           raise BSV::Wallet::InvalidSignatureError if call_count == 1
 
@@ -256,7 +257,7 @@ RSpec.describe BSV::KVStore::Global do
       let(:satoshis) { 5000 }
 
       before do
-        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature).and_return({ valid: true }) # rubocop:disable RSpec/AnyInstance
+        allow(proto_wallet).to receive(:verify_signature).and_return({ valid: true })
         allow(resolver).to receive(:query).and_return(
           lookup_answer([
                           overlay_output(
@@ -287,7 +288,7 @@ RSpec.describe BSV::KVStore::Global do
 
     context 'with history: true' do
       before do
-        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature).and_return({ valid: true }) # rubocop:disable RSpec/AnyInstance
+        allow(proto_wallet).to receive(:verify_signature).and_return({ valid: true })
         allow_any_instance_of(BSV::Overlay::Historian).to receive(:build_history).and_return(['old-value']) # rubocop:disable RSpec/AnyInstance
         allow(resolver).to receive(:query).and_return(
           lookup_answer([overlay_output(locking_script: raw_old_format_script)])
@@ -311,7 +312,7 @@ RSpec.describe BSV::KVStore::Global do
       let(:controller_hex) { 'cc' * 33 }
 
       before do
-        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature).and_return({ valid: true }) # rubocop:disable RSpec/AnyInstance
+        allow(proto_wallet).to receive(:verify_signature).and_return({ valid: true })
         allow(resolver).to receive(:query).and_return(
           lookup_answer([
                           overlay_output(locking_script: raw_old_format_script(
@@ -338,7 +339,7 @@ RSpec.describe BSV::KVStore::Global do
       let(:tags) { %w[alpha beta] }
 
       before do
-        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature).and_return({ valid: true }) # rubocop:disable RSpec/AnyInstance
+        allow(proto_wallet).to receive(:verify_signature).and_return({ valid: true })
         allow(resolver).to receive(:query).and_return(
           lookup_answer([
                           overlay_output(locking_script: raw_new_format_script(
@@ -380,7 +381,7 @@ RSpec.describe BSV::KVStore::Global do
 
     context 'when camelising query keys' do
       before do
-        allow_any_instance_of(BSV::Wallet::ProtoWallet).to receive(:verify_signature).and_return({ valid: true }) # rubocop:disable RSpec/AnyInstance
+        allow(proto_wallet).to receive(:verify_signature).and_return({ valid: true })
         allow(resolver).to receive(:query).and_return(empty_answer)
       end
 

--- a/gem/bsv-sdk/spec/bsv/kv_store/interpreter_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/kv_store/interpreter_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-sdk'
+require 'json'
+
+KV_TEST_PROTOCOL_ID = [2, 'kvstore'].freeze
+KV_TEST_PUBKEY_HASH = ("\x00" * 20).b
+
+RSpec.describe 'BSV::KVStore::Interpreter' do
+  def dummy_p2pkh
+    BSV::Script::Script.p2pkh_lock(KV_TEST_PUBKEY_HASH)
+  end
+
+  def pushdrop_script(fields)
+    BSV::Script::Script.pushdrop_lock(fields, dummy_p2pkh, lock_position: :before)
+  end
+
+  def tx_with_output(locking_script, satoshis: 1000)
+    tx = BSV::Transaction::Tx.new
+    tx.add_output(BSV::Transaction::TransactionOutput.new(
+                    satoshis: satoshis,
+                    locking_script: locking_script
+                  ))
+    tx
+  end
+
+  def old_format_script(protocol_id: KV_TEST_PROTOCOL_ID, key: 'my-key', value: 'my-value',
+                        controller: 'controller', signature: 'sig')
+    pushdrop_script([JSON.generate(protocol_id).b, key.b, value.b, controller.b, signature.b])
+  end
+
+  def new_format_script(opts = {})
+    protocol_id = opts.fetch(:protocol_id, KV_TEST_PROTOCOL_ID)
+    key         = opts.fetch(:key,         'my-key')
+    value       = opts.fetch(:value,       'my-value')
+    controller  = opts.fetch(:controller,  'controller')
+    tags        = opts.fetch(:tags,        '[]')
+    signature   = opts.fetch(:signature,   'sig')
+    pushdrop_script([JSON.generate(protocol_id).b, key.b, value.b, controller.b, tags.b, signature.b])
+  end
+
+  let(:ctx) { { key: 'my-key', protocol_id: KV_TEST_PROTOCOL_ID } }
+
+  describe '.call' do
+    context 'with missing/invalid inputs' do
+      it 'returns nil when tx is nil' do
+        expect(BSV::KVStore::Interpreter.call(nil, 0, ctx)).to be_nil
+      end
+
+      it 'returns nil when output_index is out of range' do
+        tx = tx_with_output(old_format_script)
+        expect(BSV::KVStore::Interpreter.call(tx, 5, ctx)).to be_nil
+      end
+
+      it 'returns nil when ctx is nil' do
+        tx = tx_with_output(old_format_script)
+        expect(BSV::KVStore::Interpreter.call(tx, 0, nil)).to be_nil
+      end
+
+      it 'returns nil when ctx[:key] is nil' do
+        tx = tx_with_output(old_format_script)
+        ctx_no_key = { key: nil, protocol_id: KV_TEST_PROTOCOL_ID }
+        expect(BSV::KVStore::Interpreter.call(tx, 0, ctx_no_key)).to be_nil
+      end
+
+      it 'returns nil when locking_script is nil' do
+        tx = BSV::Transaction::Tx.new
+        tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 0, locking_script: nil))
+        expect(BSV::KVStore::Interpreter.call(tx, 0, ctx)).to be_nil
+      end
+
+      it 'returns nil for a non-PushDrop locking script' do
+        tx = tx_with_output(dummy_p2pkh)
+        expect(BSV::KVStore::Interpreter.call(tx, 0, ctx)).to be_nil
+      end
+    end
+
+    context 'with old format (5 fields)' do
+      it 'returns the value when key and protocol_id match' do
+        tx = tx_with_output(old_format_script)
+        expect(BSV::KVStore::Interpreter.call(tx, 0, ctx)).to eq('my-value')
+      end
+
+      it 'returns an empty string when value field is empty' do
+        tx = tx_with_output(old_format_script(value: ''))
+        expect(BSV::KVStore::Interpreter.call(tx, 0, ctx)).to eq('')
+      end
+
+      it 'returns the value at the correct output index' do
+        tx = BSV::Transaction::Tx.new
+        tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 0, locking_script: dummy_p2pkh))
+        tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 1000, locking_script: old_format_script))
+        expect(BSV::KVStore::Interpreter.call(tx, 1, ctx)).to eq('my-value')
+      end
+
+      it 'returns nil for a non-matching output index when tx has multiple outputs' do
+        tx = BSV::Transaction::Tx.new
+        tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 0, locking_script: dummy_p2pkh))
+        tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 1000, locking_script: old_format_script))
+        expect(BSV::KVStore::Interpreter.call(tx, 0, ctx)).to be_nil
+      end
+    end
+
+    context 'with new format (6 fields)' do
+      it 'returns the value when key and protocol_id match' do
+        tx = tx_with_output(new_format_script)
+        expect(BSV::KVStore::Interpreter.call(tx, 0, ctx)).to eq('my-value')
+      end
+
+      it 'returns an empty string when value field is empty' do
+        tx = tx_with_output(new_format_script(value: ''))
+        expect(BSV::KVStore::Interpreter.call(tx, 0, ctx)).to eq('')
+      end
+    end
+
+    context 'when key mismatches' do
+      it 'returns nil when the stored key does not match ctx[:key] (old format)' do
+        tx = tx_with_output(old_format_script(key: 'other-key'))
+        expect(BSV::KVStore::Interpreter.call(tx, 0, ctx)).to be_nil
+      end
+
+      it 'returns nil when the stored key does not match ctx[:key] (new format)' do
+        tx = tx_with_output(new_format_script(key: 'other-key'))
+        expect(BSV::KVStore::Interpreter.call(tx, 0, ctx)).to be_nil
+      end
+    end
+
+    context 'when protocol_id mismatches' do
+      it 'returns nil when stored protocol_id differs (old format)' do
+        tx = tx_with_output(old_format_script(protocol_id: [1, 'other-protocol']))
+        expect(BSV::KVStore::Interpreter.call(tx, 0, ctx)).to be_nil
+      end
+
+      it 'returns nil when stored protocol_id differs (new format)' do
+        tx = tx_with_output(new_format_script(protocol_id: [1, 'other-protocol']))
+        expect(BSV::KVStore::Interpreter.call(tx, 0, ctx)).to be_nil
+      end
+
+      it 'matches compact JSON protocol_id via array equality' do
+        script = pushdrop_script(['[2,"kvstore"]'.b, 'my-key'.b, 'my-value'.b, 'ctrl'.b, 'sig'.b])
+        expect(BSV::KVStore::Interpreter.call(tx_with_output(script), 0, ctx)).to eq('my-value')
+      end
+
+      it 'matches spaced JSON protocol_id via array equality' do
+        script = pushdrop_script(['[ 2, "kvstore" ]'.b, 'my-key'.b, 'my-value'.b, 'ctrl'.b, 'sig'.b])
+        expect(BSV::KVStore::Interpreter.call(tx_with_output(script), 0, ctx)).to eq('my-value')
+      end
+    end
+
+    context 'with malformed JSON in protocol_id field' do
+      it 'returns nil' do
+        bad_script = pushdrop_script(['not-json'.b, 'my-key'.b, 'my-value'.b, 'ctrl'.b, 'sig'.b])
+        expect(BSV::KVStore::Interpreter.call(tx_with_output(bad_script), 0, ctx)).to be_nil
+      end
+    end
+
+    context 'with wrong field count' do
+      it 'returns nil when script has fewer than 5 fields' do
+        bad_script = pushdrop_script([JSON.generate(KV_TEST_PROTOCOL_ID).b, 'my-key'.b, 'my-value'.b])
+        expect(BSV::KVStore::Interpreter.call(tx_with_output(bad_script), 0, ctx)).to be_nil
+      end
+
+      it 'returns nil when script has more than 6 fields' do
+        pid = JSON.generate(KV_TEST_PROTOCOL_ID).b
+        bad_script = pushdrop_script([pid, 'my-key'.b, 'my-value'.b, 'ctrl'.b, 'tags'.b, 'sig'.b, 'extra'.b])
+        expect(BSV::KVStore::Interpreter.call(tx_with_output(bad_script), 0, ctx)).to be_nil
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/overlay/historian_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/overlay/historian_spec.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe BSV::Overlay::Historian do
+  # Counter to ensure each make_tx call produces a unique transaction hash.
+  let(:tx_counter) { [0] }
+  # Interpreter that returns the output index as the value for every output.
+  let(:index_interpreter) { ->(_tx, idx, _ctx) { idx } }
+  # Interpreter that always returns nil.
+  let(:nil_interpreter) { ->(_tx, _idx, _ctx) {} }
+
+  # Builds a minimal Tx with a unique satoshi value so no two calls produce the same hash.
+  def make_tx(output_count: 1, wtxid: nil)
+    tx = BSV::Transaction::Tx.new
+    unique_sats = (tx_counter[0] += 1) * 1000
+    output_count.times do |i|
+      tx.add_output(BSV::Transaction::TransactionOutput.new(
+                      satoshis: unique_sats + i,
+                      locking_script: BSV::Script::Script.new
+                    ))
+    end
+    # Override wtxid by stubbing when a specific value is needed for cycle tests.
+    allow(tx).to receive(:wtxid).and_return(wtxid) if wtxid
+    tx
+  end
+
+  # Attaches +source_tx+ as the source_transaction of a new input on +tx+.
+  def wire_input(tx, source_tx)
+    input = BSV::Transaction::TransactionInput.new(
+      prev_wtxid: source_tx.wtxid,
+      prev_tx_out_index: 0
+    )
+    input.source_transaction = source_tx
+    tx.add_input(input)
+  end
+
+  describe '#build_history' do
+    context 'with no interpretable outputs' do
+      it 'returns an empty array' do
+        tx = make_tx
+        historian = described_class.new(nil_interpreter)
+        expect(historian.build_history(tx)).to eq([])
+      end
+    end
+
+    context 'with one interpretable output' do
+      it 'returns that single value' do
+        tx = make_tx(output_count: 1)
+        historian = described_class.new(index_interpreter)
+        expect(historian.build_history(tx)).to eq([0])
+      end
+    end
+
+    context 'with chained transactions tx1 <- tx2 <- tx3' do
+      it 'returns values in chronological order (oldest first)' do
+        tx1 = make_tx
+        tx2 = make_tx
+        tx3 = make_tx
+
+        # Use compare_by_identity so distinct Tx objects with the same content are keyed separately.
+        labels = {}.compare_by_identity
+        labels[tx1] = 'tx1'
+        labels[tx2] = 'tx2'
+        labels[tx3] = 'tx3'
+
+        labelling_interpreter = lambda do |tx, idx, _ctx|
+          idx.zero? ? labels[tx] : nil
+        end
+
+        wire_input(tx2, tx1)
+        wire_input(tx3, tx2)
+
+        historian = described_class.new(labelling_interpreter)
+        expect(historian.build_history(tx3)).to eq(%w[tx1 tx2 tx3])
+      end
+    end
+
+    context 'with multiple inputs per transaction' do
+      it 'walks all input branches' do
+        visited_tx_ids = []
+        tracking_interpreter = lambda do |tx, idx, _ctx|
+          return nil unless idx.zero?
+
+          visited_tx_ids << tx.dtxid_hex
+          tx.dtxid_hex
+        end
+
+        tx1 = make_tx
+        tx2 = make_tx
+        tx3 = make_tx
+
+        wire_input(tx3, tx1)
+        wire_input(tx3, tx2)
+
+        historian = described_class.new(tracking_interpreter)
+        result = historian.build_history(tx3)
+
+        expect(result.length).to eq(3)
+        expect(result).to include(tx1.dtxid_hex, tx2.dtxid_hex, tx3.dtxid_hex)
+      end
+    end
+
+    context 'with circular reference' do
+      it 'does not infinite-loop and visits each tx once' do
+        # Use binary wtxid stubs so the visited set works correctly.
+        wtxid1 = "\x01" * 32
+        wtxid2 = "\x02" * 32
+
+        tx1 = make_tx(wtxid: wtxid1)
+        tx2 = make_tx(wtxid: wtxid2)
+
+        input1 = BSV::Transaction::TransactionInput.new(prev_wtxid: wtxid2, prev_tx_out_index: 0)
+        input1.source_transaction = tx2
+        allow(tx1).to receive(:inputs).and_return([input1])
+
+        input2 = BSV::Transaction::TransactionInput.new(prev_wtxid: wtxid1, prev_tx_out_index: 0)
+        input2.source_transaction = tx1
+        allow(tx2).to receive(:inputs).and_return([input2])
+
+        historian = described_class.new(index_interpreter)
+        result = historian.build_history(tx2)
+
+        expect(result.length).to eq(2)
+      end
+    end
+
+    context 'when interpreter raises' do
+      it 'swallows the exception and continues traversal' do
+        raising_interpreter = lambda do |_tx, idx, _ctx|
+          raise 'boom' if idx.zero?
+
+          idx
+        end
+
+        tx = make_tx(output_count: 3)
+        historian = described_class.new(raising_interpreter)
+        result = historian.build_history(tx)
+
+        # Outputs 1 and 2 succeed; after reverse, order is [2, 1].
+        expect(result).to eq([2, 1])
+      end
+    end
+
+    context 'when interpreter returns falsy non-nil values' do
+      it 'includes false, 0, and empty string in history' do
+        falsy_interpreter = lambda do |_tx, idx, _ctx|
+          case idx
+          when 0 then false
+          when 1 then 0
+          when 2 then ''
+          end
+        end
+
+        tx = make_tx(output_count: 3)
+        historian = described_class.new(falsy_interpreter)
+        result = historian.build_history(tx)
+
+        # Accumulated as [false, 0, ''] then reversed to ['', 0, false].
+        expect(result).to eq(['', 0, false])
+      end
+    end
+
+    context 'when input has no source_transaction' do
+      it 'skips that input without raising' do
+        input = BSV::Transaction::TransactionInput.new(
+          prev_wtxid: BSV::Primitives::Digest.sha256d('dummy'),
+          prev_tx_out_index: 0
+        )
+        # source_transaction is nil by default
+
+        tx = make_tx
+        allow(tx).to receive(:inputs).and_return([input])
+
+        historian = described_class.new(index_interpreter)
+        expect(historian.build_history(tx)).to eq([0])
+      end
+    end
+  end
+
+  describe 'caching' do
+    let(:cache) { {} }
+
+    it 'populates the cache on first call' do
+      tx = make_tx
+      historian = described_class.new(index_interpreter, history_cache: cache)
+      historian.build_history(tx)
+      expect(cache.size).to eq(1)
+    end
+
+    it 'returns equal but not identical array on cache hit' do
+      tx = make_tx
+      historian = described_class.new(index_interpreter, history_cache: cache)
+      result1 = historian.build_history(tx)
+      result2 = historian.build_history(tx)
+
+      expect(result1).to eq(result2)
+      expect(result1).not_to be(result2)
+    end
+
+    it 'invalidates when interpreter_version differs' do
+      tx = make_tx
+      h1 = described_class.new(index_interpreter, history_cache: cache, interpreter_version: 'v1')
+      h2 = described_class.new(index_interpreter, history_cache: cache, interpreter_version: 'v2')
+
+      h1.build_history(tx)
+      h2.build_history(tx)
+
+      expect(cache.size).to eq(2)
+    end
+
+    it 'mutating returned array does not corrupt the cache' do
+      tx = make_tx
+      historian = described_class.new(index_interpreter, history_cache: cache)
+      result1 = historian.build_history(tx)
+      result1 << 99
+
+      result2 = historian.build_history(tx)
+      expect(result2).not_to include(99)
+    end
+
+    it 'uses a context-dependent cache key' do
+      tx = make_tx
+      context_interpreter = ->(_, idx, ctx) { ctx == 'a' ? idx : nil }
+      historian = described_class.new(context_interpreter, history_cache: cache)
+
+      historian.build_history(tx, 'a')
+      historian.build_history(tx, 'b')
+
+      expect(cache.size).to eq(2)
+    end
+
+    it 'uses ctx_key_fn when provided' do
+      tx = make_tx
+      ctx_key_fn = ->(ctx) { ctx.nil? ? 'empty' : ctx.to_s.upcase }
+      historian = described_class.new(index_interpreter, history_cache: cache, ctx_key_fn: ctx_key_fn)
+
+      historian.build_history(tx, 'hello')
+      expect(cache.keys.first).to include('HELLO')
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/registry/client_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/registry/client_spec.rb
@@ -397,6 +397,61 @@ RSpec.describe 'BSV::Registry::Client' do
   end
 
   # ---------------------------------------------------------------------------
+  # Typed resolve wrappers
+  # ---------------------------------------------------------------------------
+  #
+  # Each typed method is a thin wrapper around #resolve(type, query).
+  # We verify delegation by observing what service name the resolver receives —
+  # each DefinitionType maps to a distinct ls_* service constant.
+
+  shared_examples 'a typed resolve wrapper' do |method_name, expected_service|
+    let(:empty_answer) { BSV::Overlay::LookupAnswer.new(type: 'freeform', outputs: []) }
+
+    before { allow(resolver).to receive(:query).and_return(empty_answer) }
+
+    it 'queries the resolver with the correct service for the definition type' do
+      client.public_send(method_name, name: 'example')
+      expect(resolver).to have_received(:query) do |question|
+        expect(question.service).to eq(expected_service)
+      end
+    end
+
+    it 'passes the query hash through to the resolver question unchanged' do
+      query = { name: 'example' }
+      client.public_send(method_name, query)
+      expect(resolver).to have_received(:query) do |question|
+        expect(question.query).to eq(query)
+      end
+    end
+
+    it 'accepts an empty query hash and passes it through' do
+      client.public_send(method_name)
+      expect(resolver).to have_received(:query) do |question|
+        expect(question.query).to eq({})
+      end
+    end
+
+    it 'returns an Array' do
+      expect(client.public_send(method_name)).to be_an(Array)
+    end
+  end
+
+  describe '#resolve_basket' do
+    it_behaves_like 'a typed resolve wrapper',
+                    :resolve_basket, BSV::Registry::Constants::SERVICE_BASKET
+  end
+
+  describe '#resolve_protocol' do
+    it_behaves_like 'a typed resolve wrapper',
+                    :resolve_protocol, BSV::Registry::Constants::SERVICE_PROTOCOL
+  end
+
+  describe '#resolve_certificate' do
+    it_behaves_like 'a typed resolve wrapper',
+                    :resolve_certificate, BSV::Registry::Constants::SERVICE_CERTIFICATE
+  end
+
+  # ---------------------------------------------------------------------------
   # #list_own_registry_entries
   # ---------------------------------------------------------------------------
 

--- a/gem/bsv-sdk/spec/bsv/storage/downloader_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/storage/downloader_spec.rb
@@ -150,6 +150,20 @@ RSpec.describe BSV::Storage::Downloader do
         expect(downloader.resolve(DOWNLOADER_UHRP_URL)).to eq(['http://good.example/file'])
       end
     end
+
+    context 'with a URL field containing invalid UTF-8 bytes' do
+      it 'skips the entry rather than returning an invalid-encoded String' do
+        future        = Time.now.to_i + 3600
+        # An invalid UTF-8 byte sequence — lone continuation byte 0x80 with no leading byte.
+        bad_url_bytes = "\x80\x80\x80".b
+        bad_script    = pushdrop_script("\x01".b, "\x02".b, bad_url_bytes, BSV::Transaction::VarInt.encode(future))
+        bad_entry     = output_entry(bad_script)
+        good_entry    = uhrp_output_entry('http://good.example/file', future)
+        allow(resolver).to receive(:query).and_return(answer_with([bad_entry, good_entry]))
+
+        expect(downloader.resolve(DOWNLOADER_UHRP_URL)).to eq(['http://good.example/file'])
+      end
+    end
   end
 
   describe '#download' do

--- a/gem/bsv-sdk/spec/bsv/storage/downloader_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/storage/downloader_spec.rb
@@ -78,6 +78,18 @@ RSpec.describe BSV::Storage::Downloader do
       end
     end
 
+    context 'when the caller supplies a uhrp:// prefixed URL' do
+      it 'normalises the URL before forwarding to the lookup query' do
+        allow(resolver).to receive(:query) do |question|
+          # Lookup query should receive the bare base58check form, not the uhrp:// form
+          expect(question.query['uhrpUrl']).to eq(DOWNLOADER_UHRP_URL)
+          non_output_list_answer
+        end
+        expect { downloader.resolve("uhrp://#{DOWNLOADER_UHRP_URL}") }
+          .to raise_error(BSV::Storage::DownloadError)
+      end
+    end
+
     context 'when resolver returns an empty output list' do
       it 'returns an empty array' do
         allow(resolver).to receive(:query).and_return(answer_with([]))
@@ -238,6 +250,29 @@ RSpec.describe BSV::Storage::Downloader do
         expect do
           described_class.new(lookup_resolver: resolver, http_client: http).download(uhrp_url)
         end.to raise_error(BSV::Storage::DownloadError, /Unable to download content/)
+      end
+    end
+
+    context 'when host returns 302 (redirects are not followed in v1)' do
+      let(:content)  { 'redirected content' }
+      let(:uhrp_url) { BSV::Storage::Utils.get_url_for_file(content) }
+
+      it 'treats 3xx as failed host and tries the next one' do
+        future = Time.now.to_i + 3600
+        allow(resolver).to receive(:query).and_return(answer_with([
+                                                                    uhrp_output_entry('http://redirect-host.example/file', future),
+                                                                    uhrp_output_entry('http://direct-host.example/file', future)
+                                                                  ]))
+
+        call_count = 0
+        http = lambda do |_url|
+          call_count += 1
+          call_count == 1 ? http_err(302) : http_ok(content)
+        end
+
+        result = described_class.new(lookup_resolver: resolver, http_client: http).download(uhrp_url)
+        expect(result.data).to eq(content)
+        expect(call_count).to eq(2)
       end
     end
 

--- a/gem/bsv-sdk/spec/bsv/storage/downloader_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/storage/downloader_spec.rb
@@ -1,0 +1,373 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bsv-sdk'
+
+# Conformance vector from StorageUtils — used as a real UHRP URL below.
+DOWNLOADER_UHRP_URL = 'XUT6PqWb3GP3LR7dmBMCJwZ3oo5g1iGCF3CrpzyuJCemkGu1WGoq'
+
+# Helpers for building real BEEF objects with PushDrop outputs.
+module DownloaderSpecHelpers
+  def dummy_lock
+    BSV::Script::Script.p2pkh_lock(("\x00" * 20).b)
+  end
+
+  def pushdrop_script(*fields)
+    BSV::Script::Script.pushdrop_lock(fields, dummy_lock)
+  end
+
+  def uhrp_output_script(url, expiry)
+    url_bytes    = url.encode('UTF-8').b
+    expiry_bytes = BSV::Transaction::VarInt.encode(expiry)
+    pushdrop_script("\x01".b, "\x02".b, url_bytes, expiry_bytes)
+  end
+
+  def beef_with_script(script)
+    txout = BSV::Transaction::TransactionOutput.new(satoshis: 1, locking_script: script)
+    tx    = BSV::Transaction::Tx.new
+    tx.add_output(txout)
+    beef = BSV::Transaction::Beef.new
+    beef.merge_transaction(tx)
+    beef.to_binary
+  end
+
+  def output_entry(script)
+    { 'beef' => beef_with_script(script), 'outputIndex' => 0 }
+  end
+
+  def uhrp_output_entry(url, expiry)
+    output_entry(uhrp_output_script(url, expiry))
+  end
+
+  def answer_with(outputs)
+    BSV::Overlay::LookupAnswer.new(type: 'output-list', outputs: outputs)
+  end
+
+  def non_output_list_answer
+    BSV::Overlay::LookupAnswer.new(type: 'freeform', outputs: [])
+  end
+end
+
+# Minimal HTTP response for the injectable http_client lambda.
+DownloaderTestResponse = Struct.new(:code, :body, :headers) do
+  def [](key)
+    headers[key]
+  end
+end
+
+def http_ok(body, mime_type: 'text/plain')
+  DownloaderTestResponse.new(200, body, { 'Content-Type' => mime_type })
+end
+
+def http_err(code)
+  DownloaderTestResponse.new(code, '', {})
+end
+
+RSpec.describe BSV::Storage::Downloader do
+  include DownloaderSpecHelpers
+
+  let(:resolver) { instance_double(BSV::Overlay::LookupResolver) }
+  let(:downloader) { described_class.new(lookup_resolver: resolver) }
+
+  describe '#resolve' do
+    context 'when resolver returns a non-output-list answer' do
+      it 'raises DownloadError' do
+        allow(resolver).to receive(:query).and_return(non_output_list_answer)
+        expect { downloader.resolve(DOWNLOADER_UHRP_URL) }
+          .to raise_error(BSV::Storage::DownloadError, 'Lookup answer must be an output list')
+      end
+    end
+
+    context 'when resolver returns an empty output list' do
+      it 'returns an empty array' do
+        allow(resolver).to receive(:query).and_return(answer_with([]))
+        expect(downloader.resolve(DOWNLOADER_UHRP_URL)).to eq([])
+      end
+    end
+
+    context 'with a single valid output' do
+      it 'returns the URL from field[2]' do
+        future = Time.now.to_i + 3600
+        allow(resolver).to receive(:query)
+          .and_return(answer_with([uhrp_output_entry('http://host1.example/file', future)]))
+
+        expect(downloader.resolve(DOWNLOADER_UHRP_URL)).to eq(['http://host1.example/file'])
+      end
+    end
+
+    context 'with an expired entry (expiry < now)' do
+      it 'drops the expired entry and returns empty' do
+        past = Time.now.to_i - 1
+        allow(resolver).to receive(:query)
+          .and_return(answer_with([uhrp_output_entry('http://expired.example/file', past)]))
+
+        expect(downloader.resolve(DOWNLOADER_UHRP_URL)).to eq([])
+      end
+    end
+
+    context 'with a mix of valid and expired entries' do
+      it 'returns only non-expired URLs' do
+        past   = Time.now.to_i - 1
+        future = Time.now.to_i + 3600
+        allow(resolver).to receive(:query).and_return(answer_with([
+                                                                    uhrp_output_entry('http://expired.example/file', past),
+                                                                    uhrp_output_entry('http://valid.example/file', future)
+                                                                  ]))
+
+        expect(downloader.resolve(DOWNLOADER_UHRP_URL)).to eq(['http://valid.example/file'])
+      end
+    end
+
+    context 'with a malformed PushDrop output (fewer than 4 fields)' do
+      it 'skips the malformed entry and continues' do
+        future      = Time.now.to_i + 3600
+        short_entry = output_entry(pushdrop_script("\x01".b, "\x02".b, 'http://short.example'.b))
+        valid_entry = uhrp_output_entry('http://valid.example/file', future)
+        allow(resolver).to receive(:query).and_return(answer_with([short_entry, valid_entry]))
+
+        expect(downloader.resolve(DOWNLOADER_UHRP_URL)).to eq(['http://valid.example/file'])
+      end
+    end
+
+    context 'with a BEEF that fails to parse' do
+      it 'skips the unparseable entry and continues' do
+        future       = Time.now.to_i + 3600
+        bad_output   = { 'beef' => 'UNPARSEABLE_BYTES', 'outputIndex' => 0 }
+        valid_entry  = uhrp_output_entry('http://good.example/file', future)
+        allow(resolver).to receive(:query).and_return(answer_with([bad_output, valid_entry]))
+
+        expect(downloader.resolve(DOWNLOADER_UHRP_URL)).to eq(['http://good.example/file'])
+      end
+    end
+  end
+
+  describe '#download' do
+    context 'with an invalid UHRP URL' do
+      it 'raises ArgumentError' do
+        expect { downloader.download('not-a-uhrp-url') }
+          .to raise_error(ArgumentError, 'Invalid parameter UHRP url')
+      end
+    end
+
+    context 'when resolve returns no hosts' do
+      it 'raises DownloadError' do
+        allow(resolver).to receive(:query).and_return(answer_with([]))
+        expect { downloader.download(DOWNLOADER_UHRP_URL) }
+          .to raise_error(BSV::Storage::DownloadError, 'No one currently hosts this file!')
+      end
+    end
+
+    context 'when first host returns 404 and second host returns valid content' do
+      let(:content)  { 'hello world content' }
+      let(:uhrp_url) { BSV::Storage::Utils.get_url_for_file(content) }
+
+      it 'fetches from the second host' do
+        future = Time.now.to_i + 3600
+        allow(resolver).to receive(:query).and_return(answer_with([
+                                                                    uhrp_output_entry('http://host1.example/file', future),
+                                                                    uhrp_output_entry('http://host2.example/file', future)
+                                                                  ]))
+
+        call_count = 0
+        http = lambda do |_url|
+          call_count += 1
+          call_count == 1 ? http_err(404) : http_ok(content, mime_type: 'text/plain')
+        end
+
+        result = described_class.new(lookup_resolver: resolver, http_client: http).download(uhrp_url)
+        expect(result.data).to eq(content)
+        expect(result.mime_type).to eq('text/plain')
+        expect(call_count).to eq(2)
+      end
+    end
+
+    context 'when hash mismatches on every host' do
+      let(:content)  { 'real content' }
+      let(:uhrp_url) { BSV::Storage::Utils.get_url_for_file(content) }
+
+      it 'raises DownloadError' do
+        future = Time.now.to_i + 3600
+        allow(resolver).to receive(:query).and_return(answer_with([
+                                                                    uhrp_output_entry('http://bad-host.example/file', future)
+                                                                  ]))
+
+        http = ->(_url) { http_ok('wrong content') }
+        expect do
+          described_class.new(lookup_resolver: resolver, http_client: http).download(uhrp_url)
+        end.to raise_error(BSV::Storage::DownloadError, /Unable to download content/)
+      end
+    end
+
+    context 'when all hosts return 4xx or 5xx' do
+      let(:content)  { 'some file' }
+      let(:uhrp_url) { BSV::Storage::Utils.get_url_for_file(content) }
+
+      it 'raises DownloadError' do
+        future = Time.now.to_i + 3600
+        allow(resolver).to receive(:query).and_return(answer_with([
+                                                                    uhrp_output_entry('http://host1.example/file', future),
+                                                                    uhrp_output_entry('http://host2.example/file', future)
+                                                                  ]))
+
+        http = ->(_url) { http_err(500) }
+        expect do
+          described_class.new(lookup_resolver: resolver, http_client: http).download(uhrp_url)
+        end.to raise_error(BSV::Storage::DownloadError, /Unable to download content/)
+      end
+    end
+
+    context 'when host returns 401 (TS contract: treated as failed host, tries next)' do
+      let(:content)  { 'protected content' }
+      let(:uhrp_url) { BSV::Storage::Utils.get_url_for_file(content) }
+
+      it 'tries the next host and returns successfully' do
+        future = Time.now.to_i + 3600
+        allow(resolver).to receive(:query).and_return(answer_with([
+                                                                    uhrp_output_entry('http://auth-host.example/file', future),
+                                                                    uhrp_output_entry('http://open-host.example/file', future)
+                                                                  ]))
+
+        call_count = 0
+        http = lambda do |_url|
+          call_count += 1
+          call_count == 1 ? http_err(401) : http_ok(content)
+        end
+
+        result = described_class.new(lookup_resolver: resolver, http_client: http).download(uhrp_url)
+        expect(result.data).to eq(content)
+        expect(call_count).to eq(2)
+      end
+    end
+
+    context 'when host returns 402' do
+      let(:content)  { 'paid content' }
+      let(:uhrp_url) { BSV::Storage::Utils.get_url_for_file(content) }
+
+      it 'treats as failed host and tries next' do
+        future = Time.now.to_i + 3600
+        allow(resolver).to receive(:query).and_return(answer_with([
+                                                                    uhrp_output_entry('http://paid-host.example/file', future),
+                                                                    uhrp_output_entry('http://free-host.example/file', future)
+                                                                  ]))
+
+        call_count = 0
+        http = lambda do |_url|
+          call_count += 1
+          call_count == 1 ? http_err(402) : http_ok(content)
+        end
+
+        result = described_class.new(lookup_resolver: resolver, http_client: http).download(uhrp_url)
+        expect(result.data).to eq(content)
+        expect(call_count).to eq(2)
+      end
+    end
+
+    context 'when host returns 403' do
+      let(:content)  { 'gated content' }
+      let(:uhrp_url) { BSV::Storage::Utils.get_url_for_file(content) }
+
+      it 'treats as failed host and tries next' do
+        future = Time.now.to_i + 3600
+        allow(resolver).to receive(:query).and_return(answer_with([
+                                                                    uhrp_output_entry('http://gated-host.example/file', future),
+                                                                    uhrp_output_entry('http://open-host.example/file', future)
+                                                                  ]))
+
+        call_count = 0
+        http = lambda do |_url|
+          call_count += 1
+          call_count == 1 ? http_err(403) : http_ok(content)
+        end
+
+        result = described_class.new(lookup_resolver: resolver, http_client: http).download(uhrp_url)
+        expect(result.data).to eq(content)
+        expect(call_count).to eq(2)
+      end
+    end
+
+    context 'when a network error occurs on a host' do
+      let(:content)  { 'network test' }
+      let(:uhrp_url) { BSV::Storage::Utils.get_url_for_file(content) }
+
+      it 'tries the next host' do
+        future = Time.now.to_i + 3600
+        allow(resolver).to receive(:query).and_return(answer_with([
+                                                                    uhrp_output_entry('http://broken-host.example/file', future),
+                                                                    uhrp_output_entry('http://working-host.example/file', future)
+                                                                  ]))
+
+        call_count = 0
+        http = lambda do |_url|
+          call_count += 1
+          raise Errno::ECONNREFUSED, 'connection refused' if call_count == 1
+
+          http_ok(content)
+        end
+
+        result = described_class.new(lookup_resolver: resolver, http_client: http).download(uhrp_url)
+        expect(result.data).to eq(content)
+        expect(call_count).to eq(2)
+      end
+    end
+
+    context 'when all hosts raise network errors' do
+      let(:content)  { 'unreachable file' }
+      let(:uhrp_url) { BSV::Storage::Utils.get_url_for_file(content) }
+
+      it 'raises DownloadError' do
+        future = Time.now.to_i + 3600
+        allow(resolver).to receive(:query).and_return(answer_with([
+                                                                    uhrp_output_entry('http://dead1.example/file', future),
+                                                                    uhrp_output_entry('http://dead2.example/file', future)
+                                                                  ]))
+
+        http = ->(_url) { raise SocketError, 'unreachable' }
+        expect do
+          described_class.new(lookup_resolver: resolver, http_client: http).download(uhrp_url)
+        end.to raise_error(BSV::Storage::DownloadError, /Unable to download content/)
+      end
+    end
+
+    context 'with a successful single-host download' do
+      let(:content)  { 'the quick brown fox' }
+      let(:uhrp_url) { BSV::Storage::Utils.get_url_for_file(content) }
+
+      it 'returns DownloadResult with data and mime_type' do
+        future = Time.now.to_i + 3600
+        allow(resolver).to receive(:query).and_return(answer_with([
+                                                                    uhrp_output_entry('http://host.example/file', future)
+                                                                  ]))
+
+        http = ->(_url) { http_ok(content, mime_type: 'application/octet-stream') }
+        result = described_class.new(lookup_resolver: resolver, http_client: http).download(uhrp_url)
+
+        expect(result).to be_a(BSV::Storage::DownloadResult)
+        expect(result.data).to eq(content)
+        expect(result.mime_type).to eq('application/octet-stream')
+      end
+    end
+
+    context 'when the body is empty (treated as failed host)' do
+      let(:content)  { 'actual content' }
+      let(:uhrp_url) { BSV::Storage::Utils.get_url_for_file(content) }
+
+      it 'tries the next host' do
+        future = Time.now.to_i + 3600
+        allow(resolver).to receive(:query).and_return(answer_with([
+                                                                    uhrp_output_entry('http://empty-host.example/file', future),
+                                                                    uhrp_output_entry('http://good-host.example/file', future)
+                                                                  ]))
+
+        call_count = 0
+        http = lambda do |_url|
+          call_count += 1
+          call_count == 1 ? DownloaderTestResponse.new(200, '', { 'Content-Type' => 'text/plain' }) : http_ok(content)
+        end
+
+        result = described_class.new(lookup_resolver: resolver, http_client: http).download(uhrp_url)
+        expect(result.data).to eq(content)
+        expect(call_count).to eq(2)
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/storage/downloader_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/storage/downloader_spec.rb
@@ -139,6 +139,17 @@ RSpec.describe BSV::Storage::Downloader do
         expect(downloader.resolve(DOWNLOADER_UHRP_URL)).to eq(['http://good.example/file'])
       end
     end
+
+    context 'with a negative outputIndex (untrusted overlay response)' do
+      it 'skips the entry rather than reading the wrong output via negative indexing' do
+        future        = Time.now.to_i + 3600
+        good_entry    = uhrp_output_entry('http://good.example/file', future)
+        negative      = good_entry.merge('outputIndex' => -1)
+        allow(resolver).to receive(:query).and_return(answer_with([negative, good_entry]))
+
+        expect(downloader.resolve(DOWNLOADER_UHRP_URL)).to eq(['http://good.example/file'])
+      end
+    end
   end
 
   describe '#download' do

--- a/gem/bsv-sdk/spec/bsv/storage/utils_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/storage/utils_spec.rb
@@ -74,6 +74,16 @@ RSpec.describe BSV::Storage::Utils do
         .to raise_error(ArgumentError)
     end
 
+    it 'raises ArgumentError on nil' do
+      expect { described_class.get_hash_from_url(nil) }
+        .to raise_error(ArgumentError, /URL must be a String/)
+    end
+
+    it 'raises ArgumentError on a non-String input' do
+      expect { described_class.get_hash_from_url(123) }
+        .to raise_error(ArgumentError, /URL must be a String/)
+    end
+
     it 'raises on a URL with wrong decoded length' do
       expect { described_class.get_hash_from_url('SomeBase58CheckTooShortOrTooLong') }
         .to raise_error(StandardError)
@@ -142,6 +152,14 @@ RSpec.describe BSV::Storage::Utils do
 
     it 'returns false for an empty string' do
       expect(described_class.valid_url?('')).to be(false)
+    end
+
+    it 'returns false for nil' do
+      expect(described_class.valid_url?(nil)).to be(false)
+    end
+
+    it 'returns false for a non-String input' do
+      expect(described_class.valid_url?(123)).to be(false)
     end
 
     it 'returns true for a uhrp:// prefixed URL' do

--- a/gem/bsv-sdk/spec/bsv/storage/utils_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/storage/utils_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# TS-SDK conformance vectors from StorageUtils.test.ts lines 6-10 and the bad-checksum URL.
+FILE_HEX = '687da27f04a112aa48f1cab2e7949f1eea4f7ba28319c1e999910cd561a634a05a3516e6db'
+HASH_HEX = '1a5ec49a3f32cd56d19732e89bde5d81755ddc0fd8515dc8b226d47654139dca'
+EXAMPLE_URL = 'XUT6PqWb3GP3LR7dmBMCJwZ3oo5g1iGCF3CrpzyuJCemkGu1WGoq'
+BAD_CHECKSUM_URL = 'XUU7cTfy6fA6q2neLDmzPqJnGB6o18PXKoGaWLPrH1SeWLKgdCKq'
+
+RSpec.describe BSV::Storage::Utils do
+  let(:example_file) { [FILE_HEX].pack('H*') }
+  let(:example_hash) { [HASH_HEX].pack('H*') }
+
+  describe '.get_url_for_hash' do
+    it 'encodes the conformance vector hash to the expected URL' do
+      expect(described_class.get_url_for_hash(example_hash)).to eq(EXAMPLE_URL)
+    end
+
+    it 'raises on a 33-byte hash' do
+      expect { described_class.get_url_for_hash("#{example_hash}\x00") }
+        .to raise_error(ArgumentError, 'Hash length must be 32 bytes (sha256)')
+    end
+
+    it 'raises on a 31-byte hash' do
+      expect { described_class.get_url_for_hash(example_hash[0, 31]) }
+        .to raise_error(ArgumentError, 'Hash length must be 32 bytes (sha256)')
+    end
+
+    it 'raises on an empty hash' do
+      expect { described_class.get_url_for_hash(''.b) }
+        .to raise_error(ArgumentError, 'Hash length must be 32 bytes (sha256)')
+    end
+
+    it 'raises on the full file bytes (wrong length)' do
+      expect { described_class.get_url_for_hash(example_file) }
+        .to raise_error(ArgumentError, 'Hash length must be 32 bytes (sha256)')
+    end
+  end
+
+  describe '.get_url_for_file' do
+    it 'produces the expected URL for the conformance vector file' do
+      expect(described_class.get_url_for_file(example_file)).to eq(EXAMPLE_URL)
+    end
+
+    it 'produces the same URL as get_url_for_hash(sha256(file))' do
+      require 'openssl'
+      direct_hash = OpenSSL::Digest::SHA256.digest(example_file)
+      expect(described_class.get_url_for_file(example_file))
+        .to eq(described_class.get_url_for_hash(direct_hash))
+    end
+  end
+
+  describe '.get_hash_from_url' do
+    it 'decodes the conformance vector URL to the correct hash hex' do
+      hash = described_class.get_hash_from_url(EXAMPLE_URL)
+      expect(hash.unpack1('H*')).to eq(HASH_HEX)
+    end
+
+    it 'decodes the same hash as hashing the file directly' do
+      require 'openssl'
+      hash_from_url = described_class.get_hash_from_url(EXAMPLE_URL)
+      hash_from_file = OpenSSL::Digest::SHA256.digest(example_file)
+      expect(hash_from_url).to eq(hash_from_file)
+    end
+
+    it 'raises on a bad-checksum URL' do
+      expect { described_class.get_hash_from_url(BAD_CHECKSUM_URL) }
+        .to raise_error(BSV::Primitives::Base58::ChecksumError)
+    end
+
+    it 'raises on an empty string' do
+      expect { described_class.get_hash_from_url('') }
+        .to raise_error(ArgumentError)
+    end
+
+    it 'raises on a URL with wrong decoded length' do
+      expect { described_class.get_hash_from_url('SomeBase58CheckTooShortOrTooLong') }
+        .to raise_error(StandardError)
+    end
+
+    it 'raises on a URL with an invalid prefix' do
+      expect { described_class.get_hash_from_url('AInvalidPrefixTestString1') }
+        .to raise_error(StandardError)
+    end
+
+    it 'accepts uhrp: prefixed URLs' do
+      hash = described_class.get_hash_from_url("uhrp:#{EXAMPLE_URL}")
+      expect(hash.unpack1('H*')).to eq(HASH_HEX)
+    end
+
+    it 'accepts uhrp:// prefixed URLs' do
+      hash = described_class.get_hash_from_url("uhrp://#{EXAMPLE_URL}")
+      expect(hash.unpack1('H*')).to eq(HASH_HEX)
+    end
+
+    it 'accepts UHRP: upper-case prefixed URLs (case-insensitive)' do
+      hash = described_class.get_hash_from_url("UHRP:#{EXAMPLE_URL}")
+      expect(hash.unpack1('H*')).to eq(HASH_HEX)
+    end
+  end
+
+  describe '.normalize_url' do
+    it 'strips the uhrp: prefix' do
+      expect(described_class.normalize_url("uhrp:#{EXAMPLE_URL}")).to eq(EXAMPLE_URL)
+    end
+
+    it 'strips uhrp:// (scheme + authority)' do
+      expect(described_class.normalize_url("uhrp://#{EXAMPLE_URL}")).to eq(EXAMPLE_URL)
+    end
+
+    it 'strips UHRP: in upper case (case-insensitive)' do
+      expect(described_class.normalize_url("UHRP:#{EXAMPLE_URL}")).to eq(EXAMPLE_URL)
+    end
+
+    it 'leaves a bare URL (no prefix) unchanged' do
+      expect(described_class.normalize_url(EXAMPLE_URL)).to eq(EXAMPLE_URL)
+    end
+
+    it 'does not strip web+uhrp:// (TS parity — only uhrp: is normalised)' do
+      with_web = "web+uhrp://#{EXAMPLE_URL}"
+      expect(described_class.normalize_url(with_web)).to eq(with_web)
+    end
+  end
+
+  describe '.valid_url?' do
+    it 'returns true for the conformance vector URL' do
+      expect(described_class.valid_url?(EXAMPLE_URL)).to be(true)
+    end
+
+    it 'returns false for a bad-checksum URL' do
+      expect(described_class.valid_url?(BAD_CHECKSUM_URL)).to be(false)
+    end
+
+    it 'returns false for a URL with wrong decoded length' do
+      expect(described_class.valid_url?('SomeBase58CheckTooShortOrTooLong')).to be(false)
+    end
+
+    it 'returns false for a URL with invalid prefix' do
+      expect(described_class.valid_url?('AnotherInvalidPrefixTestString')).to be(false)
+    end
+
+    it 'returns false for an empty string' do
+      expect(described_class.valid_url?('')).to be(false)
+    end
+
+    it 'returns true for a uhrp:// prefixed URL' do
+      expect(described_class.valid_url?("uhrp://#{EXAMPLE_URL}")).to be(true)
+    end
+  end
+end

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,12 @@ nav:
       - Storage: sdk/storage.md
       - KVStore: sdk/kvstore.md
       - Ecosystem Clients: sdk/ecosystem-clients.md
+  - Overlay services:
+      - Overview: overlays.md
+      - UHRP Storage: overlays/uhrp-storage.md
+      - Historian: overlays/historian.md
+      - KVStore: overlays/kvstore.md
+      - Registries: overlays/registries.md
   - Network:
       - Overview: network/overview.md
       - Examples: network/examples.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,9 @@ nav:
       - Transaction: sdk/transaction.md
       - Network: sdk/network.md
       - Wallet: sdk/wallet.md
+      - Storage: sdk/storage.md
+      - KVStore: sdk/kvstore.md
+      - Ecosystem Clients: sdk/ecosystem-clients.md
   - Network:
       - Overview: network/overview.md
       - Examples: network/examples.md


### PR DESCRIPTION
## Summary

Adds the four read-only ecosystem clients from HLR #762:

- `BSV::Storage::Utils` (#817) — UHRP URL helpers (encode/decode/validate)
- `BSV::Storage::Downloader` (#821) — UHRP resolver + content fetcher with SHA-256 verification
- `BSV::KVStore::Interpreter` (#820) — kvStoreInterpreter callable for Historian
- `BSV::KVStore::Global` (#822) — overlay-backed read-only KV (read paths only)
- `BSV::Registry::Client` typed resolves (#819) — `resolve_basket` / `resolve_protocol` / `resolve_certificate` sugar
- `BSV::Overlay::Historian` (#818) — generic output-history walker with pluggable interpreter and optional cache
- Docs (#823) — examples for all four components

## Test plan

- [ ] All specs pass: `bundle exec rake spec:sdk`
- [ ] RuboCop clean: `bundle exec rubocop`
- [ ] Acceptance criteria verified per sub-issue
- [ ] Conformance vectors pass for `Storage::Utils`

Closes #762, #817, #818, #819, #820, #821, #822, #823

🤖 Generated with [Claude Code](https://claude.com/claude-code)
