### PR TITLE
perf(primitives): #882 — reuse OpenSSL digest contexts (per-thread cached)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -96,6 +96,7 @@ Metrics/AbcSize:
     - 'bin/**/*'
     - 'gem/*/lib/**/*'
     - 'gem/*/spec/**/*'
+    - 'gem/*/bench/**/*'
     - 'rakelib/**/*'
     - 'spec/rake/**/*'
 
@@ -104,6 +105,7 @@ Metrics/MethodLength:
     - 'bin/**/*'
     - 'gem/*/lib/**/*'
     - 'gem/*/spec/**/*'
+    - 'gem/*/bench/**/*'
     - 'rakelib/**/*'
     - 'spec/rake/**/*'
 
@@ -112,6 +114,7 @@ Metrics/CyclomaticComplexity:
     - 'bin/**/*'
     - 'gem/*/lib/**/*'
     - 'gem/*/spec/**/*'
+    - 'gem/*/bench/**/*'
     - 'rakelib/**/*'
 
 Metrics/PerceivedComplexity:
@@ -119,6 +122,7 @@ Metrics/PerceivedComplexity:
     - 'bin/**/*'
     - 'gem/*/lib/**/*'
     - 'gem/*/spec/**/*'
+    - 'gem/*/bench/**/*'
     - 'rakelib/**/*'
 
 Metrics/ModuleLength:

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :development, :test do
   gem 'yard'
   gem 'yard-markdown'
 
+  gem 'benchmark-ips'
   gem 'prime'
   gem 'rack'
 end

--- a/gem/bsv-sdk/bench/sha256d_reuse.rb
+++ b/gem/bsv-sdk/bench/sha256d_reuse.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Micro-benchmark: BSV::Primitives::Digest.sha256d context reuse.
+#
+# Part of HLR #882 — Primitives::Digest: reuse OpenSSL contexts.
+# Run from the gem/bsv-sdk/ directory: ruby bench/sha256d_reuse.rb
+#
+# Measures cache-warm vs cache-cold sha256d per call.
+#
+# "Cache-cold" means Thread.current[:bsv_sdk_sha256_digest] is set to nil
+# immediately before the measured call, forcing OpenSSL::Digest::SHA256.new
+# (and the EVP_get_digestbyname namemap lookup) on each iteration.
+# "Cache-warm" is the normal production path — context already cached.
+#
+# Expected improvement: 1.4–2.0× per call.
+
+require 'bundler/setup'
+require 'benchmark/ips'
+require 'openssl'
+require 'securerandom'
+require_relative '../lib/bsv-sdk'
+
+input = SecureRandom.random_bytes(32)
+
+# Warm the cache once so the warm path doesn't measure first-call allocation.
+BSV::Primitives::Digest.sha256d(input)
+
+puts "Ruby #{RUBY_VERSION} | OpenSSL #{OpenSSL::VERSION} (#{OpenSSL::OPENSSL_VERSION})"
+puts 'Input: 32 random bytes | Comparing cache-cold vs cache-warm sha256d'
+puts
+
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report('sha256d cache-cold') do
+    # Force re-allocation on every call — simulates the pre-#882 behaviour.
+    Thread.current[:bsv_sdk_sha256_digest] = nil
+    BSV::Primitives::Digest.sha256d(input)
+  end
+
+  x.report('sha256d cache-warm') do
+    BSV::Primitives::Digest.sha256d(input)
+  end
+
+  x.compare!
+end

--- a/gem/bsv-sdk/bench/tx_verify_end_to_end.rb
+++ b/gem/bsv-sdk/bench/tx_verify_end_to_end.rb
@@ -60,8 +60,14 @@ BSV::Primitives::Digest.define_singleton_method(:sha256d) do |data|
   call_counter += 1
   original_sha256d.call(data)
 end
-10.times { |i| tx_probe.sighash(i, BSV::Transaction::Sighash::ALL_FORK_ID) }
-BSV::Primitives::Digest.define_singleton_method(:sha256d, original_sha256d)
+begin
+  10.times { |i| tx_probe.sighash(i, BSV::Transaction::Sighash::ALL_FORK_ID) }
+ensure
+  # Always restore — otherwise the counting singleton would linger and add
+  # per-call dispatch overhead to every subsequent benchmark iteration,
+  # skewing the cold/warm measurement.
+  BSV::Primitives::Digest.define_singleton_method(:sha256d, original_sha256d)
+end
 
 puts "Ruby #{RUBY_VERSION} | OpenSSL #{OpenSSL::VERSION} (#{OpenSSL::OPENSSL_VERSION})"
 puts 'Tx: 10 inputs × 10 outputs | sighash ALL|FORKID for all 10 inputs'
@@ -69,9 +75,11 @@ puts "sha256d call count per full sign round: #{call_counter} (expected 13 with 
 puts '(pre-#881 baseline was ~30; #882 reduces per-call cost of each)'
 puts
 
-# Build a fresh tx for benchmarking (cache starts empty each time we rebuild
-# for the cold path; the tx's own memoised component hashes are preserved
-# across iterations so only per-input preimage hashes recur per iteration).
+# Build a single tx once so we don't pay tx-construction cost per iteration.
+# Each iteration calls bench_tx.invalidate_caches below, so both cold and
+# warm branches consistently exercise all 13 sha256d calls per round; the
+# only variable between them is whether the per-thread OpenSSL::Digest
+# context is present.
 bench_tx = build_bench_tx
 
 # Warm the memoisation cache and the digest context cache.

--- a/gem/bsv-sdk/bench/tx_verify_end_to_end.rb
+++ b/gem/bsv-sdk/bench/tx_verify_end_to_end.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+# End-to-end benchmark: combined #881 (sighash cache) + #882 (digest context
+# reuse) speedup on a realistic Tx#sighash hot path.
+#
+# Part of HLR #882 — Primitives::Digest: reuse OpenSSL contexts.
+# See also: HLR #881 — Tx#sighash BIP-143 component memoisation.
+# Run from the gem/bsv-sdk/ directory: ruby bench/tx_verify_end_to_end.rb
+#
+# Measures 10-input × 10-output Tx#sighash-for-all-inputs (the inner loop
+# of a sign/verify workflow).
+#
+# "Cache-cold" simulates the pre-#882 environment: the per-thread digest
+# context is cleared before every iteration, forcing EVP_get_digestbyname
+# on each OpenSSL::Digest allocation.
+# Thread.current[:bsv_sdk_sha256_digest] = nil is the exact cold-cache probe.
+#
+# sha256d call count (from #881 regression spec): 3 component hashes +
+# 10 per-input preimage hashes = 13 total across all 10 sighash calls.
+# Pre-#881 this was ~30 (hash_prevouts + hash_sequence + hash_outputs each
+# recomputed per input). The combined improvement is call-count × per-call.
+
+require 'bundler/setup'
+require 'benchmark/ips'
+require 'openssl'
+require_relative '../lib/bsv-sdk'
+
+BENCH_LOCK = BSV::Script::Script.from_asm(
+  "OP_DUP OP_HASH160 #{'ab' * 20} OP_EQUALVERIFY OP_CHECKSIG"
+)
+
+def build_bench_tx(n_inputs: 10, n_outputs: 10)
+  tx = BSV::Transaction::Tx.new
+
+  n_inputs.times do |i|
+    input = BSV::Transaction::TransactionInput.new(
+      prev_wtxid: ([i].pack('V') + ("\x00".b * 28)),
+      prev_tx_out_index: 0
+    )
+    input.source_satoshis = 1_000_000
+    input.source_locking_script = BENCH_LOCK
+    tx.add_input(input)
+  end
+
+  n_outputs.times do |i|
+    tx.add_output(BSV::Transaction::TransactionOutput.new(
+                    satoshis: 100_000 + i,
+                    locking_script: BENCH_LOCK
+                  ))
+  end
+
+  tx
+end
+
+# Count sha256d calls for one full sighash round to confirm #881 is in effect.
+tx_probe = build_bench_tx
+call_counter = 0
+original_sha256d = BSV::Primitives::Digest.method(:sha256d)
+BSV::Primitives::Digest.define_singleton_method(:sha256d) do |data|
+  call_counter += 1
+  original_sha256d.call(data)
+end
+10.times { |i| tx_probe.sighash(i, BSV::Transaction::Sighash::ALL_FORK_ID) }
+BSV::Primitives::Digest.define_singleton_method(:sha256d, original_sha256d)
+
+puts "Ruby #{RUBY_VERSION} | OpenSSL #{OpenSSL::VERSION} (#{OpenSSL::OPENSSL_VERSION})"
+puts 'Tx: 10 inputs × 10 outputs | sighash ALL|FORKID for all 10 inputs'
+puts "sha256d call count per full sign round: #{call_counter} (expected 13 with #881)"
+puts '(pre-#881 baseline was ~30; #882 reduces per-call cost of each)'
+puts
+
+# Build a fresh tx for benchmarking (cache starts empty each time we rebuild
+# for the cold path; the tx's own memoised component hashes are preserved
+# across iterations so only per-input preimage hashes recur per iteration).
+bench_tx = build_bench_tx
+
+# Warm the memoisation cache and the digest context cache.
+10.times { |i| bench_tx.sighash(i, BSV::Transaction::Sighash::ALL_FORK_ID) }
+bench_tx.invalidate_caches
+10.times { |i| bench_tx.sighash(i, BSV::Transaction::Sighash::ALL_FORK_ID) }
+
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report('sighash × 10 cache-cold digest') do
+    # Simulate pre-#882: clear cached digest context before each full round.
+    Thread.current[:bsv_sdk_sha256_digest] = nil
+    bench_tx.invalidate_caches
+    10.times { |i| bench_tx.sighash(i, BSV::Transaction::Sighash::ALL_FORK_ID) }
+  end
+
+  x.report('sighash × 10 cache-warm digest') do
+    # Normal production path: digest context already cached.
+    bench_tx.invalidate_caches
+    10.times { |i| bench_tx.sighash(i, BSV::Transaction::Sighash::ALL_FORK_ID) }
+  end
+
+  x.compare!
+end

--- a/gem/bsv-sdk/lib/bsv/primitives/digest.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/digest.rb
@@ -10,16 +10,19 @@ module BSV
     # the hash algorithms used throughout the BSV protocol: SHA-1, SHA-256,
     # double-SHA-256, SHA-512, RIPEMD-160, Hash160, HMAC, and PBKDF2.
     #
-    # @note **Per-thread cached OpenSSL contexts**
+    # @note **Per-fibre cached OpenSSL contexts (via +Thread.current+)**
     #
     #   +sha256+, +sha256d+, +sha1+, and +sha512+ each cache one
-    #   +OpenSSL::Digest+ instance per thread in +Thread.current+ under a
-    #   namespaced key (e.g. +:bsv_sdk_sha256_digest+).  On every call the
-    #   context is reset with +OpenSSL::Digest#reset+, which calls
-    #   +EVP_DigestInit_ex+ against the +EVP_MD*+ already stored on the
-    #   context.  This skips the +EVP_get_digestbyname+ namemap lookup that
+    #   +OpenSSL::Digest+ instance per fibre in +Thread.current+ under a
+    #   namespaced key (e.g. +:bsv_sdk_sha256_digest+).  Because MRI has no
+    #   fibres in this SDK's +lib/+ today, "per fibre" and "per thread" are
+    #   the same in practice — but the primitive is fibre-local, so the more
+    #   precise term is used throughout.  On every call the context is reset
+    #   with +OpenSSL::Digest#reset+, which calls +EVP_DigestInit_ex+ against
+    #   the +EVP_MD*+ already stored on the context.  This skips the
+    #   +EVP_get_digestbyname+ namemap lookup that
     #   +OpenSSL::Digest::SHA256.new+ (or +.digest+) performs on every fresh
-    #   allocation.  The namemap cost is paid exactly once per thread per
+    #   allocation.  The namemap cost is paid exactly once per fibre per
     #   algorithm.
     #
     #   **Fibre-local semantics.**  +Thread.current[:key]+ is *fibre-local*

--- a/gem/bsv-sdk/lib/bsv/primitives/digest.rb
+++ b/gem/bsv-sdk/lib/bsv/primitives/digest.rb
@@ -9,33 +9,108 @@ module BSV
     # Thin wrappers around +OpenSSL::Digest+ and +OpenSSL::HMAC+ providing
     # the hash algorithms used throughout the BSV protocol: SHA-1, SHA-256,
     # double-SHA-256, SHA-512, RIPEMD-160, Hash160, HMAC, and PBKDF2.
+    #
+    # @note **Per-thread cached OpenSSL contexts**
+    #
+    #   +sha256+, +sha256d+, +sha1+, and +sha512+ each cache one
+    #   +OpenSSL::Digest+ instance per thread in +Thread.current+ under a
+    #   namespaced key (e.g. +:bsv_sdk_sha256_digest+).  On every call the
+    #   context is reset with +OpenSSL::Digest#reset+, which calls
+    #   +EVP_DigestInit_ex+ against the +EVP_MD*+ already stored on the
+    #   context.  This skips the +EVP_get_digestbyname+ namemap lookup that
+    #   +OpenSSL::Digest::SHA256.new+ (or +.digest+) performs on every fresh
+    #   allocation.  The namemap cost is paid exactly once per thread per
+    #   algorithm.
+    #
+    #   **Fibre-local semantics.**  +Thread.current[:key]+ is *fibre-local*
+    #   in MRI (documented since Ruby 2.0, verified on 3.3 / 3.4 / 4.0) — each
+    #   Fibre gets its own cached context.  This is stronger than the SDK
+    #   currently requires (no Fibres in +lib/+) and is correctly safe if
+    #   Fibres are introduced later.  The HLR body's "GVL makes it safe"
+    #   rationale is subtly wrong; the correct reason is fibre-local scope.
+    #
+    #   **Do not touch the cached instances externally.**  The keys
+    #   +:bsv_sdk_sha256_digest+, +:bsv_sdk_sha1_digest+, and
+    #   +:bsv_sdk_sha512_digest+ are technically reachable via +Thread.current+
+    #   but must never have +update+ called on them outside this module.
+    #   Calling +update+ out-of-band would corrupt the next call's input.
+    #
+    #   **User-visible invariants are unchanged:** return values are always
+    #   +ASCII-8BIT+ binary strings; identical inputs always produce identical
+    #   outputs; successive calls return distinct +String+ objects (output
+    #   buffers are never cached).
+    #
+    #   **Prefix convention.**  +:bsv_sdk_<algo>_digest+ is the SDK-wide
+    #   naming convention for any future +Thread.current+ usage in this
+    #   codebase — the prefix avoids collision with other libraries that may
+    #   also use +Thread.current+.
+    #
+    #   **FIPS.**  SHA-1, SHA-256, and SHA-512 remain FIPS-approved algorithms
+    #   under this pattern; the algorithm fetch happens once at +.new+, not per
+    #   call.
+    #
+    #   **CI matrix.**  Verified on MRI 3.3, 3.4, and 4.0.  JRuby and
+    #   TruffleRuby are not in the CI matrix — per-thread caching is correct on
+    #   true-parallel Rubies (each thread has independent +Thread.current+) but
+    #   unverified here.
+    #
+    #   **Why other SDKs do not do this.**  The TypeScript, Go, and Python SDKs
+    #   allocate fresh digest contexts per call because their OpenSSL bindings
+    #   cache the algorithm handle internally.  MRI's +openssl+ gem bridges
+    #   through +EVP_get_digestbyname+ on every allocation — we are patching
+    #   the Ruby binding overhead, not diverging from BSV protocol semantics.
+    #
+    #   **Out of scope with rationale:**
+    #   - +ripemd160+ — pure-Ruby implementation; no OpenSSL context.
+    #   - +hmac_sha256+ / +hmac_sha512+ — HMAC key changes per call.  A future
+    #     cache *must* key on wrapper-object identity (+object_id+), never on
+    #     key bytes — a key-bytes cache lookup would create a secret-dependent
+    #     side-channel via cache-hit timing.
+    #   - +pbkdf2_hmac_sha512+ — one-shot at BIP-39 seed derivation; not a
+    #     hot path.
     module Digest
       module_function
 
       # Compute SHA-1 digest.
       #
       # @param data [String] binary data to hash
-      # @return [String] 20-byte digest
+      # @return [String] 20-byte digest (ASCII-8BIT)
       def sha1(data)
-        OpenSSL::Digest::SHA1.digest(data)
+        d = Thread.current[:bsv_sdk_sha1_digest] ||= OpenSSL::Digest.new('SHA1')
+        d.reset
+        d.update(data)
+        d.digest
       end
 
       # Compute SHA-256 digest.
       #
       # @param data [String] binary data to hash
-      # @return [String] 32-byte digest
+      # @return [String] 32-byte digest (ASCII-8BIT)
       def sha256(data)
-        OpenSSL::Digest::SHA256.digest(data)
+        d = Thread.current[:bsv_sdk_sha256_digest] ||= OpenSSL::Digest.new('SHA256')
+        d.reset
+        d.update(data)
+        d.digest
       end
 
       # Compute double-SHA-256 (SHA-256d) digest.
       #
       # Used extensively in Bitcoin for transaction and block hashing.
+      # Inlines the two-round chain against the same cached SHA-256 context,
+      # saving one context allocation, one namemap lookup, one intermediate
+      # +String+, and one +module_function+ dispatch per call compared with
+      # the naive +sha256(sha256(data))+ decomposition.
       #
       # @param data [String] binary data to hash
-      # @return [String] 32-byte digest
+      # @return [String] 32-byte digest (ASCII-8BIT)
       def sha256d(data)
-        sha256(sha256(data))
+        d = Thread.current[:bsv_sdk_sha256_digest] ||= OpenSSL::Digest.new('SHA256')
+        d.reset
+        d.update(data)
+        first = d.digest
+        d.reset # defensive: some Ruby versions internally reset after #digest
+        d.update(first)
+        d.digest
       end
 
       alias hash256 sha256d
@@ -44,15 +119,23 @@ module BSV
       # Compute SHA-512 digest.
       #
       # @param data [String] binary data to hash
-      # @return [String] 64-byte digest
+      # @return [String] 64-byte digest (ASCII-8BIT)
       def sha512(data)
-        OpenSSL::Digest::SHA512.digest(data)
+        d = Thread.current[:bsv_sdk_sha512_digest] ||= OpenSSL::Digest.new('SHA512')
+        d.reset
+        d.update(data)
+        d.digest
       end
 
       # Compute RIPEMD-160 digest.
       #
+      # @note Uses the pure-Ruby {BSV::Primitives::Ripemd160} implementation —
+      #   no OpenSSL context is held or cached here.  RIPEMD-160 is not in
+      #   scope for the per-thread caching optimisation (different optimisation
+      #   track; not currently a hot path).
+      #
       # @param data [String] binary data to hash
-      # @return [String] 20-byte digest
+      # @return [String] 20-byte digest (ASCII-8BIT)
       def ripemd160(data)
         Ripemd160.digest(data)
       end
@@ -62,25 +145,32 @@ module BSV
       # Standard Bitcoin hash used for addresses and P2PKH script matching.
       #
       # @param data [String] binary data to hash
-      # @return [String] 20-byte digest
+      # @return [String] 20-byte digest (ASCII-8BIT)
       def hash160(data)
         ripemd160(sha256(data))
       end
 
       # Compute HMAC-SHA-256.
       #
+      # @note HMAC context reuse is deferred — the key changes per call, so a
+      #   future cache must key on wrapper-object identity (+object_id+), never
+      #   on key bytes, to avoid a secret-dependent side-channel via cache-hit
+      #   timing.
+      #
       # @param key [String] HMAC key
       # @param data [String] data to authenticate
-      # @return [String] 32-byte MAC
+      # @return [String] 32-byte MAC (ASCII-8BIT)
       def hmac_sha256(key, data)
         OpenSSL::HMAC.digest('SHA256', key, data)
       end
 
       # Compute HMAC-SHA-512.
       #
+      # @note HMAC context reuse is deferred — see +hmac_sha256+ note.
+      #
       # @param key [String] HMAC key
       # @param data [String] data to authenticate
-      # @return [String] 64-byte MAC
+      # @return [String] 64-byte MAC (ASCII-8BIT)
       def hmac_sha512(key, data)
         OpenSSL::HMAC.digest('SHA512', key, data)
       end
@@ -88,12 +178,13 @@ module BSV
       # Derive a key using PBKDF2-HMAC-SHA-512.
       #
       # Used by BIP-39 to convert mnemonic phrases into seeds.
+      # One-shot at key creation — not a hot path; no context reuse applied.
       #
       # @param password [String] the password (mnemonic phrase)
       # @param salt [String] the salt (+"mnemonic"+ + passphrase)
       # @param iterations [Integer] iteration count (default: 2048 per BIP-39)
       # @param key_length [Integer] desired output length in bytes (default: 64)
-      # @return [String] derived key bytes
+      # @return [String] derived key bytes (ASCII-8BIT)
       def pbkdf2_hmac_sha512(password, salt, iterations: 2048, key_length: 64)
         OpenSSL::PKCS5.pbkdf2_hmac(password, salt, iterations, key_length, 'sha512')
       end

--- a/gem/bsv-sdk/lib/bsv/storage/downloader.rb
+++ b/gem/bsv-sdk/lib/bsv/storage/downloader.rb
@@ -145,7 +145,7 @@ module BSV
         body = response.body.to_s
         return nil if body.empty?
 
-        actual_hash = OpenSSL::Digest::SHA256.digest(body)
+        actual_hash = BSV::Primitives::Digest.sha256(body)
         return nil unless actual_hash == expected_hash
 
         DownloadResult.new(data: body, mime_type: response['Content-Type'])

--- a/gem/bsv-sdk/lib/bsv/storage/utils.rb
+++ b/gem/bsv-sdk/lib/bsv/storage/utils.rb
@@ -38,7 +38,7 @@ module BSV
       # @param data [String] binary file content
       # @return [String] Base58Check-encoded UHRP URL
       def get_url_for_file(data)
-        hash = OpenSSL::Digest::SHA256.digest(data.b)
+        hash = BSV::Primitives::Digest.sha256(data.b)
         get_url_for_hash(hash)
       end
 

--- a/gem/bsv-sdk/spec/bsv/primitives/digest_pattern_regression_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/primitives/digest_pattern_regression_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Regression guard for HLR #882 — digest context reuse.
+#
+# All direct OpenSSL::Digest:: calls in lib/ must live inside
+# lib/bsv/primitives/digest.rb.  Any call outside that file bypasses the
+# per-thread cache and reintroduces the EVP_get_digestbyname namemap cost
+# that #882 eliminates.
+#
+# This spec fails if a future contributor adds a direct OpenSSL::Digest::
+# instantiation anywhere else in the lib/ tree.  It runs on every `bundle
+# exec rake` invocation (fast — pure grep, no digest computation).
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'OpenSSL::Digest:: bypass regression guard' do
+  it 'has no direct OpenSSL::Digest:: calls in lib/ outside primitives/digest.rb' do
+    lib_root = File.expand_path('../../../../../../lib', __dir__)
+    digest_rb = File.join(lib_root, 'bsv', 'primitives', 'digest.rb')
+
+    offenders = []
+
+    Dir.glob("#{lib_root}/**/*.rb").each do |path|
+      next if File.realpath(path) == File.realpath(digest_rb)
+
+      File.foreach(path).with_index(1) do |line, lineno|
+        offenders << "#{path}:#{lineno}: #{line.chomp}" if line.include?('OpenSSL::Digest::')
+      end
+    end
+
+    expect(offenders).to be_empty,
+                         'Found direct OpenSSL::Digest:: calls outside primitives/digest.rb — ' \
+                         "route through BSV::Primitives::Digest instead:\n#{offenders.join("\n")}"
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/gem/bsv-sdk/spec/bsv/primitives/digest_pattern_regression_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/primitives/digest_pattern_regression_spec.rb
@@ -16,7 +16,8 @@ require 'spec_helper'
 # rubocop:disable RSpec/DescribeClass
 RSpec.describe 'OpenSSL::Digest:: bypass regression guard' do
   it 'has no direct OpenSSL::Digest:: calls in lib/ outside primitives/digest.rb' do
-    lib_root = File.expand_path('../../../../../../lib', __dir__)
+    # spec/bsv/primitives → up 3 levels lands in gem/bsv-sdk, then /lib.
+    lib_root = File.expand_path('../../../lib', __dir__)
     digest_rb = File.join(lib_root, 'bsv', 'primitives', 'digest.rb')
 
     offenders = []

--- a/gem/bsv-sdk/spec/bsv/primitives/digest_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/primitives/digest_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe BSV::Primitives::Digest do
     it 'returns ASCII-8BIT encoded binary' do
       expect(described_class.sha256('test').encoding).to eq(Encoding::ASCII_8BIT)
     end
+
+    it 'returns a new String object on every call (output buffers are not cached)' do
+      x = 'test'
+      expect(described_class.sha256(x).equal?(described_class.sha256(x))).to be(false)
+    end
   end
 
   describe '.sha256d' do
@@ -19,6 +24,40 @@ RSpec.describe BSV::Primitives::Digest do
       result = described_class.sha256d('abc')
       single = described_class.sha256('abc')
       expect(result).to eq(described_class.sha256(single))
+    end
+
+    it 'returns ASCII-8BIT encoded binary' do
+      expect(described_class.sha256d('test').encoding).to eq(Encoding::ASCII_8BIT)
+    end
+
+    # Property test — catches silent second-reset omission in the inlined chain.
+    #
+    # Each input is hashed via the module (which uses the cached context path),
+    # then verified against a *freshly-allocated* OpenSSL::Digest::SHA256
+    # (which bypasses the cache entirely).  The lengths span SHA-256 block
+    # boundaries: 0, 1, 55, 56, 63, 64, 65, 1024, and 1_000_000 bytes.
+    it 'produces bit-identical output to a freshly-allocated double-SHA-256 for 100 random inputs' do
+      lengths = [0, 1, 55, 56, 63, 64, 65, 1024, 1_000_000]
+      rng = Random.new(0x42)
+
+      lengths.each do |len|
+        10.times do
+          input = rng.bytes(len)
+
+          # Fresh-allocation reference path — bypasses the module's cached context.
+          fresh = OpenSSL::Digest.new('SHA256')
+          fresh.update(input)
+          round1 = fresh.digest
+          fresh.reset
+          fresh.update(round1)
+          expected = fresh.digest
+
+          cached = described_class.sha256d(input)
+
+          expect(cached).to eq(expected),
+                            "sha256d mismatch for #{len}-byte input (first 8 bytes: #{input.bytes.first(8).inspect})"
+        end
+      end
     end
   end
 
@@ -40,6 +79,10 @@ RSpec.describe BSV::Primitives::Digest do
       expected = 'ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a' \
                  '2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f'
       expect(result.unpack1('H*')).to eq(expected)
+    end
+
+    it 'returns ASCII-8BIT encoded binary' do
+      expect(described_class.sha512('test').encoding).to eq(Encoding::ASCII_8BIT)
     end
   end
 

--- a/gem/bsv-sdk/spec/bsv/primitives/digest_thread_safety_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/primitives/digest_thread_safety_spec.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Thread-safety regression harness for HLR #882 — OpenSSL digest context reuse.
+#
+# BSV::Primitives::Digest caches one OpenSSL::Digest instance per algorithm
+# per fibre in Thread.current (fibre-local in MRI).  This spec verifies that
+# context reuse does not corrupt output across threads or fibres.
+#
+# Bit-equivalence (correct output values) is the responsibility of
+# digest_spec.rb and digest_vectors_spec.rb — those specs remain the
+# authoritative gate for correctness.  This spec asserts specifically that
+# the caching pattern does not introduce cross-thread or cross-fibre state
+# contamination.
+#
+# Design notes:
+# - No sleep, Thread.pass, or timing assertions — results collected via
+#   Queue (thread-safe) and compared against pre-computed vectors.
+# - All scenarios are fully deterministic.
+
+# Pre-computed reference vectors for thread-safety cross-checking.
+# Defined outside the describe block to avoid RSpec/LeakyConstantDeclaration.
+DIGEST_TS_VECTORS = {
+  sha256_abc: BSV::Primitives::Digest.sha256('abc').freeze,
+  sha256d_abc: BSV::Primitives::Digest.sha256d('abc').freeze,
+  sha1_abc: BSV::Primitives::Digest.sha1('abc').freeze,
+  sha512_abc: BSV::Primitives::Digest.sha512('abc').freeze,
+  sha256_xy: BSV::Primitives::Digest.sha256('xy').freeze,
+  sha256d_xy: BSV::Primitives::Digest.sha256d('xy').freeze,
+  sha1_xy: BSV::Primitives::Digest.sha1('xy').freeze,
+  sha512_xy: BSV::Primitives::Digest.sha512('xy').freeze
+}.freeze
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'BSV::Primitives::Digest thread safety' do
+  subject(:digest) { BSV::Primitives::Digest }
+
+  # ---------------------------------------------------------------------------
+  # Scenario 1 — cross-thread state-leak
+  #
+  # 16 threads × 1000 iterations.  Each thread mixes all four algorithms per
+  # iteration (not one-algo-per-thread) — exercises cross-algorithm collision
+  # within a thread's cache.  All results are compared to pre-computed vectors.
+  # ---------------------------------------------------------------------------
+  describe 'cross-thread state-leak (Scenario 1)' do
+    it 'produces correct output across 16 threads × 1000 iterations of mixed algorithms' do
+      errors = Queue.new
+
+      threads = 16.times.map do
+        Thread.new do
+          1000.times do
+            errors << [:sha256, digest.sha256('abc'), DIGEST_TS_VECTORS[:sha256_abc]] unless digest.sha256('abc') == DIGEST_TS_VECTORS[:sha256_abc]
+            unless digest.sha256d('abc') == DIGEST_TS_VECTORS[:sha256d_abc]
+              errors << [:sha256d, digest.sha256d('abc'), DIGEST_TS_VECTORS[:sha256d_abc]]
+            end
+            errors << [:sha1, digest.sha1('abc'), DIGEST_TS_VECTORS[:sha1_abc]] unless digest.sha1('abc') == DIGEST_TS_VECTORS[:sha1_abc]
+            errors << [:sha512, digest.sha512('abc'), DIGEST_TS_VECTORS[:sha512_abc]] unless digest.sha512('abc') == DIGEST_TS_VECTORS[:sha512_abc]
+          end
+        end
+      end
+
+      threads.each(&:join)
+
+      collected = []
+      collected << errors.pop until errors.empty?
+
+      expect(collected).to be_empty,
+                           "Cross-thread state contamination detected in #{collected.size} call(s): " \
+                           "#{collected.first(3).map do |algo, got, exp|
+                             "#{algo}: got #{got.unpack1('H*')[0, 8]}… expected #{exp.unpack1('H*')[0, 8]}…"
+                           end.join('; ')}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Scenario 2 — same-thread post-exception
+  #
+  # Mock OpenSSL::Digest#update to raise on a specific call; verify that the
+  # next call on the same thread produces the correct vector.  Proves the
+  # leading reset cleanses any dirty state left by the exception.
+  # ---------------------------------------------------------------------------
+  describe 'same-thread post-exception (Scenario 2)' do
+    it 'produces correct output on the call immediately following an exception' do
+      call_count = 0
+      raise_on = 3
+      original_update = OpenSSL::Digest.instance_method(:update)
+
+      patched = Module.new do
+        define_method(:update) do |data|
+          call_count += 1
+          raise 'injected failure' if call_count == raise_on
+
+          original_update.bind(self).call(data)
+        end
+      end
+
+      OpenSSL::Digest.prepend(patched)
+
+      begin
+        (raise_on + 2).times do |i|
+          begin
+            digest.sha256('abc')
+          rescue RuntimeError
+            # expected on call raise_on — swallow and continue
+          end
+
+          next unless i >= raise_on
+
+          # First call after the injected failure must produce the correct vector.
+          result = digest.sha256('abc')
+          expect(result).to eq(DIGEST_TS_VECTORS[:sha256_abc]),
+                            "Post-exception sha256 mismatch on iteration #{i}: " \
+                            "got #{result.unpack1('H*')}"
+        end
+      ensure
+        # Clear the cached context so subsequent specs start fresh.
+        # Ruby does not expose Module#unprepend, so resetting the cached
+        # instance is the safest mitigation.
+        Thread.current[:bsv_sdk_sha256_digest] = nil
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Scenario 3 — interleaved large/small in same thread
+  #
+  # Alternate 1-byte and 1 MiB inputs 1000 times.  Catches large-payload state
+  # leakage where a long message leaves residual compression state that then
+  # corrupts a subsequent short message.
+  # ---------------------------------------------------------------------------
+  describe 'interleaved large/small inputs in same thread (Scenario 3)' do
+    it 'produces correct output when alternating 1-byte and 1-MiB inputs 1000×' do
+      large_input = 'a' * 1_048_576
+      small_input = 'x'
+
+      large_expected = digest.sha256(large_input)
+      small_expected = digest.sha256(small_input)
+
+      1000.times do |i|
+        if i.even?
+          result = digest.sha256(large_input)
+          expect(result).to eq(large_expected), "Large-input mismatch on iteration #{i}"
+        else
+          result = digest.sha256(small_input)
+          expect(result).to eq(small_expected), "Small-input mismatch on iteration #{i}"
+        end
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Scenario 4 — Fibre-yield paranoia
+  #
+  # Two Fibres on one thread, each computing sha256d and yielding between calls
+  # (not mid-hash — that is not a valid interruption point).  Both fibres must
+  # produce correct vectors.
+  #
+  # Documents that Thread.current[:key] is *fibre-local* in MRI: each Fibre
+  # has its own cached context, so interleaved Fibre execution cannot
+  # contaminate another Fibre's context.
+  # ---------------------------------------------------------------------------
+  describe 'Fibre-yield paranoia (Scenario 4)' do
+    it 'produces correct output from two interleaved Fibres yielding between sha256d calls' do
+      results_a = []
+      results_b = []
+
+      fibre_a = Fiber.new do
+        100.times do
+          results_a << digest.sha256d('abc')
+          Fiber.yield
+        end
+      end
+
+      fibre_b = Fiber.new do
+        100.times do
+          results_b << digest.sha256d('xy')
+          Fiber.yield
+        end
+      end
+
+      # Interleave: a, b, a, b, …
+      200.times { |i| i.even? ? fibre_a.resume : fibre_b.resume }
+
+      expect(results_a.length).to eq(100)
+      expect(results_b.length).to eq(100)
+
+      expect(results_a).to all(eq(DIGEST_TS_VECTORS[:sha256d_abc])),
+                           'Fibre A produced incorrect sha256d output'
+      expect(results_b).to all(eq(DIGEST_TS_VECTORS[:sha256d_xy])),
+                           'Fibre B produced incorrect sha256d output'
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Thread-identity assertion
+  #
+  # Each thread's :bsv_sdk_sha256_digest object_id must be distinct from every
+  # other thread's — confirms the cache is per-thread, not a shared singleton.
+  # ---------------------------------------------------------------------------
+  describe 'thread-identity assertion' do
+    it 'allocates a distinct cached context object in each of 16 threads' do
+      identity_queue = Queue.new
+
+      threads = 16.times.map do
+        Thread.new do
+          # Warm the cache for this thread.
+          digest.sha256('warmup')
+          identity_queue << Thread.current[:bsv_sdk_sha256_digest].object_id
+        end
+      end
+
+      threads.each(&:join)
+
+      ids = []
+      ids << identity_queue.pop until identity_queue.empty?
+
+      expect(ids.length).to eq(16)
+      expect(ids.uniq.length).to eq(16),
+                                 'Duplicate object_id found — threads are sharing a cached context'
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/gem/bsv-sdk/spec/bsv/primitives/digest_thread_safety_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/primitives/digest_thread_safety_spec.rb
@@ -84,18 +84,22 @@ RSpec.describe 'BSV::Primitives::Digest thread safety' do
     it 'produces correct output on the call immediately following an exception' do
       call_count = 0
       raise_on = 3
-      original_update = OpenSSL::Digest.instance_method(:update)
 
-      patched = Module.new do
-        define_method(:update) do |data|
-          call_count += 1
-          raise 'injected failure' if call_count == raise_on
+      # Prime the cache with a fresh instance we can attach a singleton method
+      # to.  Patching this specific instance (via define_singleton_method)
+      # scopes the injected failure to just this cached context — no global
+      # OpenSSL::Digest class-wide mutation, no residue for later specs.
+      Thread.current[:bsv_sdk_sha256_digest] = nil
+      digest.sha256('warmup')
+      cached = Thread.current[:bsv_sdk_sha256_digest]
+      original_update = cached.method(:update)
 
-          original_update.bind(self).call(data)
-        end
+      cached.define_singleton_method(:update) do |data|
+        call_count += 1
+        raise 'injected failure' if call_count == raise_on
+
+        original_update.call(data)
       end
-
-      OpenSSL::Digest.prepend(patched)
 
       begin
         (raise_on + 2).times do |i|
@@ -114,9 +118,8 @@ RSpec.describe 'BSV::Primitives::Digest thread safety' do
                             "got #{result.unpack1('H*')}"
         end
       ensure
-        # Clear the cached context so subsequent specs start fresh.
-        # Ruby does not expose Module#unprepend, so resetting the cached
-        # instance is the safest mitigation.
+        # Drop the singleton-patched instance so subsequent specs get a fresh,
+        # unpatched OpenSSL::Digest on the next digest call.
         Thread.current[:bsv_sdk_sha256_digest] = nil
       end
     end

--- a/gem/bsv-sdk/spec/bsv/primitives/digest_thread_safety_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/primitives/digest_thread_safety_spec.rb
@@ -50,12 +50,21 @@ RSpec.describe 'BSV::Primitives::Digest thread safety' do
       threads = 16.times.map do
         Thread.new do
           1000.times do
-            errors << [:sha256, digest.sha256('abc'), DIGEST_TS_VECTORS[:sha256_abc]] unless digest.sha256('abc') == DIGEST_TS_VECTORS[:sha256_abc]
-            unless digest.sha256d('abc') == DIGEST_TS_VECTORS[:sha256d_abc]
-              errors << [:sha256d, digest.sha256d('abc'), DIGEST_TS_VECTORS[:sha256d_abc]]
-            end
-            errors << [:sha1, digest.sha1('abc'), DIGEST_TS_VECTORS[:sha1_abc]] unless digest.sha1('abc') == DIGEST_TS_VECTORS[:sha1_abc]
-            errors << [:sha512, digest.sha512('abc'), DIGEST_TS_VECTORS[:sha512_abc]] unless digest.sha512('abc') == DIGEST_TS_VECTORS[:sha512_abc]
+            # Capture each digest result once — if the check fails we want the
+            # recorded `got` payload to be *exactly* the value that failed,
+            # not a recomputed value that may differ under transient
+            # contamination.
+            r256 = digest.sha256('abc')
+            errors << [:sha256, r256, DIGEST_TS_VECTORS[:sha256_abc]] unless r256 == DIGEST_TS_VECTORS[:sha256_abc]
+
+            r256d = digest.sha256d('abc')
+            errors << [:sha256d, r256d, DIGEST_TS_VECTORS[:sha256d_abc]] unless r256d == DIGEST_TS_VECTORS[:sha256d_abc]
+
+            r1 = digest.sha1('abc')
+            errors << [:sha1, r1, DIGEST_TS_VECTORS[:sha1_abc]] unless r1 == DIGEST_TS_VECTORS[:sha1_abc]
+
+            r512 = digest.sha512('abc')
+            errors << [:sha512, r512, DIGEST_TS_VECTORS[:sha512_abc]] unless r512 == DIGEST_TS_VECTORS[:sha512_abc]
           end
         end
       end

--- a/gem/bsv-sdk/spec/bsv/primitives/digest_vectors_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/primitives/digest_vectors_spec.rb
@@ -58,6 +58,20 @@ RSpec.describe BSV::Primitives::Digest do
   end
 
   # ---------------------------------------------------------------------------
+  # SHA-256 long-message vector — NIST FIPS 180-4 §B.3
+  # 1 000 000 repetitions of 'a' (spans thousands of compression rounds).
+  # Verifies that context reuse does not corrupt midstream state across block
+  # boundaries.
+  # ---------------------------------------------------------------------------
+  describe '.sha256 (NIST 1M-"a" long-message vector)', :slow do
+    it 'computes the correct hash for 1 000 000 "a" characters' do
+      # NIST FIPS 180-4, Appendix B.3
+      result = described_class.sha256('a' * 1_000_000)
+      expect(result.unpack1('H*')).to eq('cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # SHA-1 — NIST FIPS 180-4
   # ---------------------------------------------------------------------------
   describe '.sha1 (NIST vectors)' do


### PR DESCRIPTION
## Summary

Reuse a per-thread `OpenSSL::Digest` instance in `BSV::Primitives::Digest` for `sha256`, `sha256d`, `sha1`, and `sha512`. The cached context is `reset` between calls, skipping the `EVP_get_digestbyname` namemap lookup that `OpenSSL::Digest::SHA256.digest(data)` performs on every fresh allocation. `sha256d` is inlined — one cached SHA-256 context, two `reset+update+digest` cycles.

Two `OpenSSL::Digest::SHA256.digest(...)` bypass sites in `lib/bsv/storage/` (`utils.rb:41`, `downloader.rb:148`) now route through `Primitives::Digest.sha256`. A grep-based regression spec ensures the un-cached pattern cannot silently reappear anywhere in `lib/` outside `digest.rb`.

Follow-on to #881 (sighash-cache, `de751aab`). Complements it: #881 reduces `sha256d` *call count* per `Tx#verify` (~30 → ~13 for 10-in × 10-out); #882 reduces the *per-call cost*. Both target the bsv-wallet stress workload profile.

## Design context

`Thread.current[:key]` is **fibre-local** in MRI (documented since Ruby 2.0, verified 3.3 / 3.4 / 4.0), not thread-local. The HLR body originally credited the GVL for safety — the synthesised specialist review corrected this: it's the fibre-local scope that provides the guarantee (each fibre gets its own cached context; no shared mutable state between fibres or threads). The module YARD explains this correctly.

Three tasks, three commits — one per sub-issue:

- `17907616` — `perf(primitives): #882 — reuse OpenSSL digest contexts (Closes #905)`
- `24d19a0d` — `perf(primitives): #882 — thread-safety spec + YARD (Closes #906)`
- `bd7cce43` — `chore(bench): #882 — digest reuse benchmark artefacts (Closes #907)`

## Benchmark numbers

Ruby 3.4.2 + PRISM, OpenSSL 3.3.0 / OpenSSL 3.6.1, arm64-darwin24:

| Bench | Cache-warm | Cache-cold | Ratio |
|---|---|---|---|
| `sha256d(32B)` | 1,008,032 i/s | 728,857 i/s | **1.38×** per call |
| Tx 10×10 sighash × 10 | ~13 `sha256d` calls / round | (30 pre-#881) | 2.3× call count via #881 |
| Tx 10×10 sighash × 10 | 29,822 i/s | 29,298 i/s | 1.02× wall-clock |

The 1.38× per-call speedup is real (within measurement noise of the 1.4× target). At whole-`Tx#verify` granularity the ECDSA signature evaluation dominates — digest work is a small fraction of total wall-clock — so the multiplicative combined #881×#882 story is honest: **2.3× fewer digest calls, 1.38× cheaper each**, but only ~1.02× at Tx-level because the hot path is not digest-bound end-to-end. This is a useful finding: further gains want to target ECDSA next, not digests.

## Security review

White-hat cleared for merge — no Critical or High findings. Five informational notes:

- `digest.rb:111` — defensive `reset` before second `update` in inlined `sha256d` verified redundant on tested OpenSSL versions but harmless.
- Fibre-local semantics verified adversarially (`Thread.current[:key]` set inside one Fibre is not visible from another Fibre on the same thread on MRI 3.4).
- `Thread.current[:bsv_sdk_sha256_digest]` is technically reachable; leading `reset` in every call fully cleanses any adversarial `.update(garbage)` prefix.
- Regression grep guard scoped to `lib/` correctly; test-side computations in `spec/`, `bin/`, `bench/` are intentional and allowed.
- `bsv-attest` / `bsv-wallet` route all digest usage through `Primitives::Digest` — no bypass sites to fix downstream.

## Test plan

- [x] `bundle exec rake spec:sdk` — 6441 examples, 0 failures, 149 pending (all 149 are pre-existing secp256k1 native-extension specs — unrelated).
- [x] `spec/conformance/` (SIGHASH FORKID vectors) and `spec/interpreter/` (script verify) pass unchanged — system-level bit-equivalence at wire boundary.
- [x] `spec/bsv/primitives/digest_thread_safety_spec.rb` — 5 examples, 0 failures (cross-thread, post-exception, interleaved large/small, Fibre-yield, thread-identity assertion). No `sleep`, no `Thread.pass`, no timing assertions.
- [x] `spec/bsv/primitives/digest_pattern_regression_spec.rb` — asserts zero `OpenSSL::Digest::` matches in `lib/` outside `digest.rb`.
- [x] Property test in `digest_spec.rb` — 90 vectors (9 block boundaries × 10 random inputs) compared against freshly-allocated `OpenSSL::Digest.new('SHA256')` reference — catches silent second-`reset` omission.
- [x] NIST 1M-`a` long-message vector added to `digest_vectors_spec.rb`.
- [x] `bundle exec rubocop` — 9 touched files, 0 offences.
- [x] `bundle exec yard doc gem/bsv-sdk/lib/bsv/primitives/digest.rb` — generates cleanly.

## Related

- Closes #882
- Closes #905
- Closes #906
- Closes #907
- Follow-on to #881 (sighash-cache, `de751aab`)
- HLR comment (synthesised breakdown post specialist review): #882 issuecomment-4849643784
