### PR TITLE
fix(docs): backport second-pass learnings from bsv-wallet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         ruby-version: ['3.3', '3.4', '4.0']
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
@@ -25,7 +25,7 @@ jobs:
           bundler-cache: true
 
       - name: Cache conformance vectors
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: tmp/conformance-vectors
           key: conformance-${{ hashFiles('.architecture/conformance.lock') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # YARD generation — uses the SDK root Gemfile.
       # Both setup-ruby steps pin Ruby to '3.4.2' exactly to match
@@ -77,9 +77,9 @@ jobs:
 
       # Upload artefact for the deploy job — skipped on PR runs since
       # the deploy job is also skipped (only push to master deploys).
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
         if: github.event_name == 'push'
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         if: github.event_name == 'push'
         with:
           path: docs/_site

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,15 +38,18 @@ jobs:
       - uses: actions/checkout@v6
 
       # YARD generation — uses the SDK root Gemfile.
-      # Both setup-ruby steps use Ruby 3.4 to match docs/Gemfile.lock's
-      # RUBY VERSION pin (3.4.2). Splitting Ruby versions between the two
-      # steps breaks `bundle exec rake docs:*` because the rake command
-      # resolves through the root Gemfile, whose gems were installed under
-      # the first setup-ruby's Ruby version.
+      # Both setup-ruby steps pin Ruby to '3.4.2' exactly to match
+      # docs/Gemfile.lock's RUBY VERSION pin. The floating '3.4' would
+      # drift on patch releases and trigger a Bundler warning (or
+      # refusal) when the installed Ruby differs from the lockfile pin.
+      # Splitting Ruby versions between the two steps also breaks
+      # `bundle exec rake docs:*` because the rake command resolves
+      # through the root Gemfile, whose gems were installed under the
+      # first setup-ruby's Ruby version.
       - name: Set up Ruby (YARD)
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.4'
+          ruby-version: '3.4.2'
           bundler-cache: true
 
       - name: Generate YARD markdown
@@ -56,7 +59,7 @@ jobs:
       - name: Set up Ruby (Jekyll)
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.4'
+          ruby-version: '3.4.2'
           working-directory: docs
           bundler-cache: true
 

--- a/Rakefile
+++ b/Rakefile
@@ -35,20 +35,38 @@ def generate_reference_index(output_dir) # rubocop:disable Metrics/AbcSize,Metri
     row['type'] == 'Module' ? modules << entry : classes << entry
   end
 
-  File.open(File.join(output_dir, 'index.md'), 'w') do |f|
-    # Jekyll frontmatter — Jekyll only processes .md files with frontmatter
-    # as content pages; without it, this file is copied verbatim as .md and
-    # _site/reference/api/index.html never exists. The defaults block in
-    # _config.yml additionally keeps it out of the side nav and search index.
+  File.open(File.join(output_dir, 'index.md'), 'w') do |f| # rubocop:disable Metrics/BlockLength
+    # Jekyll frontmatter — without it, Jekyll copies the file as static .md
+    # rather than processing it to HTML. The _config.yml `defaults:` block
+    # applies nav_exclude/search_exclude to ALL of reference/api/**; the
+    # index page explicitly overrides those so it appears as the
+    # API Reference entry under Reference. Per-class pages keep the
+    # excluded defaults (silent navigation, reachable via this index).
     f.puts '---'
     f.puts 'title: API Reference'
     f.puts 'parent: Reference'
-    f.puts 'nav_order: 99'
+    f.puts 'nav_order: 5'
+    f.puts 'nav_exclude: false'
+    f.puts 'search_exclude: false'
     f.puts '---'
     f.puts
     f.puts '# API Reference'
     f.puts
     f.puts 'Auto-generated from source using [YARD](https://yardoc.org/).'
+    f.puts
+    f.puts '{: .note }'
+    f.puts '> **Generated content**'
+    f.puts '>'
+    f.puts '> This page is overwritten by `rake docs:generate` with the ' \
+           'live module/class tree across both gems in this monorepo. ' \
+           'Run it locally to populate the API reference:'
+    f.puts '>'
+    f.puts '> ```bash'
+    f.puts '> bundle exec rake docs:generate'
+    f.puts '> ```'
+    f.puts '>'
+    f.puts '> Output lands in `docs/reference/api/` (sibling to authored ' \
+           'canonical-reference content under `docs/reference/`).'
     f.puts
     f.puts '## Modules'
     f.puts
@@ -430,12 +448,21 @@ namespace :docs do # rubocop:disable Metrics/BlockLength
   end
   desc 'Build the Jekyll docs site'
   task :build do
-    Dir.chdir('docs') { sh 'BUNDLE_GEMFILE=Gemfile bundle exec jekyll build' }
+    # Bundler.with_unbundled_env strips BUNDLE_GEMFILE / BUNDLE_PATH from the
+    # outer `bundle exec rake` context so the inner `bundle exec jekyll`
+    # resolves the docs Gemfile cleanly from cwd. Without this the outer
+    # bundle's env leaks in and jekyll/htmlproofer either resolve against
+    # the wrong Gemfile or fail to find their gems.
+    Bundler.with_unbundled_env do
+      Dir.chdir('docs') { sh 'bundle exec jekyll build' }
+    end
   end
 
   desc 'Serve the Jekyll docs locally'
   task :serve do
-    Dir.chdir('docs') { sh 'BUNDLE_GEMFILE=Gemfile bundle exec jekyll serve --livereload' }
+    Bundler.with_unbundled_env do
+      Dir.chdir('docs') { sh 'bundle exec jekyll serve --livereload' }
+    end
   end
 
   desc 'Lint docs frontmatter — asserts required keys on every hand-authored .md'
@@ -537,17 +564,19 @@ namespace :docs do # rubocop:disable Metrics/BlockLength
             'Run `bundle exec rake docs:build` first.'
     end
 
-    Dir.chdir('docs') do
-      # html-proofer is Jekyll-aware: swap_urls strips the baseurl prefix
-      # (which is a URL concept, not a filesystem path) so root-relative
-      # links like /bsv-ruby-sdk/sdk/wallet/ resolve to _site/sdk/wallet/.
-      # disable_external skips https:// links — those need network.
-      sh 'BUNDLE_GEMFILE=Gemfile bundle exec htmlproofer _site ' \
-         '--disable-external ' \
-         '--swap-urls "^/bsv-ruby-sdk:" ' \
-         '--ignore-empty-alt ' \
-         '--ignore-missing-alt ' \
-         '--allow-missing-href'
+    Bundler.with_unbundled_env do
+      Dir.chdir('docs') do
+        # html-proofer is Jekyll-aware: swap_urls strips the baseurl prefix
+        # (which is a URL concept, not a filesystem path) so root-relative
+        # links like /bsv-ruby-sdk/sdk/wallet/ resolve to _site/sdk/wallet/.
+        # disable_external skips https:// links — those need network.
+        sh 'bundle exec htmlproofer _site ' \
+           '--disable-external ' \
+           '--swap-urls "^/bsv-ruby-sdk:" ' \
+           '--ignore-empty-alt ' \
+           '--ignore-missing-alt ' \
+           '--allow-missing-href'
+      end
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,11 @@
 # Gem releases are handled by the /release Claude Code skill.
 # See CLAUDE.md for the release workflow and tag conventions.
 
+# Bundler is required explicitly so `rake docs:build` / `docs:serve` /
+# `docs:proofread` work without `bundle exec` in front — they call
+# `Bundler.with_unbundled_env` to isolate the docs Gemfile resolution,
+# and without this require the constant would not exist.
+require 'bundler'
 require 'rspec/core/rake_task'
 
 namespace :spec do

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -22,11 +22,12 @@ Auto-generated from source using [YARD](https://yardoc.org/).
 > Output lands in `docs/reference/api/` (sibling to authored canonical-reference content under `docs/reference/`).
 
 <!--
-Below this point, the module/class lists are appended by
-`generate_reference_index` in Rakefile when `rake docs:generate`
-runs. The committed file is a placeholder so a fresh clone can
-build the site without first running docs:generate (which would
-otherwise leave broken links to per-class pages that aren't
-committed — only index.md is).
+The committed file is a placeholder. `rake docs:generate` overwrites
+it entirely (mode 'w') via `generate_reference_index` in Rakefile,
+producing a fresh frontmatter + callout + full module/class lists.
+The placeholder shape exists so a fresh clone can build the site
+without first running docs:generate (which would otherwise leave
+broken links to per-class pages that aren't committed — only
+index.md is tracked under docs/reference/api/).
 -->
 

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -1,7 +1,9 @@
 ---
 title: API Reference
-nav_order: 5
 parent: Reference
+nav_order: 5
+nav_exclude: false
+search_exclude: false
 ---
 
 # API Reference
@@ -18,3 +20,13 @@ Auto-generated from source using [YARD](https://yardoc.org/).
 > ```
 >
 > Output lands in `docs/reference/api/` (sibling to authored canonical-reference content under `docs/reference/`).
+
+<!--
+Below this point, the module/class lists are appended by
+`generate_reference_index` in Rakefile when `rake docs:generate`
+runs. The committed file is a placeholder so a fresh clone can
+build the site without first running docs:generate (which would
+otherwise leave broken links to per-class pages that aren't
+committed — only index.md is).
+-->
+

--- a/docs/reference/conformance-vectors.md
+++ b/docs/reference/conformance-vectors.md
@@ -163,7 +163,7 @@ before the RSpec invocation:
 {% raw %}
 ```yaml
 - name: Cache conformance vectors
-  uses: actions/cache@v4
+  uses: actions/cache@v6
   with:
     path: tmp/conformance-vectors
     key: conformance-${{ hashFiles('.architecture/conformance.lock') }}

--- a/docs/reference/conformance-vectors.md
+++ b/docs/reference/conformance-vectors.md
@@ -160,6 +160,7 @@ correctness checkpoint, not a rubber stamp.
 The GitHub Actions workflow (`.github/workflows/ci.yml`) runs the sync step
 before the RSpec invocation:
 
+{% raw %}
 ```yaml
 - name: Cache conformance vectors
   uses: actions/cache@v4
@@ -170,6 +171,7 @@ before the RSpec invocation:
 - name: Sync conformance vectors
   run: bin/conformance/sync
 ```
+{% endraw %}
 
 The cache key is derived from the content of the lock file. A cache miss
 triggers a full anonymous fetch from codeload; a hit reuses the cached tree


### PR DESCRIPTION
## Summary

Five mechanical fixes carried over from [sgbett/bsv-wallet#496](https://github.com/sgbett/bsv-wallet/pull/496)'s post-migration Copilot rounds, plus a sixth bundle of four Dependabot Actions bumps. Closes #876.

### Docs-system patches

| # | Patch | bsv-wallet source commit |
|---|-------|--------------------------|
| 1 | `Bundler.with_unbundled_env` wrap on `docs:build` / `docs:serve` / `docs:proofread` shell-outs (drops the `BUNDLE_GEMFILE=Gemfile` band-aid) | [`b4e525f`](https://github.com/sgbett/bsv-wallet/commit/b4e525f) |
| 2 | `ruby-version: '3.4.2'` exact pin in both `setup-ruby` steps (was `'3.4'`, drifts from `docs/Gemfile.lock`'s `RUBY VERSION` pin) | [`6c1bf49`](https://github.com/sgbett/bsv-wallet/commit/6c1bf49) |
| 3 | `nav_exclude: false` / `search_exclude: false` on `docs/reference/api/index.md` (committed file + `generate_reference_index` helper) — overrides the `_config.yml` `defaults:` block so the API Reference entry actually appears in the sidebar | [`6c1bf49`](https://github.com/sgbett/bsv-wallet/commit/6c1bf49) |
| 4 | Reset committed `docs/reference/api/index.md` to placeholder-only (no module/class lists). The lists are generator output and the per-class pages are gitignored; committing them broke fresh-clone proofread | [`e41c8f2`](https://github.com/sgbett/bsv-wallet/commit/e41c8f2) |
| 5 | `{% raw %} ... {% endraw %}` wrap on the GitHub Actions YAML code block in `docs/reference/conformance-vectors.md` (silences Liquid syntax warning on `${{ hashFiles(...) }}`) | bundled per the docs-system-hygiene theme |
| 6 | `require 'bundler'` at top of Rakefile (`Bundler.with_unbundled_env` needs the constant loaded even when invoked without `bundle exec`); placeholder comment corrected (overwrites mode 'w', not "appended") | [bsv-wallet TBD](https://github.com/sgbett/bsv-wallet/issues/506) — caught by Copilot on this PR, fix to be backported to bsv-wallet |

### GitHub Actions bumps (folded in from open Dependabot PRs)

Closes #859, #866, #867, #868.

| Action | Bump | Used in |
|--------|------|---------|
| `actions/checkout` | v6 → v7 | `ci.yml`, `docs.yml` |
| `actions/cache` | v4 → v6 | `ci.yml` (conformance cache) |
| `actions/configure-pages` | v5 → v6 | `docs.yml` (Pages build) |
| `actions/upload-pages-artifact` | v3 → v5 | `docs.yml` (Pages artefact) |

The Pages-related bumps move us onto Node 24, silencing the deprecation warning the first deployed run produced.

## Test plan

- [x] `bundle exec rake docs:build` — clean, no Liquid warnings
- [x] `bundle exec rake docs:lint` — 44 files, all OK
- [x] **Fresh-clone simulation**: wipe `docs/reference/api/` except `index.md`; `rake docs:build && rake docs:proofread` passes on 45 files
- [x] Bare `rake docs:build` (without `bundle exec`) now works (was raising `NameError: uninitialized constant Bundler`)
- [x] `bundle exec rubocop Rakefile` — clean
- [x] Workflow YAML parses (both `ci.yml` and `docs.yml`)
- [ ] PR dry-run passes on this PR with the new action versions
- [ ] Post-merge deploy: https://sgbett.github.io/bsv-ruby-sdk/ shows "API Reference" entry under Reference in the sidebar (currently absent)

## Visible post-merge change

The sidebar's Reference section will gain an "API Reference" entry that has been missing since the original migration. Verified locally that the link target renders the placeholder + the generator's full module/class lists after `rake docs:generate`.

Closes #876
Closes #859
Closes #866
Closes #867
Closes #868

🤖 Generated with [Claude Code](https://claude.com/claude-code)