### PR TITLE
docs: coverage gap fills — Schnorr ZKP, KeyShares, FeeModel, ChainTracker, MerklePath, PushDrop, Registry write paths (#894)

### DIFF
--- a/docs/overlays/registries.md
+++ b/docs/overlays/registries.md
@@ -18,9 +18,10 @@ typically the entity who owns the namespace. Anyone can publish a
 definition; clients decide which operators they trust by passing
 `registry_operators` filters in their queries.
 
-The SDK ships the **read paths** (`resolve_basket`, `resolve_protocol`,
-`resolve_certificate`). Publishing, updating, and revoking definitions
-need a wallet and live in `bsv-wallet`.
+The SDK ships both the **read paths** (`resolve_basket`, `resolve_protocol`,
+`resolve_certificate`) and the **write paths** (`register_definition`,
+`update_definition`, `revoke_definition`). Write paths require a BRC-100 wallet
+to create and sign transactions.
 
 ## Why it exists
 
@@ -110,26 +111,99 @@ with the typed API in the TypeScript, Go, and Python SDKs.
 See [SDK reference: Ecosystem Clients](../sdk/ecosystem-clients.md) for
 the full method surface.
 
-## What the wallet provides
+## Write paths
 
-`Registry::Client` accepts a `wallet:` because its **write paths** are
-on the same class:
+`Registry::Client` includes write paths on the same class. These methods need a BRC-100-compatible wallet (e.g. `bsv-wallet`'s `Wallet::Client`) because they create and sign on-chain transactions. Passing `wallet: nil` and calling a write path raises `NoMethodError`.
 
-- `register_definition(type, data)` — publish a new definition (broadcast
-  to the corresponding `tm_*` topic).
-- `update_definition(...)` — spend the existing UTXO and publish a new
-  version.
-- `revoke_definition(...)` — spend the UTXO to take the definition out of
-  circulation.
-- `list_own_registry_entries(type)` — query the wallet for definitions
-  *this* identity has published.
+### `register_definition`
 
-Those methods need a BRC-100 wallet because they create-and-sign new
-transactions. The Ruby SDK's `Client` requires one for those — pass any
-BRC-100-compatible wallet (typically `bsv-wallet`'s `Wallet::Client`).
+Publishes a new definition as a PushDrop UTXO and broadcasts it to the appropriate overlay topic:
 
-If you're only reading, you can pass `wallet: nil` and use only the
-typed resolve methods. The constructor accepts it.
+```ruby
+require 'bsv-sdk'
+
+client = BSV::Registry::Client.new(wallet: my_wallet, originator: 'myapp.example.com')
+
+data = BSV::Registry::BasketDefinitionData.new(
+  basket_id:         'my-tokens',
+  name:              'My Token Collection',
+  icon_url:          'https://example.com/icon.png',
+  description:       'Stores my custom tokens',
+  documentation_url: 'https://example.com/docs'
+)
+
+result = client.register_definition(BSV::Registry::DefinitionType::BASKET, data)
+# result is a BSV::Overlay::OverlayBroadcastResult
+# raises BSV::Overlay::OverlayError (or a subclass) if the broadcast fails
+```
+
+Protocol and certificate definitions work the same way — swap the type constant and the data class:
+
+```ruby
+# Protocol definition
+proto_data = BSV::Registry::ProtocolDefinitionData.new(
+  protocol_id:       [1, 'my-protocol'],
+  name:              'My Protocol',
+  icon_url:          'https://example.com/icon.png',
+  description:       'What this protocol does',
+  documentation_url: 'https://example.com/spec'
+)
+client.register_definition(BSV::Registry::DefinitionType::PROTOCOL, proto_data)
+
+# Certificate type definition
+cert_data = BSV::Registry::CertificateDefinitionData.new(
+  type:              'aW1hZ2U=',   # Base64 type identifier
+  name:              'Profile',
+  icon_url:          'https://example.com/cert.png',
+  description:       'Basic identity profile',
+  documentation_url: 'https://example.com/cert-spec',
+  fields:            {}
+)
+client.register_definition(BSV::Registry::DefinitionType::CERTIFICATE, cert_data)
+```
+
+### `update_definition`
+
+Replaces an existing definition by spending its UTXO and publishing a new one. The update is two sequential operations (revoke then register) — not atomic. If registration fails after revocation, the old definition will have been removed without replacement.
+
+```ruby
+# Find the definition you want to update
+existing = client.list_own_registry_entries(BSV::Registry::DefinitionType::BASKET).first
+
+updated_data = BSV::Registry::BasketDefinitionData.new(
+  basket_id:         existing.definition_data.basket_id,
+  name:              'My Token Collection (v2)',
+  icon_url:          existing.definition_data.icon_url,
+  description:       'Updated description',
+  documentation_url: existing.definition_data.documentation_url
+)
+
+client.update_definition(existing, updated_data)
+# The existing UTXO is spent; a new one is published with the updated data
+```
+
+### `revoke_definition`
+
+Spends the definition UTXO to remove it from overlay lookup responses. Only definitions belonging to the current wallet's identity key can be revoked — `revoke_definition` raises `RuntimeError` if the registry operator pubkey does not match the wallet's identity key.
+
+```ruby
+my_entries = client.list_own_registry_entries(BSV::Registry::DefinitionType::BASKET)
+to_revoke  = my_entries.find { |d| d.definition_data.basket_id == 'my-tokens' }
+
+client.revoke_definition(to_revoke)
+# The UTXO is spent; the definition disappears from resolve responses
+```
+
+### `list_own_registry_entries`
+
+Queries the wallet for spendable outputs in the registry basket and returns them as `RegisteredDefinition` objects:
+
+```ruby
+my_baskets = client.list_own_registry_entries(BSV::Registry::DefinitionType::BASKET)
+my_baskets.each { |d| puts d.definition_data.name }
+```
+
+If you are only reading, inject a `resolver:` and pass `wallet: nil` — the constructor accepts it and the typed resolve methods work without a wallet.
 
 ## Edge cases worth knowing
 

--- a/docs/sdk/primitives.md
+++ b/docs/sdk/primitives.md
@@ -252,6 +252,77 @@ key.parent_fingerprint   # 4-byte parent fingerprint
 key.identifier           # 20-byte key identifier (Hash160 of public key)
 ```
 
+## Schnorr ZKP (BRC-94)
+
+`BSV::Primitives::Schnorr` is **not** BIP-340 (Taproot) signatures, not a general-purpose signature primitive, and not used for transaction signing — BSV transaction signatures use deterministic ECDSA (RFC 6979). `BSV::Primitives::Schnorr` implements the **BRC-94 Schnorr zero-knowledge proof of ECDH shared-secret knowledge**: given public keys A and B and a shared secret S = a·B (where a is A's private key), the prover demonstrates knowledge of the discrete log relationship without revealing the private key. The proof is used in Auth and certificate flows where one party needs to prove they computed the correct shared secret without transmitting the private key. See [BRC-94](https://github.com/bitcoin-sv/BRCs/blob/master/peer-to-peer/0094.md) for the specification.
+
+The two verification equations are `z·G = R + e·A` and `z·B = S' + e·S`, where R is the commitment point, S' is the blinded shared secret, z is the response scalar, and e is the challenge hash.
+
+```ruby
+alice = BSV::Primitives::PrivateKey.generate
+bob   = BSV::Primitives::PrivateKey.generate
+
+# Alice computes the ECDH shared secret: alice_private * bob_public
+shared = BSV::Primitives::PublicKey.new(
+  BSV::Primitives::Curve.multiply_point(bob.public_key.point, alice.bn)
+)
+
+# Alice generates a ZK proof that she knows the private key yielding `shared`
+proof = BSV::Primitives::Schnorr.generate_proof(
+  alice, alice.public_key, bob.public_key, shared
+)
+
+# Bob (or any verifier) checks the proof without learning Alice's private key
+valid = BSV::Primitives::Schnorr.verify_proof(
+  alice.public_key, bob.public_key, shared, proof
+)
+#=> true
+```
+
+The `Proof` struct carries three fields: `r` (commitment point, `PublicKey`), `s_prime` (blinded shared secret, `PublicKey`), and `z` (response scalar, `OpenSSL::BN`). Binary serialisation is `R(33 B) + S'(33 B) + z(variable)` — the variable-length z accommodates both this SDK's fixed 32-byte encoding and the TS SDK's minimal encoding.
+
+## Key Shares (Shamir backup)
+
+`BSV::Primitives::KeyShares` implements **Shamir's Secret Sharing over the secp256k1 scalar field** as a backup and recovery mechanism. It is **not** threshold signatures, **not** MuSig, FROST, or 2P-ECDSA, and does **not** permit distributed signing — reconstruction yields the original private key in plaintext at a single location.
+
+The use case is offline backup: split a private key into n shares and store them separately (paper wallets, hardware tokens, trusted parties). Any threshold-many shares reconstruct the key; fewer than threshold shares reveal nothing.
+
+### Cross-SDK format compatibility
+
+The backup format — `Base58(x).Base58(y).threshold.integrity` per share — is byte-compatible with the TypeScript and Go SDKs. The integrity tag is the first 8 hex characters of Hash160(compressed public key), **not an HMAC tag**. It acts as a lightweight sanity check that reconstruction produced the correct key.
+
+```ruby
+original = BSV::Primitives::PrivateKey.generate
+
+# Split into 3 shares; any 2 reconstruct the key (threshold=2, total=3)
+shares = original.to_key_shares(2, 3)
+shares.threshold    #=> 2
+shares.integrity    #=> e.g. "7a58deb5" (first 8 hex chars of Hash160(pubkey))
+
+# Serialise for storage — one human-readable string per share
+backup = shares.to_backup_format
+# e.g. ["7RWw...2.7a58deb5", "...", "..."]
+
+# Later: reconstruct from any 2 of the 3 shares
+rebuilt       = BSV::Primitives::KeyShares.from_backup_format(backup[0..1])
+reconstructed = BSV::Primitives::PrivateKey.from_key_shares(rebuilt)
+reconstructed.to_hex == original.to_hex  #=> true
+```
+
+`PrivateKey#to_key_shares_backup` is a one-call shortcut that combines `to_key_shares` and `to_backup_format`. `PrivateKey.from_key_shares_backup` accepts the backup strings directly and returns the reconstructed private key.
+
+## secp256k1-native acceleration
+
+The `secp256k1-native` gem provides the secp256k1 curve implementation used throughout `BSV::Primitives`. When the gem's optional C extension compiles successfully, it replaces the pure-Ruby field, scalar, and Jacobian point operations with native C implementations — approximately a 22× speedup. If the extension fails to build (e.g. Alpine Linux without `build-base` installed), the gem falls back to pure Ruby automatically, printing a warning to stderr.
+
+To check which is active at runtime:
+
+```ruby
+BSV::Primitives::Secp256k1.native?  #=> true if C extension is loaded, false for pure Ruby
+```
+
+The speedup applies wherever secp256k1 arithmetic is used — key generation, ECDSA signing and verification, and ECDH. Batch signing (e.g. `tx.sign_all` across many inputs) inherits the full speedup automatically.
+
 ## BIP-39 Mnemonics
 
 Generate human-readable seed phrases:

--- a/docs/sdk/script.md
+++ b/docs/sdk/script.md
@@ -219,6 +219,69 @@ result  = BSV::Script::BIP276.decode_template(encoded)
 
 **Field order note:** the two header bytes are `<version><network>` — version first, then network. This matches the BIP-276 specification and the Go SDK reference implementation. The Python SDK has these two fields reversed, a known bug that is invisible when both values are `0x01` (the default) but produces incorrect output for testnet or non-default versions. See `spec/bsv/script/bip276_spec.rb` for Go SDK cross-SDK conformance vectors that prove the correct byte order.
 
+## PushDropTemplate
+
+`BSV::Script::PushDropTemplate` is a wallet-integrated template for embedding arbitrary token data in a spendable output. It generalises the pattern used by overlay registries and token applications: push data fields onto the stack, drop them, then lock with a P2PKH condition derived from a wallet key. The pattern is sometimes called "PushDrop" because the data fields are pushed then dropped as a unit.
+
+The script layout (default `lock_position: :before`) is:
+
+```
+OP_DUP OP_HASH160 <hash160(pubkey)> OP_EQUALVERIFY OP_CHECKSIG
+<field0> <field1> ... <fieldN>
+OP_2DROP [...OP_2DROP] [OP_DROP]
+```
+
+With `lock_position: :after` the lock condition follows the drops instead:
+
+```
+<field0> ... <fieldN> OP_2DROP [...OP_2DROP] [OP_DROP]
+OP_DUP OP_HASH160 <hash160(pubkey)> OP_EQUALVERIFY OP_CHECKSIG
+```
+
+### Cross-SDK byte compatibility
+
+The Ruby SDK's default `lock_position: :before` matches the TS SDK's default since `ts-sdk` v1.1+. Both embed the fields immediately after the P2PKH locking condition and use `OP_2DROP` pairs (then a single `OP_DROP` when the field count is odd) to clean the stack. The field bytes are pushed with minimal encoding matching Bitcoin's standard push opcodes. Scripts produced by both SDKs with the same inputs are byte-identical — a requirement for cross-SDK token resolution, since the script hash is computed from the raw bytes.
+
+If you are interoperating with older tooling using `lock_position: :after`, pass that keyword explicitly; the byte layout is not interchangeable.
+
+### Construction
+
+```ruby
+# wallet must implement the BRC-100 interface (e.g. bsv-wallet's Wallet::Client)
+template = BSV::Script::PushDropTemplate.new(wallet: my_wallet, originator: 'myapp.example.com')
+
+locking_script = template.lock(
+  fields:       ['hello'.b, 'world'.b],  # binary strings
+  protocol_id:  [1, 'my-protocol'],      # BRC-43 [security_level, name]
+  key_id:       '1',
+  counterparty: 'self'                   # 'self', 'anyone', or a hex public key
+)
+locking_script.pushdrop?  #=> true
+```
+
+When `include_signature: true` (the default), an ECDSA signature over the concatenation of all fields is appended as a final field. This authenticates the token at creation time using the same derived key.
+
+When `counterparty: 'anyone'` is used, the locking key is the secp256k1 generator point (PrivateKey(1)), meaning the output is publicly spendable by any party. This is by design for overlay tokens where public revocability is intended.
+
+### Unlocking
+
+```ruby
+unlocker = template.unlock(
+  protocol_id:  [1, 'my-protocol'],
+  key_id:       '1',
+  counterparty: 'self'
+)
+input.unlocking_script_template = unlocker
+tx.sign_all
+```
+
+### Reading token fields
+
+```ruby
+locking_script.pushdrop?        #=> true
+locking_script.pushdrop_fields  #=> Array<String> — the binary field bytes
+```
+
 ## Script Interpreter
 
 Verify that an unlocking script satisfies a locking script:

--- a/docs/sdk/transaction.md
+++ b/docs/sdk/transaction.md
@@ -170,6 +170,70 @@ Fee estimation accounts for:
 - Template inputs: `estimated_length` from the template
 - Unsigned inputs (no template): 148 bytes (standard P2PKH estimate)
 
+### FeeModel and FeeModels
+
+`Transaction::FeeModel` is the abstract base class; concrete implementations live in `Transaction::FeeModels`. Two are bundled:
+
+**`FeeModels::SatoshisPerKilobyte`** — simple static rate, suitable for most applications:
+
+```ruby
+model = BSV::Transaction::FeeModels::SatoshisPerKilobyte.new           # default: 100 sat/kB
+model = BSV::Transaction::FeeModels::SatoshisPerKilobyte.new(value: 50)
+fee   = model.compute_fee(tx)  #=> Integer (satoshis)
+```
+
+**`FeeModels::LivePolicy`** — fetches the current mining fee rate from an ARC `/v1/policy` endpoint. The fetched rate is cached for a configurable TTL (default `300` seconds) so repeated calls to `compute_fee` do not repeatedly query the API. On fetch failure the model falls back to the last cached rate, or to `fallback_rate` if nothing has been cached yet:
+
+```ruby
+model = BSV::Transaction::FeeModels::LivePolicy.new(
+  arc_url:      'https://arc.taal.com',
+  fallback_rate: 100,       # sat/kB used when fetch fails and no cached rate
+  cache_ttl:     60         # override the default 300-second TTL
+)
+fee = model.compute_fee(tx)
+
+BSV::Transaction::FeeModels::LivePolicy::DEFAULT_CACHE_TTL  #=> 300
+```
+
+`LivePolicy.default` returns a policy backed by TAAL's public ARC instance with a 100 sat/kB fallback. Pass `api_key:` for authenticated access.
+
+Custom fee models implement one method: `compute_fee(transaction) -> Integer`.
+
+## ChainTrackers
+
+`Transaction::ChainTracker` is the data-source interface used by `Beef#verify`, `MerklePath#verify`, and `Tx#verify`. It answers one question: "is this merkle root valid for this block height?" The base class itself **does not cache** — it dispatches directly to the underlying network provider on every call. If you want caching, subclass it and implement it there.
+
+```ruby
+# Provider-backed default (GorillaPool)
+tracker = BSV::Transaction::ChainTracker.default
+tracker = BSV::Transaction::ChainTracker.default(testnet: true)
+
+# WhatsOnChain-backed
+tracker = BSV::Transaction::ChainTrackers::WhatsOnChain.new
+tracker = BSV::Transaction::ChainTrackers::WhatsOnChain.default
+
+# Duck-typed in-memory tracker (for testing or offline use)
+class FixedTracker < BSV::Transaction::ChainTracker
+  def initialize(headers)
+    super()
+    @headers = headers
+  end
+
+  def valid_root_for_height?(root, height)
+    @headers[height]&.casecmp(root)&.zero?
+  end
+
+  def current_height
+    @headers.keys.max
+  end
+end
+
+tracker = FixedTracker.new(800_000 => 'abcd1234...')
+mp.verify('txid_hex...', tracker)
+```
+
+Any object responding to `valid_root_for_height?` and `current_height` satisfies the interface — inheriting from `Transaction::ChainTracker` is optional.
+
 ## Script Verification
 
 Verify that an input's unlocking script satisfies the locking script:
@@ -302,35 +366,83 @@ See `spec/bsv/transaction/beef_party_spec.rb` for a full worked example includin
 
 ## Merkle Paths (BRC-74)
 
-Merkle paths (BUMPs) prove transaction inclusion in a block.
+Merkle paths (BUMPs) prove transaction inclusion in a block. A `MerklePath` stores the minimum set of intermediate hashes needed to recompute a block's merkle root from one or more transaction IDs.
 
 ### Parsing
 
 ```ruby
 mp = BSV::Transaction::MerklePath.from_hex(bump_hex)
+mp = BSV::Transaction::MerklePath.from_binary(raw_bytes).first  # returns [path, bytes_consumed]
 
-mp.block_height  # the block height
-mp.path          # tree levels, each containing leaves
+mp.block_height  # Integer — the block height
+mp.path          # Array<Array<PathElement>> — tree levels; level 0 holds the leaf(es)
 ```
+
+### Construction
+
+```ruby
+mp = BSV::Transaction::MerklePath.new(
+  block_height: 800_000,
+  path: [
+    [
+      BSV::Transaction::MerklePath::PathElement.new(offset: 0, hash: tx_wtxid,      txid: true),
+      BSV::Transaction::MerklePath::PathElement.new(offset: 1, hash: sibling_wtxid)
+    ]
+    # upper levels follow; omit when the sibling is a duplicate (set duplicate: true)
+  ]
+)
+```
+
+Hashes are stored in **wire order** (32-byte binary, reversed from display order). Level 0 must contain at least one `txid: true` leaf — that flag marks the transaction being proved, not a txid value.
 
 ### Computing the Merkle Root
 
 ```ruby
-# From a hex txid
-root_hex = mp.compute_root_hex(txid_hex)
+# Pass a display-order (reversed) hex txid; returns display-order hex root
+root_hex = mp.compute_root_hex('aabb...')   # 64-char hex
 
-# Auto-detect from txid-flagged leaves
+# Auto-detect: uses the txid-flagged leaf in level 0
 root_hex = mp.compute_root_hex
+```
+
+### Verification
+
+```ruby
+# Verify against a chain tracker — checks root matches the block at block_height
+valid = mp.verify('aabb...', tracker)  #=> true / false
 ```
 
 ### Combining Paths
 
-Merge two paths for the same block:
+Merge two paths for the same block (e.g. proving two transactions from the same block):
 
 ```ruby
 mp1.combine(mp2)
-# mp1 now contains the union of both paths
+# mp1 now contains the union of both paths; trim compresses the result
+mp1.trim  # remove redundant intermediate nodes
 ```
+
+### Caching and Performance
+
+`Transaction::Tx` memoises the bytes and digests that sighash computation reads across many inputs. The cache is a three-layer Russian-doll structure (L1 per-struct binaries → L2 wire format → L3 sighash component hashes). Most mutations are handled automatically:
+
+| Mutation | Result |
+|---|---|
+| `input.sequence=` | Invalidates `hash_sequence`, L1, L2 |
+| `input.unlocking_script=` | Invalidates L1, L2 (not sighash components) |
+| `output.satoshis=` | Invalidates `hash_outputs_*`, L1, L2 |
+| `output.locking_script=` | Invalidates `hash_outputs_*`, L1, L2 |
+| `tx.add_input` / `tx.add_output` | Invalidates all cache layers |
+| Direct `tx.inputs <<` / `pop` | **Not auto-invalidated** — call `invalidate_caches` |
+
+```ruby
+tx.inputs.pop         # bypasses the setter surface
+tx.invalidate_caches  # clears all cache layers; returns self
+```
+
+**One-owner constraint:** `add_input` and `add_output` bind an input or output to the owning transaction by setting a private `@owning_tx` backref. Passing the same object to a *different* `Transaction::Tx` raises `ArgumentError`. Construct a fresh `TransactionInput` / `TransactionOutput` per transaction.
+
+See [Sighash & Wire Cache](../reference/sighash-cache.md) for the full invalidation contract, thread-safety notes, and the "build → sign/verify" idiom.
 
 ## Complete Example
 


### PR DESCRIPTION
Closes #894. Part of #880.

Branched from `fix/891-docs-sweep` (PR #897); will need a rebase onto master after PR #897 merges.

## Summary

Four existing SDK pages receive coverage sections for topics present in the code but missing from the docs.

| Page | Additions |
|---|---|
| `docs/sdk/primitives.md` | Schnorr ZKP (BRC-94), Key Shares (Shamir backup), secp256k1-native detection |
| `docs/sdk/transaction.md` | FeeModel/FeeModels, ChainTrackers, MerklePath expansion, sighash + wire cache awareness |
| `docs/sdk/script.md` | PushDropTemplate with cross-SDK byte-compat note |
| `docs/overlays/registries.md` | Registry::Client write paths with worked examples; fix misleading intro |

## IRB-transcript Verification

All examples were verified against the current SDK before writing.

### Schnorr ZKP

```
=== Schnorr ZKP (BRC-94) ===
  Proof class:   BSV::Primitives::Schnorr::Proof
  R compressed:  037d4dc438fa974e...
  z class:       OpenSSL::BN
  Valid:         true
  Tampered (should be false): false
  OK: Schnorr ZKP examples verified
```

### KeyShares (Shamir backup)

```
=== KeyShares (Shamir backup) ===
  Original key: 2e8860890d1d6133...
  Threshold:    2
  Share count:  3
  Integrity:    7a58deb5
  Backup format (first share): 7RWwDrt2tyTF23UXEZfePpT6sSCA9WD...
  Parts in first share: 4
  Reconstructed: 2e8860890d1d6133...
  Match: true
  Integrity matches Hash160 prefix: true
  OK: KeyShares examples verified
```

### secp256k1-native detection

```
=== secp256k1-native detection ===
  BSV::Primitives::Secp256k1.native?: true
  Version: 0.17.0
  Returns Boolean: true
  OK: secp256k1 detection example verified
```

### FeeModels

```
=== FeeModels ===
  SatoshisPerKilobyte.new.value: 100
  SatoshisPerKilobyte.new(value: 100).value: 100
  Fee (100 sat/kB): 20
  LivePolicy.DEFAULT_CACHE_TTL: 300
  cache_ttl: 300
  fallback_rate: 50
  custom cache_ttl: 60
  OK: FeeModel examples verified
```

### ChainTracker

```
=== ChainTracker ===
  ChainTracker.default class: BSV::Transaction::ChainTracker
  WhatsOnChain tracker class: BSV::Transaction::ChainTrackers::WhatsOnChain
  WhatsOnChain < ChainTracker: true
  custom tracker valid_root: true
  custom tracker current_height: 800000
  OK: ChainTracker examples verified
```

### MerklePath

```
=== MerklePath (BRC-74) ===
  block_height: 800000
  path levels:  1
  Computed root hex: fb76b78e0fae95e9...
  Auto-detect root: fb76b78e0fae95e9...
  Round-trip block_height: 800000
  Round-trip root matches: true
  OK: MerklePath examples verified
```

### Sighash cache

```
=== Sighash + Wire Cache ===
  invalidate_caches returns self: true
  One-owner raised ArgumentError: TransactionInput bbbbbbbbbbbbbbbbbbbb...
  OK: Sighash cache examples verified
```

## Judgement calls

- **Misleading intro in `registries.md`:** Line 22–23 stated write paths "live in `bsv-wallet`" — incorrect; `Registry::Client` is in `bsv-sdk`. Fixed as part of expanding the write-paths section.
- **`secp256k1.native?` via `BSV::Primitives::Secp256k1`:** Docs use the SDK namespace alias (`BSV::Primitives::Secp256k1.native?`) rather than the bare `::Secp256k1.native?` — consistent with the SDK's public API surface.
- **PushDrop layout:** Verified the exact layout from `Script.pushdrop_lock` source rather than the docstring. The `lock_position: :before` layout is `P2PKH_lock + fields + drops`, not `fields + drops + lock`.
- **MerklePath wire-order note:** Added explicit note that hashes are stored in wire order (reversed from display), discovered when the first verification script failed with the wrong byte order.
- **ChainTracker no-caching one-liner:** Confirmed by reading `WhatsOnChain` — it dispatches directly to the network on every call, no memoisation.

## Checklist

- [x] Each topic has a dedicated section in the named page
- [x] All new examples verified via IRB transcript (above)
- [x] Schnorr first paragraph explicitly disambiguates from BIP-340
- [x] KeyShares first paragraph explicitly disambiguates from threshold/MuSig
- [x] `docs/sdk/transaction.md` cache subsection links to `docs/reference/sighash-cache.md` and explains owner constraint + `invalidate_caches`
- [x] `bundle exec rake docs:lint` green (47 files, all OK)
- [x] `bundle exec rake docs:proofread` green (HTML-Proofer finished successfully)
- [x] PR branched from `fix/891-docs-sweep`; rebase onto master needed after PR #897 merges

---

_Supersedes #899 (closed — wrong head ref). All commits + IRB-transcript Verification preserved from . QA verdict on #894 was already 'Ready to merge after #897 lands' — and #897 is now merged into the target base._