### PR TITLE
chore: relocate reference SDK clones to language-appropriate paths

### DIFF
--- a/.architecture/reference-baseline.md
+++ b/.architecture/reference-baseline.md
@@ -19,9 +19,13 @@ dynamically (no single pinned commit during development).
 To see what changed in a reference SDK since this baseline:
 
 ```bash
-git -C /opt/ruby/bsv-reference-sdks/go-sdk log --oneline 725db51..HEAD
-git -C /opt/ruby/bsv-reference-sdks/ts-sdk log --oneline 8acc706..HEAD
-git -C /opt/ruby/bsv-reference-sdks/py-sdk log --oneline f505ea5..HEAD
+git -C /opt/go/go-sdk log --oneline 725db51..HEAD
+git -C /opt/js/ts-stack log --oneline 8acc706..HEAD       # ts-sdk now lives in packages/sdk
+git -C /opt/python/py-sdk log --oneline f505ea5..HEAD
 ```
+
+Note: the 8acc706 baseline commit predates the ts-stack monorepo move
+(May 2026). After the next baseline update the ts-stack SHA will be the
+new anchor — the path will already be correct.
 
 Update this file when cutting a new Ruby SDK release, recording the new baseline commits.

--- a/.architecture/reference-baseline.md
+++ b/.architecture/reference-baseline.md
@@ -20,12 +20,16 @@ To see what changed in a reference SDK since this baseline:
 
 ```bash
 git -C /opt/go/go-sdk log --oneline 725db51..HEAD
-git -C /opt/js/ts-stack log --oneline 8acc706..HEAD       # ts-sdk now lives in packages/sdk
+git -C /opt/js/ts-stack log --oneline 8acc706..HEAD -- packages/sdk
 git -C /opt/python/py-sdk log --oneline f505ea5..HEAD
 ```
 
 Note: the 8acc706 baseline commit predates the ts-stack monorepo move
-(May 2026). After the next baseline update the ts-stack SHA will be the
-new anchor — the path will already be correct.
+(May 2026). The commit IS reachable from ts-stack because the standalone
+ts-sdk repo was imported via `git subtree`, but the range walks the
+whole monorepo's history. The `-- packages/sdk` path filter scopes the
+log to the TS SDK changes, which is what the comparison wants. After
+the next baseline update the ts-stack SHA will be the new anchor and
+the path filter becomes redundant.
 
 Update this file when cutting a new Ruby SDK release, recording the new baseline commits.

--- a/.architecture/reference-baseline.md
+++ b/.architecture/reference-baseline.md
@@ -26,10 +26,12 @@ git -C /opt/python/py-sdk log --oneline f505ea5..HEAD
 
 Note: the 8acc706 baseline commit predates the ts-stack monorepo move
 (May 2026). The commit IS reachable from ts-stack because the standalone
-ts-sdk repo was imported via `git subtree`, but the range walks the
-whole monorepo's history. The `-- packages/sdk` path filter scopes the
-log to the TS SDK changes, which is what the comparison wants. After
-the next baseline update the ts-stack SHA will be the new anchor and
-the path filter becomes redundant.
+ts-sdk repo was imported via `git subtree` (see ["Updating Imported
+Packages"](https://github.com/bsv-blockchain/ts-stack#updating-imported-packages)
+in the ts-stack README), but the range walks the whole monorepo's
+history. The `-- packages/sdk` path filter scopes the log to the TS
+SDK changes, which is what the comparison wants. After the next
+baseline update the ts-stack SHA will be the new anchor and the path
+filter becomes redundant.
 
 Update this file when cutting a new Ruby SDK release, recording the new baseline commits.

--- a/.architecture/reference-baseline.md
+++ b/.architecture/reference-baseline.md
@@ -11,7 +11,7 @@ dynamically (no single pinned commit during development).
 | SDK | Version | Commit | Description |
 |-----|---------|--------|-------------|
 | [go-sdk](https://github.com/bsv-blockchain/go-sdk) | v1.2.18 | `725db51` | Fix BIP276 decoding, AuthFetch data race, and add NUM2BIN tests (#288) |
-| [ts-sdk](https://github.com/bsv-blockchain/ts-sdk) | v2.0.0 | `8acc706` | Merge pull request #481 — fix/optimizations |
+| [ts-sdk](https://github.com/bsv-blockchain/ts-stack) | v2.0.0 | `8acc706` | Merge pull request #481 — fix/optimizations |
 | [py-sdk](https://github.com/bsv-blockchain/py-sdk) | v1.0.10 | `f505ea5` | Added OP_CAT template example and script (#137) |
 
 ### How to use

--- a/.architecture/reference-baseline.md
+++ b/.architecture/reference-baseline.md
@@ -11,7 +11,7 @@ dynamically (no single pinned commit during development).
 | SDK | Version | Commit | Description |
 |-----|---------|--------|-------------|
 | [go-sdk](https://github.com/bsv-blockchain/go-sdk) | v1.2.18 | `725db51` | Fix BIP276 decoding, AuthFetch data race, and add NUM2BIN tests (#288) |
-| [ts-sdk](https://github.com/bsv-blockchain/ts-stack) | v2.0.0 | `8acc706` | Merge pull request #481 — fix/optimizations |
+| [ts-stack](https://github.com/bsv-blockchain/ts-stack) (TS SDK at `packages/sdk/`) | v2.0.0 | `8acc706` | Merge pull request #481 — fix/optimizations (SHA from pre-monorepo ts-sdk, reachable via subtree import) |
 | [py-sdk](https://github.com/bsv-blockchain/py-sdk) | v1.0.10 | `f505ea5` | Added OP_CAT template example and script (#137) |
 
 ### How to use

--- a/.claude/commands/divergence-analysis.md
+++ b/.claude/commands/divergence-analysis.md
@@ -35,11 +35,11 @@ Launch three **general-purpose** subagents in parallel, one per reference SDK. P
 
 | SDK | Local clone | GitHub |
 |---|---|---|
-| TypeScript | `/opt/js/ts-stack/packages/sdk/` (in the ts-stack monorepo) | https://github.com/bsv-blockchain/ts-stack |
+| TypeScript | `/opt/js/ts-stack/` (clone root; TS SDK at `packages/sdk/` inside the ts-stack monorepo) | https://github.com/bsv-blockchain/ts-stack |
 | Go | `/opt/go/go-sdk/` | https://github.com/bsv-blockchain/go-sdk |
 | Python | `/opt/python/py-sdk/` | https://github.com/bsv-blockchain/py-sdk |
 
-Run `git -C <clone-path> pull` to update a local clone before analysis.
+Run `git -C <clone-path> pull` to update a local clone before analysis (use the clone root, not a package subdirectory).
 
 ### 3. Produce the comparison
 

--- a/.claude/commands/divergence-analysis.md
+++ b/.claude/commands/divergence-analysis.md
@@ -4,7 +4,7 @@ description: Analyses the current SDK codebase and compares it semantically to t
 
 # SDK Divergence Analysis
 
-Performs a semantic comparison of the current BSV Ruby SDK against the three official reference implementations: [go-sdk](https://github.com/bitcoin-sv/go-sdk), [ts-sdk](https://github.com/bitcoin-sv/ts-sdk), and [py-sdk](https://github.com/bitcoin-sv/py-sdk).
+Performs a semantic comparison of the current BSV Ruby SDK against the three official reference implementations: [go-sdk](https://github.com/bsv-blockchain/go-sdk), [ts-stack](https://github.com/bsv-blockchain/ts-stack) (the TypeScript SDK lives at `packages/sdk/` inside this monorepo), and [py-sdk](https://github.com/bsv-blockchain/py-sdk).
 
 ## Process
 
@@ -22,7 +22,7 @@ Launch an **Explore** subagent to produce a complete semantic inventory of the R
 
 ### 2. Inventory the reference SDKs (3 parallel subagents)
 
-Launch three **general-purpose** subagents in parallel, one per reference SDK. Each should fetch the repository from GitHub and analyse:
+Launch three **general-purpose** subagents in parallel, one per reference SDK. Prefer the local clones (faster, no rate limits); fall back to GitHub if a clone is missing. Each subagent should analyse:
 
 - Module/package/namespace organisation
 - Key classes/types and their public methods
@@ -31,10 +31,15 @@ Launch three **general-purpose** subagents in parallel, one per reference SDK. E
 - Higher-level features (BRC-42/77/78, wallet interface, broadcasters, SPV, overlay tools)
 - Architecture pattern and design decisions
 
-**Reference SDK repositories:**
-- **TypeScript:** https://github.com/bitcoin-sv/ts-sdk (also check https://github.com/bsv-blockchain/ts-sdk)
-- **Go:** https://github.com/bitcoin-sv/go-sdk (also check https://github.com/bsv-blockchain/go-sdk)
-- **Python:** https://github.com/bitcoin-sv/py-sdk (also check https://github.com/bsv-blockchain/py-sdk)
+**Reference SDK locations:**
+
+| SDK | Local clone | GitHub |
+|---|---|---|
+| TypeScript | `/opt/js/ts-stack/packages/sdk/` (in the ts-stack monorepo) | https://github.com/bsv-blockchain/ts-stack |
+| Go | `/opt/go/go-sdk/` | https://github.com/bsv-blockchain/go-sdk |
+| Python | `/opt/python/py-sdk/` | https://github.com/bsv-blockchain/py-sdk |
+
+Run `git -C <clone-path> pull` to update a local clone before analysis.
 
 ### 3. Produce the comparison
 
@@ -94,6 +99,6 @@ Present the full report directly in the conversation. Do not write to a file unl
 
 ## Notes
 
-- The reference SDK organisations may have moved from `bitcoin-sv` to `bsv-blockchain` on GitHub. Try both.
+- The TypeScript SDK was folded into the `bsv-blockchain/ts-stack` monorepo around June 2026. The standalone `bsv-blockchain/ts-sdk` repo is archived and redirects to ts-stack. Compare against `packages/sdk/` inside ts-stack.
 - The TypeScript SDK implements all cryptography from scratch (no external deps). The Go SDK uses a custom secp256k1. The Python SDK uses `coincurve` (libsecp256k1 bindings). The Ruby SDK uses OpenSSL stdlib. These are architectural choices, not divergences.
 - Focus on **semantic** comparison (what capabilities exist), not syntactic (naming conventions, language idioms).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Ruby SDK for the BSV Blockchain (`bsv-sdk` gem). Part of the official BSV SDK family alongside [go-sdk](https://github.com/bsv-blockchain/go-sdk), [ts-sdk](https://github.com/bsv-blockchain/ts-sdk), and [py-sdk](https://github.com/bsv-blockchain/py-sdk). Use those as reference implementations when building features.
+Ruby SDK for the BSV Blockchain (`bsv-sdk` gem). Part of the official BSV SDK family alongside [go-sdk](https://github.com/bsv-blockchain/go-sdk), [ts-sdk](https://github.com/bsv-blockchain/ts-stack), and [py-sdk](https://github.com/bsv-blockchain/py-sdk). Use those as reference implementations when building features.
 
 **Reference SDK clones** are kept under language-appropriate locations:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Ruby SDK for the BSV Blockchain (`bsv-sdk` gem). Part of the official BSV SDK family alongside [go-sdk](https://github.com/bsv-blockchain/go-sdk), [ts-sdk](https://github.com/bsv-blockchain/ts-sdk), and [py-sdk](https://github.com/bsv-blockchain/py-sdk). Use those as reference implementations when building features.
 
-**Reference SDK clones** are at `/opt/ruby/bsv-reference-sdks/` (`go-sdk/`, `ts-sdk/`, `py-sdk/`). Search these when implementing new features to match behaviour across SDKs. Run `git -C /opt/ruby/bsv-reference-sdks/<sdk> pull` to update before comparing.
+**Reference SDK clones** are kept under language-appropriate locations:
+
+- **TypeScript (now a monorepo)** — `/opt/js/ts-stack/` (the `bsv-blockchain/ts-stack` repo). The SDK lives at `packages/sdk/`; wallet-toolbox at `packages/wallet/wallet-toolbox/`.
+- **Go** — `/opt/go/go-sdk/` and `/opt/go/wallet-toolbox/`.
+- **Python** — `/opt/python/py-sdk/` and `/opt/python/wallet-toolbox/`.
+
+Search these when implementing new features to match behaviour across SDKs. Run `git -C <clone-path> pull` to update before comparing. The previous `/opt/ruby/bsv-reference-sdks/` location is gone — none of these are Ruby, so they don't belong under `/opt/ruby/`.
 
 The [BSV Hub protocol documentation](https://hub.bsvblockchain.org/bitcoin-protocol-documentation) is available via MCP (`.mcp.json`) for verifying protocol conformance during development.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Ruby SDK for the BSV Blockchain (`bsv-sdk` gem). Part of the official BSV SDK family alongside [go-sdk](https://github.com/bsv-blockchain/go-sdk), [ts-sdk](https://github.com/bsv-blockchain/ts-stack), and [py-sdk](https://github.com/bsv-blockchain/py-sdk). Use those as reference implementations when building features.
+Ruby SDK for the BSV Blockchain (`bsv-sdk` gem). Part of the official BSV SDK family alongside [go-sdk](https://github.com/bsv-blockchain/go-sdk), [ts-stack](https://github.com/bsv-blockchain/ts-stack) (the TS SDK lives at `packages/sdk/` inside this monorepo), and [py-sdk](https://github.com/bsv-blockchain/py-sdk). Use those as reference implementations when building features.
 
 **Reference SDK clones** are kept under language-appropriate locations:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Gem Version](https://img.shields.io/gem/v/bsv-sdk)](https://rubygems.org/gems/bsv-sdk)
 [![Ruby](https://img.shields.io/badge/ruby-%3E%3D%203.3-red)](https://rubygems.org/gems/bsv-sdk)
 
-A comprehensive Ruby SDK for the BSV Blockchain, built with faithful adherence to the [BRC specifications](https://github.com/bitcoin-sv/BRCs) and cross-SDK compatibility with the official [TypeScript](https://github.com/bsv-blockchain/ts-sdk), [Go](https://github.com/bsv-blockchain/go-sdk), and [Python](https://github.com/bsv-blockchain/py-sdk) implementations. The Ruby SDK strives to be a complete, correct, and well-tested implementation that serves the Ruby community — one that developers can rely on as a reference-quality foundation for BSV application development.
+A comprehensive Ruby SDK for the BSV Blockchain, built with faithful adherence to the [BRC specifications](https://github.com/bsv-blockchain/BRCs) and cross-SDK compatibility with the official [TypeScript](https://github.com/bsv-blockchain/ts-stack), [Go](https://github.com/bsv-blockchain/go-sdk), and [Python](https://github.com/bsv-blockchain/py-sdk) implementations. The Ruby SDK strives to be a complete, correct, and well-tested implementation that serves the Ruby community — one that developers can rely on as a reference-quality foundation for BSV application development.
 
 The project is grounded in the principles that make Ruby and Rails productive: [convention over configuration](https://rubyonrails.org/doctrine#convention-over-configuration), sensible defaults, and [the principle of least surprise](https://en.wikipedia.org/wiki/Principle_of_least_astonishment). Every component ships with a sane default that works out of the box, while exposing a pluggable composition interface for teams that need more. A `WalletClient` created with a single private key and no configuration gives you a fully functional BRC-100 wallet backed by local file storage. The same `WalletClient` interface — the same `create_action`, `list_outputs`, `internalize_action` calls — works identically when composed with PostgreSQL storage, SolidQueue background workers, UTXO pools with pre-warmed transaction caches, overlay-service chain providers, and asynchronous ARC broadcast behind a load balancer. The interface stays the same; the architecture underneath scales with you.
 
@@ -26,7 +26,7 @@ This Ruby SDK is a port of the official BSV Blockchain SDKs, which serve as its 
 
 The reference SDKs:
 
-- [TypeScript SDK](https://github.com/bsv-blockchain/ts-sdk)
+- [TypeScript SDK](https://github.com/bsv-blockchain/ts-stack)
 - [Go SDK](https://github.com/bsv-blockchain/go-sdk)
 - [Python SDK](https://github.com/bsv-blockchain/py-sdk)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,9 @@
 # BSV Ruby SDK
 
 Ruby SDK for the BSV Blockchain. Part of the official BSV SDK family alongside
-[Go](https://github.com/bitcoin-sv/go-sdk),
-[TypeScript](https://github.com/bitcoin-sv/ts-sdk), and
-[Python](https://github.com/bitcoin-sv/py-sdk).
+[Go](https://github.com/bsv-blockchain/go-sdk),
+[TypeScript](https://github.com/bsv-blockchain/ts-stack), and
+[Python](https://github.com/bsv-blockchain/py-sdk).
 
 ## Installation
 

--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -105,6 +105,6 @@ wallet picks up for writes.
   [26](https://hub.bsvblockchain.org/brc/overlays/0026),
   [87](https://hub.bsvblockchain.org/brc/overlays/0087),
   [88](https://hub.bsvblockchain.org/brc/overlays/0088)
-- Reference SDKs: [TypeScript](https://github.com/bitcoin-sv/ts-sdk),
-  [Go](https://github.com/bitcoin-sv/go-sdk),
-  [Python](https://github.com/bitcoin-sv/py-sdk)
+- Reference SDKs: [TypeScript (ts-stack monorepo)](https://github.com/bsv-blockchain/ts-stack) — SDK at `packages/sdk/`, overlay packages at `packages/overlays/`,
+  [Go](https://github.com/bsv-blockchain/go-sdk),
+  [Python](https://github.com/bsv-blockchain/py-sdk)

--- a/docs/overlays/historian.md
+++ b/docs/overlays/historian.md
@@ -124,7 +124,7 @@ instead.
 
 ## References
 
-- TypeScript: [`Historian.ts`](https://github.com/bitcoin-sv/ts-sdk/blob/master/src/overlay-tools/Historian.ts)
-- Python: [`bsv/overlay_tools/historian.py`](https://github.com/bitcoin-sv/py-sdk/blob/master/bsv/overlay_tools/historian.py)
+- TypeScript: [`Historian.ts`](https://github.com/bsv-blockchain/ts-stack/blob/main/packages/sdk/src/overlay-tools/Historian.ts)
+- Python: [`bsv/overlay_tools/historian.py`](https://github.com/bsv-blockchain/py-sdk/blob/master/bsv/overlay_tools/historian.py)
 - [SDK reference: Ecosystem Clients](../sdk/ecosystem-clients.md)
 - [KVStore overlay](kvstore.md) — the most common Historian consumer

--- a/docs/overlays/kvstore.md
+++ b/docs/overlays/kvstore.md
@@ -140,7 +140,7 @@ overlay query; writing needs a wallet to fund the new UTXO and sign it.
 
 ## References
 
-- TypeScript: [`GlobalKVStore.ts`](https://github.com/bitcoin-sv/ts-sdk/blob/master/src/kvstore/GlobalKVStore.ts) (canonical reference)
+- TypeScript: [`GlobalKVStore.ts`](https://github.com/bsv-blockchain/ts-stack/blob/main/packages/sdk/src/kvstore/GlobalKVStore.ts) (canonical reference)
 - [SDK reference: KVStore](../sdk/kvstore.md)
 - [Historian overlay](historian.md) — used for the `history: true` path
 - [BRC-100](https://hub.bsvblockchain.org/brc/wallet/0100) — wallet

--- a/docs/overlays/registries.md
+++ b/docs/overlays/registries.md
@@ -144,6 +144,6 @@ typed resolve methods. The constructor accepts it.
   naming convention (where the `tm_*` / `ls_*` names come from)
 - [BRC-43](https://hub.bsvblockchain.org/brc/key-derivation/0043) —
   protocol ID format (`[security_level, name]`)
-- Go: [`registry/methods.go`](https://github.com/bitcoin-sv/go-sdk/blob/master/registry/methods.go)
-- Python: [`bsv/registry/client.py`](https://github.com/bitcoin-sv/py-sdk/blob/master/bsv/registry/client.py)
+- Go: [`registry/methods.go`](https://github.com/bsv-blockchain/go-sdk/blob/master/registry/methods.go)
+- Python: [`bsv/registry/client.py`](https://github.com/bsv-blockchain/py-sdk/blob/master/bsv/registry/client.py)
 - [SDK reference: Ecosystem Clients](../sdk/ecosystem-clients.md)

--- a/docs/overlays/uhrp-storage.md
+++ b/docs/overlays/uhrp-storage.md
@@ -96,13 +96,21 @@ funding; publishing needs both.
 
 ## Reference implementations and infrastructure
 
-The canonical UHRP storage server reference is
-[bsv-blockchain/storage-server](https://github.com/bsv-blockchain/storage-server)
-(archived in May 2026 in favour of the ts-stack monorepo). It implements:
+The canonical UHRP storage server references now live in the
+[bsv-blockchain/ts-stack](https://github.com/bsv-blockchain/ts-stack)
+monorepo under `infra/`:
+
+- **[uhrp-server-basic](https://github.com/bsv-blockchain/ts-stack/tree/main/infra/uhrp-server-basic)** (`@bsv/uhrp-lite`) — minimal single-host implementation suitable for local-development or a single-tenant deployment.
+- **[uhrp-server-cloud-bucket](https://github.com/bsv-blockchain/ts-stack/tree/main/infra/uhrp-server-cloud-bucket)** (`@bsv/uhrp-storage-server`) — cloud-bucket-backed implementation for production deployments.
+
+Both implement:
 
 - Upload endpoints that accept file content plus a hosting commitment.
 - A notifier that broadcasts the advertisement to the overlay.
 - Billing for hosting duration.
+
+The standalone `bsv-blockchain/storage-server` repo was archived in May
+2026 when the two-tier split was introduced inside ts-stack.
 
 Public UHRP overlay nodes are reachable through the default
 `BSV::Overlay::LookupResolver` — you don't need to know specific host
@@ -126,7 +134,8 @@ URLs in normal SDK usage.
 ## References
 
 - [BRC-26](https://hub.bsvblockchain.org/brc/overlays/0026) — UHRP specification
-- [bsv-blockchain/storage-server](https://github.com/bsv-blockchain/storage-server) — reference server
-- TypeScript: [`StorageDownloader.ts`](https://github.com/bitcoin-sv/ts-sdk/blob/master/src/storage/StorageDownloader.ts)
-- Python: [`bsv/storage/downloader.py`](https://github.com/bitcoin-sv/py-sdk/blob/master/bsv/storage/downloader.py)
+- [ts-stack/infra/uhrp-server-basic](https://github.com/bsv-blockchain/ts-stack/tree/main/infra/uhrp-server-basic) — minimal reference server (`@bsv/uhrp-lite`)
+- [ts-stack/infra/uhrp-server-cloud-bucket](https://github.com/bsv-blockchain/ts-stack/tree/main/infra/uhrp-server-cloud-bucket) — production reference server (`@bsv/uhrp-storage-server`)
+- TypeScript: [`StorageDownloader.ts`](https://github.com/bsv-blockchain/ts-stack/blob/main/packages/sdk/src/storage/StorageDownloader.ts)
+- Python: [`bsv/storage/downloader.py`](https://github.com/bsv-blockchain/py-sdk/blob/master/bsv/storage/downloader.py)
 - [SDK reference: Storage](../sdk/storage.md)

--- a/docs/testing/conformance-vectors.md
+++ b/docs/testing/conformance-vectors.md
@@ -88,9 +88,10 @@ every file under `spec/conformance/`.
 ## Syncing from upstream
 
 The reference SDK clones live under language-appropriate locations:
-`/opt/go/go-sdk`, `/opt/python/py-sdk`, and `/opt/js/ts-stack/packages/sdk`
-(the TS SDK is now a package inside the `bsv-blockchain/ts-stack`
-monorepo). To refresh a vector file from the Go reference:
+`/opt/go/go-sdk`, `/opt/python/py-sdk`, and `/opt/js/ts-stack` (the TS
+SDK is at `packages/sdk/` inside the `bsv-blockchain/ts-stack` monorepo;
+`/opt/js/ts-stack` is the clone root for `git pull`). To refresh a
+vector file from the Go reference:
 
 ```sh
 git -C /opt/go/go-sdk pull

--- a/docs/testing/conformance-vectors.md
+++ b/docs/testing/conformance-vectors.md
@@ -87,6 +87,13 @@ every file under `spec/conformance/`.
 
 ## Syncing from upstream
 
+> **Note:** this manual hand-copy workflow is provisional. The ts-stack
+> monorepo now ships a canonical language-neutral conformance corpus at
+> `conformance/vectors/` with a CI-published artifact. [HLR
+> #837](https://github.com/sgbett/bsv-ruby-sdk/issues/837) tracks moving
+> the Ruby specs onto that corpus; once that lands, this section will be
+> rewritten and the per-file hand-copy procedure goes away.
+
 The reference SDK clones live under language-appropriate locations:
 `/opt/go/go-sdk`, `/opt/python/py-sdk`, and `/opt/js/ts-stack` (the TS
 SDK is at `packages/sdk/` inside the `bsv-blockchain/ts-stack` monorepo;

--- a/docs/testing/conformance-vectors.md
+++ b/docs/testing/conformance-vectors.md
@@ -87,15 +87,17 @@ every file under `spec/conformance/`.
 
 ## Syncing from upstream
 
-The reference SDK clones live under `/opt/ruby/bsv-reference-sdks/`. To
-refresh a vector file:
+The reference SDK clones live under language-appropriate locations:
+`/opt/go/go-sdk`, `/opt/python/py-sdk`, and `/opt/js/ts-stack/packages/sdk`
+(the TS SDK is now a package inside the `bsv-blockchain/ts-stack`
+monorepo). To refresh a vector file from the Go reference:
 
 ```sh
-git -C /opt/ruby/bsv-reference-sdks/go-sdk pull
-diff -q /opt/ruby/bsv-reference-sdks/go-sdk/primitives/ec/testdata/BRC42.private.vectors.json \
+git -C /opt/go/go-sdk pull
+diff -q /opt/go/go-sdk/primitives/ec/testdata/BRC42.private.vectors.json \
         spec/conformance/vectors/BRC42.private.vectors.json
 # If different, copy the new version and update README.md's commit SHA column.
-cp /opt/ruby/bsv-reference-sdks/go-sdk/primitives/ec/testdata/BRC42.private.vectors.json \
+cp /opt/go/go-sdk/primitives/ec/testdata/BRC42.private.vectors.json \
    spec/conformance/vectors/BRC42.private.vectors.json
 ```
 

--- a/gem/bsv-sdk/README.md
+++ b/gem/bsv-sdk/README.md
@@ -24,7 +24,7 @@ This Ruby SDK is a port of the official BSV Blockchain SDKs, which serve as its 
 
 The reference SDKs:
 
-- [TypeScript SDK](https://github.com/bsv-blockchain/ts-sdk)
+- [TypeScript SDK](https://github.com/bsv-blockchain/ts-stack)
 - [Go SDK](https://github.com/bsv-blockchain/go-sdk)
 - [Python SDK](https://github.com/bsv-blockchain/py-sdk)
 

--- a/gem/bsv-sdk/spec/bsv/script/interpreter/script_vectors_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/script/interpreter/script_vectors_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 # Bitcoin Core script test vectors from the Go SDK.
-# Source: bitcoin-sv/go-sdk script/interpreter/data/script_tests.json
+# Source: bsv-blockchain/go-sdk script/interpreter/data/script_tests.json
 #
 # Format: [scriptSig_asm, scriptPubKey_asm, flags, expected_result, optional_comment]
 # Comment-only entries (1-element arrays) and witness vectors are skipped.

--- a/gem/bsv-sdk/spec/bsv/transaction/sighash_vectors_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/sighash_vectors_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 # Cross-validation of BIP-143 sighash computation against TS SDK test vectors.
-# Source: bsv-blockchain/ts-sdk src/primitives/__tests/sighash.vectors.ts
+# Source: bsv-blockchain/ts-stack packages/sdk/src/primitives/__tests/sighash.vectors.ts
 #
 # Each vector: [raw_tx_hex, script_hex, input_index, hash_type, expected_sighash_hex]
 # All vectors use SIGHASH_FORKID (BIP-143).

--- a/gem/bsv-sdk/spec/bsv/transaction/tx_vectors_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/tx_vectors_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 # Cross-validation of transaction serialisation against TS SDK test vectors.
-# Source: bsv-blockchain/ts-sdk src/transaction/__tests/tx.valid.vectors.ts
+# Source: bsv-blockchain/ts-stack packages/sdk/src/transaction/__tests/tx.valid.vectors.ts
 #
 # Each vector: [[[prevout_hash, prevout_index, scriptPubKey], ...], serialised_tx_hex, flags]
 # We test round-trip: from_hex(hex).to_hex == hex

--- a/gem/bsv-sdk/spec/bsv/wallet/conformance/brc103/vectors_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/wallet/conformance/brc103/vectors_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # ---- Shared test data (mirrors go-sdk vector_test.go) ----
-BRC103_TESTDATA_DIR    = '/opt/ruby/bsv-reference-sdks/go-sdk/wallet/substrates/testdata'
+BRC103_TESTDATA_DIR    = '/opt/go/go-sdk/wallet/substrates/testdata'
 BRC103_PUB_KEY_HEX     = '025ad43a22ac38d0bc1f8bacaabb323b5d634703b7a774c4268f6a09e4ddf79097'
 BRC103_COUNTERPARTY_HEX = '0294c479f762f6baa97fbcd4393564c1d7bd8336ebd15928135bbcf575cd1a71a1'
 BRC103_VERIFIER_HEX    = '03b106dae20ae8fca0f4e8983d974c4b583054573eecdcdcfad261c035415ce1ee'
@@ -18,7 +18,9 @@ RSpec.describe 'BRC-103 cross-SDK wire conformance (go-sdk vectors)' do
   # rubocop:enable RSpec/DescribeClass
 
   before(:all) do # rubocop:disable RSpec/BeforeAfterAll
-    skip 'Go SDK reference testdata not present — clone bsv-reference-sdks to run conformance specs' unless File.directory?(BRC103_TESTDATA_DIR)
+    unless File.directory?(BRC103_TESTDATA_DIR)
+      skip 'Go SDK reference testdata not present — clone bsv-blockchain/go-sdk to /opt/go/go-sdk to run conformance specs'
+    end
   end
 
   def go_wire(name)


### PR DESCRIPTION
## Summary

The reference SDK clones — none of which are Ruby — used to live under \`/opt/ruby/bsv-reference-sdks/\`. That was always the wrong place, and the recent move of \`bsv-blockchain/ts-sdk\` into the new \`bsv-blockchain/ts-stack\` monorepo made it a natural moment to fix.

New layout:

| Language | Location |
|---|---|
| TypeScript (monorepo) | \`/opt/js/ts-stack/\` — SDK at \`packages/sdk/\`, wallet-toolbox at \`packages/wallet/wallet-toolbox/\` |
| Go | \`/opt/go/go-sdk/\`, \`/opt/go/wallet-toolbox/\` |
| Python | \`/opt/python/py-sdk/\`, \`/opt/python/wallet-toolbox/\` |

The old \`/opt/ruby/bsv-reference-sdks/\` directory has been removed. Two stale duplicate checkouts at \`/opt/js/ts-sdk\` and \`/opt/js/wallet-toolbox\` (April 2024) were also removed — superseded by ts-stack.

## Repo changes

- \`CLAUDE.md\`: documents the new locations.
- \`docs/testing/conformance-vectors.md\`: example commands point at \`/opt/go/go-sdk\`.
- \`.architecture/reference-baseline.md\`: log commands updated; note added that the existing 8acc706 ts-sdk baseline predates the ts-stack move, so the path will reset to ts-stack on the next baseline update.

## Out-of-repo updates (done locally)

- \`.claude/agents/{developer,project-manager}.md\` and \`.claude/agent-memory/*/MEMORY.md\` swept for path changes.
- User-wide memory files: \`~/.claude/projects/-opt-ruby-bsv-wallet/memory/reference_brc100_reference_sdks.md\` rewritten; MEMORY indexes updated.

## Test plan

- [x] One spec updated: gem/bsv-sdk/spec/bsv/wallet/conformance/brc103/vectors_spec.rb (hardcoded BRC103_TESTDATA_DIR now points at /opt/go/go-sdk)
- [x] Verified all of \`/opt/js/ts-stack/packages/sdk/\`, \`/opt/go/go-sdk/\`, \`/opt/python/py-sdk/\` exist after the moves
- [x] No remaining \`bsv-reference-sdks\` references in live config (CLAUDE.md, docs/, .architecture/, .claude/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #836

