### PR TITLE
ci(docs): run the docs workflow on PRs as a dry-run

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,14 @@ on:
       - '.yardopts'
       - '.github/workflows/docs.yml'
       - 'Rakefile'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'gem/*/lib/**'
+      - 'docs/**'
+      - '.yardopts'
+      - '.github/workflows/docs.yml'
+      - 'Rakefile'
   workflow_dispatch:
 
 concurrency:
@@ -62,13 +70,19 @@ jobs:
       - name: Check internal links
         run: bundle exec rake docs:proofread
 
-      # Upload artefact for the deploy job
+      # Upload artefact for the deploy job — skipped on PR runs since
+      # the deploy job is also skipped (only push to master deploys).
       - uses: actions/configure-pages@v5
+        if: github.event_name == 'push'
       - uses: actions/upload-pages-artifact@v3
+        if: github.event_name == 'push'
         with:
           path: docs/_site
 
   deploy:
+    # Only deploy on push to master. PR runs are dry-run only: they
+    # build, lint, and link-check the site without touching Pages.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

The docs migration (#865) ran cleanly through PR CI (the SDK test matrix) but produced **five master commits** debugging the docs deploy chain because `docs.yml` only triggered on push to master. None of those failures needed visual inspection — they were build/lint/link-check failures the workflow would have caught at PR time if it had run.

Add a `pull_request:` trigger so docs.yml runs as a dry-run on PRs:

- ✅ YARD generate, Jekyll build, frontmatter lint, html-proofer link check — all run on PRs
- ❌ `actions/configure-pages`, `actions/upload-pages-artifact`, `actions/deploy-pages` — gated to `push` on `master` via `if:` conditions

PRs that touch docs paths now get the same end-to-end build verification the post-merge run performs, minus the actual Pages deploy. The deploy stays single-source-of-truth on master.

## Out of scope

Real per-PR preview deploys (separate Pages site, Netlify, Vercel, etc). Today's failures didn't need visual previews — they needed the workflow to actually run.

## Test plan

- [x] YAML parses
- [ ] This PR is itself the test — the docs workflow should run as `build` only (no `deploy` job), green
- [ ] Verify post-merge: a subsequent docs-touching PR triggers `build` only; merging it triggers `build` + `deploy`

Refs #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)