### PR TITLE
docs(verify-kwarg): document script-only leaf boundary as caller's policy

### DIFF
--- a/docs/reference/verify-kwarg.md
+++ b/docs/reference/verify-kwarg.md
@@ -122,6 +122,19 @@ values back, so `Hash` is now the only accepted collection type.
   inputs are invalid — but the wallet may have committed to downstream state
   (returning `true` to a UI, marking a UTXO spendable) in the interim.
 
+- **Anchoring policy is the caller's.** `verify` accepts a leaf as verified
+  on script alone — `unlocking_script` + `source_locking_script` +
+  `source_satoshis` — so an input with `source_transaction: nil` can pass
+  and be written to the cache without ever reaching a merkle proof. If your
+  policy requires every persisted verdict to bottom out in a merkle-anchored
+  ancestor (i.e. SPV-proven), enforce that upstream: reject the input before
+  calling `verify`, or gate the cache write on the walk terminating in a
+  proof. In BEEF-shaped ingress this happens implicitly — an unresolved leaf
+  has nil source data and raises `VerificationError(:missing_source)`
+  — but the SDK itself makes no anchoring guarantee. See
+  [#914](https://github.com/sgbett/bsv-ruby-sdk/issues/914) for the
+  discussion that landed on this boundary.
+
 - **Staleness invalidation.** If a transaction's script validity or chain
   anchor could have changed (chain reorganisation, consensus flag update),
   remove its wtxid from the cache before calling `verify`. The seed treats the


### PR DESCRIPTION
## Summary

Lands the doc-only resolution of #914 following the bsv-wallet #516 integration signal ([issue comment](https://github.com/sgbett/bsv-ruby-sdk/issues/914#issuecomment-5017910262)):

- Option (c) (document, no SDK-side policy change) was the recommended call once the wallet integration showed the script-only-verdict-persisted-as-SPV shape is unreachable in BEEF-shaped ingress.
- Options (a) (strict reject on missing `sourceTransaction`) and (b) (typed cache distinguishing anchored vs script-only) not needed — the wallet built its typed cache on an orthogonal axis (trust *source*: `spv` / `self_built` / `broadcast_ack`), and BEEF ingress rejects unresolved leaves via `VerificationError(:missing_source)` before they can reach the cache.

New bullet under **Caller responsibilities** in `docs/reference/verify-kwarg.md`, placed between "Correctness" and "Staleness invalidation" — it defines *what enters* the cache, before the invalidation bullets that describe what happens after.

## What it says

- `verify` accepts a leaf on script alone (`unlocking_script` + `source_locking_script` + `source_satoshis`); `source_transaction: nil` still passes and gets cached.
- BEEF ingress makes this safe implicitly — nil source data raises before caching — but the SDK itself makes no anchoring guarantee.
- Anchoring policy is the caller's: reject upstream or gate the cache write on the walk terminating in a proof.

## Test plan

- [x] `bundle exec rake docs:lint` — frontmatter / symbols / kwargs / syntax all green
- [ ] Reviewer sanity-check the framing against the #914 discussion

Closes #914.

🤖 Generated with [Claude Code](https://claude.com/claude-code)