### PR TITLE
feat: compat completeness — ECIES Bitcore iv:, BIP-276, BeefParty

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,7 @@ Naming/MethodParameterName:
   AllowedNames:
     - a
     - b
+    - iv
     - ok
     - r
     - s

--- a/docs/sdk/primitives.md
+++ b/docs/sdk/primitives.md
@@ -130,6 +130,39 @@ plaintext = BSV::Primitives::ECIES.decrypt(ciphertext, recipient)
 
 The ciphertext format is: `BIE1` magic (4 bytes) + ephemeral public key (33 bytes) + AES-256-CBC encrypted data + HMAC-SHA256 (32 bytes).
 
+### Bitcore variant
+
+Use `Primitives::ECIES.bitcore_encrypt` / `bitcore_decrypt` when interoperating with legacy BSV tooling built on the Bitcore library (e.g. Paymail implementations, older BSV wallets). The Bitcore variant differs from the Electrum/BIE1 format in three ways: there is no `BIE1` magic prefix; it uses AES-256-CBC (not AES-128); and the ECDH shared secret is derived from the raw X-coordinate of the shared point rather than the compressed public key. The wire format is `ephemeral_pub(33) + IV(16) + ciphertext + HMAC(32)`.
+
+```ruby
+recipient = BSV::Primitives::PrivateKey.generate
+sender    = BSV::Primitives::PrivateKey.generate
+
+# Encrypt
+ciphertext = BSV::Primitives::ECIES.bitcore_encrypt(
+  'secret data',
+  recipient.public_key,
+  private_key: sender   # omit for a random ephemeral key
+)
+
+# Decrypt
+plaintext = BSV::Primitives::ECIES.bitcore_decrypt(ciphertext, recipient)
+```
+
+The `iv:` keyword argument accepts a 16-byte binary string to override the randomly-generated IV. **Supply a fixed IV only when producing deterministic test vectors — using a fixed IV in production breaks confidentiality.**
+
+```ruby
+fixed_iv = "\x00" * 16
+ciphertext = BSV::Primitives::ECIES.bitcore_encrypt(
+  plaintext,
+  recipient.public_key,
+  private_key: sender,
+  iv: fixed_iv
+)
+```
+
+See `spec/bsv/primitives/ecies_bitcore_conformance_spec.rb` for cross-SDK conformance vectors against the TS SDK.
+
 ## Hashing
 
 The `Digest` module provides all hash functions used in Bitcoin:

--- a/docs/sdk/script.md
+++ b/docs/sdk/script.md
@@ -173,6 +173,44 @@ chunks.each do |chunk|
 end
 ```
 
+## BIP-276 Text Encoding
+
+`Script::BIP276` implements the [BIP-276](https://github.com/moneybutton/bips/blob/master/bip-0276.mediawiki) text-sharing format, which provides a compact, checksummed way to pass raw scripts and script templates between BSV tools as human-readable strings.
+
+The encoded form is `<prefix>:<version-byte><network-byte><hex-payload><checksum>`, where the checksum is the first four bytes of double-SHA-256 over the full preimage.
+
+```ruby
+# Encode a script's binary form
+encoded = BSV::Script::BIP276.encode(
+  script.to_binary,
+  prefix:  BSV::Script::BIP276::PREFIX_SCRIPT,   # 'bitcoin-script'
+  network: BSV::Script::BIP276::NETWORK_MAINNET, # 1
+  version: BSV::Script::BIP276::CURRENT_VERSION  # 1
+)
+#=> "bitcoin-script:010176a914...6f0cd86a"
+
+# Decode — returns an immutable Result with :prefix, :version, :network, :data
+result = BSV::Script::BIP276.decode(encoded)
+result.prefix   #=> "bitcoin-script"
+result.version  #=> 1
+result.network  #=> 1
+result.data     #=> binary script bytes
+```
+
+Convenience helpers lock the prefix:
+
+```ruby
+# Script round-trip
+encoded = BSV::Script::BIP276.encode_script(binary_script)
+result  = BSV::Script::BIP276.decode_script(encoded)
+
+# Template round-trip
+encoded = BSV::Script::BIP276.encode_template(binary_template)
+result  = BSV::Script::BIP276.decode_template(encoded)
+```
+
+**Field order note:** the two header bytes are `<version><network>` — version first, then network. This matches the BIP-276 specification and the Go SDK reference implementation. The Python SDK has these two fields reversed, a known bug that is invisible when both values are `0x01` (the default) but produces incorrect output for testnet or non-default versions. See `spec/bsv/script/bip276_spec.rb` for Go SDK cross-SDK conformance vectors that prove the correct byte order.
+
 ## Script Interpreter
 
 Verify that an unlocking script satisfies a locking script:

--- a/docs/sdk/transaction.md
+++ b/docs/sdk/transaction.md
@@ -236,6 +236,48 @@ binary = beef.to_binary
 atomic = beef.to_atomic_binary(subject_txid)
 ```
 
+## BeefParty: Multi-Party Exchange
+
+`Transaction::BeefParty` extends `Transaction::Beef` to track per-party knowledge: each named counterparty is associated with the set of wtxids it is already known to hold. This avoids re-transmitting transaction data and merkle proofs that the recipient already possesses, keeping BEEF bundles compact in multi-step exchange flows.
+
+### Worked example
+
+```ruby
+require 'bsv-sdk'
+
+# Party A starts with a BEEF received from elsewhere
+party = BSV::Transaction::BeefParty.new(%w[alice bob])
+party.merge_beef_from_party('alice', alice_beef_binary)
+
+# Tell the bundle that bob already holds a specific transaction
+bob_known_wtxid = BSV::Transaction::TransactionInput.wtxid_from_hex(
+  'abcd1234...'  # display-order txid that bob definitely has
+)
+party.add_known_wtxids_for_party('bob', [bob_known_wtxid])
+
+# Produce a trimmed Beef for bob — TXID-only entries bob already knows are removed
+beef_for_bob = party.trimmed_beef_for_party('bob')
+
+# Bob can verify the trimmed bundle
+bob_party = BSV::Transaction::BeefParty.new(['bob'])
+bob_party.merge_beef_from_party('bob', beef_for_bob)
+```
+
+`trimmed_beef_for_party` returns a plain `Transaction::Beef` (not a `Transaction::BeefParty`) and does not mutate the original bundle. RAW_TX and RAW_TX_AND_BUMP entries are always retained even when the party knows the txid — only TXID-only entries are candidates for removal.
+
+### New methods on `Transaction::Beef`
+
+Four public methods were added to support `Transaction::BeefParty`:
+
+| Method | Purpose |
+|--------|---------|
+| `merge_txid_only(wtxid)` | Add a TXID-only entry if no entry for that wtxid exists yet; no-ops on stronger existing entries. |
+| `clone` | Return a shallow copy with independent `@bumps` and `@transactions` arrays. |
+| `trim_known_wtxids(known_wtxids)` | Return a new `Transaction::Beef` with TXID-only entries removed for the supplied set of wtxids; renumbers bump indices. |
+| `valid_wtxids` | Return the wtxids of all transactions in the bundle that are proven or chain back to proven transactions. |
+
+See `spec/bsv/transaction/beef_party_spec.rb` for a full worked example including cross-SDK conformance vectors against the TS SDK.
+
 ## Merkle Paths (BRC-74)
 
 Merkle paths (BUMPs) prove transaction inclusion in a block.

--- a/gem/bsv-sdk/lib/bsv/primitives/ecies.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/ecies.rb
@@ -147,14 +147,23 @@ module BSV
       # @param message [String] the plaintext message
       # @param public_key [PublicKey] the recipient's public key
       # @param private_key [PrivateKey, nil] optional ephemeral key (random if omitted)
+      # @param iv [String, nil] optional 16-byte ASCII-8BIT IV. When omitted a random IV is
+      #   generated via +SecureRandom+. Supply a fixed value only for deterministic test
+      #   vectors — **never use a fixed IV in production**.
       # @return [String] encrypted payload
-      def bitcore_encrypt(message, public_key, private_key: nil)
+      # @raise [ArgumentError] if +iv+ is supplied but is not exactly 16 bytes
+      def bitcore_encrypt(message, public_key, private_key: nil, iv: nil)
         message = message.b if message.encoding != Encoding::ASCII_8BIT
+
+        if iv
+          iv = iv.b if iv.encoding != Encoding::ASCII_8BIT
+          raise ArgumentError, 'iv must be exactly 16 bytes' unless iv.bytesize == 16
+        else
+          iv = SecureRandom.random_bytes(16)
+        end
 
         ephemeral = private_key || PrivateKey.generate
         key_e, key_m = derive_bitcore_keys(ephemeral, public_key)
-
-        iv = SecureRandom.random_bytes(16)
 
         cipher = OpenSSL::Cipher.new('aes-256-cbc')
         cipher.encrypt

--- a/gem/bsv-sdk/lib/bsv/script.rb
+++ b/gem/bsv-sdk/lib/bsv/script.rb
@@ -18,5 +18,6 @@ module BSV
     autoload :Stack,             'bsv/script/interpreter/stack'
 
     autoload :PushDropTemplate, 'bsv/script/push_drop_template'
+    autoload :BIP276,           'bsv/script/bip276'
   end
 end

--- a/gem/bsv-sdk/lib/bsv/script/bip276.rb
+++ b/gem/bsv-sdk/lib/bsv/script/bip276.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'bsv/primitives/digest'
+
+module BSV
+  module Script
+    # BIP-276 text encoding for scripts and templates.
+    #
+    # Encodes and decodes typed bitcoin data using the scheme described in
+    # https://github.com/moneybutton/bips/blob/master/bip-0276.mediawiki
+    #
+    # Format: `<prefix>:<version-byte><network-byte><hex-payload><checksum>`
+    # where version and network are each one byte (two hex digits), and
+    # checksum is the first 4 bytes of double-SHA256 over the full preimage
+    # (the string up to and including the payload), hex-encoded.
+    #
+    # @note Field order is version-then-network, matching the BIP-276 spec
+    #   and the Go SDK reference. The Python SDK has these reversed — a known
+    #   py-sdk bug that is invisible at default v=1, n=1.
+    module BIP276
+      # Returned by {decode}; immutable value object.
+      Result = Data.define(:prefix, :version, :network, :data)
+
+      # Custom exception hierarchy.
+      class Error < StandardError; end
+      class InvalidFormat   < Error; end
+      class InvalidChecksum < Error; end
+
+      PREFIX_SCRIPT   = 'bitcoin-script'
+      PREFIX_TEMPLATE = 'bitcoin-template'
+      CURRENT_VERSION = 1
+      NETWORK_MAINNET = 1
+      NETWORK_TESTNET = 2
+
+      # Regex: prefix(:)(version 2 hex)(network 2 hex)(data hex*)(checksum 8 hex)
+      VALID_BIP276 = /\A(.+?):([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})([0-9A-Fa-f]*)([0-9A-Fa-f]{8})\z/
+
+      module_function
+
+      # Encode a binary payload as a BIP-276 string.
+      #
+      # @param data    [String]  binary payload (e.g. a {Script::Script}'s binary form)
+      # @param prefix  [String]  {PREFIX_SCRIPT} or {PREFIX_TEMPLATE} (or any custom prefix)
+      # @param version [Integer] 1..255 — {CURRENT_VERSION} by default
+      # @param network [Integer] 1..255 — {NETWORK_MAINNET} by default
+      # @return [String] BIP-276 encoded string
+      # @raise [ArgumentError] if version or network is out of the range 1..255
+      def encode(data, prefix: PREFIX_SCRIPT, network: NETWORK_MAINNET, version: CURRENT_VERSION)
+        raise ArgumentError, "version must be 1..255, got #{version}"  unless (1..255).cover?(version)
+        raise ArgumentError, "network must be 1..255, got #{network}"  unless (1..255).cover?(network)
+
+        preimage = build_preimage(prefix, version, network, data)
+        preimage + checksum(preimage)
+      end
+
+      # Decode a BIP-276 string.
+      #
+      # @param str [String] BIP-276 encoded string
+      # @return [Result] value object with +:prefix+, +:version+, +:network+, +:data+
+      # @raise [InvalidFormat]   if the string is structurally malformed
+      # @raise [InvalidChecksum] if the checksum does not match the payload
+      def decode(str)
+        match = VALID_BIP276.match(str)
+        raise InvalidFormat, 'not a valid BIP-276 string' unless match
+
+        prefix  = match[1]
+        version = match[2].to_i(16)
+        network = match[3].to_i(16)
+
+        raise InvalidFormat, 'data payload has odd number of hex digits' if match[4].length.odd?
+
+        data = [match[4]].pack('H*')
+
+        preimage        = build_preimage(prefix, version, network, data)
+        expected        = checksum(preimage)
+        raise InvalidChecksum, 'checksum mismatch' unless match[5].downcase == expected
+
+        Result.new(prefix: prefix, version: version, network: network, data: data)
+      end
+
+      # Encode a script payload using the {PREFIX_SCRIPT} prefix.
+      #
+      # @param (see encode)
+      # @return [String] BIP-276 encoded string with +bitcoin-script+ prefix
+      def encode_script(data, network: NETWORK_MAINNET, version: CURRENT_VERSION)
+        encode(data, prefix: PREFIX_SCRIPT, network: network, version: version)
+      end
+
+      # Encode a template payload using the {PREFIX_TEMPLATE} prefix.
+      #
+      # @param (see encode)
+      # @return [String] BIP-276 encoded string with +bitcoin-template+ prefix
+      def encode_template(data, network: NETWORK_MAINNET, version: CURRENT_VERSION)
+        encode(data, prefix: PREFIX_TEMPLATE, network: network, version: version)
+      end
+
+      # Decode a BIP-276 string that must have the {PREFIX_SCRIPT} prefix.
+      #
+      # @param str [String] BIP-276 encoded string
+      # @return [Result]
+      # @raise [InvalidFormat] if prefix is not +bitcoin-script+
+      # @raise [InvalidChecksum] if the checksum does not match
+      def decode_script(str)
+        result = decode(str)
+        raise InvalidFormat, "expected prefix '#{PREFIX_SCRIPT}', got '#{result.prefix}'" \
+          unless result.prefix == PREFIX_SCRIPT
+
+        result
+      end
+
+      # Decode a BIP-276 string that must have the {PREFIX_TEMPLATE} prefix.
+      #
+      # @param str [String] BIP-276 encoded string
+      # @return [Result]
+      # @raise [InvalidFormat] if prefix is not +bitcoin-template+
+      # @raise [InvalidChecksum] if the checksum does not match
+      def decode_template(str)
+        result = decode(str)
+        raise InvalidFormat, "expected prefix '#{PREFIX_TEMPLATE}', got '#{result.prefix}'" \
+          unless result.prefix == PREFIX_TEMPLATE
+
+        result
+      end
+
+      # @api private
+      def build_preimage(prefix, version, network, data)
+        format('%<prefix>s:%<version>02x%<network>02x%<payload>s',
+               prefix: prefix, version: version, network: network, payload: data.unpack1('H*'))
+      end
+      private_class_method :build_preimage
+
+      # @api private
+      def checksum(preimage)
+        BSV::Primitives::Digest.sha256d(preimage)[0, 4].unpack1('H*')
+      end
+      private_class_method :checksum
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/script/bip276.rb
+++ b/gem/bsv-sdk/lib/bsv/script/bip276.rb
@@ -71,8 +71,12 @@ module BSV
 
         data = [match[4]].pack('H*')
 
-        preimage        = build_preimage(prefix, version, network, data)
-        expected        = checksum(preimage)
+        # Compute the checksum over the EXACT input bytes (everything except
+        # the trailing 8-hex-digit checksum) rather than rebuilding the
+        # preimage from parsed fields. Rebuilding via build_preimage would
+        # lowercase the payload hex, causing valid mixed-case input to fail.
+        preimage = str[0..-9]
+        expected = checksum(preimage)
         raise InvalidChecksum, 'checksum mismatch' unless match[5].downcase == expected
 
         Result.new(prefix: prefix, version: version, network: network, data: data)

--- a/gem/bsv-sdk/lib/bsv/transaction.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction.rb
@@ -19,6 +19,7 @@ module BSV
     autoload :ChainTracker,             'bsv/transaction/chain_tracker'
     autoload :ChainTrackers,            'bsv/transaction/chain_trackers'
     autoload :Beef,                     'bsv/transaction/beef'
+    autoload :BeefParty, 'bsv/transaction/beef_party'
     autoload :UnlockingScriptTemplate,  'bsv/transaction/unlocking_script_template'
     autoload :P2PKH,                    'bsv/transaction/p2pkh'
     autoload :Tx,                       'bsv/transaction/tx'

--- a/gem/bsv-sdk/lib/bsv/transaction/beef.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef.rb
@@ -418,8 +418,14 @@ module BSV
       #
       # @return [Transaction::Beef] a new shallow copy
       def clone
-        c = self.class.new(version: @version, bumps: @bumps.dup, transactions: @transactions.dup)
-        c.instance_variable_set(:@subject_wtxid, @subject_wtxid)
+        # Use super (Object#clone) rather than self.class.new so subclasses
+        # (e.g. Transaction::BeefParty) with different initialize signatures
+        # work correctly. Object#clone does a shallow ivar copy without
+        # invoking initialize; we then dup the two arrays so the copy's
+        # contents can mutate independently.
+        c = super
+        c.instance_variable_set(:@bumps, @bumps.dup)
+        c.instance_variable_set(:@transactions, @transactions.dup)
         c.instance_variable_set(:@txs_not_valid, @txs_not_valid&.dup)
         c
       end
@@ -505,19 +511,23 @@ module BSV
       #
       # @return [Array<String>] binary wire-order wtxids
       def valid_wtxids
-        known = Set.new
+        invalid = @txs_not_valid || Set.new
+        known   = Set.new
 
-        # Seed with proven entries
+        # Seed with proven entries (excluding any marked cyclic/unsortable)
         @transactions.each do |bt|
-          known.add(bt.wtxid) if bt.is_a?(ProvenTxEntry)
+          known.add(bt.wtxid) if bt.is_a?(ProvenTxEntry) && !invalid.include?(bt.wtxid)
         end
 
-        # Iteratively resolve unproven entries whose inputs are all known
+        # Iteratively resolve unproven entries whose inputs are all known.
+        # Skip @txs_not_valid entries — by definition they can't be ordered
+        # for validation, so a counterparty receiving them can't validate either.
         changed = true
         while changed
           changed = false
           @transactions.each do |bt|
             next if bt.is_a?(TxidOnlyEntry) || known.include?(bt.wtxid)
+            next if invalid.include?(bt.wtxid)
             next unless bt.respond_to?(:transaction)
 
             if bt.transaction.inputs.all? { |inp| known.include?(inp.prev_wtxid) }

--- a/gem/bsv-sdk/lib/bsv/transaction/beef.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef.rb
@@ -385,6 +385,151 @@ module BSV
         to_atomic_binary(subject_wtxid).unpack1('H*')
       end
 
+      # --- Supporting methods for multi-party BEEF exchange ---
+
+      # Add a TXID-only entry for +wtxid+ if no entry exists yet.
+      #
+      # If an entry already exists (in any format), the call is a no-op —
+      # TXID-only is the weakest format, so an existing stronger entry is kept.
+      #
+      # @param wtxid [String] 32-byte wire-order binary txid
+      # @return [BeefTx] the existing or newly added entry
+      def merge_txid_only(wtxid)
+        BSV::Primitives::Hex.validate_wtxid!(wtxid, name: 'wtxid')
+        existing = @transactions.find { |bt| bt.wtxid == wtxid }
+        return existing if existing
+
+        entry = TxidOnlyEntry.new(known_wtxid: wtxid)
+        @transactions << entry
+        entry
+      end
+
+      # Return a shallow copy of this Transaction::Beef.
+      #
+      # Both +@bumps+ and +@transactions+ arrays are duplicated (new arrays),
+      # but the +BeefTx+ and +MerklePath+ objects they contain are shared
+      # references. This mirrors the TS SDK's +clone+ contract: entries are
+      # effectively immutable once added to a bundle, so shallow semantics are
+      # correct. If a deeper copy is ever required, add a separate +deep_dup+
+      # rather than changing this method's contract.
+      #
+      # +@subject_wtxid+ (Atomic BEEF) and +@txs_not_valid+ (cyclic-graph
+      # metadata) are preserved on the copy.
+      #
+      # @return [Transaction::Beef] a new shallow copy
+      def clone
+        c = self.class.new(version: @version, bumps: @bumps.dup, transactions: @transactions.dup)
+        c.instance_variable_set(:@subject_wtxid, @subject_wtxid)
+        c.instance_variable_set(:@txs_not_valid, @txs_not_valid&.dup)
+        c
+      end
+
+      # Return a new Transaction::Beef with TXID-only entries removed for any
+      # wtxid in +known_wtxids+.
+      #
+      # RAW_TX and RAW_TX_AND_BUMP entries are always retained, even when their
+      # wtxid appears in +known_wtxids+. Only +TxidOnlyEntry+ records are
+      # candidates for removal (they carry no proof data the recipient needs).
+      #
+      # After dropping TXID-only entries, any BUMP that is no longer referenced
+      # by any remaining +ProvenTxEntry+ is removed, and all +bump_index+
+      # fields are renumbered to match the new bumps array (mirrors TS
+      # +trimKnownTxids+ at +Beef.ts:861-914+).
+      #
+      # Does not mutate +self+. Starts from a {#clone} so the caller's state
+      # is preserved.
+      #
+      # @param known_wtxids [Array<String>] binary wtxids the recipient already has
+      # @return [Transaction::Beef] a new bundle with the specified entries trimmed
+      def trim_known_wtxids(known_wtxids)
+        known_set = known_wtxids.to_set
+
+        trimmed = clone
+        trimmed.instance_variable_set(
+          :@transactions,
+          trimmed.transactions.reject { |bt| bt.is_a?(TxidOnlyEntry) && known_set.include?(bt.wtxid) }
+        )
+
+        # Find which bump indices are still referenced
+        referenced = Set.new
+        trimmed.transactions.each do |bt|
+          referenced.add(bt.bump_index) if bt.is_a?(ProvenTxEntry)
+        end
+
+        # If all bumps are still referenced, nothing more to do
+        return trimmed if referenced.size == trimmed.bumps.length
+
+        # Build old → new index map for surviving bumps
+        index_map = {}
+        new_idx = 0
+        trimmed.bumps.each_with_index do |_, old_idx|
+          if referenced.include?(old_idx)
+            index_map[old_idx] = new_idx
+            new_idx += 1
+          end
+        end
+
+        # Drop unreferenced bumps
+        trimmed.instance_variable_set(
+          :@bumps,
+          trimmed.bumps.each_with_index.filter_map { |bump, i| bump if referenced.include?(i) }
+        )
+
+        # Renumber bump_index on all ProvenTxEntry records
+        trimmed.instance_variable_set(
+          :@transactions,
+          trimmed.transactions.map do |bt|
+            next bt unless bt.is_a?(ProvenTxEntry)
+
+            new_bump_idx = index_map.fetch(bt.bump_index)
+            ProvenTxEntry.new(transaction: bt.transaction, bump_index: new_bump_idx).tap do |e|
+              e.transaction.merkle_path = trimmed.bumps[new_bump_idx]
+            end
+          end
+        )
+
+        trimmed
+      end
+
+      # Return the wtxids of transactions that are "valid" in this bundle.
+      #
+      # A transaction is valid when it either:
+      # - has a merkle proof (is a +ProvenTxEntry+), or
+      # - all of its inputs chain back to proven transactions within the bundle.
+      #
+      # TXID-only entries are excluded. Cyclic transactions (from
+      # +@txs_not_valid+) are also excluded.
+      #
+      # Used by {Transaction::BeefParty} to record which wtxids a party gains
+      # knowledge of after a {#merge_beef_from_party} call.
+      #
+      # @return [Array<String>] binary wire-order wtxids
+      def valid_wtxids
+        known = Set.new
+
+        # Seed with proven entries
+        @transactions.each do |bt|
+          known.add(bt.wtxid) if bt.is_a?(ProvenTxEntry)
+        end
+
+        # Iteratively resolve unproven entries whose inputs are all known
+        changed = true
+        while changed
+          changed = false
+          @transactions.each do |bt|
+            next if bt.is_a?(TxidOnlyEntry) || known.include?(bt.wtxid)
+            next unless bt.respond_to?(:transaction)
+
+            if bt.transaction.inputs.all? { |inp| known.include?(inp.prev_wtxid) }
+              known.add(bt.wtxid)
+              changed = true
+            end
+          end
+        end
+
+        known.to_a
+      end
+
       # --- Merge operations ---
 
       # Add or deduplicate a merkle path (BUMP) in this BEEF bundle.

--- a/gem/bsv-sdk/lib/bsv/transaction/beef_party.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef_party.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+module BSV
+  module Transaction
+    # Transaction::Beef subclass that tracks per-party knowledge of wtxids.
+    #
+    # Used in multi-party BEEF exchange to avoid re-transmitting transaction
+    # data and proofs that a counterparty already possesses. Each party is
+    # identified by a caller-supplied string and associated with the set of
+    # wtxids it is known to hold.
+    #
+    # @example Two-party exchange
+    #   party = BSV::Transaction::BeefParty.new(['alice', 'bob'])
+    #   party.merge_beef_from_party('alice', alice_beef)
+    #   trimmed = party.trimmed_beef_for_party('bob')  # plain Transaction::Beef
+    class BeefParty < Beef
+      # @param initial_parties [Array<String>] optional initial party identifiers
+      # @raise [ArgumentError] if +initial_parties+ contains duplicates
+      #
+      # Defaults to BEEF_V2 (BRC-96) because TXID-only entries — which are
+      # central to BeefParty's purpose — are only valid in V2. Matches the TS
+      # SDK's +new Beef()+ default.
+      def initialize(initial_parties = [])
+        super(version: BEEF_V2)
+        @party_knowledge = {}
+        initial_parties.each { |p| add_party(p) }
+      end
+
+      # @param party_id [String]
+      # @return [Boolean] true if +party_id+ has been added
+      def party?(party_id)
+        @party_knowledge.key?(party_id)
+      end
+
+      # Add a new unique party identifier.
+      #
+      # @param party_id [String]
+      # @raise [ArgumentError] if +party_id+ is already known
+      def add_party(party_id)
+        raise ArgumentError, "duplicate party #{party_id}" if party?(party_id)
+
+        @party_knowledge[party_id] = Set.new
+      end
+
+      # Record additional wtxids as known to +party_id+.
+      #
+      # Auto-creates the party if it is not yet known (TS parity). Also
+      # merges a TXID-only entry into the underlying bundle for each wtxid.
+      #
+      # @param party_id [String] party identifier (auto-created if unknown)
+      # @param wtxids [Array<String>] 32-byte wire-order binary wtxids
+      # @raise [ArgumentError] if any element of +wtxids+ is not a valid wtxid
+      def add_known_wtxids_for_party(party_id, wtxids)
+        add_party(party_id) unless party?(party_id)
+        wtxids.each do |wtxid|
+          BSV::Primitives::Hex.validate_wtxid!(wtxid, name: 'wtxid')
+          @party_knowledge[party_id].add(wtxid)
+          merge_txid_only(wtxid)
+        end
+      end
+
+      # @param party_id [String]
+      # @return [Array<String>] 32-byte wire-order binary wtxids known to +party_id+
+      # @raise [ArgumentError] if +party_id+ is unknown
+      def known_wtxids_for_party(party_id)
+        raise ArgumentError, "unknown party #{party_id}" unless party?(party_id)
+
+        @party_knowledge[party_id].to_a
+      end
+
+      # Merge a Transaction::Beef received from +party_id+.
+      #
+      # Merges all transactions and BUMPs from +beef_or_binary+ into +self+,
+      # then records the valid wtxids of the merged bundle as known to
+      # +party_id+. Auto-creates the party if not yet known.
+      #
+      # @param party_id [String] party identifier
+      # @param beef_or_binary [Transaction::Beef, String] a Transaction::Beef
+      #   instance or raw binary BEEF bytes
+      def merge_beef_from_party(party_id, beef_or_binary)
+        beef = beef_or_binary.is_a?(Beef) ? beef_or_binary : Beef.from_binary(beef_or_binary)
+        known = beef.valid_wtxids
+        merge(beef)
+        add_known_wtxids_for_party(party_id, known)
+      end
+
+      # Return a new Transaction::Beef (not Transaction::BeefParty) with
+      # TXID-only entries that are known to +party_id+ removed.
+      #
+      # RAW_TX and RAW_TX_AND_BUMP entries are always retained even when the
+      # party knows the txid — those formats carry proof data. BUMP indices
+      # are renumbered if any unreferenced bumps are dropped.
+      #
+      # Does not mutate +self+.
+      #
+      # @param party_id [String]
+      # @return [Transaction::Beef] a new trimmed bundle (plain Beef, not BeefParty)
+      # @raise [ArgumentError] if +party_id+ is unknown
+      def trimmed_beef_for_party(party_id)
+        raise ArgumentError, "unknown party #{party_id}" unless party?(party_id)
+
+        known = @party_knowledge[party_id].to_a
+
+        # Build a plain Beef from our current state so trim_known_wtxids
+        # returns a Beef, not a BeefParty.
+        plain = Beef.new(version: @version, bumps: @bumps.dup, transactions: @transactions.dup)
+        plain.instance_variable_set(:@subject_wtxid, @subject_wtxid)
+        plain.instance_variable_set(:@txs_not_valid, @txs_not_valid&.dup)
+        plain.trim_known_wtxids(known)
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/lib/bsv/transaction/beef_party.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/beef_party.rb
@@ -79,8 +79,14 @@ module BSV
       #   instance or raw binary BEEF bytes
       def merge_beef_from_party(party_id, beef_or_binary)
         beef = beef_or_binary.is_a?(Beef) ? beef_or_binary : Beef.from_binary(beef_or_binary)
-        known = beef.valid_wtxids
+        # Capture the set of wtxids the party actually sent before merging.
+        beef_wtxids = beef.transactions.map(&:wtxid)
         merge(beef)
+        # Record knowledge of any tx the party sent that is now provably valid
+        # against the merged state. This captures the cross-bundle case where
+        # an unproven tx in +beef+ becomes valid via inputs already proven in
+        # +self+ (and conversely doesn't record knowledge the party never sent).
+        known = valid_wtxids & beef_wtxids
         add_known_wtxids_for_party(party_id, known)
       end
 

--- a/gem/bsv-sdk/spec/bsv/primitives/ecies_bitcore_conformance_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/primitives/ecies_bitcore_conformance_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Static conformance vectors generated from the TS SDK reference:
+# ts-sdk/src/compat/__tests/ECIES.test.ts — key pair (PrivateKey(42), PrivateKey(88))
+# Inputs verified byte-for-byte against ECIES.bitcoreEncrypt in ts-sdk.
+ECIES_BITCORE_SENDER_PRIV_HEX = '000000000000000000000000000000000000000000000000000000000000002a'
+ECIES_BITCORE_RECIPIENT_PRIV_HEX = '0000000000000000000000000000000000000000000000000000000000000058'
+# sha256("my message is the hash of this string")
+ECIES_BITCORE_PLAINTEXT_HEX = '59cbda0066876e83ed87f63763bd4092ad9134c95e6882717fc699af3b663c0b'
+ECIES_BITCORE_IV_HEX = '00000000000000000000000000000000'
+# Full 129-byte ciphertext: ephemeral_pub(33) + IV(16) + ciphertext(48) + HMAC(32)
+ECIES_BITCORE_CIPHERTEXT_HEX = '02fe8d1eb1bcb3432b1db5833ff5f2226d9cb5e65cee430558c18ed3a3c86ce1af' \
+                               '00000000000000000000000000000000' \
+                               'df8b7f0c15301e76f3f6ecf99518592242032778e3aa97ad80e5d50d2dfe103a' \
+                               '09ba6d7693435738304a7c90b79cc56f' \
+                               '6002f1c0811504d49693b4b21e775c4fee51cfc48a854a49b7739d3901c71037'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'Primitives::ECIES.bitcore_encrypt conformance' do
+  # rubocop:enable RSpec/DescribeClass
+
+  let(:sender_priv)    { BSV::Primitives::PrivateKey.from_hex(ECIES_BITCORE_SENDER_PRIV_HEX) }
+  let(:recipient_priv) { BSV::Primitives::PrivateKey.from_hex(ECIES_BITCORE_RECIPIENT_PRIV_HEX) }
+  let(:plaintext)      { [ECIES_BITCORE_PLAINTEXT_HEX].pack('H*') }
+  let(:fixed_iv)       { [ECIES_BITCORE_IV_HEX].pack('H*') }
+  let(:expected_ct)    { [ECIES_BITCORE_CIPHERTEXT_HEX].pack('H*') }
+
+  context 'with TS conformance vector' do
+    it 'produces the expected ciphertext for fixed inputs' do
+      ct = BSV::Primitives::ECIES.bitcore_encrypt(
+        plaintext,
+        recipient_priv.public_key,
+        private_key: sender_priv,
+        iv: fixed_iv
+      )
+      expect(ct.unpack1('H*')).to eq(ECIES_BITCORE_CIPHERTEXT_HEX)
+    end
+
+    it 'decrypts the TS-generated ciphertext to the expected plaintext' do
+      result = BSV::Primitives::ECIES.bitcore_decrypt(expected_ct, recipient_priv)
+      expect(result.unpack1('H*')).to eq(ECIES_BITCORE_PLAINTEXT_HEX)
+    end
+  end
+
+  describe '.bitcore_encrypt iv parameter' do
+    it 'uses the supplied IV verbatim when provided' do
+      ct1 = BSV::Primitives::ECIES.bitcore_encrypt(
+        plaintext, recipient_priv.public_key,
+        private_key: sender_priv, iv: fixed_iv
+      )
+      ct2 = BSV::Primitives::ECIES.bitcore_encrypt(
+        plaintext, recipient_priv.public_key,
+        private_key: sender_priv, iv: fixed_iv
+      )
+      expect(ct1).to eq(ct2)
+    end
+
+    it 'falls back to a random IV when iv is omitted' do
+      ct1 = BSV::Primitives::ECIES.bitcore_encrypt(plaintext, recipient_priv.public_key)
+      ct2 = BSV::Primitives::ECIES.bitcore_encrypt(plaintext, recipient_priv.public_key)
+      expect(ct1).not_to eq(ct2)
+    end
+
+    it 'raises ArgumentError when iv is not 16 bytes' do
+      expect do
+        BSV::Primitives::ECIES.bitcore_encrypt(plaintext, recipient_priv.public_key, iv: "\x00" * 15)
+      end.to raise_error(ArgumentError, /16 bytes/)
+    end
+
+    it 'raises ArgumentError when iv is empty' do
+      expect do
+        BSV::Primitives::ECIES.bitcore_encrypt(plaintext, recipient_priv.public_key, iv: ''.b)
+      end.to raise_error(ArgumentError, /16 bytes/)
+    end
+
+    it 'raises ArgumentError when iv is too long' do
+      expect do
+        BSV::Primitives::ECIES.bitcore_encrypt(plaintext, recipient_priv.public_key, iv: "\x00" * 17)
+      end.to raise_error(ArgumentError, /16 bytes/)
+    end
+
+    it 'round-trips: encrypt with explicit iv, decrypt recovers plaintext' do
+      ct = BSV::Primitives::ECIES.bitcore_encrypt(
+        plaintext, recipient_priv.public_key,
+        private_key: sender_priv, iv: fixed_iv
+      )
+      recovered = BSV::Primitives::ECIES.bitcore_decrypt(ct, recipient_priv)
+      expect(recovered).to eq(plaintext)
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/script/bip276_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/script/bip276_spec.rb
@@ -170,6 +170,17 @@ RSpec.describe 'BSV::Script::BIP276' do
       result = mod.decode('bitcoin-script:010166616b65207363726970746F0CD86A')
       expect(result.data).to eq(FAKE_SCRIPT_BYTES)
     end
+
+    it 'accepts uppercase payload from a producer that hashed the uppercase preimage' do
+      # Regression: an earlier implementation rebuilt the preimage from the
+      # parsed data, normalising the hex to lowercase, which broke verification
+      # for spec-conformant producers that emit uppercase. The checksum is
+      # defined over the exact preimage; we now compute it over the input.
+      preimage_upper = "bitcoin-script:0101#{FAKE_SCRIPT_BYTES.unpack1('H*').upcase}"
+      checksum_hex   = BSV::Primitives::Digest.sha256d(preimage_upper)[0, 4].unpack1('H*')
+      result = mod.decode(preimage_upper + checksum_hex)
+      expect(result.data).to eq(FAKE_SCRIPT_BYTES)
+    end
   end
 
   describe 'convenience helpers' do

--- a/gem/bsv-sdk/spec/bsv/script/bip276_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/script/bip276_spec.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+FAKE_SCRIPT_BYTES = 'fake script'
+
+# Go SDK cross-SDK conformance vectors (from go-sdk/script/bip276_test.go)
+BIP276_GO_VECTORS = [
+  {
+    label: 'mainnet script',
+    encoded: 'bitcoin-script:010166616b65207363726970746f0cd86a',
+    prefix: 'bitcoin-script',
+    version: 1,
+    network: 1,
+    data: FAKE_SCRIPT_BYTES
+  },
+  {
+    label: 'testnet script (proves version-then-network field order)',
+    encoded: 'bitcoin-script:010266616b652073637269707494becee6',
+    prefix: 'bitcoin-script',
+    version: 1,
+    network: 2,
+    data: FAKE_SCRIPT_BYTES
+  },
+  {
+    label: 'template prefix',
+    encoded: 'bitcoin-template:010166616b65207363726970749e31aa72',
+    prefix: 'bitcoin-template',
+    version: 1,
+    network: 1,
+    data: FAKE_SCRIPT_BYTES
+  },
+  {
+    label: 'custom prefix',
+    encoded: 'different-prefix:010166616b6520736372697074effdb090',
+    prefix: 'different-prefix',
+    version: 1,
+    network: 1,
+    data: FAKE_SCRIPT_BYTES
+  }
+].freeze
+
+RSpec.describe 'BSV::Script::BIP276' do
+  subject(:mod) { BSV::Script::BIP276 }
+
+  describe '.encode' do
+    it 'encodes the spec example correctly (matches Go mainnet vector)' do
+      result = mod.encode(FAKE_SCRIPT_BYTES,
+                          prefix: BSV::Script::BIP276::PREFIX_SCRIPT,
+                          version: 1,
+                          network: 1)
+      expect(result).to eq('bitcoin-script:010166616b65207363726970746f0cd86a')
+    end
+
+    it 'encodes with testnet network in the correct field order (version-then-network)' do
+      result = mod.encode(FAKE_SCRIPT_BYTES,
+                          prefix: BSV::Script::BIP276::PREFIX_SCRIPT,
+                          version: 1,
+                          network: 2)
+      # 01 = version, 02 = network; if reversed this would be 0201 instead of 0102
+      expect(result).to eq('bitcoin-script:010266616b652073637269707494becee6')
+    end
+
+    it 'encodes template prefix' do
+      result = mod.encode(FAKE_SCRIPT_BYTES,
+                          prefix: BSV::Script::BIP276::PREFIX_TEMPLATE,
+                          version: 1,
+                          network: 1)
+      expect(result).to eq('bitcoin-template:010166616b65207363726970749e31aa72')
+    end
+
+    it 'encodes custom prefix' do
+      result = mod.encode(FAKE_SCRIPT_BYTES,
+                          prefix: 'different-prefix',
+                          version: 1,
+                          network: 1)
+      expect(result).to eq('different-prefix:010166616b6520736372697074effdb090')
+    end
+
+    it 'encodes empty data' do
+      result = mod.encode('', prefix: BSV::Script::BIP276::PREFIX_SCRIPT, version: 1, network: 1)
+      expect(result).to eq('bitcoin-script:0101f8648dd7')
+    end
+
+    it 'encodes version 255 and network 255 (max boundary)' do
+      result = mod.encode('x', prefix: 'p', version: 255, network: 255)
+      expect(result).to start_with('p:ffff78')
+    end
+
+    it 'rejects version 0' do
+      expect { mod.encode('x', version: 0) }.to raise_error(ArgumentError, /version/)
+    end
+
+    it 'rejects version greater than 255' do
+      expect { mod.encode('x', version: 256) }.to raise_error(ArgumentError, /version/)
+    end
+
+    it 'rejects network 0' do
+      expect { mod.encode('x', network: 0) }.to raise_error(ArgumentError, /network/)
+    end
+
+    it 'rejects network greater than 255' do
+      expect { mod.encode('x', network: 256) }.to raise_error(ArgumentError, /network/)
+    end
+  end
+
+  describe '.decode' do
+    it 'decodes the Go SDK mainnet vector' do
+      result = mod.decode('bitcoin-script:010166616b65207363726970746f0cd86a')
+      expect(result.prefix).to  eq('bitcoin-script')
+      expect(result.version).to eq(1)
+      expect(result.network).to eq(1)
+      expect(result.data).to    eq(FAKE_SCRIPT_BYTES)
+    end
+
+    it 'decodes the Go SDK testnet vector and proves version-then-network field order' do
+      result = mod.decode('bitcoin-script:010266616b652073637269707494becee6')
+      # The second byte (02) must land in network, not version.
+      expect(result.version).to eq(1)
+      expect(result.network).to eq(2)
+      expect(result.data).to    eq(FAKE_SCRIPT_BYTES)
+    end
+
+    it 'decodes a vector with A-F hex digits in version and network' do
+      encoded = mod.encode('test', prefix: 'bitcoin-script', version: 170, network: 255)
+      result  = mod.decode(encoded)
+      expect(result.version).to eq(170) # 0xAA
+      expect(result.network).to eq(255) # 0xFF
+      expect(result.data).to    eq('test')
+    end
+
+    it 'decodes empty data' do
+      encoded = mod.encode('', prefix: 'bitcoin-script', version: 1, network: 1)
+      result  = mod.decode(encoded)
+      expect(result.data).to eq('')
+    end
+
+    it 'returns an immutable Result value object' do
+      result = mod.decode('bitcoin-script:010166616b65207363726970746f0cd86a')
+      expect(result).to be_a(BSV::Script::BIP276::Result)
+      expect { result.data = 'x' }.to raise_error(NoMethodError)
+    end
+
+    it 'raises InvalidFormat on missing colon separator' do
+      expect { mod.decode('bitcoin-script010166616b65207363726970746f0cd86a') }
+        .to raise_error(BSV::Script::BIP276::InvalidFormat)
+    end
+
+    it 'raises InvalidFormat on a short (truncated) string' do
+      expect { mod.decode('bitcoin-script:01') }
+        .to raise_error(BSV::Script::BIP276::InvalidFormat)
+    end
+
+    it 'raises InvalidFormat on non-hex characters in data' do
+      expect { mod.decode('bitcoin-script:0101ZZ00000000') }
+        .to raise_error(BSV::Script::BIP276::InvalidFormat)
+    end
+
+    it 'raises InvalidFormat on odd-length data hex' do
+      # 'bitcoin-script:0101abc0cd86a' — regex matches with data="a" (1 hex char, odd length).
+      # The explicit parity check catches this before reaching checksum verification.
+      expect { mod.decode('bitcoin-script:0101abc0cd86a') }
+        .to raise_error(BSV::Script::BIP276::InvalidFormat)
+    end
+
+    it 'raises InvalidChecksum on a tampered checksum' do
+      expect { mod.decode('bitcoin-script:010166616b65207363726970740000ffff') }
+        .to raise_error(BSV::Script::BIP276::InvalidChecksum)
+    end
+
+    it 'accepts mixed-case checksum hex' do
+      result = mod.decode('bitcoin-script:010166616b65207363726970746F0CD86A')
+      expect(result.data).to eq(FAKE_SCRIPT_BYTES)
+    end
+  end
+
+  describe 'convenience helpers' do
+    describe '.encode_script / .decode_script' do
+      it 'round-trips a payload through encode_script and decode_script' do
+        encoded = mod.encode_script('my script data')
+        result  = mod.decode_script(encoded)
+        expect(result.prefix).to eq(BSV::Script::BIP276::PREFIX_SCRIPT)
+        expect(result.data).to   eq('my script data')
+      end
+
+      it 'decode_script raises InvalidFormat on non-script prefix' do
+        encoded = mod.encode_template('x')
+        expect { mod.decode_script(encoded) }
+          .to raise_error(BSV::Script::BIP276::InvalidFormat, /bitcoin-script/)
+      end
+    end
+
+    describe '.encode_template / .decode_template' do
+      it 'round-trips a payload through encode_template and decode_template' do
+        encoded = mod.encode_template('my template')
+        result  = mod.decode_template(encoded)
+        expect(result.prefix).to eq(BSV::Script::BIP276::PREFIX_TEMPLATE)
+        expect(result.data).to   eq('my template')
+      end
+
+      it 'decode_template raises InvalidFormat on non-template prefix' do
+        encoded = mod.encode_script('x')
+        expect { mod.decode_template(encoded) }
+          .to raise_error(BSV::Script::BIP276::InvalidFormat, /bitcoin-template/)
+      end
+    end
+  end
+
+  describe 'cross-SDK conformance (Go SDK vectors)' do
+    BIP276_GO_VECTORS.each do |vec|
+      context vec[:label] do
+        it "encodes to #{vec[:encoded]}" do
+          result = mod.encode(vec[:data], prefix: vec[:prefix], version: vec[:version], network: vec[:network])
+          expect(result).to eq(vec[:encoded])
+        end
+
+        it "decodes #{vec[:encoded]} correctly" do
+          result = mod.decode(vec[:encoded])
+          expect(result.prefix).to  eq(vec[:prefix])
+          expect(result.version).to eq(vec[:version])
+          expect(result.network).to eq(vec[:network])
+          expect(result.data).to    eq(vec[:data])
+        end
+      end
+    end
+  end
+
+  describe 'round-trip' do
+    [
+      { prefix: 'bitcoin-script',   version: 1,   network: 1,   data: 'test' },
+      { prefix: 'bitcoin-script',   version: 1,   network: 2,   data: 'test' },
+      { prefix: 'bitcoin-template', version: 255, network: 255, data: "\x00\xff".b },
+      { prefix: 'custom',           version: 100, network: 200, data: 'data' },
+      { prefix: 'bitcoin-script',   version: 1,   network: 1,   data: '' }
+    ].each do |tc|
+      it "preserves all fields for v#{tc[:version]}/n#{tc[:network]}/prefix=#{tc[:prefix]}" do
+        encoded = mod.encode(tc[:data], prefix: tc[:prefix], version: tc[:version], network: tc[:network])
+        result  = mod.decode(encoded)
+        expect(result.prefix).to  eq(tc[:prefix])
+        expect(result.version).to eq(tc[:version])
+        expect(result.network).to eq(tc[:network])
+        expect(result.data).to    eq(tc[:data])
+      end
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/transaction/beef_party_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/beef_party_spec.rb
@@ -1,0 +1,237 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'yaml'
+
+BEEF_PARTY_VECTORS = YAML.load_file(
+  File.join(__dir__, '../../fixtures/beef_party_vectors.yml')
+).freeze
+
+RSpec.describe BSV::Transaction::BeefParty do
+  let(:proven_wtxid) do
+    [BEEF_PARTY_VECTORS['proven_dtxid']].pack('H*').reverse
+  end
+
+  let(:spend_wtxid) do
+    [BEEF_PARTY_VECTORS['spend_dtxid']].pack('H*').reverse
+  end
+
+  let(:input_beef) do
+    BSV::Transaction::Beef.from_hex(BEEF_PARTY_VECTORS['input_beef_hex'])
+  end
+
+  describe 'general' do
+    it 'subclasses Beef' do
+      expect(described_class.superclass).to eq(BSV::Transaction::Beef)
+    end
+  end
+
+  describe '#initialize' do
+    it 'starts with no parties when called with no args' do
+      bp = described_class.new
+      expect(bp.party?('alice')).to be(false)
+    end
+
+    it 'accepts an initial parties array' do
+      bp = described_class.new(%w[alice bob])
+      expect(bp.party?('alice')).to be(true)
+      expect(bp.party?('bob')).to be(true)
+    end
+
+    it 'raises on duplicate parties in the initial list' do
+      expect { described_class.new(%w[alice alice]) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#party? / #add_party' do
+    subject(:bp) { described_class.new }
+
+    it 'reports false for unknown parties' do
+      expect(bp.party?('alice')).to be(false)
+    end
+
+    it 'reports true after add_party' do
+      bp.add_party('alice')
+      expect(bp.party?('alice')).to be(true)
+    end
+
+    it 'raises ArgumentError on duplicate add_party' do
+      bp.add_party('alice')
+      expect { bp.add_party('alice') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#add_known_wtxids_for_party' do
+    subject(:bp) { described_class.new(['alice']) }
+
+    it 'records wtxids against a known party' do
+      bp.add_known_wtxids_for_party('alice', [proven_wtxid])
+      expect(bp.known_wtxids_for_party('alice')).to include(proven_wtxid)
+    end
+
+    it 'auto-creates an unknown party (TS parity)' do
+      expect(bp.party?('carol')).to be(false)
+      bp.add_known_wtxids_for_party('carol', [proven_wtxid])
+      expect(bp.party?('carol')).to be(true)
+    end
+
+    it 'rejects malformed wtxids (hex string instead of binary)' do
+      expect do
+        bp.add_known_wtxids_for_party('alice', [BEEF_PARTY_VECTORS['proven_dtxid']])
+      end.to raise_error(ArgumentError)
+    end
+
+    it 'is idempotent — adding the same wtxid twice does not double-count' do
+      bp.add_known_wtxids_for_party('alice', [proven_wtxid])
+      bp.add_known_wtxids_for_party('alice', [proven_wtxid])
+      count = bp.known_wtxids_for_party('alice').count { |w| w == proven_wtxid }
+      expect(count).to eq(1)
+    end
+
+    it 'merges TXID-only entries into the underlying BEEF' do
+      bp.add_known_wtxids_for_party('alice', [proven_wtxid])
+      entry = bp.transactions.find { |bt| bt.wtxid == proven_wtxid }
+      expect(entry).not_to be_nil
+    end
+
+    it 'does not downgrade an existing stronger entry to TXID-only' do
+      bp.merge(input_beef)
+      # proven_wtxid is a TXID-only in input_beef; merged as TXID-only
+      bp.add_known_wtxids_for_party('alice', [proven_wtxid])
+      entry = bp.transactions.find { |bt| bt.wtxid == proven_wtxid }
+      # It was TxidOnly in input_beef — merging keeps it as TxidOnly; add_known... does not change it
+      expect(entry).to be_a(BSV::Transaction::Beef::TxidOnlyEntry)
+    end
+  end
+
+  describe '#known_wtxids_for_party' do
+    subject(:bp) { described_class.new(['alice']) }
+
+    it 'returns the recorded wtxids' do
+      bp.add_known_wtxids_for_party('alice', [proven_wtxid])
+      expect(bp.known_wtxids_for_party('alice')).to eq([proven_wtxid])
+    end
+
+    it 'raises ArgumentError on unknown party' do
+      expect { bp.known_wtxids_for_party('carol') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#trimmed_beef_for_party' do
+    subject(:bp) do
+      party = described_class.new(%w[alice bob])
+      party.merge(input_beef)
+      party.add_known_wtxids_for_party('alice', [proven_wtxid])
+      party
+    end
+
+    it 'returns a new Beef (not a BeefParty)' do
+      result = bp.trimmed_beef_for_party('alice')
+      expect(result).to be_a(BSV::Transaction::Beef)
+      expect(result).not_to be_a(described_class)
+    end
+
+    it 'does not mutate self' do
+      original_count = bp.transactions.length
+      bp.trimmed_beef_for_party('alice')
+      expect(bp.transactions.length).to eq(original_count)
+    end
+
+    it 'drops TXID-only entries known to the party' do
+      result = bp.trimmed_beef_for_party('alice')
+      expect(result.transactions.none? { |bt| bt.wtxid == proven_wtxid }).to be(true)
+    end
+
+    it 'retains RawTxEntry even when the party knows the txid' do
+      bp.add_known_wtxids_for_party('alice', [spend_wtxid])
+      result = bp.trimmed_beef_for_party('alice')
+      entry = result.transactions.find { |bt| bt.wtxid == spend_wtxid }
+      # spend_wtxid entry is a RawTxEntry — not trimmed
+      expect(entry).to be_a(BSV::Transaction::Beef::RawTxEntry)
+    end
+
+    it 'returns a no-op trim for a party that knows nothing' do
+      result = bp.trimmed_beef_for_party('bob')
+      expect(result.transactions.length).to eq(bp.transactions.length)
+    end
+
+    it 'raises ArgumentError for an unknown party' do
+      expect { bp.trimmed_beef_for_party('carol') }.to raise_error(ArgumentError)
+    end
+
+    it 'preserves @subject_wtxid for Atomic BEEF' do
+      subject_wtxid = "\xFF".b * 32
+      bp.instance_variable_set(:@subject_wtxid, subject_wtxid)
+      result = bp.trimmed_beef_for_party('alice')
+      expect(result.instance_variable_get(:@subject_wtxid)).to eq(subject_wtxid)
+    end
+  end
+
+  describe '#merge_beef_from_party' do
+    subject(:bp) { described_class.new(%w[alice bob]) }
+
+    it 'accepts a Beef instance' do
+      bp.merge_beef_from_party('alice', input_beef)
+      expect(bp.party?('alice')).to be(true)
+    end
+
+    it 'accepts a binary BEEF blob' do
+      binary = [BEEF_PARTY_VECTORS['input_beef_hex']].pack('H*')
+      bp.merge_beef_from_party('bob', binary)
+      expect(bp.party?('bob')).to be(true)
+    end
+
+    it 'records the valid wtxids of the merged BEEF as known to the party' do
+      # input_beef has spend_tx as RawTxEntry; its inputs chain to the TXID-only proven_tx
+      # but proven_tx is TXID-only — not a proven or resolved tx, so valid_wtxids
+      # for input_beef depends on whether proven_tx's inputs are available
+      # For the input_beef (no bumps, proven_tx as TXID-only) valid_wtxids may be empty.
+      # Use a BEEF with a real ProvenTxEntry instead:
+      brc62_hex = '0100beef01fe636d0c0007021400fe507c0c7aa754cef1f7889d5fd395cf1f785dd7de98eed895dbedfe4e5bc70d' \
+                  '1502ac4e164f5bc16746bb0868404292ac8318bbac3800e4aad13a014da427adce3e010b00bc4ff395efd11719b2' \
+                  '77694cface5aa50d085a0bb81f613f70313acd28cf4557010400574b2d9142b8d28b61d88e3b2c3f44d858411356' \
+                  'b49a28a4643b6d1a6a092a5201030051a05fc84d531b5d250c23f4f886f6812f9fe3f402d61607f977b4ecd2701c' \
+                  '19010000fd781529d58fc2523cf396a7f25440b409857e7e221766c57214b1d38c7b481f01010062f542f45ea366' \
+                  '0f86c013ced80534cb5fd4c19d66c56e7e8c5d4bf2d40acc5e010100b121e91836fd7cd5102b654e9f72f3cf6fdb' \
+                  'fd0b161c53a9c54b12c841126331020100000001cd4e4cac3c7b56920d1e7655e7e260d31f29d9a388d04910f1bb' \
+                  'd72304a79029010000006b483045022100e75279a205a547c445719420aa3138bf14743e3f42618e5f86a19bde14bb' \
+                  '95f7022064777d34776b05d816daf1699493fcdf2ef5a5ab1ad710d9c97bfb5b8f7cef3641210263e2dee22b1ddc' \
+                  '5e11f6fab8bcd2378bdd19580d640501ea956ec0e786f93e76ffffffff013e660000000000001976a9146bfd5c7f' \
+                  'be21529d45803dbcf0c87dd3c71efbc288ac0000000001000100000001ac4e164f5bc16746bb0868404292ac8318' \
+                  'bbac3800e4aad13a014da427adce3e000000006a47304402203a61a2e931612b4bda08d541cfb980885173b8dcf6' \
+                  '4a3471238ae7abcd368d6402204cbf24f04b9aa2256d8901f0ed97866603d2be8324c2bfb7a37bf8fc90edd5b441' \
+                  '210263e2dee22b1ddc5e11f6fab8bcd2378bdd19580d640501ea956ec0e786f93e76ffffffff013c660000000000' \
+                  '001976a9146bfd5c7fbe21529d45803dbcf0c87dd3c71efbc288ac0000000000'
+      full_beef = BSV::Transaction::Beef.from_hex(brc62_hex)
+      bp.merge_beef_from_party('alice', full_beef)
+      known = bp.known_wtxids_for_party('alice')
+      expect(known).not_to be_empty
+    end
+
+    it 'auto-creates the party when unknown' do
+      expect(bp.party?('carol')).to be(false)
+      bp.merge_beef_from_party('carol', input_beef)
+      expect(bp.party?('carol')).to be(true)
+    end
+  end
+
+  describe 'cross-SDK conformance' do
+    it 'produces the same trimmed BEEF binary as the TS SDK (alice trim)' do
+      bp = described_class.new(%w[alice bob])
+      bp.merge(input_beef)
+      bp.add_known_wtxids_for_party('alice', [proven_wtxid])
+
+      result = bp.trimmed_beef_for_party('alice')
+      expect(result.to_hex).to eq(BEEF_PARTY_VECTORS['trimmed_for_alice_hex'])
+    end
+
+    it 'produces the same trimmed BEEF binary as the TS SDK (bob no-op trim)' do
+      bp = described_class.new(%w[alice bob])
+      bp.merge(input_beef)
+      bp.add_known_wtxids_for_party('alice', [proven_wtxid])
+
+      result = bp.trimmed_beef_for_party('bob')
+      expect(result.to_hex).to eq(BEEF_PARTY_VECTORS['trimmed_for_bob_hex'])
+    end
+  end
+end

--- a/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
@@ -1586,6 +1586,15 @@ RSpec.describe BSV::Transaction::Beef do
       expect(base.transactions.length).to eq(2)
       expect(cloned.transactions.length).to eq(3)
     end
+
+    it 'preserves the subclass when called on a Transaction::BeefParty' do
+      # Regression: an earlier implementation used self.class.new(version:, ...)
+      # which broke for subclasses with different initialize signatures.
+      bp = BSV::Transaction::BeefParty.new(%w[alice])
+      cloned_bp = bp.clone
+      expect(cloned_bp).to be_a(BSV::Transaction::BeefParty)
+      expect(cloned_bp).not_to be(bp)
+    end
   end
 
   describe '#trim_known_wtxids' do
@@ -1683,6 +1692,14 @@ RSpec.describe BSV::Transaction::Beef do
 
     it 'returns an empty array for an empty BEEF' do
       expect(described_class.new.valid_wtxids).to eq([])
+    end
+
+    it 'excludes wtxids marked unsortable in @txs_not_valid' do
+      # Regression: an earlier implementation forgot to consult @txs_not_valid,
+      # so cyclic/unsortable proven entries leaked through as valid.
+      proven_entry = base.transactions.find { |bt| bt.is_a?(described_class::ProvenTxEntry) }
+      base.instance_variable_set(:@txs_not_valid, Set.new([proven_entry.wtxid]))
+      expect(base.valid_wtxids).not_to include(proven_entry.wtxid)
     end
   end
 end

--- a/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/beef_spec.rb
@@ -1505,4 +1505,184 @@ RSpec.describe BSV::Transaction::Beef do
       expect(tx2.wtxid).to eq(tx1.wtxid)
     end
   end
+
+  # --- New supporting methods (T3 / #831) ---
+
+  describe '#merge_txid_only' do
+    let(:beef) { described_class.new(version: described_class::BEEF_V2) }
+    let(:wtxid) { "\xAB".b * 32 }
+
+    it 'adds a TxidOnlyEntry when no entry exists' do
+      beef.merge_txid_only(wtxid)
+      expect(beef.transactions.length).to eq(1)
+      expect(beef.transactions.first).to be_a(described_class::TxidOnlyEntry)
+      expect(beef.transactions.first.wtxid).to eq(wtxid)
+    end
+
+    it 'is idempotent — calling twice does not add a duplicate' do
+      beef.merge_txid_only(wtxid)
+      beef.merge_txid_only(wtxid)
+      expect(beef.transactions.length).to eq(1)
+    end
+
+    it 'does not overwrite a stronger existing entry' do
+      base = described_class.from_hex(brc62_hex)
+      proven_wtxid = base.transactions.find { |bt| bt.is_a?(described_class::ProvenTxEntry) }.wtxid
+      base.merge_txid_only(proven_wtxid)
+      # Entry should still be ProvenTxEntry, not replaced by TxidOnlyEntry
+      entry = base.transactions.find { |bt| bt.wtxid == proven_wtxid }
+      expect(entry).to be_a(described_class::ProvenTxEntry)
+    end
+
+    it 'returns the existing entry when one is already present' do
+      beef.merge_txid_only(wtxid)
+      existing = beef.transactions.first
+      returned = beef.merge_txid_only(wtxid)
+      expect(returned).to be(existing)
+    end
+
+    it 'raises ArgumentError for a malformed wtxid' do
+      expect { beef.merge_txid_only('not32bytes') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#clone' do
+    let(:base) { described_class.from_hex(brc62_hex) }
+    let(:cloned) { base.clone }
+
+    it 'returns a new Beef instance' do
+      expect(cloned).not_to be(base)
+      expect(cloned).to be_a(described_class)
+    end
+
+    it 'duplicates the bumps array (new array, same references — shallow)' do
+      expect(cloned.bumps).not_to be(base.bumps)
+      expect(cloned.bumps.first).to be(base.bumps.first)
+    end
+
+    it 'duplicates the transactions array (new array, same entry references — shallow)' do
+      expect(cloned.transactions).not_to be(base.transactions)
+      expect(cloned.transactions.first).to be(base.transactions.first)
+    end
+
+    it 'preserves version' do
+      expect(cloned.version).to eq(base.version)
+    end
+
+    it 'preserves @subject_wtxid for Atomic BEEF' do
+      subject_wtxid = "\xFF".b * 32
+      base.instance_variable_set(:@subject_wtxid, subject_wtxid)
+      expect(base.clone.instance_variable_get(:@subject_wtxid)).to eq(subject_wtxid)
+    end
+
+    it 'preserves @txs_not_valid when set' do
+      dummy = described_class::TxidOnlyEntry.new(known_wtxid: "\x01".b * 32)
+      base.instance_variable_set(:@txs_not_valid, [dummy])
+      expect(base.clone.instance_variable_get(:@txs_not_valid)).to eq([dummy])
+    end
+
+    it 'does not mutate self when the clone is modified' do
+      cloned.transactions << described_class::TxidOnlyEntry.new(known_wtxid: "\xCC".b * 32)
+      expect(base.transactions.length).to eq(2)
+      expect(cloned.transactions.length).to eq(3)
+    end
+  end
+
+  describe '#trim_known_wtxids' do
+    let(:base) { described_class.from_hex(brc62_hex) }
+    let(:proven_entry) { base.transactions.find { |bt| bt.is_a?(described_class::ProvenTxEntry) } }
+    let(:proven_wtxid) { proven_entry.wtxid }
+
+    it 'returns a new Beef (does not mutate self)' do
+      txid_only_wtxid = "\xDE".b * 32
+      base.transactions << described_class::TxidOnlyEntry.new(known_wtxid: txid_only_wtxid)
+      result = base.trim_known_wtxids([txid_only_wtxid])
+      expect(result).not_to be(base)
+      expect(base.transactions.length).to eq(3)
+    end
+
+    it 'drops TxidOnlyEntry records whose wtxid is in the known set' do
+      txid_only_wtxid = "\xDE".b * 32
+      base.transactions << described_class::TxidOnlyEntry.new(known_wtxid: txid_only_wtxid)
+      result = base.trim_known_wtxids([txid_only_wtxid])
+      expect(result.transactions.none? { |bt| bt.wtxid == txid_only_wtxid }).to be(true)
+    end
+
+    it 'retains ProvenTxEntry even when its wtxid is in the known set' do
+      result = base.trim_known_wtxids([proven_wtxid])
+      expect(result.transactions.any? { |bt| bt.wtxid == proven_wtxid }).to be(true)
+      expect(result.transactions.find { |bt| bt.wtxid == proven_wtxid }).to be_a(described_class::ProvenTxEntry)
+    end
+
+    it 'retains RawTxEntry even when its wtxid is in the known set' do
+      raw_entry = base.transactions.find { |bt| bt.is_a?(described_class::RawTxEntry) }
+      result = base.trim_known_wtxids([raw_entry.wtxid])
+      expect(result.transactions.any? { |bt| bt.wtxid == raw_entry.wtxid }).to be(true)
+    end
+
+    it 'removes unreferenced bumps after dropping TXID-only entries' do
+      # Build a BEEF with a TXID-only entry whose only consumer would be a BUMP reference,
+      # but the TXID-only entry doesn't reference a BUMP itself — bump stays if ProvenTxEntry
+      # still references it; bump goes if no proven entries remain.
+      beef2 = described_class.new(version: described_class::BEEF_V2)
+      beef2.bumps << base.bumps.first
+      txid_only_wtxid = "\xDE".b * 32
+      beef2.transactions << described_class::TxidOnlyEntry.new(known_wtxid: txid_only_wtxid)
+      result = beef2.trim_known_wtxids([txid_only_wtxid])
+      expect(result.bumps.length).to eq(0)
+    end
+
+    it 'reindexes bump_index after removing unreferenced bumps' do
+      # Build a BEEF with two BUMPs: one used by proven_entry, one extra (orphaned after trim)
+      beef2 = described_class.from_hex(brc62_hex)
+      # Add an extra BUMP (duplicate the first for simplicity)
+      extra_bump = beef2.bumps.first
+      beef2.bumps.unshift(extra_bump)
+      # Update proven entry to use the new index (1, was 0 before unshift)
+      old_entry = beef2.transactions.find { |bt| bt.is_a?(described_class::ProvenTxEntry) }
+      idx = beef2.transactions.index(old_entry)
+      beef2.transactions[idx] = described_class::ProvenTxEntry.new(
+        transaction: old_entry.transaction,
+        bump_index: 1
+      )
+      # Add a TXID-only entry that has no BUMP
+      txid_only_wtxid = "\xDE".b * 32
+      beef2.transactions << described_class::TxidOnlyEntry.new(known_wtxid: txid_only_wtxid)
+      # Drop the TXID-only; the extra_bump (index 0) becomes orphaned; proven entry moves to index 0
+      result = beef2.trim_known_wtxids([txid_only_wtxid])
+      expect(result.bumps.length).to eq(1)
+      proven = result.transactions.find { |bt| bt.is_a?(described_class::ProvenTxEntry) }
+      expect(proven.bump_index).to eq(0)
+    end
+
+    it 'is a no-op when the known set has wtxids not present in the bundle' do
+      phantom_wtxid = "\xFF".b * 32
+      result = base.trim_known_wtxids([phantom_wtxid])
+      expect(result.transactions.length).to eq(base.transactions.length)
+    end
+  end
+
+  describe '#valid_wtxids' do
+    let(:base) { described_class.from_hex(brc62_hex) }
+
+    it 'includes the proven transaction' do
+      proven_wtxid = base.transactions.find { |bt| bt.is_a?(described_class::ProvenTxEntry) }.wtxid
+      expect(base.valid_wtxids).to include(proven_wtxid)
+    end
+
+    it 'includes the spending transaction (inputs chain to proven)' do
+      raw_wtxid = base.transactions.find { |bt| bt.is_a?(described_class::RawTxEntry) }.wtxid
+      expect(base.valid_wtxids).to include(raw_wtxid)
+    end
+
+    it 'excludes TxidOnlyEntry records' do
+      txid_only_wtxid = "\xDE".b * 32
+      base.transactions << described_class::TxidOnlyEntry.new(known_wtxid: txid_only_wtxid)
+      expect(base.valid_wtxids).not_to include(txid_only_wtxid)
+    end
+
+    it 'returns an empty array for an empty BEEF' do
+      expect(described_class.new.valid_wtxids).to eq([])
+    end
+  end
 end

--- a/gem/bsv-sdk/spec/fixtures/beef_party_vectors.yml
+++ b/gem/bsv-sdk/spec/fixtures/beef_party_vectors.yml
@@ -1,0 +1,30 @@
+# Cross-SDK conformance vectors for BSV::Transaction::BeefParty
+# Generated from TS reference SDK (BeefParty.ts / Beef.ts) against the
+# BRC-62 Go SDK test vector.
+#
+# Scenario: A BeefParty with alice and bob.
+# - proven_tx: the mined transaction (BUMP proof exists); represented as TXID-only.
+# - spend_tx:  the spending transaction (no proof), provided as RAW_TX.
+# - alice knows the proven_tx already (TXID-only entry in the bundle).
+# - bob knows nothing.
+# - trimmed_for_alice_hex: proven TXID-only entry removed; 0 txs, 0 bumps for alice.
+# - trimmed_for_bob_hex: same as input (no-op trim); 2 txs, 0 bumps for bob.
+#
+# All hex strings are V2 (BRC-96) BEEF.
+# dtxid = display-order hex (as TS SDK uses internally).
+# wtxid  = wire-order binary (little-endian / reversed).
+
+proven_dtxid: "3ecead27a44d013ad1aae40038acbb1883ac9242406808bb4667c15b4f164eac"
+spend_dtxid: "157428aee67d11123203735e4c540fa1bdab3b36d5882c6f8c5ff79f07d20d1c"
+
+# Input BEEF: proven_tx as TXID-only + spend_tx as RAW_TX, no bumps.
+# alice already knows the proven_tx (TXID-only) so it should be trimmed for her.
+input_beef_hex: "0200beef000202ac4e164f5bc16746bb0868404292ac8318bbac3800e4aad13a014da427adce3e000100000001ac4e164f5bc16746bb0868404292ac8318bbac3800e4aad13a014da427adce3e000000006a47304402203a61a2e931612b4bda08d541cfb980885173b8dcf64a3471238ae7abcd368d6402204cbf24f04b9aa2256d8901f0ed97866603d2be8324c2bfb7a37bf8fc90edd5b441210263e2dee22b1ddc5e11f6fab8bcd2378bdd19580d640501ea956ec0e786f93e76ffffffff013c660000000000001976a9146bfd5c7fbe21529d45803dbcf0c87dd3c71efbc288ac00000000"
+
+# Trimmed for alice: TXID-only entry dropped; spend_tx remains as RAW_TX.
+# 1 tx, 0 bumps.
+trimmed_for_alice_hex: "0200beef0001000100000001ac4e164f5bc16746bb0868404292ac8318bbac3800e4aad13a014da427adce3e000000006a47304402203a61a2e931612b4bda08d541cfb980885173b8dcf64a3471238ae7abcd368d6402204cbf24f04b9aa2256d8901f0ed97866603d2be8324c2bfb7a37bf8fc90edd5b441210263e2dee22b1ddc5e11f6fab8bcd2378bdd19580d640501ea956ec0e786f93e76ffffffff013c660000000000001976a9146bfd5c7fbe21529d45803dbcf0c87dd3c71efbc288ac00000000"
+
+# Trimmed for bob: bob knows nothing; no-op trim; same as input.
+# 2 txs, 0 bumps.
+trimmed_for_bob_hex: "0200beef000202ac4e164f5bc16746bb0868404292ac8318bbac3800e4aad13a014da427adce3e000100000001ac4e164f5bc16746bb0868404292ac8318bbac3800e4aad13a014da427adce3e000000006a47304402203a61a2e931612b4bda08d541cfb980885173b8dcf64a3471238ae7abcd368d6402204cbf24f04b9aa2256d8901f0ed97866603d2be8324c2bfb7a37bf8fc90edd5b441210263e2dee22b1ddc5e11f6fab8bcd2378bdd19580d640501ea956ec0e786f93e76ffffffff013c660000000000001976a9146bfd5c7fbe21529d45803dbcf0c87dd3c71efbc288ac00000000"


### PR DESCRIPTION
## Summary

Three "compat completeness" additions identified in the 2026-05-27 SDK divergence analysis, landed together to keep diff churn manageable:

- **`Primitives::ECIES` Bitcore variant** (#829) — adds an optional `iv:` keyword argument to `bitcore_encrypt` (16-byte validation; random when omitted) and ships a deterministic conformance vector generated against the TS SDK. The Bitcore variant itself was already implemented; this finishes it.
- **`Script::BIP276`** (#830) — new module providing `encode` / `decode` plus `encode_script` / `encode_template` / `decode_script` / `decode_template` convenience helpers. Field order is **version-then-network** (matches the BIP-276 spec and the Go SDK; the py-sdk implementation has these reversed — a known bug invisible at default v=1, n=1 that we will file upstream after merge). Cross-SDK conformance against four Go SDK vectors, including the testnet vector that proves field order.
- **`Transaction::BeefParty`** (#831) — `Transaction::Beef` subclass that tracks per-party knowledge of wtxids for multi-party BEEF exchange. Adds four supporting methods to the parent `Beef` class (`merge_txid_only`, `clone`, `trim_known_wtxids`, `valid_wtxids`) — kept in the same PR because half a parent is worse than no subclass. `Beef#clone` is shallow to match TS semantics, documented in YARD. Cross-SDK conformance vector at `gem/bsv-sdk/spec/fixtures/beef_party_vectors.yml`.

Docs (#832): user-facing sections added in `docs/sdk/primitives.md` (Bitcore subsection under ECIES), `docs/sdk/script.md` (BIP-276), and `docs/sdk/transaction.md` (BeefParty walkthrough). Prose uses the `Transaction::Beef` / `Primitives::ECIES` / `Script::BIP276` convention; code blocks remain fully `BSV::`-qualified per CLAUDE.md.

### Scope note — legacy sighash

The original HLR named four tasks. The legacy-sighash item was dropped during planning after review against the SDK's Protocol Philosophy (see https://github.com/sgbett/bsv-ruby-sdk/issues/763#issuecomment-4737928326). FORK_ID has been mandatory on BSV since 2017-08-01, so providing a constructor for pre-fork sighash would contradict the "construct only what's valid" principle — even though the TS/Go/Py reference SDKs include it for multi-chain reasons.

## Test plan

- [x] `bundle exec rake spec:sdk` — 6191 examples, 0 failures, 22 pending (unchanged integration/conformance set)
- [x] `bundle exec rubocop` — 427 files inspected, 0 offences
- [x] Sub-issue acceptance criteria verified individually (#829, #830, #831, #832)
- [x] BIP-276 cross-SDK conformance vectors (Go SDK) pass
- [x] BeefParty cross-SDK conformance vector (TS-derived) passes
- [x] ECIES Bitcore TS conformance vector passes round-trip
- [ ] Security review (Phase 5 — triggered automatically on ECIES + BeefParty changes)

Closes #763, #829, #830, #831, #832.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
