### PR TITLE
docs(verify-kwarg): note chain_tracker binding of the verified: cache

### DIFF
--- a/docs/reference/verify-kwarg.md
+++ b/docs/reference/verify-kwarg.md
@@ -132,6 +132,14 @@ values back, so `Hash` is now the only accepted collection type.
   flags under which they were originally verified. Invalidate the cache when
   consensus flags change.
 
+- **Chain-tracker binding.** A cache is bound to the `chain_tracker` (and its
+  network and consensus context) that populated it. The SDK records only *that*
+  a wtxid was verified, not *which* tracker proved it, so a seeded wtxid
+  short-circuits verification regardless of the `chain_tracker` passed to a
+  later `verify`. Do not reuse a cache across different trackers or networks —
+  a subtree proven under a weak or attacker-influenced tracker would then be
+  trusted by an authoritative one.
+
 - **Thread-safety.** Do not mutate the `Hash` from another thread while
   `verify` is running. The SDK does **not** freeze the caller's Hash (it needs
   to write to it) and does not defend against concurrent mutation.


### PR DESCRIPTION
## Summary

Documents a trust-boundary subtlety of the `verified:` cache added in #912: the cache records only *that* a wtxid was verified, not *which* `chain_tracker` proved it. A seeded wtxid short-circuits verification regardless of the tracker passed to a later `verify`, so reusing a cache across trackers/networks could let a subtree proven under a weak or attacker-influenced tracker be trusted by an authoritative one.

Adds a **Chain-tracker binding** bullet to §Caller responsibilities. Docs only — no code change.

## Context

Follow-up to the pre-merge security review on #912 (finding **L1**, Low). Caller-mediated; not a code defect. L2 from the same review (persisting non-merkle-anchored verdicts) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)