### PR TITLE
fix(docs): emit Jekyll frontmatter from YARD index generator

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,6 +36,16 @@ def generate_reference_index(output_dir) # rubocop:disable Metrics/AbcSize,Metri
   end
 
   File.open(File.join(output_dir, 'index.md'), 'w') do |f|
+    # Jekyll frontmatter — Jekyll only processes .md files with frontmatter
+    # as content pages; without it, this file is copied verbatim as .md and
+    # _site/reference/api/index.html never exists. The defaults block in
+    # _config.yml additionally keeps it out of the side nav and search index.
+    f.puts '---'
+    f.puts 'title: API Reference'
+    f.puts 'parent: Reference'
+    f.puts 'nav_order: 99'
+    f.puts '---'
+    f.puts
     f.puts '# API Reference'
     f.puts
     f.puts 'Auto-generated from source using [YARD](https://yardoc.org/).'


### PR DESCRIPTION
## Summary

Latest post-merge docs run ([28355447269](https://github.com/sgbett/bsv-ruby-sdk/actions/runs/28355447269)) failed htmlproofer with:

> internally linking to reference/api/, which does not exist
> internally linking to api/, which does not exist

Root cause: `rake docs:generate` wipes `docs/reference/api/` and regenerates `index.md` **without frontmatter**. Jekyll only processes `.md` files with frontmatter as content pages; without it, the file is copied verbatim as `.md` and `_site/reference/api/index.html` is never produced. The links in `docs/index.md` (`reference/api/`) and `docs/reference/index.md` (`api/`) then 404.

Fix: same pattern as the protocols-generator fix in `6e672441` — the generator emits its own frontmatter at the top of the file. Now idempotent: `rake docs:generate` re-runs without breaking the docs build.

## Test plan

- [x] `rake docs:generate` locally produces `docs/reference/api/index.md` with frontmatter
- [x] `rake docs:build` succeeds
- [x] `rake docs:proofread` — 308 internal links checked, all clean
- [ ] Post-merge docs workflow completes through the proofread step and deploys

Refs #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)