### PR TITLE
refactor: use existing dtxid accessors in Beef wire-inputs debug log

### DIFF
--- a/gem/bsv-sdk/lib/bsv/transaction/beef.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef.rb
@@ -800,8 +800,7 @@ module BSV
 
               input.source_transaction = source
               BSV.logger&.debug do
-                "[Beef] wired input #{input.prev_wtxid.reverse.unpack1('H*')}:#{input.prev_tx_out_index} " \
-                  "-> source #{source.wtxid.reverse.unpack1('H*')}"
+                "[Beef] wired input #{input.dtxid_hex}:#{input.prev_tx_out_index} -> source #{source.dtxid}"
               end
             end
 


### PR DESCRIPTION
## Summary
- Replace inlined `.reverse.unpack1('H*')` on `input.prev_wtxid` and `source.wtxid` with the existing `TransactionInput#dtxid_hex` and `Tx#dtxid` accessors.
- Debug log now reads in domain terms rather than byte-order primitives.

## Test plan
- [x] `bundle exec rake spec:sdk` green (6094 examples, 0 failures, 22 pending).
- [x] `bundle exec rubocop` clean on touched file.

Closes #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)