### PR TITLE
docs(release): clarify pre-1.0.0 version bump mapping in Step 5

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -179,6 +179,22 @@ Apply bump rules (applied in order, first match wins):
 - Any commit matching `feat:` → **MINOR**
 - Otherwise → **PATCH**
 
+**Pre-1.0.0 (`0.y.z`) shifts one position down.** While the gem's major version is
+`0`, the public API is treated as unstable. The `0` is pinned, the **minor** acts as
+the breaking-change position and the **patch** as the compatible-change position — the
+same reading Cargo and npm's `^0.y.z` caret use, and the one that makes Ruby's `~>`
+operator meaningful (`~> 0.26.1` admits patch bumps but not a minor bump):
+
+- **MAJOR** (breaking) → bump the **minor** position — a `0.1` release
+  (e.g. `0.26.0` → `0.27.0`)
+- **MINOR** (`feat:`) or **PATCH** → bump the **patch** position — a `0.0.1` release
+  (e.g. `0.26.0` → `0.26.1`)
+
+Pre-1.0 the only distinction that carries compatibility meaning is breaking vs
+non-breaking: a new feature and a bug fix are both backward-compatible, so both land on
+the patch position. Once the gem reaches `1.0.0`, apply the MAJOR/MINOR/PATCH mapping
+directly.
+
 Show suggested bump with reasoning:
 
 ```


### PR DESCRIPTION
## Problem

`/release` Step 5 classifies commits into MAJOR/MINOR/PATCH but never explained how that maps onto a `0.y.z` version. Taken literally, a MAJOR classification would bump the current `0.26.0` gem to `1.0.0` — wrong while the SDK is pre-1.0.

## Change

Documents the zero-major convention in Step 5. Pre-1.0.0 the **minor** is the breaking-change position and the **patch** is the compatible-change position:

- **MAJOR** (breaking) → bump the **minor** — a `0.1` release (e.g. `0.26.0` → `0.27.0`)
- **MINOR** (`feat:`) or **PATCH** → bump the **patch** — a `0.0.1` release (e.g. `0.26.0` → `0.26.1`)
- Standard MAJOR/MINOR/PATCH mapping resumes at `1.0.0`.

This is the reading Cargo and npm's `^0.y.z` caret use, and the one that keeps Ruby's `~>` operator meaningful: `~> 0.26.1` admits patch bumps (features + fixes) but not a minor bump (a breaking change), so consumers get compatible updates automatically and opt in to breaking ones. Pre-1.0 the only distinction that carries compatibility meaning is breaking vs non-breaking, so a new feature and a bug fix — both backward-compatible — land on the same (patch) position.

Docs-only change to `.claude/commands/release.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)