### PR TITLE
fix(docs): README Basic Usage uses correct prev_wtxid: keyword (#891)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ locking_script = BSV::Script::Script.p2pkh_lock(pubkey_hash)
 tx = BSV::Transaction::Tx.new
 
 # Add an input referencing a previous transaction output
+# wtxid_from_hex converts a display-order hex txid to wire-order binary
+utxo_txid = '5884e5db9de218238671572340b207ee85b628074e7e467096c267266baf77a4'
 input = BSV::Transaction::TransactionInput.new(
-  prev_tx_id: source_txid_bytes,   # 32-byte binary txid of the UTXO
+  prev_wtxid: BSV::Transaction::TransactionInput.wtxid_from_hex(utxo_txid),
   prev_tx_out_index: 0
 )
 input.source_satoshis = 100_000


### PR DESCRIPTION
Part of #891. Lands the highest-impact narrow fix from the accuracy sweep.

## Summary

- `prev_tx_id:` → `prev_wtxid:` (the actual `TransactionInput#initialize` keyword)
- Resolves the `source_txid_bytes` free variable by inlining a real hex txid and converting it with `wtxid_from_hex`, making the snippet self-contained and runnable end-to-end

## Verification

IRB transcript confirming the corrected snippet runs without errors:

```
$ bundle exec ruby -Igem/bsv-sdk/lib /tmp/test_readme_snippet.rb
0100000001a477af6b2667c29670467e4e0728b685ee07b240235771862318e29ddbe58458000000006a47304402203cc3d4e83b1cd421d13072a223fdfb5297696cedf0c56ad7a269ae35c6b94ddd0220775d59199513d6d87cf177a56a178cf74f508609e8967931ad3acbf20aba46e0412103960eb57262728c1ea92c76c72740d41b8888d819f27d3bf40eebedd82313c315ffffffff01905f0100000000001976a9140708a8259eb89b56f1544cf13436b8bfcd88717388ac00000000
Script ran successfully!
```

(Output varies by run as `PrivateKey.generate` produces a fresh random key each time — the point is zero errors.)