### PR TITLE
fix(docs): exclude vendor/ and .bundle/ from docs:lint scan

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -435,12 +435,17 @@ namespace :docs do # rubocop:disable Metrics/BlockLength
     docs_root = File.expand_path('docs', __dir__)
 
     # Exclude generated and non-content paths:
-    #   _site/       — Jekyll output, not source
+    #   _site/        — Jekyll output, not source
     #   reference/api/ — YARD-generated, no hand-authored frontmatter
-    #   README.md    — contributor meta-documentation, not a site page
+    #   vendor/       — CI bundler-cache lands gems here; their READMEs
+    #                   are not our docs
+    #   .bundle/      — Bundler config dir
+    #   README.md     — contributor meta-documentation, not a site page
     excluded_prefixes = [
       File.join(docs_root, '_site'),
-      File.join(docs_root, 'reference', 'api')
+      File.join(docs_root, 'reference', 'api'),
+      File.join(docs_root, 'vendor'),
+      File.join(docs_root, '.bundle')
     ]
     excluded_files = [File.join(docs_root, 'README.md')]
 


### PR DESCRIPTION
## Summary

The Documentation workflow failed on first post-merge run of #865 ([run 28354686611](https://github.com/sgbett/bsv-ruby-sdk/actions/runs/28354686611)). Lint walked into `docs/vendor/bundle/` (created by CI's `bundler-cache: true` with `working-directory: docs`) and flagged every gem's README/CHANGELOG as missing frontmatter.

Locally we don't see it because RVM stores gems outside the project tree.

Fix: add `docs/vendor` and `docs/.bundle` to the lint task's `excluded_prefixes` — same shape as the existing `_site/` and `reference/api/` exclusions, applied to the CI-only gem cache.

## Test plan

- [x] Locally simulated CI by `mkdir -p docs/vendor/bundle/ruby/3.4.0/gems/foo-1.0 && echo "no frontmatter" > .../README.md`; `rake docs:lint` correctly skipped it ("44 file(s) checked, all OK")
- [x] Cleanup confirmed working tree clean
- [x] RuboCop on `Rakefile` clean
- [ ] Post-merge docs workflow run completes through the lint step

Refs #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)