### PR TITLE
fix(docs): accuracy sweep across docs/** and READMEs (#891)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ locking_script = BSV::Script::Script.p2pkh_lock(pubkey_hash)
 tx = BSV::Transaction::Tx.new
 
 # Add an input referencing a previous transaction output
+# wtxid_from_hex converts a display-order hex txid to wire-order binary
+utxo_txid = '5884e5db9de218238671572340b207ee85b628074e7e467096c267266baf77a4'
 input = BSV::Transaction::TransactionInput.new(
-  prev_tx_id: source_txid_bytes,   # 32-byte binary txid of the UTXO
+  prev_wtxid: BSV::Transaction::TransactionInput.wtxid_from_hex(utxo_txid),
   prev_tx_out_index: 0
 )
 input.source_satoshis = 100_000

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -101,10 +101,10 @@ tx.add_output(BSV::Transaction::TransactionOutput.new(
 # Sign the input
 tx.sign(0, private_key)
 
-# Broadcast via Arcade (GorillaPool)
-arc = BSV::Network::ARC.default
-response = arc.broadcast(tx)
-puts response.txid  # display-order hex (ARC API boundary)
+# Broadcast via GorillaPool (Arcade protocol, public endpoint)
+provider = BSV::Network::Providers::GorillaPool.default
+result = provider.call(:broadcast, tx)
+puts result.data['txid'] if result.http_success?  # display-order hex (ARC API boundary)
 ```
 
 ## Using Templates for Signing

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -92,7 +92,7 @@ tx.add_output(BSV::Transaction::TransactionOutput.new(
 ))
 
 # Add a change output (send remaining funds back)
-fee = tx.estimated_fee
+fee = BSV::Transaction::FeeModels::SatoshisPerKilobyte.new.compute_fee(tx)
 tx.add_output(BSV::Transaction::TransactionOutput.new(
   satoshis: 1_000_000 - fee,
   locking_script: locking_script

--- a/docs/network/examples.md
+++ b/docs/network/examples.md
@@ -8,22 +8,25 @@ parent: Network
 
 ## Quick Start — Using Defaults
 
-The simplest path uses `.default` on the facade classes. No configuration needed.
+The simplest path uses `.default` on provider and tracker classes. No configuration needed.
 
 ### Broadcast a transaction
 
 ```ruby
-arc = BSV::Network::ARC.default
-response = arc.broadcast(tx)
-puts response.txid
+# GorillaPool Arcade (public endpoint, no auth required)
+provider = BSV::Network::Providers::GorillaPool.default
+result = provider.call(:broadcast, tx)
+puts result.data['txid'] if result.http_success?
 ```
 
 ### Fetch UTXOs for an address
 
 ```ruby
-woc = BSV::Network::WhatsOnChain.default
-utxos = woc.fetch_utxos('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa')
-utxos.each { |u| puts "#{u.tx_hash}:#{u.tx_pos} — #{u.satoshis} sats" }
+woc = BSV::Network::Providers::WhatsOnChain.default
+result = woc.call(:get_utxos, '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa')
+if result.http_success?
+  result.data.each { |u| puts "#{u['tx_hash']}:#{u['tx_pos']} — #{u['value']} sats" }
+end
 ```
 
 ### Verify a merkle root (SPV)
@@ -39,8 +42,8 @@ puts valid ? 'confirmed' : 'not found'
 Every `.default` accepts `testnet: true`:
 
 ```ruby
-arc = BSV::Network::ARC.default(testnet: true)
-woc = BSV::Network::WhatsOnChain.default(testnet: true)
+provider = BSV::Network::Providers::GorillaPool.default(testnet: true)
+woc = BSV::Network::Providers::WhatsOnChain.default(testnet: true)
 tracker = BSV::Transaction::ChainTrackers::WhatsOnChain.default(testnet: true)
 ```
 
@@ -103,8 +106,12 @@ end
 
 ```ruby
 # Use TAAL's ARC instance instead of GorillaPool
-arc = BSV::Network::ARC.new('https://arc.taal.com', api_key: 'my-taal-key')
-response = arc.broadcast(tx)
+arc = BSV::Network::Protocols::ARC.new(
+  base_url: 'https://arc.taal.com',
+  api_key: 'my-taal-key'
+)
+result = arc.call(:broadcast, tx)
+puts result.data['txid'] if result.http_success?
 ```
 
 ### Build a provider from scratch
@@ -183,20 +190,18 @@ result = arcade.call(:broadcast, tx)
 
 ### Result types
 
-All protocol calls return Result objects:
+All protocol calls return a `BSV::Network::ProtocolResponse`:
 
 ```ruby
 result = woc_protocol.call(:get_tx, txid)
 
-case
-when result.success?
-  puts result.data         # the response payload
-when result.not_found?
+if result.http_success?
+  puts result.data           # the response payload
+elsif result.http_not_found?
   puts 'transaction not found'
-when result.error?
-  puts result.message      # error description
-  puts result.retryable?   # can we try another provider?
-  puts result.metadata     # structured data (e.g. arc_status)
+else
+  puts result.error_message  # error description
+  puts result.retryable?     # can we try another provider?
 end
 ```
 
@@ -295,11 +300,11 @@ The new `auth:` hash is the preferred form. Both work; `auth:` takes precedence 
 both are supplied.
 
 ```ruby
-# Legacy — still works
-arc = BSV::Network::ARC.default(api_key: 'my-key')
+# Legacy — still works on providers
+provider = BSV::Network::Providers::GorillaPool.default(api_key: 'my-key')
 
 # Preferred — explicit about the mechanism
-arc = BSV::Network::ARC.default(auth: { bearer: 'my-key' })
+provider = BSV::Network::Providers::GorillaPool.default(auth: { bearer: 'my-key' })
 ```
 
 For WhatsOnChain, the protocol sends a bare key (no `Bearer` prefix). Both the

--- a/docs/network/examples.md
+++ b/docs/network/examples.md
@@ -73,7 +73,7 @@ puts gp.commands.to_a.sort
 woc = BSV::Network::Providers::WhatsOnChain.default
 
 result = woc.call(:get_tx, 'abc123...')
-puts result.data if result.success?  # raw hex
+puts result.data if result.http_success?  # raw hex
 
 result = woc.call(:is_utxo, 'abc123...', 0)
 puts result.data  # true (unspent) or false (spent)

--- a/docs/network/overview.md
+++ b/docs/network/overview.md
@@ -127,31 +127,28 @@ The `rate_limit` value is requests per second. Each provider factory sets a
 | `GorillaPool` | 3 | Public tier limit |
 | `TAAL` | `nil` | Depends on subscription tier |
 
-## SDK Facades
+## SDK Entry Points
 
-For convenience, the SDK provides facade classes that preserve the familiar API from
-the TypeScript and Go reference SDKs:
+The SDK exposes three stable entry points for the network layer:
 
 ```ruby
-# Broadcasting (ARC protocol via GorillaPool)
-arc = BSV::Network::ARC.default
-response = arc.broadcast(tx)
+# Broadcasting — via a provider (GorillaPool Arcade by default)
+provider = BSV::Network::Providers::GorillaPool.default
+result = provider.call(:broadcast, tx)
+puts result.data['txid'] if result.http_success?
 
-# Chain data (WoCREST protocol via WhatsOnChain)
-woc = BSV::Network::WhatsOnChain.default
-utxos = woc.fetch_utxos(address)
-tx = woc.fetch_transaction(txid)
+# Chain data — via the WoCREST provider
+woc = BSV::Network::Providers::WhatsOnChain.default
+result = woc.call(:get_utxos, address)
+result.data.each { |u| puts "#{u['tx_hash']}:#{u['tx_pos']}" } if result.http_success?
 
-# SPV verification (WoCREST protocol via WhatsOnChain)
+# SPV verification — ChainTrackers::WhatsOnChain wraps WoCREST with a higher-level API
 tracker = BSV::Transaction::ChainTrackers::WhatsOnChain.new(network: :main)
 tracker.valid_root_for_height?(merkle_root, height)
 ```
 
-Facades are **contract translators** — they delegate to the protocol layer internally
-but return domain objects (UTXO, Transaction, BroadcastResponse) and raise exceptions
-(BroadcastError, ChainProviderError) that consumers expect. The protocol layer speaks
-Result types (Success, Error, NotFound); facades translate these into the imperative
-contracts that application code uses.
+The protocol layer returns `BSV::Network::ProtocolResponse` objects — check
+`result.http_success?` before reading `result.data`.
 
 > **Note on `ChainTrackers`:** `ChainTrackers::WhatsOnChain` is a legacy facade that
 > wraps WhatsOnChain's chain-info endpoint directly. It continues to work unchanged.

--- a/docs/overlays/registries.md
+++ b/docs/overlays/registries.md
@@ -86,7 +86,7 @@ basket.definition_data.registry_operator   # => pubkey hex of the publisher
 basket.satoshis                            # => 1
 basket.txid                                # => display-order txid
 basket.output_index                        # => 0
-basket.beef                                # => BSV::Transaction::Beef (verifiable, embeddable)
+basket.beef                                # => raw BEEF bytes (String); parse with BSV::Transaction::Beef.from_binary
 ```
 
 ### Trust model — filter by operator

--- a/docs/overlays/registries.md
+++ b/docs/overlays/registries.md
@@ -55,8 +55,11 @@ node can choose to index only the kinds it cares about.
 ```ruby
 require 'bsv-sdk'
 
-# Resolver-only construction — read paths don't need a wallet
-client = BSV::Registry::Client.new(wallet: nil)
+# Resolver-only construction — inject a resolver directly so no wallet is needed.
+# Without resolver:, the client calls wallet.get_network to build one, which
+# will raise NoMethodError if wallet: is nil.
+resolver = BSV::Overlay::LookupResolver.new(network_preset: :mainnet)
+client = BSV::Registry::Client.new(wallet: nil, resolver: resolver)
 
 # Resolve baskets by id, name, or both
 baskets = client.resolve_basket(basket_id: 'ordinals')

--- a/docs/sdk/network.md
+++ b/docs/sdk/network.md
@@ -14,58 +14,67 @@ For the underlying architecture (Protocols, Providers, Commands), see the
 
 ## Broadcasting Transactions
 
-### Default Broadcaster
+Broadcasting uses the `BSV::Network::Providers` layer. A provider composes one or more
+wire protocols and routes commands through a single `call` interface, returning a
+`BSV::Network::ProtocolResponse`.
 
-The quickest way to broadcast is via `ARC.default`, which points at GorillaPool's
-public Arcade endpoint:
+### Default Broadcaster — GorillaPool (Arcade)
+
+The simplest path uses `GorillaPool.default`, which points at GorillaPool's public
+Arcade endpoint:
 
 ```ruby
-arc = BSV::Network::ARC.default
-response = arc.broadcast(tx)
+provider = BSV::Network::Providers::GorillaPool.default
+result = provider.call(:broadcast, tx)
 
-puts response.txid      #=> "abc123..."
-puts response.tx_status #=> "SEEN_ON_NETWORK"
+if result.http_success?
+  puts result.data['txid']    #=> "abc123..."
+else
+  puts result.error_message   #=> rejection detail
+end
 ```
 
 For testnet:
 
 ```ruby
-arc = BSV::Network::ARC.default(testnet: true)
+provider = BSV::Network::Providers::GorillaPool.default(testnet: true)
 ```
 
-### Custom Endpoint
+### TAAL ARC
 
-Point at any ARC-compatible endpoint. Use `auth:` to specify the authentication mechanism:
+To broadcast via TAAL's ARC endpoint instead:
 
 ```ruby
-# Bearer token (default for GorillaPool and TAAL ARC)
-arc = BSV::Network::ARC.new(
-  'https://my-arc-server.example.com',
+provider = BSV::Network::Providers::TAAL.default(auth: { bearer: ENV['TAAL_KEY'] })
+result = provider.call(:broadcast, tx)
+
+if result.http_success?
+  puts result.data['txid']      #=> display-order hex (ARC API boundary)
+  puts result.data['txStatus']  #=> "SEEN_ON_NETWORK"
+end
+```
+
+### Custom ARC Endpoint
+
+Point the ARC protocol directly at any ARC-compatible endpoint:
+
+```ruby
+arc = BSV::Network::Protocols::ARC.new(
+  base_url: 'https://my-arc-server.example.com',
   auth: { bearer: 'my-api-key' }
 )
-
-# Raw API key in Authorization header (no Bearer prefix)
-arc = BSV::Network::ARC.new(
-  'https://my-arc-server.example.com',
-  auth: { api_key: 'my-api-key' }
-)
-
-# The legacy api_key: shorthand is still supported and sends Bearer
-arc = BSV::Network::ARC.new(
-  'https://my-arc-server.example.com',
-  api_key: 'my-api-key'
-)
+result = arc.call(:broadcast, tx)
 ```
 
-### Broadcast Options
+### ARC Broadcast Options
 
-`broadcast` accepts several optional parameters:
+`call(:broadcast, tx, ...)` forwards keyword options to the ARC escape hatch:
 
 ```ruby
-arc.broadcast(tx,
-  wait_for: 'SEEN_ON_NETWORK',      # hold connection until status reached
-  skip_fee_validation: true,          # bypass minimum-fee check
-  skip_script_validation: true        # bypass script correctness check
+result = arc.call(:broadcast, tx,
+  wait_for: 'SEEN_ON_NETWORK',   # hold connection until status reached
+  skip_fee_validation: true,       # bypass minimum-fee check
+  skip_script_validation: true     # bypass script correctness check
 )
 ```
 
@@ -77,39 +86,54 @@ arc.broadcast(tx,
 
 ### Batch Broadcasting
 
-Submit multiple transactions in a single request:
+Submit multiple transactions in a single ARC request:
 
 ```ruby
-results = arc.broadcast_many([tx1, tx2, tx3])
+# Use the ARC protocol directly for batch support
+arc = BSV::Network::Protocols::ARC.new(
+  base_url: 'https://arc.taal.com',
+  auth: { bearer: ENV['TAAL_KEY'] }
+)
+result = arc.call(:broadcast_many, [tx1, tx2, tx3])
 
-results.each do |result|
-  if result.is_a?(BSV::Network::BroadcastResponse)
-    puts "#{result.txid}: #{result.tx_status}"
-  else
-    # BroadcastError — this tx was rejected but others may have succeeded
-    puts "Failed: #{result.message}"
+if result.http_success?
+  result.data.each do |entry|
+    puts "#{entry['txid']}: #{entry['txStatus']}"
   end
+else
+  puts result.error_message
 end
 ```
 
-`broadcast_many` returns a mixed array — each element is either a `BroadcastResponse` (success) or a `BroadcastError` (per-transaction failure). HTTP-level errors raise for the entire batch.
+`broadcast_many` returns a `ProtocolResponse`. On success, `result.data` is an array
+of per-transaction hashes — each has `txid` and `txStatus`. HTTP-level failures set
+`http_success?` to false for the entire batch; per-transaction rejections are
+detectable by checking `txStatus` within the array.
 
 ### Transaction Status
 
-Query the status of a previously broadcast transaction:
+Query the status of a previously broadcast transaction via ARC:
 
 ```ruby
-response = arc.status('abc123...')
-puts response.tx_status   #=> "MINED"
-puts response.block_height #=> 800_123
+arc = BSV::Network::Protocols::ARC.new(
+  base_url: 'https://arc.taal.com',
+  auth: { bearer: ENV['TAAL_KEY'] }
+)
+result = arc.call(:get_tx_status, 'abc123...')  # display-order hex at ARC boundary
+if result.http_success?
+  puts result.data['txStatus']    #=> "MINED"
+  puts result.data['blockHeight'] #=> 800123
+end
 ```
 
 ### Callbacks
 
-ARC can notify your server when a transaction's status changes:
+Pass callback options when building the ARC protocol:
 
 ```ruby
-arc = BSV::Network::ARC.default(
+arc = BSV::Network::Protocols::ARC.new(
+  base_url: 'https://arc.taal.com',
+  auth: { bearer: ENV['TAAL_KEY'] },
   callback_url: 'https://my-server.com/tx-status',
   callback_token: 'my-secret-token'
 )
@@ -188,7 +212,7 @@ The SDK (`bsv-sdk`) is **declarative** — it defines data structures, serialisa
 | Need | Where |
 |------|-------|
 | Build and sign a transaction | `bsv-sdk` — `BSV::Transaction` |
-| Broadcast a transaction | `bsv-sdk` — `BSV::Network::ARC` |
+| Broadcast a transaction | `bsv-sdk` — `BSV::Network::Providers` / `BSV::Network::Protocols::ARC` |
 | Verify a BEEF proof | `bsv-sdk` — `BSV::Transaction::Beef#verify` |
 | Manage UTXOs and baskets | `bsv-wallet` — `BSV::Wallet::Client` |
 | Track output baskets | `bsv-wallet` — basket parameter on outputs |

--- a/docs/sdk/transaction.md
+++ b/docs/sdk/transaction.md
@@ -148,18 +148,20 @@ dtxid = tx.dtxid       # 64-char hex (display order — for JSON and UIs)
 
 ## Fee Estimation
 
-The SDK estimates transaction size to calculate fees:
+The SDK estimates transaction size to calculate fees via `FeeModel` implementations:
 
 ```ruby
 # Total values
 tx.total_input_satoshis    # sum of all input source_satoshis
 tx.total_output_satoshis   # sum of all output satoshis
 
-# Estimated fee at the default rate (0.5 sat/byte)
-fee = tx.estimated_fee
+# Estimated fee at the default rate (100 sat/kB)
+fee_model = BSV::Transaction::FeeModels::SatoshisPerKilobyte.new
+fee = fee_model.compute_fee(tx)
 
-# Custom fee rate
-fee = tx.estimated_fee(satoshis_per_byte: 1.0)
+# Custom fee rate (e.g. 500 sat/kB)
+fee_model = BSV::Transaction::FeeModels::SatoshisPerKilobyte.new(value: 500)
+fee = fee_model.compute_fee(tx)
 ```
 
 Fee estimation accounts for:
@@ -363,7 +365,7 @@ tx.add_output(BSV::Transaction::TransactionOutput.new(
 ))
 
 # Change
-fee = tx.estimated_fee
+fee = BSV::Transaction::FeeModels::SatoshisPerKilobyte.new.compute_fee(tx)
 tx.add_output(BSV::Transaction::TransactionOutput.new(
   satoshis: 1_000_000 - 500_000 - fee,
   locking_script: sender_lock

--- a/docs/testing/custom-provider.md
+++ b/docs/testing/custom-provider.md
@@ -102,8 +102,8 @@ result.data  # => "0100000083..." (480 hex chars = 3 x 80-byte headers)
 
 # Error handling
 result = tracker.call(:find_header, height: 999_999_999)
-result.success?    # => false
-result.not_found?  # => true
+result.http_success?    # => false
+result.http_not_found?  # => true
 ```
 
 ### Introspection

--- a/gem/bsv-sdk/README.md
+++ b/gem/bsv-sdk/README.md
@@ -89,8 +89,10 @@ locking_script = BSV::Script::Script.p2pkh_lock(pubkey_hash)
 tx = BSV::Transaction::Tx.new
 
 # Add an input referencing a previous transaction output
+# wtxid_from_hex converts a display-order hex txid to wire-order binary
+utxo_txid = '5884e5db9de218238671572340b207ee85b628074e7e467096c267266baf77a4'
 input = BSV::Transaction::TransactionInput.new(
-  prev_tx_id: source_txid_bytes,   # 32-byte binary txid of the UTXO
+  prev_wtxid: BSV::Transaction::TransactionInput.wtxid_from_hex(utxo_txid),
   prev_tx_out_index: 0
 )
 input.source_satoshis = 100_000


### PR DESCRIPTION
Closes #891. Part of #880.

## Audit Punch-List

| file:line | claim | reality | fix |
|---|---|---|---|
| `README.md:83` | `prev_tx_id: source_txid_bytes` | kwarg is `prev_wtxid:`; `source_txid_bytes` is a free variable | Replace with `prev_wtxid: wtxid_from_hex(utxo_txid)` using inline hex literal |
| `gem/bsv-sdk/README.md:93` | `prev_tx_id: source_txid_bytes` | same as above | Same fix |
| `docs/sdk/network.md:23` | `arc = BSV::Network::ARC.default` | `BSV::Network::ARC` does not exist as a class | Replace with `Providers::GorillaPool.default.call(:broadcast, tx)` |
| `docs/sdk/network.md:26` | `response.txid` / `response.tx_status` | No facade — response is `ProtocolResponse`; field is `result.data['txid']` | Fix to `result.data['txid']` + `result.data['txStatus']` |
| `docs/sdk/network.md:42,48,54` | `BSV::Network::ARC.new(...)` | No such class | Replace with `Protocols::ARC.new(base_url:, auth:)` |
| `docs/sdk/network.md:86` | `result.is_a?(BSV::Network::BroadcastResponse)` | `BroadcastResponse` does not exist | Fix to use `result.http_success?` + `result.data` array |
| `docs/sdk/network.md:102` | `arc.status('abc123...')` | No `status` method on facade (no facade) | Fix to `arc.call(:get_tx_status, 'abc123...')` |
| `docs/sdk/network.md:112` | `BSV::Network::ARC.default(callback_url:)` | No such class | Fix to `Protocols::ARC.new(..., callback_url:, callback_token:)` |
| `docs/sdk/network.md:191` | `BSV::Network::ARC` in table | Misleading reference | Update to `Providers` / `Protocols::ARC` |
| `docs/network/examples.md:16` | `BSV::Network::ARC.default` Quick Start | No such class | Fix to `Providers::GorillaPool.default.call(:broadcast, tx)` |
| `docs/network/examples.md:24` | `BSV::Network::WhatsOnChain.default` | No such class | Fix to `Providers::WhatsOnChain.default.call(:get_utxos, addr)` |
| `docs/network/examples.md:42` | `BSV::Network::ARC.default(testnet: true)` | No such class | Fix to `Providers::GorillaPool.default(testnet: true)` |
| `docs/network/examples.md:43` | `BSV::Network::WhatsOnChain.default(testnet: true)` | No such class | Fix to `Providers::WhatsOnChain.default(testnet: true)` |
| `docs/network/examples.md:76` | `result.success?` | Method does not exist on `ProtocolResponse` | Fix to `result.http_success?` |
| `docs/network/examples.md:106` | `BSV::Network::ARC.new(...)` | No such class | Fix to `Protocols::ARC.new(base_url:, api_key:)` |
| `docs/network/examples.md:192` | `result.success?` / `result.not_found?` / `result.error?` / `result.metadata` | None of these methods exist | Fix to `result.http_success?` / `result.http_not_found?` / `result.error_message` |
| `docs/network/examples.md:299,302` | `BSV::Network::ARC.default(api_key:)` / `BSV::Network::ARC.default(auth:)` | No such class | Fix to `Providers::GorillaPool.default(...)` |
| `docs/network/overview.md:137,141` | `BSV::Network::ARC.default` / `BSV::Network::WhatsOnChain.default` | No such classes | Replace with real Provider entry points |
| `docs/network/overview.md:151` | `BroadcastResponse` / `BroadcastError` | Do not exist | Remove from description |
| `docs/guides/getting-started.md:105` | `arc = BSV::Network::ARC.default; response = arc.broadcast(tx); response.txid` | No facade | Fix to `Providers::GorillaPool.default.call(:broadcast, tx)` + `result.data['txid']` |
| `docs/guides/getting-started.md:95` | `tx.estimated_fee` | Deprecated method | Fix to `FeeModels::SatoshisPerKilobyte.new.compute_fee(tx)` |
| `docs/sdk/transaction.md:159,162,366` | `tx.estimated_fee` | Deprecated method | Fix to `FeeModels::SatoshisPerKilobyte.new.compute_fee(tx)` |
| `docs/overlays/registries.md:59` | `BSV::Registry::Client.new(wallet: nil)` silently works | `resolver_for` calls `wallet_network` → `nil.get_network` → `NoMethodError` | Fix to inject `resolver: BSV::Overlay::LookupResolver.new(network_preset: :mainnet)` |
| `docs/overlays/registries.md:87` | `basket.beef # => BSV::Transaction::Beef` | `beef` attr is raw String bytes | Fix annotation to note `from_binary` is required |
| `docs/testing/custom-provider.md:105,106` | `result.success?` / `result.not_found?` | Methods do not exist | Fix to `result.http_success?` / `result.http_not_found?` |

**Post-#888 anti-patterns:** No `tx.inputs <<` / `tx.inputs.pop` patterns found in docs. The reference doc `docs/reference/sighash-cache.md` correctly documents `invalidate_caches` as the escape hatch for direct mutation.

**Cross-Tx reuse pattern:** No examples found that attach the same input/output to two `Tx` instances.

## Verification

### Runnable examples

**README Basic Usage (both repo-root and gem):**
```
$ bundle exec ruby -Igem/bsv-sdk/lib /tmp/test_readme_snippet.rb
0100000001a477af6b2667c29670467e4e0728b685...
Script ran successfully!
```

**sdk/transaction.md complete example:**
```
$ bundle exec ruby -Igem/bsv-sdk/lib /tmp/verify_docs_examples.rb
=== 1: README Basic Usage ===
0100000001a477af6b26...
  OK: repo-root README
=== 2: Transaction doc complete example ===
0100000001a477af6b26...
  OK: sdk/transaction.md complete example
=== 3: ChainTrackers::WhatsOnChain.default exists ===
  OK: tracker class = BSV::Transaction::ChainTrackers::WhatsOnChain
=== 4: ChainTracker.default exists ===
  OK: tracker2 class = BSV::Transaction::ChainTracker
=== 5: GorillaPool provider exists ===
  OK: provider class = BSV::Network::Provider
  OK: provider can call :broadcast (command available = true)
=== 6: LookupResolver exists ===
  OK: resolver class = BSV::Overlay::LookupResolver
=== 7: Registry::Client with resolver: ===
  OK: client class = BSV::Registry::Client
=== 8: Protocols::ARC.new signature ===
  OK: ARC protocol class = BSV::Network::Protocols::ARC

All examples verified!
```

### `# illustrative` annotation

No examples were converted to `# illustrative` — all broken examples were corrected to the real API. Network examples that involve live HTTP calls remain as-is with placeholder txids/addresses (they clearly require a running network endpoint).

### Linters

```
$ bundle exec rake docs:lint
docs:lint — 45 file(s) checked, all OK

$ bundle exec rake docs:proofread
HTML-Proofer finished successfully.
```