### PR TITLE
fix(docs): add jekyll-relative-links so internal .md links resolve

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -19,3 +19,7 @@ ruby '>= 3.3'
 gem 'jekyll', '~> 4.3'
 gem 'just-the-docs', '= 0.12.0'
 gem 'jekyll-redirect-from', '= 0.16.0'
+# Rewrites relative .md links in markdown to their permalink form at build
+# time. MkDocs did this transparently; Jekyll does not — without this plugin,
+# every internal [link](path/to/file.md) breaks in the rendered HTML.
+gem 'jekyll-relative-links', '= 0.6.1'

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
+    jekyll-relative-links (0.6.1)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
     jekyll-seo-tag (2.9.0)
@@ -170,6 +172,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.3)
   jekyll-redirect-from (= 0.16.0)
+  jekyll-relative-links (= 0.6.1)
   just-the-docs (= 0.12.0)
 
 CHECKSUMS
@@ -207,6 +210,7 @@ CHECKSUMS
   jekyll (4.4.1) sha256=4c1144d857a5b2b80d45b8cf5138289579a9f8136aadfa6dd684b31fe2bc18c1
   jekyll-include-cache (0.2.1) sha256=c7d4b9e551732a27442cb2ce853ba36a2f69c66603694b8c1184c99ab1a1a205
   jekyll-redirect-from (0.16.0) sha256=6635cae569ef9b0f90ffb71ec014ba977177fafb44d32a2b0526288d4d9be6db
+  jekyll-relative-links (0.6.1) sha256=d11301f57b39e94b6c04fff2a3b145fe2f6a27be631a403e2542fa2e1548dd6d
   jekyll-sass-converter (3.1.0) sha256=83925d84f1d134410c11d0c6643b0093e82e3a3cf127e90757a85294a3862443
   jekyll-seo-tag (2.9.0) sha256=0260015a8e1df9bf195cdfb0c675b7b2883fd8cbf12556e1c1cbe36a831c6852
   jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -19,6 +19,12 @@ mermaid:
 
 plugins:
   - jekyll-redirect-from
+  - jekyll-relative-links
+
+# Make jekyll-relative-links process every .md, not just collections.
+relative_links:
+  enabled: true
+  collections: false
 
 # Trailing-slash URLs (e.g. /guides/getting-started/) match the URL shape
 # produced by MkDocs, so existing links in README and external references


### PR DESCRIPTION
## Summary

Post-merge docs deploy ([run 28354865096](https://github.com/sgbett/bsv-ruby-sdk/actions/runs/28354865096)) failed lychee with 54 broken-link errors — all internal `[text](path/to/file.md)` references. MkDocs auto-rewrote these to permalink URLs at build time; Jekyll does not by default.

Fix: add `jekyll-relative-links` (Jekyll core team plugin, on the GitHub Pages whitelist) which rewrites relative `.md` links to their permalink form. Internal anchor fragments (e.g. `#wire-layer-errors`) survive intact.

## Test plan

- [x] `cd docs && bundle install` adds `jekyll-relative-links 0.6.1`
- [x] `rake docs:build` produces `_site/` with 0 internal `.md` links remaining (verified by grep). The 7 remaining `.md` URLs are all external GitHub blob URLs which `lychee --offline` ignores.
- [x] Spot-check: `sdk/wallet.md#wire-layer-errors` from `brc-103-wire.md` source now renders as `/bsv-ruby-sdk/sdk/wallet/#wire-layer-errors` in the built HTML
- [x] `rake docs:lint` still green (44 files OK)
- [ ] Post-merge docs workflow completes through lychee step

Refs #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)