### PR TITLE
docs: adopt Transaction::Tx prose convention from bsv-wallet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ In prose, comments, YARD tags, and spec descriptions:
 
 - **`Transaction::Tx`** names the Ruby class or its instances. Use this whenever the meaning is "the class instance specifically". The `BSV::` prefix is redundant for the audience — gem consumers read `Namespace::Class` instinctively.
 - **`transaction`** (lowercase) is the English noun for the abstract entity. Use this when the representation doesn't matter, or when several representations are in play.
-- **`Tx`** bare is reserved for Ruby code at call sites (where `BSV::Transaction::Tx` resolves it fully). In prose it reads as an alien identifier.
+- **`Tx`** bare is for Ruby code where the `BSV::Transaction` namespace is already in lexical scope (inside a `module BSV::Transaction` block, a sibling file in that namespace, or after `include BSV::Transaction`). It does not resolve in unrelated namespaces — use `BSV::Transaction::Tx` there. Outside Ruby code, bare `Tx` reads as an alien identifier.
 
 The same shape extends to peer classes (`Transaction::Beef`, `Transaction::TransactionInput`, `Transaction::TransactionOutput`, `Transaction::ChainTracker`, etc.).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,38 @@ Transaction IDs use an explicit naming convention to prevent byte-order bugs:
 
 Any method that accepts a txid parameter must validate the format using `BSV::Primitives::Hex.validate_wtxid!` or `BSV::Primitives::Hex.validate_dtxid_hex!`. This catches byte-order mismatches at call time rather than producing silent corruption. See `docs/guides/wtxid-dtxid.md` for the full rationale.
 
+### Transaction Class Convention: `Transaction::Tx` in prose
+
+A transaction is an abstract entity with several representations: bytes on the wire, a BEEF bundle, a Ruby `Transaction::Tx` instance. The English word and the Ruby class are not interchangeable.
+
+In prose, comments, YARD tags, and spec descriptions:
+
+- **`Transaction::Tx`** names the Ruby class or its instances. Use this whenever the meaning is "the class instance specifically". The `BSV::` prefix is redundant for the audience — gem consumers read `Namespace::Class` instinctively.
+- **`transaction`** (lowercase) is the English noun for the abstract entity. Use this when the representation doesn't matter, or when several representations are in play.
+- **`Tx`** bare is reserved for Ruby code at call sites (where `BSV::Transaction::Tx` resolves it fully). In prose it reads as an alien identifier.
+
+The same shape extends to peer classes (`Transaction::Beef`, `Transaction::TransactionInput`, `Transaction::TransactionOutput`, `Transaction::ChainTracker`, etc.).
+
+#### Examples
+
+| Reads | Means |
+|-------|-------|
+| "the cached `Transaction::Tx`" | Ruby instance, fully hydrated |
+| "`Transaction::Tx#verify` walks via `input.source_transaction`" | Class method reference |
+| "the transaction is rejected at broadcast time" | The abstract entity at any stage |
+| "atomic BEEF carries the transaction graph" | Abstract entity, multi-representation |
+
+#### Runnable code blocks keep `BSV::`
+
+This convention applies to prose. **Runnable Ruby code blocks in `docs/` keep the fully-qualified `BSV::Foo::Bar` form** because they have to compile when copy-pasted. The orthogonal rule:
+
+- **Where text is parsed by humans** (prose, comments, YARD tags, headings) — drop `BSV::`.
+- **Where text is parsed by Ruby** (code blocks meant to be run, method bodies) — keep `BSV::`.
+
+#### Source
+
+Mirrored from the `bsv-wallet` gem's `CLAUDE.md`, where the convention was settled in PR sgbett/bsv-wallet#304 during the SDK 0.24.0 rename migration. HLR sgbett/bsv-ruby-sdk#825 extends it here to keep the two gems aligned.
+
 ## Cryptography
 
 Elliptic curve operations (secp256k1) are provided by the [`secp256k1-native`](https://github.com/sgbett/secp256k1-native) gem — a pure Ruby implementation ported from the TypeScript reference SDK, with an optional native C extension that accelerates field, scalar, and Jacobian point operations (~22× speedup). The `bsv-sdk` exposes these as `BSV::Primitives::Secp256k1` and `BSV::Primitives::Secp256k1Native`. An OpenSSL compatibility shim (`openssl_ec_shim.rb`) replaces `OpenSSL::PKey::EC` classes so consumer code continues to use the same API. See the [secp256k1-native documentation](https://github.com/sgbett/secp256k1-native/blob/master/docs/secp256k1.md) for implementation details.

--- a/gem/bsv-sdk/lib/bsv/kv_store/interpreter.rb
+++ b/gem/bsv-sdk/lib/bsv/kv_store/interpreter.rb
@@ -44,7 +44,7 @@ module BSV
       # Implements the Historian interpreter contract:
       # +interpreter.call(tx, output_index, ctx)+ → String or nil.
       #
-      # @param tx [BSV::Transaction::Tx, nil] the transaction to inspect
+      # @param tx [Transaction::Tx, nil] the transaction to inspect
       # @param output_index [Integer] index into +tx.outputs+
       # @param ctx [Hash, nil] must contain +:key+ (String) and +:protocol_id+ (Array)
       # @return [String, nil] the decoded UTF-8 value, or nil on any mismatch/error

--- a/gem/bsv-sdk/lib/bsv/mcp/tools/helpers.rb
+++ b/gem/bsv-sdk/lib/bsv/mcp/tools/helpers.rb
@@ -21,7 +21,7 @@ module BSV
 
         # Convert a Transaction to a hash suitable for JSON responses.
         #
-        # @param tx [BSV::Transaction::Tx]
+        # @param tx [Transaction::Tx]
         # @return [Hash]
         def self.transaction_to_h(tx)
           {
@@ -33,7 +33,7 @@ module BSV
           }
         end
 
-        # Convert a TransactionInput to a hash.
+        # Convert a Transaction::TransactionInput to a hash.
         # @api private
         def self.input_to_h(input, _index)
           unlock_script = input.unlocking_script
@@ -46,7 +46,7 @@ module BSV
           }
         end
 
-        # Convert a TransactionOutput to a hash.
+        # Convert a Transaction::TransactionOutput to a hash.
         # @api private
         def self.output_to_h(output, index)
           script = output.locking_script

--- a/gem/bsv-sdk/lib/bsv/overlay/admin_token_template.rb
+++ b/gem/bsv-sdk/lib/bsv/overlay/admin_token_template.rb
@@ -80,7 +80,7 @@ module BSV
         # Computes the BIP-143 sighash (SIGHASH_ALL|FORK_ID) and signs it
         # using the wallet's derived key for the protocol.
         #
-        # @param tx [BSV::Transaction::Tx] the spending transaction
+        # @param tx [Transaction::Tx] the spending transaction
         # @param input_index [Integer] which input to sign
         # @return [BSV::Script::Script] the unlocking script
         def sign(tx, input_index)
@@ -101,7 +101,7 @@ module BSV
 
         # Estimated byte length of the unlocking script.
         #
-        # @param _tx [BSV::Transaction::Tx] unused
+        # @param _tx [Transaction::Tx] unused
         # @param _input_index [Integer] unused
         # @return [Integer]
         def estimated_length(_tx, _input_index)

--- a/gem/bsv-sdk/lib/bsv/overlay/historian.rb
+++ b/gem/bsv-sdk/lib/bsv/overlay/historian.rb
@@ -47,7 +47,7 @@ module BSV
       # Traverses input ancestry from +start_transaction+ and returns all interpreted
       # values in chronological order (oldest first).
       #
-      # @param start_transaction [BSV::Transaction::Tx]
+      # @param start_transaction [Transaction::Tx]
       # @param context           [Object, nil] forwarded verbatim to the interpreter
       # @return [Array] interpreted values, oldest first
       def build_history(start_transaction, context = nil)

--- a/gem/bsv-sdk/lib/bsv/overlay/topic_broadcaster.rb
+++ b/gem/bsv-sdk/lib/bsv/overlay/topic_broadcaster.rb
@@ -74,7 +74,7 @@ module BSV
 
       # Broadcast a transaction to all interested overlay hosts.
       #
-      # @param tx [BSV::Transaction::Tx] the transaction to broadcast
+      # @param tx [Transaction::Tx] the transaction to broadcast
       # @return [OverlayBroadcastResult]
       def broadcast(tx)
         beef = serialise_beef(tx)

--- a/gem/bsv-sdk/lib/bsv/registry/client.rb
+++ b/gem/bsv-sdk/lib/bsv/registry/client.rb
@@ -472,7 +472,7 @@ module BSV
       #
       # @param definition_type [String]
       # @param output [Hash] wallet output with :outpoint, :satoshis keys
-      # @param beef [BSV::Transaction::Beef] parsed BEEF
+      # @param beef [Transaction::Beef] parsed BEEF
       # @param beef_raw [String] raw BEEF bytes
       # @return [RegisteredDefinition, nil]
       def parse_own_output_to_registered_definition(definition_type, output, beef, beef_raw)

--- a/gem/bsv-sdk/lib/bsv/script/push_drop_template.rb
+++ b/gem/bsv-sdk/lib/bsv/script/push_drop_template.rb
@@ -93,7 +93,7 @@ module BSV
         # the wallet's derived key, then returns a P2PKH unlock wrapped in a
         # PushDrop unlock (which is a pass-through).
         #
-        # @param tx [BSV::Transaction::Tx] the spending transaction
+        # @param tx [Transaction::Tx] the spending transaction
         # @param input_index [Integer] which input to sign
         # @return [BSV::Script::Script] the unlocking script
         def sign(tx, input_index)
@@ -125,7 +125,7 @@ module BSV
 
         # Estimated byte length of the unlocking script.
         #
-        # @param _tx [BSV::Transaction::Tx] unused
+        # @param _tx [Transaction::Tx] unused
         # @param _input_index [Integer] unused
         # @return [Integer]
         def estimated_length(_tx, _input_index)

--- a/gem/bsv-sdk/lib/bsv/transaction/beef.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef.rb
@@ -72,10 +72,10 @@ module BSV
 
       # A BEEF entry containing a raw transaction without a merkle proof.
       class RawTxEntry < BeefTx
-        # @return [Tx] the transaction
+        # @return [Transaction::Tx] the transaction
         attr_reader :transaction
 
-        # @param transaction [Tx] the transaction
+        # @param transaction [Transaction::Tx] the transaction
         # @raise [ArgumentError] if transaction is nil
         def initialize(transaction:)
           raise ArgumentError, 'RawTxEntry requires a transaction' if transaction.nil?
@@ -97,13 +97,13 @@ module BSV
 
       # A BEEF entry containing a raw transaction with an associated BUMP index.
       class ProvenTxEntry < BeefTx
-        # @return [Tx] the transaction
+        # @return [Transaction::Tx] the transaction
         attr_reader :transaction
 
         # @return [Integer] index into the BEEF bumps array
         attr_reader :bump_index
 
-        # @param transaction [Tx] the transaction
+        # @param transaction [Transaction::Tx] the transaction
         # @param bump_index [Integer] index into the bumps array
         # @raise [ArgumentError] if transaction or bump_index is nil
         def initialize(transaction:, bump_index:)
@@ -188,7 +188,7 @@ module BSV
       # After parsing, input source transactions are wired automatically.
       #
       # @param data [String] raw BEEF binary
-      # @return [Beef] the parsed BEEF bundle
+      # @return [Transaction::Beef] the parsed BEEF bundle
       def self.from_binary(data)
         raise ArgumentError, "truncated BEEF: need at least 4 bytes for version, got #{data.bytesize}" if data.bytesize < 4
 
@@ -247,7 +247,7 @@ module BSV
       # Deserialise a BEEF bundle from a hex string.
       #
       # @param hex [String] hex-encoded BEEF data
-      # @return [Beef] the parsed BEEF bundle
+      # @return [Transaction::Beef] the parsed BEEF bundle
       def self.from_hex(hex)
         from_binary(BSV::Primitives::Hex.decode(hex, name: 'BEEF hex'))
       end
@@ -320,7 +320,7 @@ module BSV
       # Find a transaction in the bundle by its wire-order transaction ID.
       #
       # @param wtxid [String] 32-byte wire-order wtxid
-      # @return [Tx, nil] the matching transaction, or nil
+      # @return [Transaction::Tx, nil] the matching transaction, or nil
       def find_transaction(wtxid)
         BSV::Primitives::Hex.validate_wtxid!(wtxid, name: 'wtxid')
         BSV.logger&.debug { "[Beef] find_transaction: #{wtxid.reverse.unpack1('H*')} in #{@transactions.length} entries" }
@@ -353,7 +353,7 @@ module BSV
       # Find a transaction with all source_transactions wired for signing.
       #
       # @param wtxid [String] 32-byte wire-order wtxid
-      # @return [Tx, nil] the transaction with wired inputs, or nil
+      # @return [Transaction::Tx, nil] the transaction with wired inputs, or nil
       def find_transaction_for_signing(wtxid)
         BSV::Primitives::Hex.validate_wtxid!(wtxid, name: 'wtxid')
         tx = find_transaction(wtxid)
@@ -367,7 +367,7 @@ module BSV
       # and merkle paths) for atomic proof validation.
       #
       # @param wtxid [String] 32-byte wire-order wtxid
-      # @return [Tx, nil] the transaction with full proof tree, or nil
+      # @return [Transaction::Tx, nil] the transaction with full proof tree, or nil
       def find_atomic_transaction(wtxid)
         BSV::Primitives::Hex.validate_wtxid!(wtxid, name: 'wtxid')
         tx = find_transaction(wtxid)
@@ -440,7 +440,7 @@ module BSV
       # (same txid) are upgraded if a stronger format is now available (F5.7):
       # TXID_ONLY → RAW_TX or RAW_TX_AND_BUMP; RAW_TX → RAW_TX_AND_BUMP.
       #
-      # @param tx [Tx] the transaction to merge
+      # @param tx [Transaction::Tx] the transaction to merge
       # @return [BeefTx] the (possibly existing or upgraded) BeefTx entry
       def merge_transaction(tx)
         wtxid = tx.wtxid
@@ -512,7 +512,7 @@ module BSV
       # BUMP indices are remapped during merge. New BeefTx instances are
       # constructed rather than sharing references with the source bundle (F5.9).
       #
-      # @param other [Beef] the BEEF bundle to merge from
+      # @param other [Transaction::Beef] the BEEF bundle to merge from
       # @return [self]
       # @raise [ArgumentError] if a transaction in +other+ has a +bump_index+
       #   that does not point to any BUMP in +other.bumps+ (i.e. the source
@@ -821,7 +821,7 @@ module BSV
       #   RAW_TX    → RAW_TX_AND_BUMP (if bump now available)
       #
       # @param existing [BeefTx] the current entry in @transactions
-      # @param tx [Tx, nil] the raw transaction (may be nil for TXID_ONLY → TXID_ONLY)
+      # @param tx [Transaction::Tx, nil] the raw transaction (may be nil for TXID_ONLY → TXID_ONLY)
       # @param bump_index [Integer, nil] a BUMP index already validated against @bumps
       # @return [BeefTx, nil] the upgraded entry, or nil when no upgrade is needed
       def upgrade_beef_tx(existing, tx, bump_index: nil)

--- a/gem/bsv-sdk/lib/bsv/transaction/chain_tracker.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/chain_tracker.rb
@@ -56,7 +56,7 @@ module BSV
       # Return a default ChainTracker backed by the GorillaPool provider.
       #
       # @param testnet [Boolean] when true, uses the testnet provider
-      # @return [ChainTracker]
+      # @return [Transaction::ChainTracker]
       def self.default(testnet: false)
         new(BSV::Network::Providers::GorillaPool.default(testnet: testnet))
       end

--- a/gem/bsv-sdk/lib/bsv/transaction/fee_model.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/fee_model.rb
@@ -17,7 +17,7 @@ module BSV
     class FeeModel
       # Compute the fee for a transaction.
       #
-      # @param transaction [Tx] the transaction to compute the fee for
+      # @param transaction [Transaction::Tx] the transaction to compute the fee for
       # @return [Integer] the fee in satoshis
       # @raise [NotImplementedError] if not overridden by a subclass
       def compute_fee(_transaction)

--- a/gem/bsv-sdk/lib/bsv/transaction/fee_models/live_policy.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/fee_models/live_policy.rb
@@ -66,7 +66,7 @@ module BSV
 
         # Compute the fee for a transaction using the latest ARC rate.
         #
-        # @param transaction [Tx] the transaction to compute the fee for
+        # @param transaction [Transaction::Tx] the transaction to compute the fee for
         # @return [Integer] the fee in satoshis
         def compute_fee(transaction)
           rate = current_rate

--- a/gem/bsv-sdk/lib/bsv/transaction/fee_models/satoshis_per_kilobyte.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/fee_models/satoshis_per_kilobyte.rb
@@ -23,7 +23,7 @@ module BSV
 
         # Compute the fee for a transaction based on its estimated size.
         #
-        # @param transaction [Tx] the transaction to compute the fee for
+        # @param transaction [Transaction::Tx] the transaction to compute the fee for
         # @return [Integer] the fee in satoshis
         def compute_fee(transaction)
           size = transaction.estimated_size

--- a/gem/bsv-sdk/lib/bsv/transaction/merkle_path.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/merkle_path.rb
@@ -322,7 +322,7 @@ module BSV
       # logic is: reject when `current_height - block_height < 100` (immature).
       #
       # @param dtxid_hex [String] hex-encoded transaction ID (display order)
-      # @param chain_tracker [ChainTracker] chain tracker to verify the root against
+      # @param chain_tracker [Transaction::ChainTracker] chain tracker to verify the root against
       # @return [Boolean] true if the computed root matches the block at this height
       def verify(dtxid_hex, chain_tracker)
         BSV::Primitives::Hex.validate_dtxid_hex!(dtxid_hex, name: 'dtxid_hex')

--- a/gem/bsv-sdk/lib/bsv/transaction/p2pkh.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/p2pkh.rb
@@ -24,7 +24,7 @@ module BSV
 
       # Generate the P2PKH unlocking script for the given input.
       #
-      # @param tx [Tx] the transaction being signed
+      # @param tx [Transaction::Tx] the transaction being signed
       # @param input_index [Integer] the input index to sign
       # @return [Script::Script] the unlocking script (signature + pubkey)
       def sign(tx, input_index)

--- a/gem/bsv-sdk/lib/bsv/transaction/transaction_input.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/transaction_input.rb
@@ -26,7 +26,7 @@ module BSV
       # @return [Script::Script, nil] locking script of the source output (needed for sighash)
       attr_accessor :source_locking_script
 
-      # @return [Tx, nil] the full source transaction (for BEEF wiring)
+      # @return [Transaction::Tx, nil] the full source transaction (for BEEF wiring)
       attr_accessor :source_transaction
 
       # @return [UnlockingScriptTemplate, nil] template for deferred signing

--- a/gem/bsv-sdk/lib/bsv/transaction/tx.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/tx.rb
@@ -59,7 +59,7 @@ module BSV
 
       # Append a transaction input.
       #
-      # @param input [TransactionInput] the input to add
+      # @param input [Transaction::TransactionInput] the input to add
       # @return [self] for chaining
       def add_input(input)
         @inputs << input
@@ -68,7 +68,7 @@ module BSV
 
       # Append a transaction output.
       #
-      # @param output [TransactionOutput] the output to add
+      # @param output [Transaction::TransactionOutput] the output to add
       # @return [self] for chaining
       def add_output(output)
         @outputs << output
@@ -144,7 +144,7 @@ module BSV
       # Deserialise a transaction from binary data.
       #
       # @param data [String] raw binary transaction
-      # @return [Tx] the parsed transaction
+      # @return [Transaction::Tx] the parsed transaction
       def self.from_binary(data)
         raise ArgumentError, "truncated transaction: need at least 10 bytes, got #{data.bytesize}" if data.bytesize < 10
 
@@ -182,7 +182,7 @@ module BSV
       # Deserialise a transaction from a hex string.
       #
       # @param hex [String] hex-encoded transaction
-      # @return [Tx] the parsed transaction
+      # @return [Transaction::Tx] the parsed transaction
       def self.from_hex(hex)
         from_binary(BSV::Primitives::Hex.decode(hex, name: 'transaction hex'))
       end
@@ -190,7 +190,7 @@ module BSV
       # Deserialise a transaction from Extended Format (BRC-30) binary data.
       #
       # @param data [String] raw EF binary
-      # @return [Tx] the parsed transaction with source data on inputs
+      # @return [Transaction::Tx] the parsed transaction with source data on inputs
       # @raise [ArgumentError] if the EF marker is invalid
       def self.from_ef(data)
         raise ArgumentError, "truncated EF transaction: need at least 10 bytes, got #{data.bytesize}" if data.bytesize < 10
@@ -250,7 +250,7 @@ module BSV
       # Deserialise a transaction from an Extended Format hex string.
       #
       # @param hex [String] hex-encoded EF transaction
-      # @return [Tx] the parsed transaction with source data on inputs
+      # @return [Transaction::Tx] the parsed transaction with source data on inputs
       def self.from_ef_hex(hex)
         from_ef(BSV::Primitives::Hex.decode(hex, name: 'EF transaction hex'))
       end
@@ -260,7 +260,7 @@ module BSV
       #
       # @param data [String] binary data containing the transaction
       # @param offset [Integer] byte offset to start reading from
-      # @return [Array(Tx, Integer)] the transaction and bytes consumed
+      # @return [Array(Transaction::Tx, Integer)] the transaction and bytes consumed
       def self.from_binary_with_offset(data, offset = 0)
         if data.bytesize < offset + 10
           raise ArgumentError, "truncated transaction: need at least 10 bytes at offset #{offset}, got #{data.bytesize - offset}"
@@ -370,7 +370,7 @@ module BSV
       # +wire_source_transactions+ pass in +Beef.from_binary+.
       #
       # @param data [String] raw BEEF binary
-      # @return [Tx, nil] the subject transaction with ancestry wired,
+      # @return [Transaction::Tx, nil] the subject transaction with ancestry wired,
       #   or nil if the BEEF is empty or contains no raw transaction entries
       def self.from_beef(data)
         beef = Beef.from_binary(data)
@@ -384,7 +384,7 @@ module BSV
       # Parse a BEEF hex string and return the subject transaction.
       #
       # @param hex [String] hex-encoded BEEF
-      # @return [Tx, nil] the subject transaction with ancestry wired,
+      # @return [Transaction::Tx, nil] the subject transaction with ancestry wired,
       #   or nil if the BEEF is empty or contains no raw transaction entries
       def self.from_beef_hex(hex)
         from_beef(BSV::Primitives::Hex.decode(hex, name: 'BEEF hex'))
@@ -622,7 +622,7 @@ module BSV
       # - +:script_failure+ — Ruby raises; TS/Python return +false+; Go also propagates errors
       # - +:missing_source+ — Ruby raises; consistent with TS/Go/Python (all raise/error)
       #
-      # @param chain_tracker [ChainTracker] chain tracker for merkle root validation
+      # @param chain_tracker [Transaction::ChainTracker] chain tracker for merkle root validation
       # @param fee_model [FeeModel, nil] optional fee model to validate the root transaction's fee
       # @return [true] on successful verification
       # @raise [VerificationError] with code +:invalid_merkle_proof+ if a merkle proof is invalid
@@ -806,7 +806,7 @@ module BSV
       # is required. Otherwise, requires a wired +source_transaction+ and a
       # valid output at +prev_tx_out_index+.
       #
-      # @param input [TransactionInput]
+      # @param input [Transaction::TransactionInput]
       # @param idx [Integer] input index, used in error messages
       # @return [TransactionOutput, nil]
       def ef_source_output(input, idx)

--- a/gem/bsv-sdk/lib/bsv/transaction/unlocking_script_template.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/unlocking_script_template.rb
@@ -14,7 +14,7 @@ module BSV
     class UnlockingScriptTemplate
       # Generate the unlocking script for a transaction input.
       #
-      # @param _tx [Tx] the transaction being signed
+      # @param _tx [Transaction::Tx] the transaction being signed
       # @param _input_index [Integer] the input index to sign
       # @return [Script::Script] the generated unlocking script
       # @raise [NotImplementedError] if not overridden by a subclass
@@ -24,7 +24,7 @@ module BSV
 
       # Estimate the unlocking script length in bytes (for fee estimation).
       #
-      # @param _tx [Tx] the transaction
+      # @param _tx [Transaction::Tx] the transaction
       # @param _input_index [Integer] the input index
       # @return [Integer] estimated script length in bytes
       # @raise [NotImplementedError] if not overridden by a subclass


### PR DESCRIPTION
## Summary

Mirrors the prose convention settled in `bsv-wallet` PR sgbett/bsv-wallet#304 into this gem. In prose, comments, and YARD tags, the Ruby class instance is `Transaction::Tx` (and peer classes are `Transaction::Beef` etc.) — no redundant `BSV::` prefix. The orthogonal rule "runnable code blocks keep `BSV::`" is captured explicitly so the two conventions don't collide on `@example` blocks or `docs/` snippets.

This is purely housekeeping. No behaviour change, no public API change.

## Changes

- **`CLAUDE.md`** — new "Transaction Class Convention" subsection under the existing Transaction ID Convention, with rule table, examples, and the runnable-code-blocks caveat.
- **~33 YARD type tags** across 17 `lib/` files swept from bare `[Tx]` / `[Beef]` / `[ChainTracker]` / `[TransactionInput]` / `[TransactionOutput]` or fully-qualified `[BSV::Transaction::*]` to the canonical `[Transaction::*]` form.
- **`mcp/tools/helpers.rb`** — prose comments updated ("Convert a TransactionInput to a hash" → "Convert a Transaction::TransactionInput to a hash").

## Test plan

- [x] `bundle exec rake spec:sdk` — 6094 examples, 0 failures, 22 pre-existing pending (testnet integration tags).
- [x] `bundle exec rubocop` — 405 files, no offences.
- [x] Verified no remaining bare `[Tx]`/`[Beef]` YARD tags in `lib/` and no `[BSV::Transaction::*]` outside of `@example` blocks.

Closes #825
Refs PR sgbett/bsv-wallet#304 (originating discussion in companion gem)
Refs PR #824 round-3 Copilot comment 3398446899 (where the divergence was first noticed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)