### PR TITLE
docs: explain why BeefParty exists

### DIFF
--- a/docs/sdk/transaction.md
+++ b/docs/sdk/transaction.md
@@ -240,6 +240,20 @@ atomic = beef.to_atomic_binary(subject_txid)
 
 `Transaction::BeefParty` extends `Transaction::Beef` to track per-party knowledge: each named counterparty is associated with the set of wtxids it is already known to hold. This avoids re-transmitting transaction data and merkle proofs that the recipient already possesses, keeping BEEF bundles compact in multi-step exchange flows.
 
+### Why it exists
+
+A complete `Transaction::Beef` carries every transaction it depends on, either with a merkle path proof or with all of its input transactions inlined. That's the invariant readers rely on for SPV verification without consulting a block explorer.
+
+The cost shows up in a typical wallet-chained-creation loop:
+
+1. Query a wallet storage provider for spendable outputs.
+2. The provider returns a Beef validating those outputs.
+3. Construct a new transaction using some of those outputs as inputs, sending a Beef that validates the inputs.
+4. The provider returns the new raw transaction and a Beef validating the change outputs you'll later spend.
+5. Return to step 1, building on old and new spendable outputs.
+
+As soon as transaction creation out-paces the block mining rate, the same proof tree is sent back and forth across multiple rounds — most of the bundle is data the counterparty already has. `BeefParty` is the bookkeeping layer that lets each side track what the other has already seen and trim re-sends down to only the new material.
+
 ### Worked example
 
 ```ruby

--- a/docs/sdk/transaction.md
+++ b/docs/sdk/transaction.md
@@ -247,12 +247,12 @@ A complete `Transaction::Beef` carries every transaction it depends on, either w
 The cost shows up in a typical wallet-chained-creation loop:
 
 1. Query a wallet storage provider for spendable outputs.
-2. The provider returns a Beef validating those outputs.
-3. Construct a new transaction using some of those outputs as inputs, sending a Beef that validates the inputs.
-4. The provider returns the new raw transaction and a Beef validating the change outputs you'll later spend.
+2. The provider returns a `Transaction::Beef` validating those outputs.
+3. Construct a new transaction using some of those outputs as inputs, sending a `Transaction::Beef` that validates the inputs.
+4. The provider returns the new raw transaction and a `Transaction::Beef` validating the change outputs you'll later spend.
 5. Return to step 1, building on old and new spendable outputs.
 
-As soon as transaction creation out-paces the block mining rate, the same proof tree is sent back and forth across multiple rounds — most of the bundle is data the counterparty already has. `BeefParty` is the bookkeeping layer that lets each side track what the other has already seen and trim re-sends down to only the new material.
+As soon as transaction creation outpaces the block mining rate, the same proof tree is sent back and forth across multiple rounds — most of the bundle is data the counterparty already has. `Transaction::BeefParty` is the bookkeeping layer that lets each side track what the other has already seen and trim resends down to only the new material.
 
 ### Worked example
 


### PR DESCRIPTION
## Summary

Adds a short "Why it exists" subsection to the BeefParty docs page, explaining the wallet-chained-creation problem that motivates the class. Lifted from the ts-stack canonical reference (see context below) and reworded in British English.

The existing section described the mechanics (party knowledge, trimming) but not what problem the trimming actually solves. New readers landing on the page now see the motivation before the API.

## Why now

I checked the new ts-stack documentation site for upstream BeefParty docs while wrapping up HLR #763. The rendered API site at \`bsv-blockchain.github.io/ts-stack/\` doesn't surface BeefParty (the \`/api/sdk/\` TypeDoc paths return 404), but the canonical reference markdown is at:

\`bsv-blockchain/ts-stack\` → \`packages/sdk/docs/reference/transaction.md\` → \`### Class: BeefParty\`

That source includes a "typical usage scenario" paragraph the Ruby docs were missing. This PR ports it across.

## Test plan

- [x] No code touched, no tests to run
- [x] Doc renders correctly in markdown preview
- [x] British English

🤖 Generated with [Claude Code](https://claude.com/claude-code)