### PR TITLE
chore(lint): adopt Style/ArrayIntersect from rubocop 1.88

### DIFF
--- a/gem/bsv-sdk/lib/bsv/overlay/topic_broadcaster.rb
+++ b/gem/bsv-sdk/lib/bsv/overlay/topic_broadcaster.rb
@@ -356,7 +356,11 @@ module BSV
         when 'all'
           @topics.all? { |t| acked.include?(t) }
         when 'any'
-          @topics.any? { |t| acked.include?(t) }
+          # +Set#intersect?+ accepts any Enumerable and handles the mixed types:
+          # +acked+ is a Set<String>, +@topics+ is an Array<String>. Rubocop's
+          # +Style/ArrayIntersect+ autocorrect flipped it to +@topics.intersect?(acked)+,
+          # which raises TypeError because +Array#intersect?+ won't accept a Set.
+          acked.intersect?(@topics)
         when Array
           requirement.all? { |t| acked.include?(t) }
         else

--- a/gem/bsv-sdk/spec/bsv/script/interpreter/script_vectors_spec.rb
+++ b/gem/bsv-sdk/spec/bsv/script/interpreter/script_vectors_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe 'Bitcoin Core script vectors' do
       comment = vec[4] || ''
       flags = flags_str.split(',')
 
-      if flags.any? { |f| UNSUPPORTED_FLAGS.include?(f) }
+      if flags.intersect?(UNSUPPORTED_FLAGS)
         skipped_count += 1
         next
       end


### PR DESCRIPTION
## Summary

Rubocop 1.87 → 1.88 enabled `Style/ArrayIntersect` as a new default cop. Two pre-existing `Array#any? { include? }` calls fail CI on every PR that resolves the newer rubocop (this gem doesn't commit `Gemfile.lock`, so bundler resolves within `~> 1.85` freshly on each CI run — which currently pulls 1.88.2).

## Changes

- **`script_vectors_spec.rb:199`** — both operands are Arrays; straight autocorrect to `flags.intersect?(UNSUPPORTED_FLAGS)`.
- **`topic_broadcaster.rb:359`** — `acked` is a `Set<String>`, `@topics` is `Array<String>`. Rubocop's naïve autocorrect flipped it to `@topics.intersect?(acked)`, which raises `TypeError: no implicit conversion of Set into Array` (`Array#intersect?` won't take a Set). Manual fix puts the Set on the left — `acked.intersect?(@topics)` — since `Set#intersect?` accepts any Enumerable. Inline comment documents the trap so a future rubocop pass doesn't quietly flip it back.

## Test plan

- [x] `bundle exec rubocop` — 445 files, no offenses (rubocop 1.88.2 locally)
- [x] `bundle exec rake spec:sdk` — 6461 examples, 0 failures, 22 pending
- [ ] CI green

## Unblocks

- #915 — `docs(release): clarify pre-1.0.0 version bump mapping`
- #916 — `docs(verify-kwarg): document script-only leaf boundary`

Both were failing on this rubocop bump — nothing wrong with either PR. They go green on rebase.

Part of #917.

🤖 Generated with [Claude Code](https://claude.com/claude-code)