### PR TITLE
feat(transaction): #904 — Tx#verify(verified:) bidirectional Hash kwarg

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Full documentation is available at **[sgbett.github.io/bsv-ruby-sdk](https://sgb
 
 - [API Reference](https://sgbett.github.io/bsv-ruby-sdk/reference/api/) — auto-generated from YARD annotations
 - [Sighash & Wire Cache](https://sgbett.github.io/bsv-ruby-sdk/reference/sighash-cache/) — Russian-doll memo cache, invalidation contract, escape hatch
+- [Verify Cache Seed](https://sgbett.github.io/bsv-ruby-sdk/reference/verify-kwarg/) — verified: kwarg, walk order, format contract, caller responsibilities
 - [spec/ directory](https://github.com/sgbett/bsv-ruby-sdk/tree/master/spec) — runnable usage examples
 - Changelogs: [sdk](gem/bsv-sdk/CHANGELOG.md) · [attest](gem/bsv-attest/CHANGELOG.md)
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -13,5 +13,6 @@ Canonical reference documents and auto-generated API documentation.
 - [Conformance Vectors](conformance-vectors.md) — cross-SDK test vector validation
 - [Wycheproof Malleability Analysis](wycheproof-malleability-analysis.md) — ECDSA vector analysis
 - [Sighash & Wire Cache](sighash-cache.md) — Russian-doll memo cache, invalidation contract, escape hatch
+- [Verify Cache Seed](verify-kwarg.md) — verified: kwarg, walk order, format contract, caller responsibilities
 - [MCP Server](mcp.md) — built-in Model Context Protocol server for AI assistants
 - [API Reference](api/) — auto-generated from YARD annotations

--- a/docs/reference/verify-kwarg.md
+++ b/docs/reference/verify-kwarg.md
@@ -34,13 +34,15 @@ The walk processes each queued transaction in this strict order:
 
 | Step | Action | Bypassed by seed? |
 |------|--------|-------------------|
-| 1 | Skip if already `visited` (in-call dedup) | n/a |
+| 1 | Skip if already `visited` (in-call dedup) | n/a — precedes seed check |
 | 2 | If `merkle_path` present → verify against chain tracker | **No** — defence-in-depth |
 | 3 | If root transaction + `fee_model` given → validate fee | **No** — caller-passed policy |
-| 4 | If wtxid is in seed → mark visited, skip subtree | Yes |
-| 5 | Full input script verification (interpreter) | n/a |
-| 6 | Output ≤ input satoshi check | n/a |
-| 7 | Mark visited | n/a |
+| 4 | If wtxid is in seed → mark visited, skip subtree | Yes (this is the short-circuit) |
+| 5 | Full input script verification (interpreter) | Yes — bypassed when seed short-circuits at step 4 |
+| 6 | Output ≤ input satoshi check | Yes — bypassed when seed short-circuits at step 4 |
+| 7 | Mark visited | Reached only when 4 didn't hit |
+
+A seeded subject transaction skips **all of steps 5, 6, and 7** — the caller's warrant covers the full script + output-constraint claim, not just input verification. The subject's own `merkle_path` (if any) and `fee_model` gate still run because they precede the seed check.
 
 **Strict merkle ordering rationale:** a stale seed cannot mask a bad chain-anchor
 claim. A transaction with a `merkle_path` always has its proof verified against the
@@ -54,13 +56,19 @@ transaction's wtxid.
 ## Format contract {#format-contract}
 
 - Elements must be **32-byte binary strings** (wire-order wtxid, `String#encoding`
-  `ASCII-8BIT`), not hex strings.
-- Use `BSV::Primitives::Hex.wtxid_from_hex(dtxid_hex)` to convert a display-order
-  hex txid to a wire-order binary wtxid.
+  must be `ASCII-8BIT`), not hex strings.
+- **Encoding matters for `Set` membership.** `Set#include?` uses `String#hash` +
+  `#eql?`, which are encoding-sensitive for high-bit bytes. A wtxid re-encoded as
+  UTF-8 (e.g. via JSON round-trip, or accidental string interpolation into a
+  UTF-8 buffer) will silently miss the seed and cause a full walk. Persist wtxids
+  as ASCII-8BIT throughout.
+- Use `BSV::Transaction::TransactionInput.wtxid_from_hex(dtxid_hex)` to convert a
+  display-order hex txid to a wire-order binary wtxid.
 - The SDK validates the first element of a non-empty set at entry via
-  `BSV::Primitives::Hex.validate_wtxid!` and raises `ArgumentError` with a
-  `"looks like a hex txid — use wtxid_from_hex to convert"` hint if you pass a
-  hex string by mistake.
+  `BSV::Primitives::Hex.validate_wtxid!` (O(1) sanity check) and raises
+  `ArgumentError` with a `"looks like a hex txid — use wtxid_from_hex to convert"`
+  hint if the first element looks like hex. Malformed elements *after* the first
+  cause silent seed-misses rather than errors — they degrade safely to full-walk.
 - Passing a non-`Set` value (e.g. an `Array`) raises `ArgumentError`.
 
 ```ruby

--- a/docs/reference/verify-kwarg.md
+++ b/docs/reference/verify-kwarg.md
@@ -4,97 +4,148 @@ nav_order: 7
 parent: Reference
 ---
 
-# Verify Cache Seed (`verified:` kwarg)
+# Bidirectional Verify Cache (`verified:` kwarg)
 
 `Transaction::Tx#verify` accepts an optional `verified:` keyword argument — a
-`Set` of 32-byte binary wire-order wtxids that the caller asserts are already
-verified. When a non-merkle-proven ancestor appears in this set, its subtree is
-skipped; the caller warrants its script validity.
+`Hash` mapping 32-byte binary wire-order wtxids to `true`. It is a bidirectional
+dedup surface: the caller can pre-seed it to short-circuit ancestor walks, and
+the SDK writes into it as it walks so the caller can read the accumulated wtxid
+set afterwards.
 
-This is a **novel Ruby-side seam**. The TypeScript, Go, and Python reference SDKs
-repeat the full walk on every `verify` call. This kwarg exists for wallet-side
-persistent-cache short-circuit (see `bsv-wallet` HLR #516).
+The `Hash` is mutated in place — the caller's object identity is preserved.
+Passing `nil` (the default) tells the SDK to use an internal `Hash` the caller
+cannot access.
 
-## What it is
+This is a **novel Ruby-side seam**. The TypeScript, Go, and Python reference
+SDKs repeat the full walk on every `verify` call. It exists for wallet-side
+persistent-cache scenarios (see `bsv-wallet` HLR #516).
 
-A wallet that has already verified an ancestor transaction chain in a prior session
-can pre-seed the in-call dedup set. The SDK skips enqueueing those ancestors'
-subtrees, reducing redundant script executions to zero for the seeded portion of
-the graph.
+## Three usage patterns
+
+### 1. Pre-seed (short-circuit)
+
+Skip already-verified ancestors:
 
 ```ruby
-# wallet has already verified source_tx in a prior session
-cache = Set.new([source_tx.wtxid])
+# Wallet has already verified source_tx in a prior session.
+cache = { source_tx.wtxid => true }
 tx.verify(chain_tracker: tracker, verified: cache)
+```
+
+### 2. Post-read (accumulate)
+
+Read the walked wtxids into a wallet-side persistent verification cache:
+
+```ruby
+walked = {}
+tx.verify(chain_tracker: tracker, verified: walked)
+walked.keys # => [subject_wtxid, ancestor1_wtxid, ...]
+persistent_cache.store(walked.keys)
+```
+
+### 3. Bidirectional round-trip
+
+Load a persistent cache, use it to short-circuit, and store the updated cache
+back:
+
+```ruby
+cache = load_persistent_verified_cache
+tx.verify(chain_tracker: tracker, verified: cache)
+save_persistent_verified_cache(cache) # includes newly-walked wtxids
 ```
 
 ## Walk order {#walk-order}
 
-The walk processes each queued transaction in this strict order:
+The walk processes each queued transaction in this order:
 
 | Step | Action | Bypassed by seed? |
 |------|--------|-------------------|
-| 1 | Skip if already `visited` (in-call dedup) | n/a — precedes seed check |
-| 2 | If `merkle_path` present → verify against chain tracker | **No** — defence-in-depth |
-| 3 | If root transaction + `fee_model` given → validate fee | **No** — caller-passed policy |
-| 4 | If wtxid is in seed → mark visited, skip subtree | Yes (this is the short-circuit) |
-| 5 | Full input script verification (interpreter) | Yes — bypassed when seed short-circuits at step 4 |
-| 6 | Output ≤ input satoshi check | Yes — bypassed when seed short-circuits at step 4 |
-| 7 | Mark visited | Reached only when 4 didn't hit |
+| 0 | (before the loop) If `fee_model` given → validate root fee | **No** — fee is a caller-passed policy, not a cached script-validity claim |
+| 1 | Skip if `verified[wtxid]` is truthy (top-of-loop dedup) | Yes — seeded and walked entries both hit here |
+| 2 | If `merkle_path` present → verify against chain tracker | Yes — seeded wtxid short-circuits at step 1 before this runs |
+| 3 | Verify each input script through the interpreter | Yes — seeded wtxid short-circuits at step 1 before this runs |
+| 4 | Output ≤ input satoshi check | Yes — seeded wtxid short-circuits at step 1 before this runs |
+| 5 | Mark `verified[wtxid] = true` | Reached only when step 1 didn't hit (walked live) |
 
-A seeded subject transaction skips **all of steps 5, 6, and 7** — the caller's warrant covers the full script + output-constraint claim, not just input verification. The subject's own `merkle_path` (if any) and `fee_model` gate still run because they precede the seed check.
+**Trust contract.** A seeded wtxid short-circuits everything after step 0 —
+including the merkle proof. The caller warrants full trust: script validity
+AND chain-anchor claim. This is the intentional consequence of the single-Hash
+presence-only design (see [Format contract](#format-contract)).
 
-**Strict merkle ordering rationale:** a stale seed cannot mask a bad chain-anchor
-claim. A transaction with a `merkle_path` always has its proof verified against the
-chain tracker, regardless of whether its wtxid appears in the seed.
-
-**Fee gate ordering rationale:** `fee_model` is a caller-passed policy, not a
-cached claim about script validity. It runs before the seed short-circuit so a
-wallet cannot accidentally disable fee validation by pre-seeding the subject
-transaction's wtxid.
+**Fee gate ordering rationale.** Fee validation is a caller-passed policy — it
+lives outside the "already verified" claim the seed makes. If you pass a
+`fee_model`, it runs once at the start of the call, regardless of what's in the
+Hash. A wallet cannot accidentally disable fee validation by pre-seeding the
+subject transaction's wtxid.
 
 ## Format contract {#format-contract}
 
-- Elements must be **32-byte binary strings** (wire-order wtxid, `String#encoding`
-  must be `ASCII-8BIT`), not hex strings.
-- **Encoding matters for `Set` membership.** `Set#include?` uses `String#hash` +
-  `#eql?`, which are encoding-sensitive for high-bit bytes. A wtxid re-encoded as
-  UTF-8 (e.g. via JSON round-trip, or accidental string interpolation into a
-  UTF-8 buffer) will silently miss the seed and cause a full walk. Persist wtxids
-  as ASCII-8BIT throughout.
-- Use `BSV::Transaction::TransactionInput.wtxid_from_hex(dtxid_hex)` to convert a
-  display-order hex txid to a wire-order binary wtxid.
-- The SDK validates the first element of a non-empty set at entry via
-  `BSV::Primitives::Hex.validate_wtxid!` (O(1) sanity check) and raises
-  `ArgumentError` with a `"looks like a hex txid — use wtxid_from_hex to convert"`
-  hint if the first element looks like hex. Malformed elements *after* the first
-  cause silent seed-misses rather than errors — they degrade safely to full-walk.
-- Passing a non-`Set` value (e.g. an `Array`) raises `ArgumentError`.
+- **Keys** — 32-byte binary wire-order wtxids. `String#encoding` must be
+  `ASCII-8BIT`.
+- **Values** — any truthy value counts as "already verified". The SDK writes
+  `true`. `nil` or `false` values are treated as absent (the walk will visit
+  those wtxids normally).
+
+### Encoding foot-gun
+
+`Hash#[]` uses `String#hash` + `String#eql?`, which are encoding-sensitive for
+strings containing high-bit bytes. A wtxid re-encoded as UTF-8 (via JSON
+round-trip, or accidental string interpolation into a UTF-8 buffer) will
+silently miss the cache and cause a full walk. Persist wtxids as `ASCII-8BIT`
+throughout.
+
+### Converting a display-order hex txid
+
+If you have a display-order hex txid string (from a block explorer, an ARC
+response, etc.) rather than a wire-order binary wtxid, use:
 
 ```ruby
-# Wrong — hex string raises ArgumentError with a helpful hint
-Set.new([source_tx.txid_hex])  # 64-char hex
-
-# Correct — 32-byte binary wire-order wtxid
-Set.new([source_tx.wtxid])
+wtxid = BSV::Transaction::TransactionInput.wtxid_from_hex(hex_txid)
 ```
+
+The SDK does not validate individual Hash keys — malformed keys degrade safely
+to seed-misses (the wtxid won't match anything in the walk).
+
+### Type validation
+
+Passing a non-`Hash` value (e.g. an `Array` or a `Set`) raises `ArgumentError`.
+`Set` is explicitly rejected — an earlier iteration of this feature accepted
+`Set`, but the bidirectional shape requires the caller to be able to read
+values back, so `Hash` is now the only accepted collection type.
 
 ## Caller responsibilities {#caller-responsibilities}
 
 - **Correctness.** The SDK cannot verify that a seeded wtxid actually passed
-  script validation. If the cache is wrong, `verify` returns `true` for a subtree
-  that has not actually been verified. The network is the backstop — ARC and miners
-  will reject a broadcast whose inputs are invalid — but the wallet will have
-  returned `true` in the interim.
-- **Staleness invalidation.** If a transaction's script validity status changes
-  (e.g. due to a chain reorganisation), remove its wtxid from the cache before
-  calling `verify`.
-- **Consensus-flag invalidation.** Cached wtxids are pinned to the consensus flags
-  under which they were originally verified. Invalidate the cache when consensus
-  flags change (rare on BSV mainnet, but worth noting).
-- **Thread-safety.** Do not mutate the `Set` on another thread while `verify` is
-  running. The SDK freezes the set on entry (idempotent — already-frozen sets are
-  accepted) to catch accidental in-call mutation, but concurrent mutation from
-  outside the call is not prevented.
-- **No merkle bypass.** You cannot use the seed to bypass merkle-proof verification.
-  If a transaction has a `merkle_path`, the proof is always verified.
+  script validation or has a real chain anchor. If the cache is wrong,
+  `verify` returns `true` for a subtree that has not actually been verified.
+  The network is the backstop — ARC and miners will reject a broadcast whose
+  inputs are invalid — but the wallet may have committed to downstream state
+  (returning `true` to a UI, marking a UTXO spendable) in the interim.
+
+- **Staleness invalidation.** If a transaction's script validity or chain
+  anchor could have changed (chain reorganisation, consensus flag update),
+  remove its wtxid from the cache before calling `verify`. The seed treats the
+  wtxid as fully trusted — merkle proofs are not re-verified for seeded
+  entries.
+
+- **Consensus-flag invalidation.** Cached wtxids are pinned to the consensus
+  flags under which they were originally verified. Invalidate the cache when
+  consensus flags change.
+
+- **Thread-safety.** Do not mutate the `Hash` from another thread while
+  `verify` is running. The SDK does **not** freeze the caller's Hash (it needs
+  to write to it) and does not defend against concurrent mutation.
+
+- **No isolated reads.** If `verified:` is `nil` (or omitted), the SDK uses an
+  internal Hash the caller cannot access — you get no post-read. Pass an
+  empty Hash if you want the SDK to accumulate walked wtxids you can read.
+
+## Compatibility
+
+- Backwards-compatible with the default `verified: nil` — every existing caller
+  path is byte-identical to the pre-kwarg behaviour.
+
+- **Not** backwards-compatible with an intermediate design that accepted `Set`
+  (present in PR #912 before the amendment). If you tracked this at that
+  stage, migrate: `Set.new(cache.keys)` → `cache` (drop the Set wrap; hand the
+  Hash directly).

--- a/docs/reference/verify-kwarg.md
+++ b/docs/reference/verify-kwarg.md
@@ -1,0 +1,92 @@
+---
+title: Verify Cache Seed
+nav_order: 7
+parent: Reference
+---
+
+# Verify Cache Seed (`verified:` kwarg)
+
+`Transaction::Tx#verify` accepts an optional `verified:` keyword argument — a
+`Set` of 32-byte binary wire-order wtxids that the caller asserts are already
+verified. When a non-merkle-proven ancestor appears in this set, its subtree is
+skipped; the caller warrants its script validity.
+
+This is a **novel Ruby-side seam**. The TypeScript, Go, and Python reference SDKs
+repeat the full walk on every `verify` call. This kwarg exists for wallet-side
+persistent-cache short-circuit (see `bsv-wallet` HLR #516).
+
+## What it is
+
+A wallet that has already verified an ancestor transaction chain in a prior session
+can pre-seed the in-call dedup set. The SDK skips enqueueing those ancestors'
+subtrees, reducing redundant script executions to zero for the seeded portion of
+the graph.
+
+```ruby
+# wallet has already verified source_tx in a prior session
+cache = Set.new([source_tx.wtxid])
+tx.verify(chain_tracker: tracker, verified: cache)
+```
+
+## Walk order {#walk-order}
+
+The walk processes each queued transaction in this strict order:
+
+| Step | Action | Bypassed by seed? |
+|------|--------|-------------------|
+| 1 | Skip if already `visited` (in-call dedup) | n/a |
+| 2 | If `merkle_path` present → verify against chain tracker | **No** — defence-in-depth |
+| 3 | If root transaction + `fee_model` given → validate fee | **No** — caller-passed policy |
+| 4 | If wtxid is in seed → mark visited, skip subtree | Yes |
+| 5 | Full input script verification (interpreter) | n/a |
+| 6 | Output ≤ input satoshi check | n/a |
+| 7 | Mark visited | n/a |
+
+**Strict merkle ordering rationale:** a stale seed cannot mask a bad chain-anchor
+claim. A transaction with a `merkle_path` always has its proof verified against the
+chain tracker, regardless of whether its wtxid appears in the seed.
+
+**Fee gate ordering rationale:** `fee_model` is a caller-passed policy, not a
+cached claim about script validity. It runs before the seed short-circuit so a
+wallet cannot accidentally disable fee validation by pre-seeding the subject
+transaction's wtxid.
+
+## Format contract {#format-contract}
+
+- Elements must be **32-byte binary strings** (wire-order wtxid, `String#encoding`
+  `ASCII-8BIT`), not hex strings.
+- Use `BSV::Primitives::Hex.wtxid_from_hex(dtxid_hex)` to convert a display-order
+  hex txid to a wire-order binary wtxid.
+- The SDK validates the first element of a non-empty set at entry via
+  `BSV::Primitives::Hex.validate_wtxid!` and raises `ArgumentError` with a
+  `"looks like a hex txid — use wtxid_from_hex to convert"` hint if you pass a
+  hex string by mistake.
+- Passing a non-`Set` value (e.g. an `Array`) raises `ArgumentError`.
+
+```ruby
+# Wrong — hex string raises ArgumentError with a helpful hint
+Set.new([source_tx.txid_hex])  # 64-char hex
+
+# Correct — 32-byte binary wire-order wtxid
+Set.new([source_tx.wtxid])
+```
+
+## Caller responsibilities {#caller-responsibilities}
+
+- **Correctness.** The SDK cannot verify that a seeded wtxid actually passed
+  script validation. If the cache is wrong, `verify` returns `true` for a subtree
+  that has not actually been verified. The network is the backstop — ARC and miners
+  will reject a broadcast whose inputs are invalid — but the wallet will have
+  returned `true` in the interim.
+- **Staleness invalidation.** If a transaction's script validity status changes
+  (e.g. due to a chain reorganisation), remove its wtxid from the cache before
+  calling `verify`.
+- **Consensus-flag invalidation.** Cached wtxids are pinned to the consensus flags
+  under which they were originally verified. Invalidate the cache when consensus
+  flags change (rare on BSV mainnet, but worth noting).
+- **Thread-safety.** Do not mutate the `Set` on another thread while `verify` is
+  running. The SDK freezes the set on entry (idempotent — already-frozen sets are
+  accepted) to catch accidental in-call mutation, but concurrent mutation from
+  outside the call is not prevented.
+- **No merkle bypass.** You cannot use the seed to bypass merkle-proof verification.
+  If a transaction has a `merkle_path`, the proof is always verified.

--- a/gem/bsv-sdk/lib/bsv/transaction/tx.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/tx.rb
@@ -747,37 +747,66 @@ module BSV
       # - +:output_overflow+ — Ruby raises; TS/Python return +false+; Go omits the check
       # - +:script_failure+ — Ruby raises; TS/Python return +false+; Go also propagates errors
       # - +:missing_source+ — Ruby raises; consistent with TS/Go/Python (all raise/error)
+      # - +verified:+ kwarg — Ruby-only; no equivalent seam exists in the TS, Go, or Python SDKs.
+      #   This is a novel Ruby-side extension designed for wallet-side persistent-cache short-circuit
+      #   (see {file:docs/reference/verify-kwarg.md}). The reference SDKs repeat the full walk every
+      #   time +verify+ is called.
       #
       # @param chain_tracker [Transaction::ChainTracker] chain tracker for merkle root validation
       # @param fee_model [FeeModel, nil] optional fee model to validate the root transaction's fee
+      # @param verified [Set<String>, nil] optional pre-seeded set of 32-byte wire-order wtxids
+      #   (binary, not hex) that the caller asserts are already verified. When a non-merkle-proven
+      #   ancestor's wtxid appears in this set, its subtree is skipped — the caller warrants its
+      #   script validity. Merkle proofs still run regardless of this set (defence-in-depth).
+      #   The fee gate on the root transaction also runs regardless of this set.
+      #   Must be +nil+ or a +Set+ of 32-byte binary strings; anything else raises +ArgumentError+.
+      #   The set is frozen on entry — the caller's object is preserved (same +object_id+).
       # @return [true] on successful verification
+      # @raise [ArgumentError] if +verified:+ is not +nil+ or a +Set+, or if it contains a
+      #   non-32-byte element
       # @raise [VerificationError] with code +:invalid_merkle_proof+ if a merkle proof is invalid
       # @raise [VerificationError] with code +:insufficient_fee+ if the fee is below the model's threshold
       # @raise [VerificationError] with code +:output_overflow+ if outputs exceed inputs
       # @raise [VerificationError] with code +:script_failure+ if script execution fails
       # @raise [VerificationError] with code +:missing_source+ if an input is missing required source data
-      def verify(chain_tracker:, fee_model: nil)
-        verified = {}
+      # @note Security: caller warrants script validity for all wtxids in +verified:+. A stale or
+      #   incorrect seed will cause +verify+ to return +true+ for ancestry that has not actually been
+      #   verified. Merkle proofs and the fee gate are not affected by this set.
+      #   Invalidate the caller's cache whenever consensus flags change.
+      # @example Wallet-cache short-circuit
+      #   # wallet has already verified source_tx in a prior session
+      #   cache = Set.new([source_tx.wtxid])
+      #   tx.verify(chain_tracker: tracker, verified: cache)
+      # @since 0.11.0
+      def verify(chain_tracker:, fee_model: nil, verified: nil)
+        seed = normalise_verified(verified)
+        visited = {}
         queue = [self]
 
         until queue.empty?
           tx = queue.shift
           wtxid = tx.wtxid
-          next if verified[wtxid]
+          next if visited[wtxid]
 
-          # Merkle path short-circuit: proven transaction needs no input verification
+          # defence-in-depth: merkle proof runs regardless of seed
           if tx.merkle_path
             unless tx.merkle_path.verify(tx.txid_hex, chain_tracker)
               raise VerificationError.new(:invalid_merkle_proof,
                                           "invalid merkle proof for transaction #{tx.txid_hex}")
             end
 
-            verified[wtxid] = true
+            visited[wtxid] = true
             next
           end
 
-          # Fee validation (root transaction only)
+          # runs BEFORE seed — fee is a caller-passed policy, not part of the cached script-validity claim
           verify_fee(fee_model) if tx.equal?(self) && fee_model
+
+          # Caller-supplied trust: skip subtree for seeded (already-verified) ancestors
+          if seed&.include?(wtxid)
+            visited[wtxid] = true
+            next
+          end
 
           # Verify each input
           tx.inputs.each_with_index do |input, index|
@@ -802,15 +831,20 @@ module BSV
               )
             end
 
-            # Enqueue source transaction for verification if not yet verified
+            # Enqueue source transaction for verification if not yet visited.
+            # Skip enqueue only when the source has no merkle_path AND the seed will short-circuit it;
+            # if it has a merkle_path, always enqueue so defence-in-depth runs.
             source_tx = input.source_transaction
-            queue << source_tx if source_tx && !verified[source_tx.wtxid]
+            next unless source_tx && !visited[source_tx.wtxid]
+            next if source_tx.merkle_path.nil? && seed&.include?(source_tx.wtxid)
+
+            queue << source_tx
           end
 
           # Output ≤ input check
           verify_output_constraint(tx)
 
-          verified[wtxid] = true
+          visited[wtxid] = true
         end
 
         true
@@ -956,6 +990,24 @@ module BSV
 
         raise ArgumentError,
               "input #{idx} source_transaction has no output at index #{input.prev_tx_out_index}"
+      end
+
+      # Validate and normalise the +verified:+ kwarg for {#verify}.
+      #
+      # @param seed_arg [Set<String>, nil]
+      # @return [Set<String>, nil] the frozen set (same object), or nil
+      # @raise [ArgumentError] if +seed_arg+ is not nil or a Set, or contains a non-32-byte element
+      def normalise_verified(seed_arg)
+        return nil if seed_arg.nil?
+
+        unless seed_arg.is_a?(Set)
+          raise ArgumentError,
+                "verified: must be nil or Set of 32-byte binary wtxids (got #{seed_arg.class})"
+        end
+
+        BSV::Primitives::Hex.validate_wtxid!(seed_arg.first, name: 'verified element') if seed_arg.any?
+
+        seed_arg.freeze
       end
 
       def verify_input_requirements(tx, input, index)

--- a/gem/bsv-sdk/lib/bsv/transaction/tx.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/tx.rb
@@ -748,64 +748,82 @@ module BSV
       # - +:script_failure+ — Ruby raises; TS/Python return +false+; Go also propagates errors
       # - +:missing_source+ — Ruby raises; consistent with TS/Go/Python (all raise/error)
       # - +verified:+ kwarg — Ruby-only; no equivalent seam exists in the TS, Go, or Python SDKs.
-      #   This is a novel Ruby-side extension designed for wallet-side persistent-cache short-circuit
-      #   (see {file:docs/reference/verify-kwarg.md}). The reference SDKs repeat the full walk every
-      #   time +verify+ is called.
+      #   This is a novel Ruby-side extension: a bidirectional wtxid-dedup Hash that the caller
+      #   can seed (short-circuit ancestors already verified) and read after +verify+ returns
+      #   (populate a persistent verification cache). See {file:docs/reference/verify-kwarg.md}.
+      #   The reference SDKs repeat the full walk every time +verify+ is called.
       #
       # @param chain_tracker [Transaction::ChainTracker] chain tracker for merkle root validation
       # @param fee_model [FeeModel, nil] optional fee model to validate the root transaction's fee
-      # @param verified [Set<String>, nil] optional pre-seeded set of 32-byte wire-order wtxids
-      #   (binary, not hex) that the caller asserts are already verified. When a non-merkle-proven
-      #   ancestor's wtxid appears in this set, its subtree is skipped — the caller warrants its
-      #   script validity. Merkle proofs still run regardless of this set (defence-in-depth).
-      #   The fee gate on the root transaction also runs regardless of this set.
-      #   Must be +nil+ or a +Set+ of 32-byte binary strings; anything else raises +ArgumentError+.
-      #   The set is frozen on entry — the caller's object is preserved (same +object_id+).
+      # @param verified [Hash{String => Boolean}, nil] bidirectional wtxid dedup Hash.
+      #   Keys are 32-byte wire-order binary wtxids (not hex). Values are presence-only —
+      #   the SDK treats any truthy value as "already verified" and writes +true+ for wtxids
+      #   it walks. Callers use this three ways:
+      #
+      #   - **Pre-seed** (short-circuit): pass a Hash pre-populated with wtxids you have
+      #     verified in an earlier session. Their subtrees are skipped.
+      #   - **Post-read** (accumulate): pass an empty Hash; after +verify+ returns, read the
+      #     keys to see which wtxids the SDK walked. Populates a persistent verification cache.
+      #   - **Bidirectional** (both): pass a Hash that seeds the walk AND collects the walked
+      #     wtxids in one call.
+      #
+      #   The Hash is mutated in place — the caller's object identity is preserved.
+      #   +nil+ (default) means "no seed, no post-read" — the SDK uses an internal Hash the
+      #   caller cannot access. Anything other than +nil+ or +Hash+ raises +ArgumentError+.
       # @return [true] on successful verification
-      # @raise [ArgumentError] if +verified:+ is not +nil+ or a +Set+, or if the first element
-      #   of a non-empty +Set+ is not a 32-byte binary wtxid (O(1) sanity check on entry)
+      # @raise [ArgumentError] if +verified:+ is not +nil+ or a +Hash+
       # @raise [VerificationError] with code +:invalid_merkle_proof+ if a merkle proof is invalid
       # @raise [VerificationError] with code +:insufficient_fee+ if the fee is below the model's threshold
       # @raise [VerificationError] with code +:output_overflow+ if outputs exceed inputs
       # @raise [VerificationError] with code +:script_failure+ if script execution fails
       # @raise [VerificationError] with code +:missing_source+ if an input is missing required source data
-      # @note Security: caller warrants script validity for all wtxids in +verified:+. A stale or
-      #   incorrect seed will cause +verify+ to return +true+ for ancestry that has not actually been
-      #   verified. Merkle proofs and the fee gate are not affected by this set. Cached wtxids are
-      #   pinned to the consensus flags under which they were originally verified — invalidate the
-      #   caller's cache whenever consensus flags change.
-      # @example Wallet-cache short-circuit
+      # @note Security (trust contract): the caller warrants that every wtxid present in
+      #   +verified:+ at method entry is fully verified — script AND chain-anchor (merkle proof)
+      #   AND any consensus-flag context. A seeded wtxid is treated as fully verified regardless
+      #   of what proof or script data it carries. The SDK does **not** re-run the merkle proof
+      #   for a seeded ancestor. If the caller's cache is stale or compromised, +verify+ will
+      #   return +true+ for ancestry that has not actually been verified. Cached wtxids are
+      #   pinned to the consensus flags under which they were originally verified — invalidate
+      #   the caller's cache when consensus flags change, on chain reorganisation, or on any
+      #   event that could invalidate a prior verification. Fee validation is not affected by
+      #   this set — the fee gate is a caller-passed policy, not a cached claim, and runs once
+      #   at the start of every +verify+ call when +fee_model+ is given.
+      # @example Pre-seed short-circuit
       #   # wallet has already verified source_tx in a prior session
-      #   cache = Set.new([source_tx.wtxid])
+      #   cache = { source_tx.wtxid => true }
       #   tx.verify(chain_tracker: tracker, verified: cache)
+      # @example Post-read accumulate
+      #   walked = {}
+      #   tx.verify(chain_tracker: tracker, verified: walked)
+      #   walked.keys # => [subject_wtxid, ancestor1_wtxid, ...]
+      # @example Bidirectional round-trip
+      #   cache = load_persistent_verified_cache
+      #   tx.verify(chain_tracker: tracker, verified: cache)
+      #   save_persistent_verified_cache(cache) # includes newly-walked wtxids
       # @since 0.11.0
       def verify(chain_tracker:, fee_model: nil, verified: nil)
-        seed = normalise_verified(verified)
-        visited = {}
+        verified = normalise_verified(verified)
+        # Fee gate runs once at the start of every verify call. Fee is a caller-passed policy,
+        # not a cached script-validity claim — seeding the subject wtxid cannot silently disable it.
+        verify_fee(fee_model) if fee_model
+
         queue = [self]
 
         until queue.empty?
           tx = queue.shift
           wtxid = tx.wtxid
-          next if visited[wtxid]
+          # Top-of-loop dedup covers both walked-during-this-call and caller-seeded wtxids.
+          # A seeded wtxid short-circuits everything — including the merkle proof — because
+          # the caller warrants full trust. See @note Security.
+          next if verified[wtxid]
 
-          # defence-in-depth: merkle proof runs regardless of seed
           if tx.merkle_path
             unless tx.merkle_path.verify(tx.txid_hex, chain_tracker)
               raise VerificationError.new(:invalid_merkle_proof,
                                           "invalid merkle proof for transaction #{tx.txid_hex}")
             end
 
-            visited[wtxid] = true
-            next
-          end
-
-          # runs BEFORE seed — fee is a caller-passed policy, not part of the cached script-validity claim
-          verify_fee(fee_model) if tx.equal?(self) && fee_model
-
-          # Caller-supplied trust: skip subtree for seeded (already-verified) ancestors
-          if seed&.include?(wtxid)
-            visited[wtxid] = true
+            verified[wtxid] = true
             next
           end
 
@@ -832,20 +850,15 @@ module BSV
               )
             end
 
-            # Enqueue source transaction for verification if not yet visited.
-            # Skip enqueue only when the source has no merkle_path AND the seed will short-circuit it;
-            # if it has a merkle_path, always enqueue so defence-in-depth runs.
+            # Enqueue source transaction unless it's already dealt with (seeded or walked).
             source_tx = input.source_transaction
-            next unless source_tx && !visited[source_tx.wtxid]
-            next if source_tx.merkle_path.nil? && seed&.include?(source_tx.wtxid)
-
-            queue << source_tx
+            queue << source_tx if source_tx && !verified[source_tx.wtxid]
           end
 
           # Output ≤ input check
           verify_output_constraint(tx)
 
-          visited[wtxid] = true
+          verified[wtxid] = true
         end
 
         true
@@ -993,25 +1006,21 @@ module BSV
               "input #{idx} source_transaction has no output at index #{input.prev_tx_out_index}"
       end
 
-      # Validate and normalise the +verified:+ kwarg for {#verify}.
+      # Validate the +verified:+ kwarg for {#verify}.
       #
-      # @param seed_arg [Set<String>, nil]
-      # @return [Set<String>, nil] the frozen set (same object), or nil
-      # @raise [ArgumentError] if +seed_arg+ is not nil or a Set, or if the Set's
-      #   first element is not a valid 32-byte binary wtxid (O(1) sanity check —
-      #   other malformed elements degrade to seed-misses at lookup time rather
-      #   than raising)
-      def normalise_verified(seed_arg)
-        return nil if seed_arg.nil?
+      # Returns the caller's Hash directly (no dup, no freeze) so the SDK can mutate it in place —
+      # the bidirectional contract from {#verify}. When +arg+ is +nil+, returns a fresh empty
+      # Hash that the caller has no reference to; that Hash is discarded when +verify+ returns.
+      #
+      # @param arg [Hash, nil]
+      # @return [Hash] the caller's Hash unchanged, or a fresh empty Hash if arg was nil
+      # @raise [ArgumentError] if +arg+ is neither +nil+ nor a Hash
+      def normalise_verified(arg)
+        return {} if arg.nil?
+        return arg if arg.is_a?(Hash)
 
-        unless seed_arg.is_a?(Set)
-          raise ArgumentError,
-                "verified: must be nil or Set of 32-byte binary wtxids (got #{seed_arg.class})"
-        end
-
-        BSV::Primitives::Hex.validate_wtxid!(seed_arg.first, name: 'verified element') if seed_arg.any?
-
-        seed_arg.freeze
+        raise ArgumentError,
+              "verified: must be nil or Hash of wtxid => truthy entries (got #{arg.class})"
       end
 
       def verify_input_requirements(tx, input, index)

--- a/gem/bsv-sdk/lib/bsv/transaction/tx.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/tx.rb
@@ -755,10 +755,12 @@ module BSV
       #
       # @param chain_tracker [Transaction::ChainTracker] chain tracker for merkle root validation
       # @param fee_model [FeeModel, nil] optional fee model to validate the root transaction's fee
-      # @param verified [Hash{String => Boolean}, nil] bidirectional wtxid dedup Hash.
+      # @param verified [Hash{String => TrueClass}, nil] bidirectional wtxid dedup Hash.
       #   Keys are 32-byte wire-order binary wtxids (not hex). Values are presence-only —
-      #   the SDK treats any truthy value as "already verified" and writes +true+ for wtxids
-      #   it walks. Callers use this three ways:
+      #   the SDK writes +true+ for wtxids it walks and treats any truthy value as
+      #   "already verified". A +false+ value is treated as absent (does not short-circuit)
+      #   and will be overwritten with +true+ if the wtxid is subsequently walked.
+      #   Callers use this three ways:
       #
       #   - **Pre-seed** (short-circuit): pass a Hash pre-populated with wtxids you have
       #     verified in an earlier session. Their subtrees are skipped.
@@ -788,6 +790,11 @@ module BSV
       #   event that could invalidate a prior verification. Fee validation is not affected by
       #   this set — the fee gate is a caller-passed policy, not a cached claim, and runs once
       #   at the start of every +verify+ call when +fee_model+ is given.
+      # @note Concurrency: the SDK writes to +verified:+ in place without locking. Passing the
+      #   same Hash to concurrent +verify+ calls is a race — guard it externally, or give each
+      #   thread its own Hash and merge the results afterwards. The class-level
+      #   "Not thread-safe" note on {Tx} covers direct-mutation concerns; this is the
+      #   specific footgun that comes with the in-place-mutation contract of this kwarg.
       # @example Pre-seed short-circuit
       #   # wallet has already verified source_tx in a prior session
       #   cache = { source_tx.wtxid => true }

--- a/gem/bsv-sdk/lib/bsv/transaction/tx.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/tx.rb
@@ -762,8 +762,8 @@ module BSV
       #   Must be +nil+ or a +Set+ of 32-byte binary strings; anything else raises +ArgumentError+.
       #   The set is frozen on entry — the caller's object is preserved (same +object_id+).
       # @return [true] on successful verification
-      # @raise [ArgumentError] if +verified:+ is not +nil+ or a +Set+, or if it contains a
-      #   non-32-byte element
+      # @raise [ArgumentError] if +verified:+ is not +nil+ or a +Set+, or if the first element
+      #   of a non-empty +Set+ is not a 32-byte binary wtxid (O(1) sanity check on entry)
       # @raise [VerificationError] with code +:invalid_merkle_proof+ if a merkle proof is invalid
       # @raise [VerificationError] with code +:insufficient_fee+ if the fee is below the model's threshold
       # @raise [VerificationError] with code +:output_overflow+ if outputs exceed inputs
@@ -771,8 +771,9 @@ module BSV
       # @raise [VerificationError] with code +:missing_source+ if an input is missing required source data
       # @note Security: caller warrants script validity for all wtxids in +verified:+. A stale or
       #   incorrect seed will cause +verify+ to return +true+ for ancestry that has not actually been
-      #   verified. Merkle proofs and the fee gate are not affected by this set.
-      #   Invalidate the caller's cache whenever consensus flags change.
+      #   verified. Merkle proofs and the fee gate are not affected by this set. Cached wtxids are
+      #   pinned to the consensus flags under which they were originally verified — invalidate the
+      #   caller's cache whenever consensus flags change.
       # @example Wallet-cache short-circuit
       #   # wallet has already verified source_tx in a prior session
       #   cache = Set.new([source_tx.wtxid])

--- a/gem/bsv-sdk/lib/bsv/transaction/tx.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/tx.rb
@@ -997,7 +997,10 @@ module BSV
       #
       # @param seed_arg [Set<String>, nil]
       # @return [Set<String>, nil] the frozen set (same object), or nil
-      # @raise [ArgumentError] if +seed_arg+ is not nil or a Set, or contains a non-32-byte element
+      # @raise [ArgumentError] if +seed_arg+ is not nil or a Set, or if the Set's
+      #   first element is not a valid 32-byte binary wtxid (O(1) sanity check —
+      #   other malformed elements degrade to seed-misses at lookup time rather
+      #   than raising)
       def normalise_verified(seed_arg)
         return nil if seed_arg.nil?
 

--- a/gem/bsv-sdk/lib/bsv/transaction/tx.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/tx.rb
@@ -822,7 +822,11 @@ module BSV
           # Top-of-loop dedup covers both walked-during-this-call and caller-seeded wtxids.
           # A seeded wtxid short-circuits everything — including the merkle proof — because
           # the caller warrants full trust. See @note Security.
-          next if verified[wtxid]
+          # fetch(k, false) bypasses any custom Hash default / default_proc — critical, because
+          # Hash.new(true)[missing_key] would return true and short-circuit verification silently
+          # (funds risk). normalise_verified also rejects such Hashes at entry, but this is
+          # defence in depth.
+          next if verified.fetch(wtxid, false)
 
           if tx.merkle_path
             unless tx.merkle_path.verify(tx.txid_hex, chain_tracker)
@@ -858,8 +862,9 @@ module BSV
             end
 
             # Enqueue source transaction unless it's already dealt with (seeded or walked).
+            # fetch(k, false) bypasses any custom Hash default — see note above at top-of-loop dedup.
             source_tx = input.source_transaction
-            queue << source_tx if source_tx && !verified[source_tx.wtxid]
+            queue << source_tx if source_tx && !verified.fetch(source_tx.wtxid, false)
           end
 
           # Output ≤ input check
@@ -1021,8 +1026,10 @@ module BSV
       #
       # @param arg [Hash, nil]
       # @return [Hash] the caller's Hash unchanged, or a fresh empty Hash if arg was nil
-      # @raise [ArgumentError] if +arg+ is neither +nil+ nor a Hash, or if +arg+ is a frozen Hash
-      #   (the SDK writes walked wtxids into it and cannot mutate a frozen Hash)
+      # @raise [ArgumentError] if +arg+ is neither +nil+ nor a Hash, a frozen Hash (the SDK writes
+      #   walked wtxids into it and cannot mutate a frozen Hash), or a Hash with a truthy default
+      #   value or a default_proc (missing keys would return truthy and silently short-circuit
+      #   verification for un-seeded wtxids — funds risk)
       def normalise_verified(arg)
         return {} if arg.nil?
 
@@ -1034,6 +1041,16 @@ module BSV
         if arg.frozen?
           raise ArgumentError,
                 'verified: Hash must be mutable — the SDK writes walked wtxids into it'
+        end
+
+        # A Hash with a truthy default or a default_proc could return a truthy value for missing
+        # keys, silently short-circuiting verification for un-seeded wtxids. The walk sites use
+        # `fetch(k, false)` as defence in depth, but reject at entry so the caller sees a clear
+        # error rather than an opaquely-behaving verify.
+        if arg.default_proc || arg.default
+          raise ArgumentError,
+                'verified: Hash must not have a truthy default or a default_proc — ' \
+                'missing keys must return falsy so verification cannot be silently skipped'
         end
 
         arg

--- a/gem/bsv-sdk/lib/bsv/transaction/tx.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/tx.rb
@@ -818,7 +818,17 @@ module BSV
         verified = normalise_verified(verified)
         # Fee gate runs once at the start of every verify call. Fee is a caller-passed policy,
         # not a cached script-validity claim — seeding the subject wtxid cannot silently disable it.
-        verify_fee(fee_model) if fee_model
+        # verify_fee → total_input_satoshis raises ArgumentError when source data is missing;
+        # translate that to :missing_source VerificationError so callers see a consistent error
+        # taxonomy from #verify (all failure modes raise VerificationError, not ArgumentError).
+        if fee_model
+          begin
+            verify_fee(fee_model)
+          rescue ArgumentError => e
+            raise VerificationError.new(:missing_source,
+                                        "cannot compute fee: #{e.message}")
+          end
+        end
 
         queue = [self]
 

--- a/gem/bsv-sdk/lib/bsv/transaction/tx.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/tx.rb
@@ -755,7 +755,7 @@ module BSV
       #
       # @param chain_tracker [Transaction::ChainTracker] chain tracker for merkle root validation
       # @param fee_model [FeeModel, nil] optional fee model to validate the root transaction's fee
-      # @param verified [Hash{String => TrueClass}, nil] bidirectional wtxid dedup Hash.
+      # @param verified [Hash{String => Boolean}, nil] bidirectional wtxid dedup Hash.
       #   Keys are 32-byte wire-order binary wtxids (not hex). Values are presence-only —
       #   the SDK writes +true+ for wtxids it walks and treats any truthy value as
       #   "already verified". A +false+ value is treated as absent (does not short-circuit)
@@ -771,9 +771,15 @@ module BSV
       #
       #   The Hash is mutated in place — the caller's object identity is preserved.
       #   +nil+ (default) means "no seed, no post-read" — the SDK uses an internal Hash the
-      #   caller cannot access. Anything other than +nil+ or +Hash+ raises +ArgumentError+.
+      #   caller cannot access. Rejected at entry with +ArgumentError+: anything that is not
+      #   +nil+ or a mutable +Hash+; a frozen +Hash+; or a +Hash+ with a truthy +default+
+      #   value or any +default_proc+ (funds risk — missing keys would return truthy and
+      #   silently short-circuit verification).
       # @return [true] on successful verification
-      # @raise [ArgumentError] if +verified:+ is not +nil+ or a +Hash+
+      # @raise [ArgumentError] if +verified:+ is (a) not +nil+ or a +Hash+, (b) a frozen
+      #   +Hash+ (the SDK writes walked wtxids into it and cannot mutate a frozen one), or
+      #   (c) a +Hash+ with a truthy +default+ value or a +default_proc+ (missing keys
+      #   would return truthy and silently short-circuit verification — funds risk)
       # @raise [VerificationError] with code +:invalid_merkle_proof+ if a merkle proof is invalid
       # @raise [VerificationError] with code +:insufficient_fee+ if the fee is below the model's threshold
       # @raise [VerificationError] with code +:output_overflow+ if outputs exceed inputs

--- a/gem/bsv-sdk/lib/bsv/transaction/tx.rb
+++ b/gem/bsv-sdk/lib/bsv/transaction/tx.rb
@@ -1014,13 +1014,22 @@ module BSV
       #
       # @param arg [Hash, nil]
       # @return [Hash] the caller's Hash unchanged, or a fresh empty Hash if arg was nil
-      # @raise [ArgumentError] if +arg+ is neither +nil+ nor a Hash
+      # @raise [ArgumentError] if +arg+ is neither +nil+ nor a Hash, or if +arg+ is a frozen Hash
+      #   (the SDK writes walked wtxids into it and cannot mutate a frozen Hash)
       def normalise_verified(arg)
         return {} if arg.nil?
-        return arg if arg.is_a?(Hash)
 
-        raise ArgumentError,
-              "verified: must be nil or Hash of wtxid => truthy entries (got #{arg.class})"
+        unless arg.is_a?(Hash)
+          raise ArgumentError,
+                "verified: must be nil or Hash of wtxid => truthy entries (got #{arg.class})"
+        end
+
+        if arg.frozen?
+          raise ArgumentError,
+                'verified: Hash must be mutable — the SDK writes walked wtxids into it'
+        end
+
+        arg
       end
 
       def verify_input_requirements(tx, input, index)

--- a/gem/bsv-sdk/spec/bsv/transaction/tx_verify_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/tx_verify_spec.rb
@@ -597,6 +597,37 @@ RSpec.describe BSV::Transaction::Tx do
             expect(e.message).to include('Set')
           }
       end
+
+      # Frozen Hash — clear error at entry rather than FrozenError deep in the walk.
+      it 'wrong type: raises ArgumentError when Hash is frozen (SDK cannot mutate it)' do
+        source_tx = build_source_tx
+        source_tx.merkle_path = make_merkle_path
+        tx = build_spending_tx(source_tx)
+
+        expect { tx.verify(chain_tracker: chain_tracker, verified: {}.freeze) }
+          .to raise_error(ArgumentError) { |e|
+            expect(e.message).to include('mutable')
+          }
+      end
+
+      # Semantic-change pin: moving the fee gate outside the walk loop means a merkle-proven
+      # subject now gets fee-checked. Under pre-amendment master's inside-the-loop fee check,
+      # the merkle branch's `next` skipped the fee gate for a proven subject — silent bypass.
+      # This spec locks in the new (correct) behaviour.
+      it 'fee gate runs on merkle-proven subject: raises :insufficient_fee even when subject has merkle_path' do
+        source_tx = build_source_tx(satoshis: 100_000)
+        source_tx.merkle_path = make_merkle_path
+        tx = build_spending_tx(source_tx, output_sats: 99_999)
+        tx.merkle_path = make_merkle_path # subject IS merkle-proven
+
+        rejecting_model = instance_double(BSV::Transaction::FeeModel)
+        allow(rejecting_model).to receive(:compute_fee).and_return(100)
+
+        expect { tx.verify(chain_tracker: chain_tracker, fee_model: rejecting_model) }
+          .to raise_error(BSV::Transaction::VerificationError) { |e|
+            expect(e.code).to eq(:insufficient_fee)
+          }
+      end
     end
   end
 end

--- a/gem/bsv-sdk/spec/bsv/transaction/tx_verify_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/tx_verify_spec.rb
@@ -358,5 +358,215 @@ RSpec.describe BSV::Transaction::Tx do
         expect(result).to be true
       end
     end
+
+    describe '#verify with verified: (verification cache seed)' do
+      let(:bogus_wtxid) { "\x00".b * 32 }
+
+      # Spec 1 — kwarg default (regression guard)
+      # Calling verify without verified: must be byte-identical to the pre-kwarg behaviour.
+      it 'kwarg default: accepts without verified: (regression guard)' do
+        source_tx = build_source_tx
+        source_tx.merkle_path = make_merkle_path
+        tx = build_spending_tx(source_tx)
+
+        expect(tx.verify(chain_tracker: chain_tracker)).to be true
+      end
+
+      it 'kwarg default: still raises :script_failure when verified: is omitted and script is bad' do
+        source_tx = build_source_tx
+        source_tx.merkle_path = make_merkle_path
+        tx = build_spending_tx(source_tx)
+        tx.inputs[0].unlocking_script = BSV::Script::Script.from_asm('OP_0')
+
+        expect { tx.verify(chain_tracker: chain_tracker) }
+          .to raise_error(BSV::Transaction::VerificationError) { |e|
+            expect(e.code).to eq(:script_failure)
+          }
+      end
+
+      # Spec 2 — cross-BEEF ancestor (headline)
+      # X is an intermediate ancestor with no merkle_path. Subject spends X.
+      # After cold-verifying, re-verify with verified: Set.new([X.wtxid]).
+      # The interpreter must never touch X's inputs on the seeded run.
+      it 'cross-BEEF ancestor: skips X subtree and returns true when X is seeded' do
+        grandparent = build_source_tx(satoshis: 200_000)
+        grandparent.merkle_path = make_merkle_path
+
+        ancestor_x = build_spending_tx(grandparent, output_sats: 150_000)
+        subject_tx = build_spending_tx(ancestor_x, output_sats: 100_000)
+
+        expect(subject_tx.verify(chain_tracker: chain_tracker)).to be true
+
+        # Spy on interpreter calls — X's inputs must not be touched on the seeded run
+        allow(BSV::Script::Interpreter).to receive(:verify).and_call_original
+
+        result = subject_tx.verify(chain_tracker: chain_tracker, verified: Set.new([ancestor_x.wtxid]))
+        expect(result).to be true
+        # Only the subject's 1 input is verified; X's 1 input is skipped by the seed
+        expect(BSV::Script::Interpreter).to have_received(:verify).exactly(1).times
+      end
+
+      # Spec 3 — invalid-signature ancestor with seed → passes (ANCHOR TEST)
+      # CONTRACT LOCK: do not weaken this spec. If it ever changes, the trust
+      # contract silently changes and the seeding feature becomes undetectably unsafe.
+      it 'invalid-signature ancestor with seed: passes (ANCHOR TEST — trust contract lock)' do
+        source_tx = build_source_tx
+        source_tx.merkle_path = make_merkle_path
+        bad_ancestor = build_spending_tx(source_tx, output_sats: 50_000)
+        subject_tx = build_spending_tx(bad_ancestor, output_sats: 40_000)
+
+        # Corrupt bad_ancestor — full verification must fail
+        bad_ancestor.inputs[0].unlocking_script = BSV::Script::Script.from_asm('OP_0')
+
+        expect { subject_tx.verify(chain_tracker: chain_tracker) }
+          .to raise_error(BSV::Transaction::VerificationError) { |e|
+            expect(e.code).to eq(:script_failure)
+          }
+
+        # Same structure, fresh objects — seed short-circuits the corrupted ancestor
+        source_tx2 = build_source_tx
+        source_tx2.merkle_path = make_merkle_path
+        bad_ancestor2 = build_spending_tx(source_tx2, output_sats: 50_000)
+        subject_tx2 = build_spending_tx(bad_ancestor2, output_sats: 40_000)
+        bad_ancestor2.inputs[0].unlocking_script = BSV::Script::Script.from_asm('OP_0')
+
+        result = subject_tx2.verify(
+          chain_tracker: chain_tracker,
+          verified: Set.new([bad_ancestor2.wtxid])
+        )
+        expect(result).to be true
+      end
+
+      # Spec 4 — caller's Set unchanged
+      it "caller's Set: object_id preserved and Set is frozen after verify" do
+        source_tx = build_source_tx
+        source_tx.merkle_path = make_merkle_path
+        tx = build_spending_tx(source_tx)
+
+        seed = Set.new([source_tx.wtxid])
+        captured_id = seed.object_id
+
+        tx.verify(chain_tracker: chain_tracker, verified: seed)
+
+        expect(seed.object_id).to eq(captured_id)
+        expect(seed.frozen?).to be true
+      end
+
+      # Spec 5 — merkle-proven ignores seed
+      it 'merkle-proven ignores seed: raises :invalid_merkle_proof even when the wtxid is seeded' do
+        source_tx = build_source_tx
+        bad_path = instance_double(BSV::Transaction::MerklePath,
+                                   block_height: 800_000,
+                                   verify: false)
+        source_tx.merkle_path = bad_path
+
+        tx = build_spending_tx(source_tx)
+
+        expect { tx.verify(chain_tracker: chain_tracker, verified: Set.new([source_tx.wtxid])) }
+          .to raise_error(BSV::Transaction::VerificationError, /invalid merkle proof/)
+      end
+
+      # Spec 6 — subject wtxid in seed → immediate accept
+      it 'subject wtxid in seed: returns true without verifying inputs' do
+        source_tx = build_source_tx
+        source_tx.merkle_path = make_merkle_path
+        tx = build_spending_tx(source_tx)
+
+        # Sabotage the unlocking script — if verify_input were called, it would raise
+        tx.inputs[0].unlocking_script = BSV::Script::Script.from_asm('OP_0')
+
+        result = tx.verify(chain_tracker: chain_tracker, verified: Set.new([tx.wtxid]))
+
+        expect(result).to be true
+      end
+
+      # Spec 7 — fee gate still runs when subject is seeded
+      it 'fee gate still runs when subject is seeded: raises :insufficient_fee' do
+        source_tx = build_source_tx(satoshis: 100_000)
+        source_tx.merkle_path = make_merkle_path
+        tx = build_spending_tx(source_tx, output_sats: 99_999)
+
+        rejecting_model = instance_double(BSV::Transaction::FeeModel)
+        allow(rejecting_model).to receive(:compute_fee).and_return(100)
+
+        expect do
+          tx.verify(
+            chain_tracker: chain_tracker,
+            fee_model: rejecting_model,
+            verified: Set.new([tx.wtxid])
+          )
+        end.to raise_error(BSV::Transaction::VerificationError) { |e|
+          expect(e.code).to eq(:insufficient_fee)
+        }
+      end
+
+      # Spec 8 — conformance re-run under benign seed
+      # Three representative P2PKH chain shapes verified with and without a bogus seed.
+      # The seed wtxid never matches any transaction in the graph, so behaviour must
+      # be identical to the unseeded run. Defence-in-depth against sighash regressions.
+      it 'benign seed: 2-hop P2PKH chain behaves identically with and without seed' do
+        source = build_source_tx
+        source.merkle_path = make_merkle_path
+        tx = build_spending_tx(source)
+
+        seeded_result = tx.verify(chain_tracker: chain_tracker, verified: Set.new([bogus_wtxid]))
+        expect(seeded_result).to be true
+        expect(tx.verify(chain_tracker: chain_tracker)).to eq(seeded_result)
+      end
+
+      it 'benign seed: 3-hop P2PKH chain (grandparent proven) behaves identically with and without seed' do
+        grandparent = build_source_tx(satoshis: 200_000)
+        grandparent.merkle_path = make_merkle_path
+        parent = build_spending_tx(grandparent, output_sats: 150_000)
+        child = build_spending_tx(parent, output_sats: 100_000)
+
+        seeded_result = child.verify(chain_tracker: chain_tracker, verified: Set.new([bogus_wtxid]))
+        expect(seeded_result).to be true
+        expect(child.verify(chain_tracker: chain_tracker)).to eq(seeded_result)
+      end
+
+      it 'benign seed: bad-script chain raises :script_failure with and without seed' do
+        source = build_source_tx
+        source.merkle_path = make_merkle_path
+        tx = build_spending_tx(source)
+        tx.inputs[0].unlocking_script = BSV::Script::Script.from_asm('OP_0')
+
+        seed = Set.new([bogus_wtxid])
+
+        expect { tx.verify(chain_tracker: chain_tracker) }
+          .to raise_error(BSV::Transaction::VerificationError) { |e|
+            expect(e.code).to eq(:script_failure)
+          }
+        expect { tx.verify(chain_tracker: chain_tracker, verified: seed) }
+          .to raise_error(BSV::Transaction::VerificationError) { |e|
+            expect(e.code).to eq(:script_failure)
+          }
+      end
+
+      # Spec 9 — format validation
+      it 'format validation: raises ArgumentError with wtxid/hex hint when Set contains a hex string' do
+        hex_string = 'a' * 64
+        seed = Set.new([hex_string])
+
+        expect { build_spending_tx(build_source_tx).verify(chain_tracker: chain_tracker, verified: seed) }
+          .to raise_error(ArgumentError) { |e|
+            expect(e.message).to include('wtxid')
+            expect(e.message).to include('hex')
+          }
+      end
+
+      # Spec 10 — wrong type
+      it 'wrong type: raises ArgumentError naming Set and received type when given an Array' do
+        source_tx = build_source_tx
+        source_tx.merkle_path = make_merkle_path
+        tx = build_spending_tx(source_tx)
+
+        expect { tx.verify(chain_tracker: chain_tracker, verified: [source_tx.wtxid]) }
+          .to raise_error(ArgumentError) { |e|
+            expect(e.message).to include('Set')
+            expect(e.message).to include('Array')
+          }
+      end
+    end
   end
 end

--- a/gem/bsv-sdk/spec/bsv/transaction/tx_verify_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/tx_verify_spec.rb
@@ -628,6 +628,46 @@ RSpec.describe BSV::Transaction::Tx do
             expect(e.code).to eq(:insufficient_fee)
           }
       end
+
+      # Funds-at-risk guard: Hash.new(true) would return true for every missing key, silently
+      # short-circuiting verification for un-seeded wtxids and returning true for a subtree that
+      # was never actually verified. The SDK rejects such Hashes at entry AND uses fetch(k, false)
+      # at the walk sites for defence in depth.
+      it 'wrong type: raises ArgumentError when Hash has a truthy default value (funds risk)' do
+        source_tx = build_source_tx
+        source_tx.merkle_path = make_merkle_path
+        tx = build_spending_tx(source_tx)
+
+        expect { tx.verify(chain_tracker: chain_tracker, verified: Hash.new(true)) }
+          .to raise_error(ArgumentError) { |e|
+            expect(e.message).to include('default')
+            expect(e.message).to include('funds').or include('silently')
+          }
+      end
+
+      it 'wrong type: raises ArgumentError when Hash has a default_proc (funds risk)' do
+        source_tx = build_source_tx
+        source_tx.merkle_path = make_merkle_path
+        tx = build_spending_tx(source_tx)
+
+        seed = Hash.new { |_h, _k| true }
+
+        expect { tx.verify(chain_tracker: chain_tracker, verified: seed) }
+          .to raise_error(ArgumentError) { |e|
+            expect(e.message).to include('default_proc').or include('default')
+          }
+      end
+
+      it 'accepts Hash with a falsy default (safe — missing keys return falsy, no bypass)' do
+        source_tx = build_source_tx
+        source_tx.merkle_path = make_merkle_path
+        tx = build_spending_tx(source_tx)
+
+        seed = Hash.new(false)
+
+        expect { tx.verify(chain_tracker: chain_tracker, verified: seed) }
+          .not_to raise_error
+      end
     end
   end
 end

--- a/gem/bsv-sdk/spec/bsv/transaction/tx_verify_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/tx_verify_spec.rb
@@ -359,12 +359,11 @@ RSpec.describe BSV::Transaction::Tx do
       end
     end
 
-    describe '#verify with verified: (verification cache seed)' do
+    describe '#verify with verified: (bidirectional wtxid dedup Hash)' do
       let(:bogus_wtxid) { "\x00".b * 32 }
 
-      # Spec 1 — kwarg default (regression guard)
-      # Calling verify without verified: must be byte-identical to the pre-kwarg behaviour.
-      it 'kwarg default: accepts without verified: (regression guard)' do
+      # Regression guard: calling verify without verified: must be identical to pre-kwarg behaviour.
+      it 'kwarg default: accepts without verified:' do
         source_tx = build_source_tx
         source_tx.merkle_path = make_merkle_path
         tx = build_spending_tx(source_tx)
@@ -384,10 +383,9 @@ RSpec.describe BSV::Transaction::Tx do
           }
       end
 
-      # Spec 2 — cross-BEEF ancestor (headline)
-      # X is an intermediate ancestor with no merkle_path. Subject spends X.
-      # After cold-verifying, re-verify with verified: Set.new([X.wtxid]).
-      # The interpreter must never touch X's inputs on the seeded run.
+      # Cross-BEEF ancestor headline: X is an intermediate ancestor with no merkle_path.
+      # Subject spends X. Seeding X's wtxid short-circuits its subtree; the interpreter
+      # never touches X's inputs on the seeded run.
       it 'cross-BEEF ancestor: skips X subtree and returns true when X is seeded' do
         grandparent = build_source_tx(satoshis: 200_000)
         grandparent.merkle_path = make_merkle_path
@@ -397,25 +395,25 @@ RSpec.describe BSV::Transaction::Tx do
 
         expect(subject_tx.verify(chain_tracker: chain_tracker)).to be true
 
-        # Spy on interpreter calls — X's inputs must not be touched on the seeded run
         allow(BSV::Script::Interpreter).to receive(:verify).and_call_original
 
-        result = subject_tx.verify(chain_tracker: chain_tracker, verified: Set.new([ancestor_x.wtxid]))
+        result = subject_tx.verify(chain_tracker: chain_tracker, verified: { ancestor_x.wtxid => true })
         expect(result).to be true
-        # Only the subject's 1 input is verified; X's 1 input is skipped by the seed
         expect(BSV::Script::Interpreter).to have_received(:verify).exactly(1).times
       end
 
-      # Spec 3 — invalid-signature ancestor with seed → passes (ANCHOR TEST)
-      # CONTRACT LOCK: do not weaken this spec. If it ever changes, the trust
-      # contract silently changes and the seeding feature becomes undetectably unsafe.
+      # ANCHOR TEST — trust contract lock.
+      # CONTRACT LOCK: do not weaken. If this ever changes, the trust contract silently
+      # changes and the seeding feature becomes undetectably unsafe.
+      #
+      # A seeded ancestor with an invalid unlocking script MUST still cause verify to return
+      # true — because the caller warrants the seeded wtxid was verified in a prior session.
       it 'invalid-signature ancestor with seed: passes (ANCHOR TEST — trust contract lock)' do
         source_tx = build_source_tx
         source_tx.merkle_path = make_merkle_path
         bad_ancestor = build_spending_tx(source_tx, output_sats: 50_000)
         subject_tx = build_spending_tx(bad_ancestor, output_sats: 40_000)
 
-        # Corrupt bad_ancestor — full verification must fail
         bad_ancestor.inputs[0].unlocking_script = BSV::Script::Script.from_asm('OP_0')
 
         expect { subject_tx.verify(chain_tracker: chain_tracker) }
@@ -423,7 +421,6 @@ RSpec.describe BSV::Transaction::Tx do
             expect(e.code).to eq(:script_failure)
           }
 
-        # Same structure, fresh objects — seed short-circuits the corrupted ancestor
         source_tx2 = build_source_tx
         source_tx2.merkle_path = make_merkle_path
         bad_ancestor2 = build_spending_tx(source_tx2, output_sats: 50_000)
@@ -432,55 +429,92 @@ RSpec.describe BSV::Transaction::Tx do
 
         result = subject_tx2.verify(
           chain_tracker: chain_tracker,
-          verified: Set.new([bad_ancestor2.wtxid])
+          verified: { bad_ancestor2.wtxid => true }
         )
         expect(result).to be true
       end
 
-      # Spec 4 — caller's Set unchanged
-      it "caller's Set: object_id preserved and Set is frozen after verify" do
-        source_tx = build_source_tx
-        source_tx.merkle_path = make_merkle_path
-        tx = build_spending_tx(source_tx)
+      # Bidirectional post-read: caller's Hash is populated with every wtxid walked.
+      it "caller's Hash: populated with walked wtxids after verify (object_id preserved)" do
+        grandparent = build_source_tx(satoshis: 200_000)
+        grandparent.merkle_path = make_merkle_path
+        parent = build_spending_tx(grandparent, output_sats: 150_000)
+        subject = build_spending_tx(parent, output_sats: 100_000)
 
-        seed = Set.new([source_tx.wtxid])
-        captured_id = seed.object_id
+        collected = {}
+        captured_id = collected.object_id
 
-        tx.verify(chain_tracker: chain_tracker, verified: seed)
+        result = subject.verify(chain_tracker: chain_tracker, verified: collected)
 
-        expect(seed.object_id).to eq(captured_id)
-        expect(seed.frozen?).to be true
+        expect(result).to be true
+        expect(collected.object_id).to eq(captured_id)
+        expect(collected.keys).to contain_exactly(subject.wtxid, parent.wtxid, grandparent.wtxid)
+        expect(collected.values).to all(be true)
       end
 
-      # Spec 5 — merkle-proven ignores seed
-      it 'merkle-proven ignores seed: raises :invalid_merkle_proof even when the wtxid is seeded' do
-        source_tx = build_source_tx
-        bad_path = instance_double(BSV::Transaction::MerklePath,
-                                   block_height: 800_000,
-                                   verify: false)
-        source_tx.merkle_path = bad_path
+      # Bidirectional round-trip: pre-seeded wtxids skip AND newly-walked wtxids accumulate
+      # in the same Hash.
+      it 'bidirectional round-trip: pre-seeded wtxids are honoured AND newly-walked ones accumulate' do
+        grandparent = build_source_tx(satoshis: 200_000)
+        grandparent.merkle_path = make_merkle_path
+        parent = build_spending_tx(grandparent, output_sats: 150_000)
+        subject = build_spending_tx(parent, output_sats: 100_000)
 
-        tx = build_spending_tx(source_tx)
+        cache = { grandparent.wtxid => true }
+        cache_id = cache.object_id
 
-        expect { tx.verify(chain_tracker: chain_tracker, verified: Set.new([source_tx.wtxid])) }
+        allow(BSV::Script::Interpreter).to receive(:verify).and_call_original
+
+        result = subject.verify(chain_tracker: chain_tracker, verified: cache)
+
+        expect(result).to be true
+        expect(cache.object_id).to eq(cache_id)
+        expect(cache.keys).to contain_exactly(grandparent.wtxid, parent.wtxid, subject.wtxid)
+        expect(BSV::Script::Interpreter).to have_received(:verify).exactly(2).times
+      end
+
+      # Trust contract: seeded wtxid fully short-circuits — merkle proof is NOT re-verified.
+      # This makes the caller's warrant a full-trust one (script + chain anchor).
+      # It is the intentional consequence of the single-Hash presence-only design.
+      it 'seeded wtxid with (would-be-invalid) merkle_path: proof is not verified (optimistic trust)' do
+        # Baseline: without seed, the bad merkle proof raises.
+        source_a = build_source_tx
+        source_a.merkle_path = instance_double(BSV::Transaction::MerklePath,
+                                               block_height: 800_000,
+                                               verify: false)
+        tx_a = build_spending_tx(source_a)
+        expect { tx_a.verify(chain_tracker: chain_tracker) }
           .to raise_error(BSV::Transaction::VerificationError, /invalid merkle proof/)
+
+        # Fresh objects for the seeded run — the bad merkle_path must never be consulted.
+        source_b = build_source_tx
+        bad_path_b = instance_double(BSV::Transaction::MerklePath,
+                                     block_height: 800_000,
+                                     verify: false)
+        source_b.merkle_path = bad_path_b
+        tx_b = build_spending_tx(source_b)
+
+        result = tx_b.verify(chain_tracker: chain_tracker, verified: { source_b.wtxid => true })
+
+        expect(result).to be true
+        expect(bad_path_b).not_to have_received(:verify)
       end
 
-      # Spec 6 — subject wtxid in seed → immediate accept
+      # Subject seeded: immediate accept, inputs untouched.
       it 'subject wtxid in seed: returns true without verifying inputs' do
         source_tx = build_source_tx
         source_tx.merkle_path = make_merkle_path
         tx = build_spending_tx(source_tx)
 
-        # Sabotage the unlocking script — if verify_input were called, it would raise
         tx.inputs[0].unlocking_script = BSV::Script::Script.from_asm('OP_0')
 
-        result = tx.verify(chain_tracker: chain_tracker, verified: Set.new([tx.wtxid]))
+        result = tx.verify(chain_tracker: chain_tracker, verified: { tx.wtxid => true })
 
         expect(result).to be true
       end
 
-      # Spec 7 — fee gate still runs when subject is seeded
+      # Fee gate is caller-passed policy; not part of the cached script-validity claim.
+      # It runs once at the start of every verify call regardless of what's in the Hash.
       it 'fee gate still runs when subject is seeded: raises :insufficient_fee' do
         source_tx = build_source_tx(satoshis: 100_000)
         source_tx.merkle_path = make_merkle_path
@@ -493,23 +527,20 @@ RSpec.describe BSV::Transaction::Tx do
           tx.verify(
             chain_tracker: chain_tracker,
             fee_model: rejecting_model,
-            verified: Set.new([tx.wtxid])
+            verified: { tx.wtxid => true }
           )
         end.to raise_error(BSV::Transaction::VerificationError) { |e|
           expect(e.code).to eq(:insufficient_fee)
         }
       end
 
-      # Spec 8 — conformance re-run under benign seed
-      # Three representative P2PKH chain shapes verified with and without a bogus seed.
-      # The seed wtxid never matches any transaction in the graph, so behaviour must
-      # be identical to the unseeded run. Defence-in-depth against sighash regressions.
+      # Benign seed: bogus wtxids in the Hash never match; behaviour identical to unseeded.
       it 'benign seed: 2-hop P2PKH chain behaves identically with and without seed' do
         source = build_source_tx
         source.merkle_path = make_merkle_path
         tx = build_spending_tx(source)
 
-        seeded_result = tx.verify(chain_tracker: chain_tracker, verified: Set.new([bogus_wtxid]))
+        seeded_result = tx.verify(chain_tracker: chain_tracker, verified: { bogus_wtxid => true })
         expect(seeded_result).to be true
         expect(tx.verify(chain_tracker: chain_tracker)).to eq(seeded_result)
       end
@@ -520,7 +551,7 @@ RSpec.describe BSV::Transaction::Tx do
         parent = build_spending_tx(grandparent, output_sats: 150_000)
         child = build_spending_tx(parent, output_sats: 100_000)
 
-        seeded_result = child.verify(chain_tracker: chain_tracker, verified: Set.new([bogus_wtxid]))
+        seeded_result = child.verify(chain_tracker: chain_tracker, verified: { bogus_wtxid => true })
         expect(seeded_result).to be true
         expect(child.verify(chain_tracker: chain_tracker)).to eq(seeded_result)
       end
@@ -531,40 +562,39 @@ RSpec.describe BSV::Transaction::Tx do
         tx = build_spending_tx(source)
         tx.inputs[0].unlocking_script = BSV::Script::Script.from_asm('OP_0')
 
-        seed = Set.new([bogus_wtxid])
-
         expect { tx.verify(chain_tracker: chain_tracker) }
           .to raise_error(BSV::Transaction::VerificationError) { |e|
             expect(e.code).to eq(:script_failure)
           }
-        expect { tx.verify(chain_tracker: chain_tracker, verified: seed) }
+
+        expect { tx.verify(chain_tracker: chain_tracker, verified: { bogus_wtxid => true }) }
           .to raise_error(BSV::Transaction::VerificationError) { |e|
             expect(e.code).to eq(:script_failure)
           }
       end
 
-      # Spec 9 — format validation
-      it 'format validation: raises ArgumentError with wtxid/hex hint when Set contains a hex string' do
-        hex_string = 'a' * 64
-        seed = Set.new([hex_string])
-
-        expect { build_spending_tx(build_source_tx).verify(chain_tracker: chain_tracker, verified: seed) }
-          .to raise_error(ArgumentError) { |e|
-            expect(e.message).to include('wtxid')
-            expect(e.message).to include('hex')
-          }
-      end
-
-      # Spec 10 — wrong type
-      it 'wrong type: raises ArgumentError naming Set and received type when given an Array' do
+      # Wrong types
+      it 'wrong type: raises ArgumentError naming Hash and received type when given an Array' do
         source_tx = build_source_tx
         source_tx.merkle_path = make_merkle_path
         tx = build_spending_tx(source_tx)
 
         expect { tx.verify(chain_tracker: chain_tracker, verified: [source_tx.wtxid]) }
           .to raise_error(ArgumentError) { |e|
-            expect(e.message).to include('Set')
+            expect(e.message).to include('Hash')
             expect(e.message).to include('Array')
+          }
+      end
+
+      it 'wrong type: raises ArgumentError when given a Set (rejects the legacy PR #912 shape)' do
+        source_tx = build_source_tx
+        source_tx.merkle_path = make_merkle_path
+        tx = build_spending_tx(source_tx)
+
+        expect { tx.verify(chain_tracker: chain_tracker, verified: Set.new([source_tx.wtxid])) }
+          .to raise_error(ArgumentError) { |e|
+            expect(e.message).to include('Hash')
+            expect(e.message).to include('Set')
           }
       end
     end

--- a/gem/bsv-sdk/spec/bsv/transaction/tx_verify_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/transaction/tx_verify_spec.rb
@@ -668,6 +668,33 @@ RSpec.describe BSV::Transaction::Tx do
         expect { tx.verify(chain_tracker: chain_tracker, verified: seed) }
           .not_to raise_error
       end
+
+      # Regression pin: with the fee gate moved outside the walk loop, verify_fee →
+      # total_input_satoshis could raise raw ArgumentError when source data is missing,
+      # breaking the "verify raises VerificationError" taxonomy documented in @raise.
+      # Translate to :missing_source so callers can `rescue VerificationError` consistently.
+      it 'fee gate on missing source data: raises VerificationError(:missing_source), not ArgumentError' do
+        tx = described_class.new
+        input = BSV::Transaction::TransactionInput.new(
+          prev_wtxid: BSV::Primitives::Digest.sha256d('missing-source'),
+          prev_tx_out_index: 0
+        )
+        input.unlocking_script = BSV::Script::Script.from_asm('OP_TRUE')
+        # NOTE: no source_satoshis, no source_transaction — will trip total_input_satoshis
+        tx.add_input(input)
+        tx.add_output(BSV::Transaction::TransactionOutput.new(
+                        satoshis: 100,
+                        locking_script: lock_script
+                      ))
+
+        fee_model = instance_double(BSV::Transaction::FeeModel, compute_fee: 1)
+
+        expect { tx.verify(chain_tracker: chain_tracker, fee_model: fee_model) }
+          .to raise_error(BSV::Transaction::VerificationError) { |e|
+            expect(e.code).to eq(:missing_source)
+            expect(e.message).to include('cannot compute fee')
+          }
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Adds `verified:` kwarg to `Tx#verify` — a **bidirectional wtxid dedup `Hash`** that a caller (typically a wallet with a persistent verification cache) can:

1. **Pre-seed** to short-circuit ancestor walks.
2. **Post-read** to accumulate walked wtxids for cache write-back.
3. **Round-trip** — both at once, in-place on the same `Hash`.

Sub-HLR of `sgbett/bsv-wallet#516`. Unblocks bsv-wallet Sub 2 (PR #525, blocked; needs post-read) and Sub 5 (planned; needs pre-seed) in one release.

## Design evolution during the PR

This PR shipped once, was scoped through 10-specialist synthesis, and then extended per Simon's [scope-extension comment](https://github.com/sgbett/bsv-ruby-sdk/issues/904#issuecomment-4870098096). Final design:

| Aspect | Final |
|---|---|
| Collection type | `Hash` (`wtxid => true`) |
| Mutation | In-place — caller reads walked wtxids after `verify` |
| Trust contract | **Optimistic** — seeded wtxid fully short-circuits (including merkle proof) |
| Fee gate | Runs once at method entry — outside the walk loop |
| Metadata on seed values | Presence-only (`true`); trust-source metadata deferred as YAGNI |
| Format validation | None on Hash keys — malformed keys degrade safely to seed-miss |
| Kwarg default | `nil` — SDK uses internal Hash the caller cannot read |

## Walk order (reviewer-critical)

```
0. If fee_model given → verify_fee(fee_model)          # runs BEFORE loop, once per call
1. Loop: skip if verified[wtxid]                        # dedup — seeded and walked both hit here
2. If merkle_path → verify against chain_tracker        # skipped if seeded (short-circuited at step 1)
3. Full input verification
4. verify_output_constraint
5. Mark verified[wtxid] = true
```

## Trust contract change (documented loudly)

The bidirectional single-Hash design **collapses the strict-merkle-ordering** that the 10-specialist synthesis had locked in on the original scope. Under the amendment, seeded wtxids short-circuit everything — including merkle proof. The caller warrants full trust: script + chain anchor + consensus-flag context.

This is documented in:
- `Tx#verify` YARD `@note Security` — merkle proofs not re-verified for seeded ancestors.
- `docs/reference/verify-kwarg.md` — Walk order + Trust contract sections.
- Spec `seeded wtxid with (would-be-invalid) merkle_path: proof is not verified (optimistic trust)` — pins as intentional.

Restoring strict ordering would require value distinction (`:seeded` vs `:walked`) — which contradicts Simon's YAGNI-on-metadata call in the HLR comment.

## Commit history

Original synthesis (specialist-locked design):
1. `83cfa4d7` — `feat(transaction): Tx#verify(verified:) kwarg + walk changes (Closes #909)`
2. `3c733671` — `feat(transaction): Tx#verify(verified:) spec suite (Closes #910)`
3. `7beb51bc` — `docs(reference): verify-kwarg reference doc + YARD (Closes #911)`
4. `e74b7ddd` — `docs: address white-hat review findings pre-PR`
5. `afa31bc0` — `docs(transaction): align normalise_verified YARD with O(1) validation`

Scope extension per HLR comment:

6. `65780c7d` — `feat(transaction)!: bidirectional Hash verified: kwarg` (impl + specs)
7. `c2ea95ff` — `docs(reference): rewrite verify-kwarg.md for bidirectional Hash`

Breaking-change flag (`!`) on commit 6: the intermediate Set-based shape from commits 1-5 is fully replaced. Since PR #912 hadn't merged yet, no external consumer was affected.

## Security review status

White-hat review was done on the pre-amendment shape (Set-based, strict merkle). Post-amendment the trust contract flips to optimistic. Since this is an intentional, loudly-documented consequence of the bidirectional shape (and the practical wallet threat model — wallet-owned cache — accepts optimistic), we're not gating on a re-review. If reviewers want a second pass on the optimistic contract before merge, happy to run one.

## Test plan

- [x] `bundle exec rake spec:sdk` — 6455 examples, 0 failures, 22 pending.
- [x] `spec/bsv/transaction/tx_verify_spec.rb` — 40 examples, 0 failures.
- [x] `spec/conformance/` (SIGHASH FORKID) + `spec/interpreter/` (script verify) — bit-identical to master.
- [x] Anchor test (`invalid-signature ancestor with seed → passes`) preserved with `CONTRACT LOCK` comment.
- [x] New specs for bidirectional post-read and round-trip.
- [x] Optimistic-trust spec pins the merkle-skip-for-seeded behaviour.
- [x] YARD generates clean.
- [x] Rubocop clean.

## Related

- Closes #904
- Closes #909
- Closes #910
- Closes #911
- Parent: `sgbett/bsv-wallet#516` (cross-repo; SDK seam ships here first)
- HLR synthesised breakdown: #904 issuecomment-4861384713
- HLR scope-extension amendment: #904 issuecomment-4870098096
