### PR TITLE
fix(docs): restore default layout in Jekyll defaults block

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -31,11 +31,19 @@ relative_links:
 # continue to resolve after the migration.
 permalink: pretty
 
-# Exclude YARD-generated API output from both side-nav and Lunr search index.
-# YARD writes hundreds of per-class pages; including them in the nav would
-# bury hand-authored content, and indexing them causes severe Lunr index bloat
-# that degrades search performance for end users.
+# Defaults — note these REPLACE the theme's defaults rather than merging
+# with them, so we must restore the `layout: default` setting that
+# just-the-docs would otherwise apply to all pages. Without it, Jekyll
+# renders pages as bare content (no <head>, no nav, no theme styling).
+#
+# The second scope excludes YARD-generated API output from both side-nav
+# and Lunr search index — YARD writes hundreds of per-class pages and
+# would otherwise bury hand-authored content and bloat the search index.
 defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default
   - scope:
       path: "reference/api"
     values:


### PR DESCRIPTION
## Summary

Deployed docs site rendered as **bare HTML** — no `<head>`, no nav, no theme styling. Visible at https://sgbett.github.io/bsv-ruby-sdk/ after yesterday's deploy chain finally went green.

Root cause: Jekyll's `defaults:` block in user `_config.yml` **replaces** the theme's `defaults:` rather than merging with it. just-the-docs sets `layout: default` for all pages via its own defaults; our defaults (which only set `nav_exclude`/`search_exclude` for `reference/api`) wiped that, so no page got wrapped in the layout.

Fix: add a separate `path: ""` scope that restores `layout: default` globally, keeping the YARD-output exclusion as its own scope. Comment in the file notes the replace-not-merge gotcha so the next person doesn't trip on it.

## Test plan

- [x] `rake docs:build` locally — `_site/index.html` now starts with `<!DOCTYPE html>`, pulls in `just-the-docs-default.css` + light/dark variants, renders full sidebar nav + search bar
- [x] `rake docs:proofread` — 45 files, 0 errors
- [ ] **docs.yml dry-run** runs on this PR (first exercise of the trigger added in #873)
- [ ] Post-merge: deployed site at https://sgbett.github.io/bsv-ruby-sdk/ renders themed

Refs #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)