### PR TITLE
chore(docs): three Copilot cleanups in one

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,7 @@ on:
       - '.yardopts'
       - '.github/workflows/docs.yml'
       - 'Rakefile'
+      - 'Gemfile'
   pull_request:
     branches: [master]
     paths:
@@ -17,6 +18,7 @@ on:
       - '.yardopts'
       - '.github/workflows/docs.yml'
       - 'Rakefile'
+      - 'Gemfile'
   workflow_dispatch:
 
 concurrency:

--- a/Rakefile
+++ b/Rakefile
@@ -460,7 +460,10 @@ namespace :docs do # rubocop:disable Metrics/BlockLength
     excluded_files = [File.join(docs_root, 'README.md')]
 
     md_files = Dir.glob(File.join(docs_root, '**', '*.md')).reject do |f|
-      excluded_prefixes.any? { |prefix| f.start_with?(prefix) } ||
+      # Add a trailing path separator to each prefix so the match is strict
+      # directory containment (e.g. `docs/vendor/x.md` matches `docs/vendor`
+      # but a hypothetical `docs/vendorized/x.md` would not).
+      excluded_prefixes.any? { |prefix| f.start_with?("#{prefix}/") } ||
         excluded_files.include?(f)
     end
 
@@ -523,7 +526,17 @@ namespace :docs do # rubocop:disable Metrics/BlockLength
   end
 
   desc 'Check internal links and anchors in the built site (offline)'
-  task proofread: :build do
+  task :proofread do
+    # No Rake-level dependency on :build so CI can run them as separate
+    # steps without rebuilding twice. Callers (CI + local) are expected
+    # to have run `rake docs:build` first; surface a clear message
+    # rather than letting htmlproofer fail with an opaque "no files".
+    site_dir = File.expand_path('docs/_site', __dir__)
+    unless File.directory?(site_dir) && !Dir.empty?(site_dir)
+      abort "docs:proofread — #{site_dir} is missing or empty. " \
+            'Run `bundle exec rake docs:build` first.'
+    end
+
     Dir.chdir('docs') do
       # html-proofer is Jekyll-aware: swap_urls strips the baseurl prefix
       # (which is a URL concept, not a filesystem path) so root-relative


### PR DESCRIPTION
## Summary

Bundles three minor polish items from Copilot reviews left over after the docs migration (#861):

| # | Concern | Fix |
|---|---------|-----|
| #871 | `docs:proofread` Rake-depended on `:build`, but the workflow ran `docs:build` as a separate step → Jekyll built twice per CI run | Drop the prerequisite; defensive check on `_site/` for clear local error |
| #869 | `docs:lint` `excluded_prefixes` matched via plain `start_with?` — `docs/vendor` would also exclude a future `docs/vendorized/...` | Match against `prefix + "/"` for strict directory containment |
| #873 | `docs.yml` `paths:` filter didn't include the root `Gemfile` even though YARD generation uses it | Add `Gemfile` to both push and pull_request triggers |

`.gemspec` files left out of the trigger list — gemspec changes (version, file lists, descriptions) don't materially affect YARD output, which reads from `gem/*/lib/**/*.rb`.

## Test plan

- [x] `rake docs:build && rake docs:proofread` — builds once, checks 308 internal links, all clean
- [x] `rake docs:proofread` without prior build — fails with clear message, exit 1
- [x] `rake docs:lint` still green (44 files)
- [x] RuboCop clean on Rakefile
- [x] Workflow YAML parses
- [ ] PR dry-run runs and passes
- [ ] Post-merge docs deploy stays green and visibly faster (one less build)

Refs #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)